### PR TITLE
[CI] qwen36: give test_all_buckets_fit_trace_region the budget its 64-layer load needs

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -376,7 +376,7 @@ models:
     wh_galaxy: 260
     wh_galaxy_perf: 65
     bh_p150: 20
-    bh_quietbox_2: 465
+    bh_quietbox_2: 480  # +15 for test_decode_bucketing's own 1800 s budget (#55790)
     bh_galaxy: 75
     bh_sc1: 370
     bh_sc4: 50

--- a/models/demos/blackhole/qwen36/tests/test_decode_bucketing.py
+++ b/models/demos/blackhole/qwen36/tests/test_decode_bucketing.py
@@ -822,6 +822,10 @@ def test_bucketed_on_device_sampling_traces(mesh_device, reset_seeds, ensure_gc)
 
 @torch.no_grad()
 @_parametrize_traced(trace_bytes=1073741824)  # exactly the b8 model spec's trace_region_size
+# The full 64-layer 27B build from /mnt/MLPerf dominates this test: 44 s of a 63 s warm run, 231 s of a
+# 251 s cold run in CI, and >5 min on a cold NAS tile. The trace-region check itself is ~20 s. The
+# repo-wide 300 s default therefore sat below the test's median and it flaked 60-70% of scheduled runs.
+@pytest.mark.timeout(1800)
 def test_all_buckets_fit_trace_region(mesh_device, reset_seeds, ensure_gc):
     """Four live decode and sampling traces fit in 1 GB and remain replay-safe."""
     from models.tt_transformers.tt.common import copy_host_to_device

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -198,18 +198,25 @@
     pytest --timeout 90 models/demos/blackhole/qwen36/tests/test_gdn_tp.py
     pytest --timeout 60 models/demos/blackhole/qwen36/tests/test_mlp_tp.py
     pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_model_tp.py
-    pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_decode_bucketing.py -k "test_bucket_warmup_compiles_all_widths_before_capture or test_all_buckets_fit_trace_region or test_bucket_trace_teardown_releases_all_stores"
+    pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_decode_bucketing.py -k "test_bucket_warmup_compiles_all_widths_before_capture or test_bucket_trace_teardown_releases_all_stores"
     pytest --timeout 120 models/demos/blackhole/qwen36/tests/test_mlp.py
     pytest --timeout 120 models/demos/blackhole/qwen36/tests/test_patch_merger.py
     pytest --timeout 120 models/demos/blackhole/qwen36/tests/test_vision_attention.py
     pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_vision_block.py
     pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_model.py
     pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_wrapped_model.py
+    # Last on purpose: this test builds the full 64-layer 27B model from /mnt/MLPerf (the trace-region
+    # property it proves needs full depth). Passing CI runs took 58-251 s, and the layer load alone
+    # ranges 44 s (warm page cache) to >5 min (cold NAS), so 300 s sat below the median. Give it its
+    # own budget so a slow load does not also take out the seven files that used to follow it.
+    pytest --timeout 1800 models/demos/blackhole/qwen36/tests/test_decode_bucketing.py -k "test_all_buckets_fit_trace_region"
   model: qwen3.6-27b
   model_family: Qwen
   skus:
     bh_quietbox_2:
-      timeout: 28
+      # 28 min assumed the 300 s cap on test_decode_bucketing; with its real cost (up to ~13 min on a
+      # cold NAS) the whole entry reconstructs to ~33 min from the 2026-09-08 run.
+      timeout: 40
       tier: 1
   owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models


### PR DESCRIPTION
### PR Category
Bug fix (CI config / test budget)

