### PR TITLE
[CI] GPT-OSS 120B unit: raise the dispatch-progress watchdog under watcher on bh_quietbox_2

### DIFF
--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -713,6 +713,15 @@
 - name: GPT-OSS 120B unit tests
   cmd: |
     export TT_METAL_WATCHER=15  # poll less often than the CI default of 2s
+    # TT_METAL_WATCHER=<n> only changes the host poll interval; NOC sanitize, waypoints and the ring
+    # buffer are still compiled into every kernel, and setup-job's TT_METAL_OPERATION_TIMEOUT_SECONDS=5
+    # fires when the dispatcher's command counter does not advance for 5 s, i.e. when ONE program runs
+    # longer than 5 s. Under watcher the MoE experts' SparseMatmul at prefill_4096 on bh_quietbox_2
+    # (1x4) takes >5 s (2.8 s -> 12.7 s measured on the smaller case), so the watchdog declared a hang,
+    # tt-triage halted the RISCs, and every later test (test_rope seq_16384 first) failed on a dead
+    # device -- red since #53594 re-enabled the watcher on 2026-08-21. Real backstops remain: the
+    # 22-min job budget and pytest --timeout 1500.
+    export TT_METAL_OPERATION_TIMEOUT_SECONDS=60
     export HF_MODEL=models/demos/gpt_oss/configs/gpt-oss-120b TT_MM_THROTTLE_PERF=2
     # Tensor cache is pre-built on the NAS — skip loading model weights by default.
     # Check mlperf-write-access in the workflow to load weights and regenerate the cache.


### PR DESCRIPTION
### PR Category
Bug fix (CI config)

### Summary
`GPT-OSS 120B unit tests [bh_quietbox_2]` (Tier 1 Models unit, scheduled) has failed every run since 2026-08-25 (35 consecutive runs on 9 different qb2 tiles) with the same two failures:

```
test_modules.py::test_decoder[blackhole-unpaged-layer_0-prefill_4096-1x1]      <- root
test_rope.py::test_rope_vs_hf_reference[blackhole-batch_1-seq_16384-1x4]        <- collateral
TT_THROW: TIMEOUT: device timeout, potential hang detected, the device is unrecoverable (system_memory_manager.cpp:787)
```

The rope test is not the bug: it is simply the next device test after the decoder test wedges the chip, and its own backtrace is an event wait on a device tt-triage has already halted. `ttnn.slice` at 16384 rows is identical in kind to the passing 8192 case.

The decoder failure is a **false hang**. `TT_METAL_OPERATION_TIMEOUT_SECONDS=5` (from `setup-job`) fires when the dispatcher's command counter has not advanced for 5 s. That counter is frozen for the whole duration of one program, so the rule is effectively "no single op may run longer than 5 s". Under the watcher, the MoE experts' `SparseMatmul` at `prefill_4096` on a 1x4 QuietBox exceeds that: the next-smaller experts case in the same suite measures 2.82 s watcher-off vs 12.73 s watcher-on (4.5x).

Trigger: #53594 (`616fbb2ce9e`, merged 2026-08-21 10:33 UTC) re-enabled the watcher for this job with `export TT_METAL_WATCHER=15  # poll less often`. `TT_METAL_WATCHER=<n>` only sets the host dump interval (`rtoptions.cpp`); NOC sanitize, waypoints, stack-usage and ring-buffer instrumentation are compiled into every kernel whenever it is enabled, and `setup-job` adds `TT_METAL_WATCHER_NOINLINE=1` on top. Last green: 2026-08-21 04:16 (watcher off, `prefill_4096` passed in 48.5 s, `seq_16384` passed). 08-22 to 08-24 never reached the test (Blackhole ethernet FW wedge, infra). First run with watcher on, 2026-08-25, failed exactly this way and every run since.

Fix: `export TT_METAL_OPERATION_TIMEOUT_SECONDS=60` in the job command, with the reasoning in a comment. Keeps the watcher's fault detection (the point of #50886), keeps the 22-minute job budget and `pytest --timeout 1500` as the real hang backstops.

### Notes for reviewers
- Alternative A: `export TT_METAL_WATCHER_DISABLE_SANITIZE_NOC=1` to drop the per-transaction cost while keeping asserts. Not chosen because the remaining instrumentation still slows the op and the 5 s single-op cap is not a property this model satisfies under any instrumentation.
- Alternative B: revert to `unset TT_METAL_WATCHER` (the 08-21 config). Zero risk, but undoes the #50886 rollout for this model.
- Do not cap or xfail `test_rope.py` at `seq_16384`: it would hide a symptom of another test's failure and leave the job red.
- Secondary observation, not addressed: a single MoE `SparseMatmul` at 4096 tokens is ~1-2 s even without the watcher (`M = 1` tile per batch entry, so the batch dimension is not parallelised across the 130-core BH grid). Worth its own perf issue.
- Validation needs #55774 too: with the watcher on, `test_decoder[...decode_low_latency...]` on this SKU hits the `nlp_create_qkv_heads_decode` runtime-arg overrun fixed there. The run below is on a throwaway branch `mtairum/validate-gpt-oss-bhqb2` = this PR + `9adcd617cc1` from #55774.

### CI
- `(Tier 1) Models Unit Tests`, model=`gpt-oss-120b`, sku=`bh_quietbox_2 (BH QB2)`, on `mtairum/validate-gpt-oss-bhqb2` (this PR + #55774): https://github.com/tenstorrent/tt-metal/actions/runs/34258155099
  - **Passed.** [`GPT-OSS 120B unit tests [bh_quietbox_2]`](https://github.com/tenstorrent/tt-metal/actions/runs/34258155099/job/102172001975): `48 passed, 24 skipped in 586.89s`, watcher on, `TT_METAL_OPERATION_TIMEOUT_SECONDS=60` in effect; `test_decoder[...prefill_4096-1x1]` and `test_rope_vs_hf_reference[...seq_16384-1x4]` both green. Same job red on main for 35 consecutive scheduled runs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gpt-oss-bhqb2-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gpt-oss-bhqb2-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gpt-oss-bhqb2-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gpt-oss-bhqb2-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gpt-oss-bhqb2-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gpt-oss-bhqb2-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gpt-oss-bhqb2-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gpt-oss-bhqb2-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gpt-oss-bhqb2-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gpt-oss-bhqb2-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gpt-oss-bhqb2-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gpt-oss-bhqb2-op-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gpt-oss-bhqb2-op-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gpt-oss-bhqb2-op-timeout)

