### PR TITLE
[CI] qwen3-32b T3K: size the trace region for the eval-32-perf-report leg and fix scalar sampling params for batch decode (#55953)

### DIFF
--- a/models/common/modules/sampling/params.py
+++ b/models/common/modules/sampling/params.py
@@ -398,7 +398,15 @@ def slice_sampling_params(sampling_params: SamplingParams, rows: Sequence[int]) 
     def slice_value(value: Any, name: str) -> Any:
         normalized = _host_value(value)
         if not _is_sequence(normalized):
-            return normalized
+            # A scalar describes every selected row, exactly like a one-entry sequence below: the
+            # decode runtime hands the result to prepare_sampling_params, which counts active rows
+            # from the temperature field, and then places one row per selected slot. Leaving the
+            # scalar as-is described a single request for a multi-slot decode ("expected 1
+            # destination slots, got 32", #55953). ``None`` stays ``None`` (field not set) and a
+            # scalar seed stays request-owned rather than being handed to sibling rows.
+            if normalized is None or name == "seed":
+                return normalized
+            return [normalized for _ in selected]
         values = list(normalized)
         if not values:
             raise ValueError(f"sampling_params.{name} cannot be empty")

--- a/models/common/tests/models/qwen3_32b/test_demo_contract.py
+++ b/models/common/tests/models/qwen3_32b/test_demo_contract.py
@@ -319,7 +319,7 @@ def test_demo_resolves_qwen3_trace_region_and_matches_ring_fabric():
     assert 'resolve_trace_region_size("qwen3-32b", env)' in _DEMO_SOURCE
     assert '"trace_region_size": 50_000_000' not in _DEMO_SOURCE
     assert "ttnn.FabricConfig.FABRIC_1D_RING" in _DEMO_SOURCE
-    assert resolve_trace_region_size("qwen3-32b", "T3K") == 90_000_000
+    assert resolve_trace_region_size("qwen3-32b", "T3K") == 120_000_000
     assert resolve_trace_region_size("qwen3-32b", "P150x4") == 100_000_000
 
 

--- a/models/common/tests/modules/sampling/test_params.py
+++ b/models/common/tests/modules/sampling/test_params.py
@@ -186,6 +186,38 @@ def test_slice_sampling_params_preserves_field_alignment_without_mutating_input(
     assert params.temperature == [0.1, 0.2, 0.3]
 
 
+def test_slice_sampling_params_broadcasts_scalars_to_every_selected_row():
+    # A demo-style request: one scalar per field, meant for every active decode slot.
+    params = SamplingParams(temperature=0.0, top_k=32, top_p=0.08, seed=7)
+
+    sliced = slice_sampling_params(params, [4, 0, 9])
+
+    assert sliced.temperature == [0.0, 0.0, 0.0]
+    assert sliced.top_k == [32, 32, 32]
+    assert sliced.top_p == [0.08, 0.08, 0.08]
+    assert sliced.presence_penalty == [0.0, 0.0, 0.0]
+    assert sliced.enable_log_probs == [False, False, False]
+    # Seeds are request-owned and never broadcast to sibling rows.
+    assert sliced.seed == 7
+    assert params.temperature == 0.0
+
+
+def test_scalar_sampling_request_places_onto_every_active_decode_slot():
+    # Regression for #55953: qwen3-32b eval-32-perf-report compiles decode for 32 active slots with
+    # SamplingParams(temperature=0.0, top_k=32, top_p=0.08); the sliced request must describe 32 rows.
+    slots = tuple(range(32))
+    request = slice_sampling_params(SamplingParams(temperature=0.0, top_k=32, top_p=0.08), slots)
+
+    prepared = prepare_sampling_params(request, 32, max_device_top_k=32, allow_force_argmax=True)
+    placed = place_prepared_sampling_params(prepared, slots)
+
+    assert prepared.active_rows == 32
+    assert placed.active_mask == tuple([True] * 32)
+    assert placed.top_k == tuple([1] * 32)  # temperature 0 normalizes to greedy rows
+    assert placed.greedy_mask == tuple([True] * 32)
+    assert placed.temperature == tuple([1.0] * 32)  # greedy rows carry the neutral temperature
+
+
 def test_prepared_slice_preserves_prompt_output_and_slot_remap_alignment():
     prompt_tokens = torch.tensor([[10, 11], [20, 21], [30, 31]])
     output_tokens = [[100], [200, 201], [300]]

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -109,7 +109,7 @@ sizes:
     aliases: ["Qwen3-32B", "Qwen/Qwen3-32B"]
     skus:
       wh_llmbox_perf:
-        trace_region_size: 90000000
+        trace_region_size: 120000000
       wh_galaxy_perf:
         trace_region_size: 200000000
       bh_p150:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1849,6 +1849,11 @@
       --cov=models.common.modules.sampling.penalties_1d \
       --cov-report=term-missing \
       --cov-config=models/common/tests/setup.cfg || fail=1
+    pytest models/common/tests/modules/sampling/test_params.py \
+      -m "not slow" \
+      --tb=short \
+      --durations=10 \
+      --deselect "models/common/tests/modules/sampling/test_params.py::test_legacy_device_sampling_capabilities_declare_the_exact_limit[models/tt_transformers/tt/generator_vllm.py]" || fail=1
     pytest models/common/tests/modules/sampling/test_sampling_1d.py \
       -m "not slow" \
       --tb=short \


### PR DESCRIPTION
### PR Category
Bug fix (CI config)

### Summary
`Qwen3-32B e2e tests [wh_llmbox_perf]` (Tier 2 Models e2e, scheduled) has failed every run since 2026-09-05 in `models/common/tests/demos/qwen3_32b/demo.py::test_qwen3_32b[performance-eval-32-perf-report-T3K]`:

```
TT_FATAL @ tt_metal/impl/allocator/bank_manager.cpp:462: false
Out of Memory: Not enough space to allocate 6832128 B TRACE buffer across 12 banks,
where each bank needs to store 573440 B, but bank size is 7503872 B
(allocated: 6963200 B, free: 540672 B, largest free block: 540672 B)
```

The allocation is a captured mesh trace buffer (`BufferType::TRACE`) in the reserved trace region on the 12 Wormhole DRAM banks, not the KV cache. With `trace_region_size = 90,000,000` for `qwen3-32b` on `wh_llmbox_perf` the per-bank budget is 7,503,872 B; nine captured traces already used 6,963,200 B/bank and the tenth needed 573,440 B/bank, with an eleventh still to come. The full set needs at least ~97.3 MB.

Cause: #53575 (`f390e297fdc`, merged 2026-09-04 21:31 UTC) added the `eval-32-perf-report` param, the only Qwen3-32B leg that captures prefill traces (`trace_mode="all"`) with on-device sampling. It raised `p300x2` to 100 MB (measured 92.3 MB full capture) but left `wh_llmbox_perf` at 90 MB. The node is auto-selected into the T3K job because `tests/pipeline_reorg/models_e2e_tests.yaml:234` uses `-k "eval-32 and performance"` and `eval-32` is a substring of `eval-32-perf-report`. Last green run 2026-09-04 03:17 (`e8ebdec7e`), first OOM 2026-09-05 03:16 (`bb2154967`), 100% since; the 09-03 failure of the same job was an unrelated GitHub timeout. Sibling params `performance-eval-32-T3K` (decode-only traces) and `performance-token-accuracy-T3K` pass in the same job.

Fix: `models/model_trace_region_sizes.yaml` `qwen3-32b` / `wh_llmbox_perf`: 90 MB → 120 MB (~23% headroom; p300x2 is 100 MB, Galaxy full capture measured 102 MB), and the matching pin in `models/common/tests/models/qwen3_32b/test_demo_contract.py`.

Second defect, exposed once the OOM was gone (#55953): the same leg then failed in decode compile with `ValueError: expected 1 destination slots, got 32` at `models/common/modules/sampling/params.py` `place_prepared_sampling_params`. Cause: `slice_sampling_params` broadcast a one-entry sequence to all selected rows but returned a bare scalar unchanged; `prepare_sampling_params` then counted one active row from the scalar temperature, and placement refused to put that single row onto the 32 active slots of the batch-32 decode compile. The demo's on-device request is `SamplingParams(temperature=0.0, top_k=32, top_p=0.08)`, one scalar per field, so every batch-32 decode compile with on-device sampling hit this. Fix: treat a scalar like a one-entry sequence in `slice_sampling_params` (`None` stays unset; a scalar seed stays request-owned, matching `_normalize_seeds`). Two host-only tests added in `models/common/tests/modules/sampling/test_params.py`, one of them the exact 32-slot shape from the CI failure. The perf-report leg stays in the T3K job; nothing in the CI selector changes.

### Notes for reviewers
- The `-k "eval-32 and performance"` selector enrols any future `eval-32-*` param into the T3K job unreviewed, and the perf-report leg is written around P150x4 policy yet runs only on T3K in CI. Pinning the node id or adding an explicit entry for the intended SKU is the owner's call; not changed here.
- Alternative is `trace_region_size: 0` (dynamic), which #53575 chose for llama3.1-8b / bh_p150; kept the reserved-region approach here for consistency with p300x2.
- Diagnosis from the CI log and source only; the CI run below is the validation.

### CI
- `(Tier 2) Models End-To-End Tests`, model=`qwen3-32b`, sku=`wh_llmbox_perf (T3000 perf)`: https://github.com/tenstorrent/tt-metal/actions/runs/34257949316
  - Result: the trace-region OOM is gone (0 `Out of Memory` lines; all captures complete; `performance-eval-32-T3K` passed). `performance-eval-32-perf-report-T3K` then fails further along, in decode compile, with `ValueError: expected 1 destination slots, got 32` at `models/common/modules/sampling/params.py:336` (`place_prepared_sampling_params`, reached from `run_perf_benchmark` → `_compile_prefill_and_decode` → `compile_decode`). That is a separate defect in the perf-report leg, not a trace-sizing issue; filed as #55953 for the leg owner.
- The selector-exclusion commit was dropped on 2026-09-10 in favour of fixing the leg. Commit `55e553a1644` carries the `slice_sampling_params` fix + tests. Validation of the full job with the perf-report leg back in (same workflow/model/sku): https://github.com/tenstorrent/tt-metal/actions/runs/34462770077 ([job 102826367877](https://github.com/tenstorrent/tt-metal/actions/runs/34462770077/job/102826367877), f10cs08, queued 9.5 h, ran 19:18–19:33 UTC):
  - `token-accuracy-T3K`: **PASSED** (460 s).
  - `performance-eval-32-T3K`: **PASSED** (no TRACE OOM at 120 MB).
  - `performance-eval-32-perf-report-T3K`: **now runs end to end** (no `expected 1 destination slots, got 32`, i.e. #55953 is fixed on device; prefill 4.48 s, decode compile 0.05 s, decode steps ~49 ms) and **fails on its perf targets**: `tok/s/u 20.1 < target 22.0; ttft_ms 140.0 > target 123.0`. This leg had never completed in CI before (it crashed on the slot-count error, and on the OOM before that), so its targets have never been validated against a T3K CI run; whether 20.1 tok/s/u is a real shortfall or a target sized for another platform is being checked. The trace-region size does not affect throughput, so it is not the cause. The unit group that owns the changed module (`(Tier 1) Models Unit Tests`, model=`tt-transformers-common`, sku=`wh_llmbox (T3000)`, includes `TT-Transformers sampling module unit tests` with its 80% coverage gate): https://github.com/tenstorrent/tt-metal/actions/runs/34462930785 — host-only leg green (`test_penalties_1d.py` 95 passed, coverage 99%), the device leg (`test_sampling_1d.py`) was killed by the 4-minute step budget 21 s into `test_sampling1d_logprobs_topk[1x8]`, its last and slowest test. That is not a hang and not this PR: the scheduled job has been killed at exactly 240 s on every run since 2026-09-08 20:13 on five different T3K VMs, because the job was already at 93–97 % of its budget and a compile-time slowdown on main pushed it over. #56085 raises that budget (4 → 6 min); once it merges this job is expected to go green with the changes here.
- `test_params.py`, which holds the two new tests, was collected by no CI job. Commit `f1330bf589d` adds it to the sampling module job as a third invocation (deselecting `test_legacy_device_sampling_capabilities_declare_the_exact_limit[models/tt_transformers/tt/generator_vllm.py]`, which correctly flags that `Exaone4_5_ForConditionalGeneration` advertises on-device sampling without a `max_device_top_k`; out of scope here). Run 34465420310 never reached the new invocation because the hanging device leg ran first and ate the job budget, so the `test_params.py` invocation now runs before `test_sampling_1d.py` (commit `ab2453a4e63`). Re-run https://github.com/tenstorrent/tt-metal/actions/runs/34467238902 ([sampling module job](https://github.com/tenstorrent/tt-metal/actions/runs/34467238902/job/102840728200)): `test_penalties_1d.py` 95 passed; **`test_params.py` 31 passed / 1 deselected in 5.1 s, both new tests (`test_slice_sampling_params_broadcasts_scalars_to_every_selected_row`, `test_scalar_sampling_request_places_onto_every_active_decode_slot`) PASSED on CI**; then `test_sampling_1d.py` was killed at the 240 s step budget inside `test_sampling1d_logprobs_topk[1x8]`, as on main since 09-08 20:13 (see #56085), so the job is red for that pre-existing budget reason only. Host-only: `test_params.py` 30 passed, `test_decode_runtime.py` 52 passed, `test_sampling_state_1d.py` 32 passed (one pre-existing `test_legacy_device_sampling_capabilities_declare_the_exact_limit` failure is environmental and untouched).
- Rebased onto main `3f254861838` on 2026-09-10; the earlier run links refer to the pre-rebase head. Later the same day the explanatory comment block in `models/model_trace_region_sizes.yaml` was dropped (reviewer request); the two validation runs above were dispatched on `55e553a1644`, which differs from the current head `ab2453a4e63` only by removed comment lines (in `models/model_trace_region_sizes.yaml` and `tests/pipeline_reorg/models_unit_tests.yaml`), the `test_params.py` CI wiring, and a rebase onto main past #55790.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/qwen3-32b-t3k-trace-region-120mb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/qwen3-32b-t3k-trace-region-120mb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/qwen3-32b-t3k-trace-region-120mb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/qwen3-32b-t3k-trace-region-120mb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/qwen3-32b-t3k-trace-region-120mb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/qwen3-32b-t3k-trace-region-120mb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/qwen3-32b-t3k-trace-region-120mb)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/qwen3-32b-t3k-trace-region-120mb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/qwen3-32b-t3k-trace-region-120mb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/qwen3-32b-t3k-trace-region-120mb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/qwen3-32b-t3k-trace-region-120mb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/qwen3-32b-t3k-trace-region-120mb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/qwen3-32b-t3k-trace-region-120mb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/qwen3-32b-t3k-trace-region-120mb)