### Summary
`Qwen3.6 unit tests [bh_quietbox_2]` (Tier 1 Models unit, scheduled) fails 60-70% of runs in `models/demos/blackhole/qwen36/tests/test_decode_bucketing.py::test_all_buckets_fit_trace_region[blackhole-device_params0-1x4]` with `Failed: Timeout (>300.0s) from pytest-timeout`. It has flaked like this since it landed on 2026-08-12; two auto-triage issues (#53343, #54379) were opened and auto-closed on the next lucky pass.

The test builds the **full 64-layer** Qwen3.6-27B model on purpose: it proves that all decode buckets' traces fit the b8 `trace_region_size` (1 GiB), which only holds at full depth. From CI `--durations` and the `Loading layers` progress bars:

| Passing run | `call` time | layer load |
|---|---|---|
| 08-12, 09-04 (warm page cache) | 58 s, 63 s | 39-44 s |
| 09-05, 09-07, 09-07 | 200 s, 213 s, 251 s | 181-231 s |
| failing runs (cold NAS) | killed at 300 s | 11-56 of 64 layers, 5.3-27 s/layer |

The trace capture + replay the test actually checks is ~20 s in every run. The 300 s cap (repo default and the job's `--timeout 300`) sits below the test's median cost. When it fires, the seven pytest commands after it in the same `bash -e` block never run, so one slow NAS read also blanks vision/model coverage for the day.

Fix:
- `tests/pipeline_reorg/models_unit_tests.yaml`: run `test_all_buckets_fit_trace_region` as its own last pytest invocation with `--timeout 1800`; the two sibling tests in the file keep 300 s. Raise the `bh_quietbox_2` SKU budget 28 → 40 min (the 09-08 run reconstructs to ~33 min with the load allowed to finish).
- `test_decode_bucketing.py`: matching `@pytest.mark.timeout(1800)` with the measurements in a comment, so the budget travels with the test.

### Notes for reviewers
- This buys margin; it does not make the load cheaper. The structural fix is that qwen36 explicitly disables the warm-ttnn-cache HF-load skip (`tt/model.py:562-568`, because GDN conv weights and q/k norms are consumed on the host without `cache_file_name`), and `tp_common.shard_w` materializes the host tensor before `ttnn.as_tensor` checks the cache, so every build re-reads the ~50 GB HF checkpoint on top of the ~25 GB `.tensorbin` cache. Capturing those host-consumed weights to the `weight_cache.py` sidecar (the gemma3/gemma4 pattern, #50550) would remove the whole HF pass. Separate PR, model owner's call (@ this entry's owner).
- Fewer layers or dummy weights were rejected: fewer layers deletes the property under test; `Qwen36ModelArgs.load_state_dict` has no dummy-weights plumbing and an uncached dummy build would be slower (host tilize + quantize + write-back).
- Open PR #54572 raises this SKU budget to 36 and adds two more pytest commands to the entry but leaves the 300 s cap in place; this PR is compatible with it.

### CI
- `(Tier 1) Models Unit Tests`, model=`qwen3.6-27b`, sku=`bh_quietbox_2 (BH QB2)`: https://github.com/tenstorrent/tt-metal/actions/runs/34258978577
  - First dispatch (34258025601) failed at `Verify test timeouts against budget`: tier-1 unit bh_quietbox_2 was 385/390 min on main, so the 28 → 40 bump needed `.github/time_budget.yaml` +10 (second commit).
  - Run 34258978577 (qb2 pool reading /mnt/MLPerf ~10x slower than normal that evening, see #55786): the first 10 pytest commands passed (7 / 13 / 2 / 14 / 2 / 1 / 1 / 1 / 1 / 1+2 skipped), `test_model_tp.py` alone took 13m47s, and the job hit the 40-min wall clock before `test_all_buckets_fit_trace_region` finished. Inconclusive for the new budget; re-dispatch on a healthy pool. Yaml and time-budget checks pass.
- Re-dispatch on a healthy qb2 pool (2026-09-09 14:09 UTC; the Gemma-4-E4B cold weight build on the same pool took ~3 min that hour, i.e. normal speed): https://github.com/tenstorrent/tt-metal/actions/runs/34361744386 — **PASSED** ([`Qwen3.6 unit tests [bh_quietbox_2]`](https://github.com/tenstorrent/tt-metal/actions/runs/34361744386/job/102503167862), qb2-120-p05t08). All 12 pytest invocations green; `test_all_buckets_fit_trace_region` took 409.9 s of call time, i.e. it passes under the new 1800 s cap and would have failed the old 300 s cap on this tile; `test_model_tp.py` took 12m13s. Test step 26m03s, job 27m48s wall, inside the 40 min SKU timeout.
- Rebased onto main (`ba9cfe38a68`) on 2026-09-09 16:40 UTC (budget `345 → 355`), and again onto `3f254861838` on 2026-09-10: main's unit tier-1 `bh_quietbox_2` budget is now 465 min with 477 min requested once this entry is included, so the bump is `465 → 480` (+15; the second commit message says so). `verify_time_budget.py models_unit_tests.yaml time_budget.yaml unit 1` passes locally with 477 of 480 min requested. The second confirmation run on the old head (34371674665) was cancelled in favour of the rebased head: https://github.com/tenstorrent/tt-metal/actions/runs/34374677154 — hit the 40 min wall clock on qb2-120-p02t08: 10 of 12 invocations green in 17 min, then the 64-layer load in `test_all_buckets_fit_trace_region` ran at 42–55 s per layer (killed at layer 48/64), versus about 44 s for the whole load on a healthy tile. Same tile-level slowness as the 09-08 evening (#55786), not a change in this PR. Retry https://github.com/tenstorrent/tt-metal/actions/runs/34380346809 (qb2-120-p05t04) also hit tile slowness, this time earlier: the 2-test third invocation took 58 s instead of 15 s and two `test_model_tp.py` tests (`test_model_tp_contract`, `test_model_tp_long_prefill`) hit their 300 s pytest timeout; on the healthy tile at 14:49 UTC the same file passed 14/14 in 12 min. These are pre-existing tests this PR does not touch. Third try https://github.com/tenstorrent/tt-metal/actions/runs/34386764443 (qb2-120-p03t01): 13 of 14 `test_model_tp.py` tests passed, `test_model_tp_contract` alone hit its 300 s cap at 352 s; on the healthy tile at 14:49 UTC the same test took 162.6 s, and on qb2-120-p05t04 it hit 300.3 s. Another bh_quietbox_2 job from the #55957 investigation was running on the pool for most of this run. `test_model_tp_contract` is a pre-existing test this PR does not touch, and its 300 s cap is the same class of problem this PR fixes for `test_all_buckets_fit_trace_region` (a full 27B load inside one 300 s pytest timeout); worth a follow-up if it keeps tripping. Fourth try https://github.com/tenstorrent/tt-metal/actions/runs/34390137556 (qb2-120-p02t06, no other bh_quietbox_2 job of mine on the pool): 10 of 12 invocations green including all of `test_model_tp.py` (`test_model_tp_contract` 287 s), then the 64-layer load inside `test_all_buckets_fit_trace_region` ran at 40.9 s per layer and the job hit the 40 min wall clock at layer 57 of 64. Same tile-speed problem as the 16:16 run; measurements for the pool are collected on #55786.
- **Where this leaves the PR:** the change is a budget change only (the test's own `--timeout 1800`, the SKU timeout 28 → 40, the tier budget +10). It was validated end to end on a healthy tile (run 34361744386, 14:49 UTC), and the rebase changed nothing but the budget number (345 → 355). On today's slow tiles the job cannot finish inside 40 minutes regardless of this PR, because a 64-layer load at 41–55 s per layer alone takes 45–60 minutes; the scheduled job on main has the same exposure. I am not re-dispatching further today; a re-run when the pool is back to normal is the remaining confirmation.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/qwen36-trace-region-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/qwen36-trace-region-test-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/qwen36-trace-region-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/qwen36-trace-region-test-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/qwen36-trace-region-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/qwen36-trace-region-test-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/qwen36-trace-region-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/qwen36-trace-region-test-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/qwen36-trace-region-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/qwen36-trace-region-test-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/qwen36-trace-region-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/qwen36-trace-region-test-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/qwen36-trace-region-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/qwen36-trace-region-test-timeout)











