### PR TITLE
[CI] model_targets: re-seed llama3.1-8b DP and qwen2.5-vl-32b TTFT targets tripping "much better than expected"

### DIFF
--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -685,6 +685,7 @@ targets:
           # 34079232201, 34183001770; three different qb2 tiles): 207.6-208.5 t/s, 51.9-52.1 t/s/u.
           # Consistent step up from 149/37, so the old center tripped the "much better than
           # expected" upper bound (171.8 / 42.9) on every run. TTFT unchanged (still in band).
+          # Validated on run 34255364518 (job 102168738297).
           - status: active
             perf:
               prefill_time_to_first_token: 14.4
@@ -1126,11 +1127,8 @@ targets:
             status: active
             # Re-seeded from run 27036772693 (ci eval-32); the earlier 7.63/189
             # were the token-matching teacher-forcing artifacts, not eval perf.
-            # Re-seeded again 2026-09-08: the last 3 scheduled runs (34008626074, 34079232201,
-            # 34183001770) measured 29.9-30.1 t/s/u on three different qb2 tiles, tripping the
-            # old 22.1 center's upper bound (25.4) every run. TTFT unchanged (still in band).
             perf:
-              decode_t/s/u: 30.0
+              decode_t/s/u: 22.1
               prefill_time_to_first_token: 82
             accuracy: {}
   qwen2.5-72b:
@@ -1163,12 +1161,7 @@ targets:
             seq_len: 128
             status: active
             perf:
-              # TTFT re-centered 2026-09-08: scheduled runs since 2026-08-20 measured 233-348 ms
-              # (233 / 293 on 09-06 / 09-07, ~330-348 in late August), all below the old 419
-              # center's tol-0.15 floor (356) -> "much better than expected" on every reading.
-              # 300 ms with tol 0.35 gives [195, 405], spanning the observed range.
-              prefill_time_to_first_token: 300
-              prefill_time_to_first_token_tolerance: 0.35
+              prefill_time_to_first_token: 419
               # b1 decode is run-to-run unstable: measured ~10.9-13.2 t/s across
               # recent scheduled runs + 3 targeted reruns. The old 13.77 center
               # sat at the top of the range, so its tol-0.15 floor (11.70) tripped
@@ -1287,7 +1280,8 @@ targets:
               # tripping ("much better than expected"). Center on the observed mean so
               # the [178, 414] band spans both clusters and still gates gross regressions.
               # 2026-09-08: a 167 ms reading (run 34013235507) fell under the 178 floor; recenter
-              # on 260 so the tol-0.4 band [156, 364] still covers both clusters.
+              # on 260 so the tol-0.4 band [156, 364] still covers both clusters. Validated on run
+              # 34255378909 (job 102166690435).
               prefill_time_to_first_token: 260
               prefill_time_to_first_token_tolerance: 0.4
               # decode_t/s/u is run-to-run unstable (see #48510). The earlier 18.0 center
@@ -1362,17 +1356,11 @@ targets:
             # 6/6 recent scheduled runs measured decode_t/s ~680-703, t/s/u ~21.8,
             # TTFT ~86-88ms (old targets 278 / 18.7 / 207 were stale). decode_t/s
             # = batch_size * decode_t/s/u (32 * 21.6 ~= 691).
-            # 2026-09-08: decode swings tile to tile on qb2 (929 t/s on qb2-120-p02t09 on 09-07,
-            # 561 t/s on qb2-120-p06t03 on 09-08, in-band on other days), so both tol-0.15 bounds
-            # tripped within two days. Widen decode tolerance to 0.35 ([449, 933] / [14.0, 29.2])
-            # until the tile variance is understood; TTFT keeps its own 0.2.
             perf:
               prefill_time_to_first_token: 87
               prefill_time_to_first_token_tolerance: 0.2
               decode_t/s/u: 21.6
-              decode_t_s_u_tolerance: 0.35
               decode_t/s: 691
-              decode_t_s_tolerance: 0.35
             accuracy: {}
             owner_id: U03PUAKE719 # Miguel Tairum Cruz
             team: models
@@ -1436,9 +1424,7 @@ targets:
             seq_len: 128
             status: active
             perf:
-              # 2026-09-08: TTFT measured 136 ms (run 34006475344) under the old 174 center's
-              # tol-0.2 floor (139); recenter on 160 -> [128, 192].
-              prefill_time_to_first_token: 160.0
+              prefill_time_to_first_token: 174.0
               decode_t/s: 26.0
               decode_t/s/u: 26.0
               tolerance: 0.2

--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -681,11 +681,15 @@ targets:
           # tripped the validator's "much better than expected" upper bound. The 14 scheduled
           # runs before #48886 sat at 18.9-21.3 t/s/u with no runner correlation, so this is a
           # genuine step change from that optimization, not machine variance.
+          # Re-seeded 2026-09-08 from the last 3 scheduled b4 data-parallel runs (34008626074,
+          # 34079232201, 34183001770; three different qb2 tiles): 207.6-208.5 t/s, 51.9-52.1 t/s/u.
+          # Consistent step up from 149/37, so the old center tripped the "much better than
+          # expected" upper bound (171.8 / 42.9) on every run. TTFT unchanged (still in band).
           - status: active
             perf:
               prefill_time_to_first_token: 14.4
-              decode_t/s/u: 37.3
-              decode_t/s: 149.4
+              decode_t/s/u: 52.0
+              decode_t/s: 208.0
             accuracy:
               top1: 90.0
               top5: 97.6
@@ -1122,8 +1126,11 @@ targets:
             status: active
             # Re-seeded from run 27036772693 (ci eval-32); the earlier 7.63/189
             # were the token-matching teacher-forcing artifacts, not eval perf.
+            # Re-seeded again 2026-09-08: the last 3 scheduled runs (34008626074, 34079232201,
+            # 34183001770) measured 29.9-30.1 t/s/u on three different qb2 tiles, tripping the
+            # old 22.1 center's upper bound (25.4) every run. TTFT unchanged (still in band).
             perf:
-              decode_t/s/u: 22.1
+              decode_t/s/u: 30.0
               prefill_time_to_first_token: 82
             accuracy: {}
   qwen2.5-72b:
@@ -1156,7 +1163,12 @@ targets:
             seq_len: 128
             status: active
             perf:
-              prefill_time_to_first_token: 419
+              # TTFT re-centered 2026-09-08: scheduled runs since 2026-08-20 measured 233-348 ms
+              # (233 / 293 on 09-06 / 09-07, ~330-348 in late August), all below the old 419
+              # center's tol-0.15 floor (356) -> "much better than expected" on every reading.
+              # 300 ms with tol 0.35 gives [195, 405], spanning the observed range.
+              prefill_time_to_first_token: 300
+              prefill_time_to_first_token_tolerance: 0.35
               # b1 decode is run-to-run unstable: measured ~10.9-13.2 t/s across
               # recent scheduled runs + 3 targeted reruns. The old 13.77 center
               # sat at the top of the range, so its tol-0.15 floor (11.70) tripped
@@ -1274,7 +1286,9 @@ targets:
               # center left the tol-0.4 floor at 211ms, which the ~205ms cluster kept
               # tripping ("much better than expected"). Center on the observed mean so
               # the [178, 414] band spans both clusters and still gates gross regressions.
-              prefill_time_to_first_token: 296
+              # 2026-09-08: a 167 ms reading (run 34013235507) fell under the 178 floor; recenter
+              # on 260 so the tol-0.4 band [156, 364] still covers both clusters.
+              prefill_time_to_first_token: 260
               prefill_time_to_first_token_tolerance: 0.4
               # decode_t/s/u is run-to-run unstable (see #48510). The earlier 18.0 center
               # (set pre-data, post-#48037) is now stale-low: the last 8 scheduled runs
@@ -1348,11 +1362,17 @@ targets:
             # 6/6 recent scheduled runs measured decode_t/s ~680-703, t/s/u ~21.8,
             # TTFT ~86-88ms (old targets 278 / 18.7 / 207 were stale). decode_t/s
             # = batch_size * decode_t/s/u (32 * 21.6 ~= 691).
