### PR TITLE
[Bug fix] qwen25_coder_32b demo: cross the warmup/capture barrier and trace decode only for eval-32

### DIFF
--- a/models/common/models/qwen25_coder_32b/executor.py
+++ b/models/common/models/qwen25_coder_32b/executor.py
@@ -63,6 +63,7 @@ class TracedQwen25Coder32BExecutor(Qwen25Coder32BExecutor):
         mesh_device,
         ondevice_decode_loop: bool = False,
         fast_prefill_last_token: bool = False,
+        trace_mode: str = "all",
     ):
         del mesh_device, fast_prefill_last_token
         super().__init__(
@@ -70,7 +71,7 @@ class TracedQwen25Coder32BExecutor(Qwen25Coder32BExecutor):
             model.model_args,
             _compat_executor_config(
                 model,
-                trace_mode="all",
+                trace_mode=trace_mode,
                 device_sampling_enabled=bool(ondevice_decode_loop),
             ),
         )

--- a/models/common/tests/demos/qwen25_coder_32b/demo.py
+++ b/models/common/tests/demos/qwen25_coder_32b/demo.py
@@ -56,6 +56,7 @@ from models.common.models.qwen25_coder_32b.model import (
 from models.common.sampling.sampling_params import SamplingParams
 from models.common.tests.demos.cleanup_utils import cleanup_model_case
 from models.common.tests.demos.run_helpers import (
+    eval_decode_trace_mode,
     load_eval_repeat_prompts_batch32,
     run_eval_repeat_batch32,
     run_perf_benchmark,
@@ -943,6 +944,34 @@ def _run_token_accuracy(model, mesh_device, expected):
     assert meas_top5 >= min_top5, f"Top-5 accuracy {top5:.1f}% (ceil {meas_top5}) below threshold {min_top5:.1f}%"
 
 
+def _warmup_demo_executor(executor, *, kv_cache, page_table):
+    """Compile eager programs and capture the configured traces before the first real request.
+
+    Since #52724 trace capture is reachable only through the warmup coordinator: ``compile_prefill``
+    registers capture plans but ``TraceCompiler.capture_all()`` runs from ``warmup_model_*(enable_trace=True)``,
+    and the traced execution paths reject an uncaptured trace instead of falling back to eager. Every
+    other migrated demo crosses this barrier once per freshly built executor; without it the first
+    traced request raises ``TraceCoverageError`` (issue #54685).
+    """
+    config = executor.config
+    prefill_kwargs = {
+        "kv_cache": kv_cache,
+        "can_sample_on_device": config.device_sampling_enabled,
+    }
+    decode_kwargs = {
+        "kv_cache": kv_cache,
+        "max_batch_size": int(executor.model.config.max_batch_size),
+        "num_blocks": int(page_table.shape[-1]),
+        "can_sample_on_device": config.device_sampling_enabled,
+    }
+    executor.warmup_model_decode(enable_trace=False, **decode_kwargs)
+    executor.warmup_model_prefill(enable_trace=False, **prefill_kwargs)
+    if config.trace.prefill_enabled:
+        executor.warmup_model_prefill(enable_trace=True, **prefill_kwargs)
+    if config.trace.decode_enabled:
+        executor.warmup_model_decode(enable_trace=True, **decode_kwargs)
+
+
 def _run_perf_benchmark(
     model,
     mesh_device,
@@ -1017,6 +1046,7 @@ def _run_perf_benchmark(
         kv_cache_shape = (max_num_blocks, ma.n_kv_heads // mesh_device.get_num_devices(), block_size, ma.head_dim)
         kv_cache = traced_executor.allocate_kv_cache(kv_cache_shape, torch.bfloat16, ma.n_layers)
         page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(max_batch_size, max_num_blocks_per_user)
+        _warmup_demo_executor(traced_executor, kv_cache=kv_cache, page_table=page_table)
 
         # Decode-token budget, clamped to the KV-cache headroom. Prompts bucket to ~128 and we keep a
         # 16-token margin, so the high-water decode position stays inside max_seq_len.
@@ -1163,11 +1193,22 @@ def _run_eval_repeat_batch32(model, mesh_device):
 
     # Fresh traced executor + zeroed KV cache per repeat (driver owns the lifecycle), so the rotated
     # batches are fully independent — see run_eval_repeat_batch32 for why reuse corrupts the 3rd repeat.
+    # eval-32 is a cross-batch determinism gate, not a TTFT gate: run prefill eager and trace decode
+    # only, like the qwen3_32b / llama33_70b / qwen25_72b eval-32 legs. Under trace_mode="all" the
+    # planner's batched 1024-token prefill wave (two prompts padding to the same bucket) needs a
+    # (regular-batched, 2, 1024) trace the generic warmup sweep does not capture (#54685).
     def make_executor():
-        return TracedQwen25Coder32BExecutor(model, mesh_device)
+        return TracedQwen25Coder32BExecutor(
+            model,
+            mesh_device,
+            ondevice_decode_loop=sampling_params is not None,
+            trace_mode=eval_decode_trace_mode(os.environ.get("EVAL_DECODE_MODE", "traced")),
+        )
 
     def allocate_kv_cache(executor):
-        return executor.allocate_kv_cache(kv_cache_shape, torch.bfloat16, ma.n_layers)
+        kv_cache = executor.allocate_kv_cache(kv_cache_shape, torch.bfloat16, ma.n_layers)
+        _warmup_demo_executor(executor, kv_cache=kv_cache, page_table=page_table)
+        return kv_cache
 
     # TTTv1 ci-eval-32 numeric prompts (parity).
     prompts = load_eval_repeat_prompts_batch32()

--- a/models/common/tests/models/qwen25_coder_32b/test_demo_contract.py
+++ b/models/common/tests/models/qwen25_coder_32b/test_demo_contract.py
@@ -104,3 +104,27 @@ def test_demo_allocates_kv_cache_with_vllm_shape_compatibility_arguments():
 def test_perf_and_eval_use_traced_model_owned_wrapper():
     assert _calls("_run_perf_benchmark", "TracedQwen25Coder32BExecutor")
     assert _calls("_run_eval_repeat_batch32", "TracedQwen25Coder32BExecutor")
+
+
+def test_eval_repeat_traces_decode_only_and_warms_up_before_trace_activation():
+    call = _calls("_run_eval_repeat_batch32", "TracedQwen25Coder32BExecutor")[0]
+    trace_mode = next(keyword for keyword in call.keywords if keyword.arg == "trace_mode")
+    ondevice_decode_loop = next(keyword for keyword in call.keywords if keyword.arg == "ondevice_decode_loop")
+
+    assert ast.unparse(trace_mode.value) == "eval_decode_trace_mode(os.environ.get('EVAL_DECODE_MODE', 'traced'))"
+    assert ast.unparse(ondevice_decode_loop.value) == "sampling_params is not None"
+    # Each freshly built executor must cross the warmup/capture barrier before its first request.
+    assert _calls("_run_eval_repeat_batch32", "_warmup_demo_executor")
+    assert _calls("_run_perf_benchmark", "_warmup_demo_executor")
+
+
+def test_warmup_helper_compiles_eager_then_captures_both_phases():
+    source = ast.unparse(_function("_warmup_demo_executor"))
+
+    assert "warmup_model_decode(enable_trace=False" in source
+    assert "warmup_model_prefill(enable_trace=False" in source
+    assert "warmup_model_prefill(enable_trace=True" in source
+    assert "warmup_model_decode(enable_trace=True" in source
+    assert source.index("warmup_model_decode(enable_trace=False") < source.index(
+        "warmup_model_prefill(enable_trace=True"
+    )


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`Qwen2.5-Coder-32B e2e tests [wh_llmbox_perf]` (Tier 2 Models e2e, scheduled) has failed every run since 2026-08-26 (issue #54685; last pass 08-25 03:20 on `1a0b226441fe`, first fail 08-26 03:24 on `e9d049407479`) in `models/common/tests/demos/qwen25_coder_32b/demo.py::test_qwen25_coder_32b[performance-eval-32-T3K]`:

```
models.common.llm_runtime.execution.TraceCoverageError: Required prefill trace is unavailable:
reason=the required trace is not registered and captured; operation=prefill; trace_mode=all;
signature_material=((operation_variant, regular-batched), (padded_batch_size, 2), (invocation_sequence_length, 1024), ...)
```

Root cause is not a missing cover entry; the demo **never captures any trace**. Since #52724 (`3a193357d6f2`, merged 2026-08-25 17:16 UTC, inside the window) `TraceCompiler.capture_all()` is reachable only through `WarmupCoordinator` (`warmup_model_*(enable_trace=True)`), and the traced execution paths reject a required-trace miss instead of falling back to eager. This is the only one of the twelve migrated demos under `models/common/tests/demos/` with no `_warmup_demo_executor` / `warmup_model_*` call: `compile_prefill` registers the capture plan (the failing signature is one of exactly two entries in `configured_coverage` in the log) but every `TraceRecord.artifact` stays `None`, so `TracedExecutor._preflight_prefill` raises on the first request it checks. Before #52724 the old `TracedLLMExecutor` captured inside `compile_prefill` and fell back to eager.

A second, independent defect made the naive fix insufficient: the new planner batches two prompts that pad to the same 1024 bucket into one `(regular-batched, 2, 1024)` wave (`prefill/plan.py:430-443`), while the warmup cover only sweeps batch sizes at length 128 (`warmup.py:674`), so a `trace_mode="all"` eval executor would still miss that signature. The eval-32 leg is a cross-batch determinism gate, not a TTFT gate; the qwen3_32b, llama33_70b and qwen25_72b eval-32 legs all run `decode_only` (and qwen3_32b's `decode_only` leg passes in the same CI run where its `"all"` leg fails on a trace-region OOM, #55789).

Changes:
- `demo.py`: port `_warmup_demo_executor` from `qwen3_32b/demo.py` (eager compile of decode and prefill, then capture of whichever phases the trace config enables); call it in the eval-32 `allocate_kv_cache` closure and after the perf benchmark's KV allocation.
- `demo.py`: build the eval-32 executor with `trace_mode=eval_decode_trace_mode(os.environ.get("EVAL_DECODE_MODE", "traced"))` (→ `decode_only`) and `ondevice_decode_loop=sampling_params is not None`, matching the siblings.
- `qwen25_coder_32b/executor.py`: `TracedQwen25Coder32BExecutor` gets the same `trace_mode: str = "all"` keyword `TracedQwen3_32BExecutor` has (default unchanged).
- `test_demo_contract.py`: pin the trace mode, the `ondevice_decode_loop` threading, the warmup calls in both drivers, and the helper's eager-then-capture order (host-only; 13 pass locally).

### Notes for reviewers
- `_run_perf_benchmark` (the `batch-32` perf leg) is not in the scheduled CI selection; it gets the same warmup call because a traced executor without it cannot run at all post-#52724. That path keeps `trace_mode="all"`; its prompts bucket to 128 where the warmup sweep does cover batched waves. Untested on hardware here.
- Not fixed, needs its own PR: the planner/warmup-cover divergence at `warmup.py:674` (`batches = prefill_batch_sizes if sequence_length == 128 else (1,)`). Any `trace_mode="all"` path that batches a non-128 bucket, including vLLM serving through `Qwen25Coder32BGenerator`, can hit the same miss. Bounded fix: widen the cover up to `max_prefill_batch_size` at the model's `trace_prefill_supported_seq_lens`, and assert at seal time that every planner-emittable signature is covered. `test_warmup.py:559` currently pins the narrow behaviour.
- The `SAMPLING_MODE=on_device_topk` perf legs would additionally want `disable_batched_prefill=... or config.device_sampling_enabled` in `Qwen25Coder32BExecutor.__init__`, as llama3_8b / llama33_70b / qwen3_32b do. Left out to keep this PR to the CI failure.
- Owner @gwangTT; the lifecycle bot on #54685 is asking to disable this test. Prefer this fix.

### CI
- `(Tier 2) Models End-To-End Tests`, model=`qwen2.5-coder-32b`, sku=`wh_llmbox_perf (T3000 perf)`: https://github.com/tenstorrent/tt-metal/actions/runs/34258497799

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/coder-32b-eval-warmup-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/coder-32b-eval-warmup-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/coder-32b-eval-warmup-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/coder-32b-eval-warmup-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/coder-32b-eval-warmup-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/coder-32b-eval-warmup-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/coder-32b-eval-warmup-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/coder-32b-eval-warmup-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/coder-32b-eval-warmup-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/coder-32b-eval-warmup-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/coder-32b-eval-warmup-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/coder-32b-eval-warmup-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/coder-32b-eval-warmup-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/coder-32b-eval-warmup-barrier)