+            # 2026-09-08: decode swings tile to tile on qb2 (929 t/s on qb2-120-p02t09 on 09-07,
+            # 561 t/s on qb2-120-p06t03 on 09-08, in-band on other days), so both tol-0.15 bounds
+            # tripped within two days. Widen decode tolerance to 0.35 ([449, 933] / [14.0, 29.2])
+            # until the tile variance is understood; TTFT keeps its own 0.2.
             perf:
               prefill_time_to_first_token: 87
               prefill_time_to_first_token_tolerance: 0.2
               decode_t/s/u: 21.6
+              decode_t_s_u_tolerance: 0.35
               decode_t/s: 691
+              decode_t_s_tolerance: 0.35
             accuracy: {}
             owner_id: U03PUAKE719 # Miguel Tairum Cruz
             team: models
@@ -1416,7 +1436,9 @@ targets:
             seq_len: 128
             status: active
             perf:
-              prefill_time_to_first_token: 174.0
+              # 2026-09-08: TTFT measured 136 ms (run 34006475344) under the old 174 center's
+              # tol-0.2 floor (139); recenter on 160 -> [128, 192].
+              prefill_time_to_first_token: 160.0
               decode_t/s: 26.0
               decode_t/s/u: 26.0
               tolerance: 0.2


### PR DESCRIPTION
### PR Category
Bug fix (CI perf targets)

### Summary
Two e2e legs failed every scheduled run in the 2026-09-05..09-08 window at `Report and Validate Perf and Accuracy targets` because the measurement left the band in the **good** direction ("much better than expected, update target"). No model got slower. Values in `models/model_targets.yaml`:

| Model / SKU / config | Metric | Old target (band) | Measured (runs) | New |
|---|---|---|---|---|
| llama3.1-8b / p300x2 (bh_quietbox_2), b4 data-parallel | decode t/s, t/s/u | 149.4 (≤171.8), 37.3 (≤42.9) | 207.6-208.5, 51.9-52.1 (34008626074, 34079232201, 34183001770; 3 tiles) | 208 / 52 |
| qwen2.5-vl-32b / wh_llmbox_perf, b1 s128 | TTFT | 296 ms tol 0.4 (≥178) | 167 (34013235507) | 260, tol 0.4 → [156, 364] |

Each entry carries a dated comment with the runs it was seeded from and the validating run.

Originally this PR also re-centered qwen2.5-32b, qwen2.5-vl-72b TTFT, qwen3.6-27b TTFT and widened qwen3-32b bh_quietbox_2 decode tolerance; those four hunks were dropped on 2026-09-09 because #55343 (approved) re-seeds the same entries. Its qwen3-32b 931 / 29.1 center versus the 561 t/s reading of 09-08 is raised as a comment there.

### Notes for reviewers
- `flux.1-schnell` / `bh_quietbox_2` and `shallow-unet` / `bh_p150` are reported by the validator as active combos with no target entry (warning on ~23 jobs). Not addressed here; needs measured values from their owners.
- Validation is the `Report and Validate` step of the e2e jobs; both remaining entries are validated below.

### CI
- `(Tier 2) Models End-To-End Tests`, model=`all`, sku=`bh_quietbox_2 (BH QB2)`: https://github.com/tenstorrent/tt-metal/actions/runs/34255364518
  - **Passed** for this PR's entry: [`Llama 3.1-8B data-parallel e2e tests [bh_quietbox_2]`](https://github.com/tenstorrent/tt-metal/actions/runs/34255364518/job/102168738297) with 208 / 52. (Qwen2.5-32B also passed with the since-dropped 30.0 center; Qwen3-32B BH timed out twice mid weight-load on the degraded qb2 pool.)
- `(Tier 3) Models End-To-End Tests`, model=`qwen2.5-vl-32b`, sku=`wh_llmbox_perf (T3000 perf)`: https://github.com/tenstorrent/tt-metal/actions/runs/34255378909
  - **Passed**: [`Qwen2.5-VL-32B e2e tests [wh_llmbox_perf]`](https://github.com/tenstorrent/tt-metal/actions/runs/34255378909/job/102166690435), `2 passed, 6 skipped`, validate step green with the 260 ms center.
- Runs for the dropped entries, kept for the record: qwen2.5-vl-72b 34255368904 (passed with the dropped 300 ±35% center; TTFT 225.7 ms), qwen3.6-27b 34255373521 (timed out twice in weight load, inconclusive).
