### PR TITLE
[Bug fix] gemma4: key the weight cache by tensorbin layout; stop E4B CI reading the poisoned legacy cache

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -368,7 +368,7 @@ models:
     wh_n150: 105
     wh_n300: 60
     bh_p150: 33
-    bh_p300: 8
+    bh_p300: 13  # +5 for the Gemma-4-E4B one-off cold cache build (#55795)
     bh_quietbox_2: 42
   unit_tier1:
     wh_llmbox: 150

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -368,7 +368,7 @@ models:
     wh_n150: 105
     wh_n300: 60
     bh_p150: 33
-    bh_p300: 13  # +5 for the Gemma-4-E4B one-off cold cache build (#55795)
+    bh_p300: 13
     bh_quietbox_2: 42
   unit_tier1:
     wh_llmbox: 150

--- a/models/demos/gemma4/tt/common.py
+++ b/models/demos/gemma4/tt/common.py
@@ -112,12 +112,27 @@ def create_tt_model(
     # variant, a marker seeded under the old overrides would certify a warm build whose files do
     # not exist -- and as_tensor would persist placeholders for them. (#45400 review, finding B2)
     _precision_for_variant = Gemma4Precision.load(model_path, _worker_mesh)
+    # The variant must also pin every knob that decides WHICH tensorbin FILENAMES a build needs, not
+    # only their dtype: a warm marker seeded before a filename change certifies a build whose files
+    # do not exist yet, and as_tensor then persists the dataless placeholders under the new names
+    # (weight_cache.py "Build options that change an as_tensor cache FILENAME ... must match
+    # exactly"). #50648 renamed the fused gate/up, .ws attention and .ws down-proj files without
+    # touching this identity and poisoned the Gemma-4-E4B caches on bh_p300 / bh_quietbox_2
+    # (#54831: 2085 of 2131 keys served as torch.empty and written to disk). Bump the layout tag
+    # whenever a cache filename scheme changes.
+    _cache_layout = {
+        "layout": "v2-fused-gate-up-ws",
+        "attn_dram_shard": os.environ.get("GEMMA4_ATTN_DRAM_SHARD", "1"),
+        "mlp_dram_shard": os.environ.get("GEMMA4_MLP_DRAM_SHARD", "1"),
+        "dram_cores": os.environ.get("GEMMA4_DRAM_CORES", "8"),
+    }
     cache_identity = dict(
         model_name=os.path.basename(str(model_path).rstrip("/")) or "gemma4",
         n_layers=model_args.num_hidden_layers,
         mesh_shape=_worker_mesh,
         build_variant={
             "precision": {k: str(v) for k, v in sorted(_precision_for_variant._overrides.items())},
+            "cache_layout": _cache_layout,
         },
     )
     loaded_real_weights = False

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -586,6 +586,10 @@
   cmd: |
     uv pip install -r models/demos/gemma4/requirements.txt
     export HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=google/gemma-4-E4B-it TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/google--gemma-4-E4B-it
+    # The legacy tensor_cache_bf16/ dirs for E4B on bh_p300 / bh_quietbox_2 hold placeholder-derived
+    # tensorbins written after #50648 renamed the cache files (#54831). Build into the mesh-qualified
+    # dir instead of falling back to legacy; E4B is small enough to cold-build inside the budget.
+    export GEMMA4_WEIGHT_CACHE_MESH_ONLY=1
     pytest -s --timeout 1000 models/demos/gemma4/demo/text_demo.py::test_demo
     pytest -s --timeout 600 \
       models/demos/gemma4/tests/unit/test_lm_head.py \
@@ -602,7 +606,9 @@
     # Note: do not add bh_p150 here — models e2e_tier3 bh_p150 budget is 7m
     # and Gemma-4-E2B already uses 5m on that SKU (f562aa60493 over-budget).
     bh_p300:
-      timeout: 5
+      # 10 (was 5): the first run after GEMMA4_WEIGHT_CACHE_MESH_ONLY=1 cold-builds the mesh-qualified
+      # cache on the rw lfc mount; later runs are warm again.
+      timeout: 10
       tier: 3
       release_ready: false
     bh_quietbox_2:

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -606,8 +606,6 @@
     # Note: do not add bh_p150 here — models e2e_tier3 bh_p150 budget is 7m
     # and Gemma-4-E2B already uses 5m on that SKU (f562aa60493 over-budget).
     bh_p300:
-      # 10 (was 5): the first run after GEMMA4_WEIGHT_CACHE_MESH_ONLY=1 cold-builds the mesh-qualified
-      # cache on the rw lfc mount; later runs are warm again.
       timeout: 10
       tier: 3
       release_ready: false

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -590,6 +590,9 @@
     # tensorbins written after #50648 renamed the cache files (#54831). Build into the mesh-qualified
     # dir instead of falling back to legacy; E4B is small enough to cold-build inside the budget.
     export GEMMA4_WEIGHT_CACHE_MESH_ONLY=1
+    # Warm as_tensor cache loads hang forever on bh_quietbox_2 when the mmapped tensorbin is fed to
+    # the pinned host-memory write path (#55957); use the memcpy path until that is fixed.
+    export TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES=0
     pytest -s --timeout 1000 models/demos/gemma4/demo/text_demo.py::test_demo
     pytest -s --timeout 600 \
       models/demos/gemma4/tests/unit/test_lm_head.py \


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`Gemma-4-E4B e2e tests [bh_p300]` and `[bh_quietbox_2]` (Tier 3 Models e2e, scheduled) fail every run since 2026-08-28 (issue #54831) in `models/demos/gemma4/tests/unit/test_model.py::test_full_model` with `Full model PCC too low: -0.004 … 0.04`; every generated token is `<pad>` (id 0). Last green 2026-08-27 07:33 (`0b11ac6f5843`), first red 2026-08-28 07:35 (`1a0aa0765ebb`).

**This is silent weight-cache poisoning, not a numerics regression.** The only commit in that window touching `models/demos/gemma4` is #50648 (`2a6d4e25512`, "Gemma4 optimizations [Performance]", merged 08-27 17:08). It:

1. Renamed the `ttnn.as_tensor` cache files on the dense path: `gate_proj.weight*` + `up_proj.weight*` → fused `gate_up_proj.weight{tp}{pad}{dtype}` (and `.ws` variant), `down_proj.weight*` → `down_proj.weight.ws*`, `wqkv*` / `o_proj*` → `*.ws` (`shared_mlp.py:158-185`, `attention/weights.py:169-170`).
2. Left the weight-cache identity unchanged (`common.py:115-122`: `model_name`, `n_layers`, `mesh_shape`, precision overrides; `WEIGHT_CACHE_FORMAT_VERSION` still 3). `models/common/weight_cache.py:192-196` spells out the broken contract: *"Build options that change an as_tensor cache FILENAME … must match exactly … any it is missing would be regenerated from the placeholder."*
3. Added mesh-qualified cache dirs with a silent fallback to the legacy unqualified dir when the mesh dir is empty (`model_config.py:88-101`).

Causal chain, confirmed from the CI logs of both failing legs:

```
common:create_tt_model:126 - Warm ttnn weight cache detected -- skipping HF state_dict load (gemma4 hybrid).
model_config:_resolve_mesh_qualified_weight_cache:92 - Gemma4 weight cache: mesh-qualified dir .../tensor_cache_bf16_mesh1x2 is empty; reusing legacy .../tensor_cache_bf16.
weight_cache:build_cached_state_dict:422 - Warm ttnn weight cache: built state_dict for 2131 weights (46 real host weights, no full HF load).
```

2085 of 2131 keys are `torch.empty` placeholders (`weight_cache.py:341`). `as_tensor` misses the five renamed files, converts the placeholders and **writes them to disk**. From then on every attention and MLP weight in the legacy cache is garbage; embedding, all RMSNorm gammas, q/k norms, per-layer-input tables and the tied lm_head (unchanged filenames or sidecar-real) are correct, which is why `test_lm_head` passes right before `test_full_model` fails, and why the PCC is bit-stable per runner. Pre-softcap logits overshoot the `final_logit_softcapping = 30` knee and every position decodes to token 0.

Why only E4B: the other Gemma-4 sizes were validated by #50648's own CI (Tiers 1/2, 12B/26B-A4B/31B) and rebuilt their caches cold; E4B is Tier 3 and was structurally excluded from that run.

### Changes
- `models/demos/gemma4/tt/common.py`: add a `cache_layout` block to `build_variant` (layout tag `v2-fused-gate-up-ws` plus `GEMMA4_ATTN_DRAM_SHARD`, `GEMMA4_MLP_DRAM_SHARD`, `GEMMA4_DRAM_CORES`, the knobs that select which filenames a build needs). `marker_path()` hashes the variant into the marker filename, so any future filename change forces a cold rebuild instead of a warm build over missing files. This makes the class of bug impossible; it does not by itself un-poison existing files.
- `tests/pipeline_reorg/models_e2e_tests.yaml`: run the E4B leg with `GEMMA4_WEIGHT_CACHE_MESH_ONLY=1` (the escape hatch #50648 shipped) so it builds into the empty mesh-qualified dir instead of reusing the poisoned legacy dir; bump `bh_p300` 5 → 10 min for the one-off cold build on its rw `lfc` mount (bh_quietbox_2 is read-only and mirrors to `generated/`, so it cold-builds each run; E4B is small).

### Notes for reviewers
- **Infra action still needed:** delete `tt_cache/google--gemma-4-E4B-it/tensor_cache_bf16/` under `/localdev/blackhole_demos/huggingface_data/` on bh-gh-07/08/09 and the quietbox `/mnt/models/huggingface/...` copy. Nothing on main reads them after this PR, but any other consumer of the legacy path would get garbage weights.
- Not done here, owner's call: make `_resolve_mesh_qualified_weight_cache`'s legacy fallback fail closed (treat a legacy-dir hit as cold), or drop it. Left alone because it exists so 31B legs on qb2 do not cold-rebuild under their budgets.
- Defence in depth for `models/common/weight_cache.py`: `as_tensor` cannot tell a placeholder from a real tensor; tagging placeholder tensors so `from_torch_and_dump` refuses to persist them would make this failure loud instead of silent and permanent. Separate PR.
- Diagnosis from CI logs and source (no hardware); the CI runs below validate. Expected: PCC back above the gate on both SKUs, first run slower (cold build).

### CI
- `(Tier 3) Models End-To-End Tests`, model=`gemma-4-e4b`, sku=`all` (bh_p300 + bh_quietbox_2): https://github.com/tenstorrent/tt-metal/actions/runs/34259073850
  - Attempt 1, both inconclusive: bh_p300 (bh-gh-07) "runner lost communication with the server" mid-test; bh_quietbox_2 (qb2-120-p06t03) ran `text_demo.py::test_demo` green (cold mesh-only build, ~5 min), `test_lm_head` green (PCC 0.99995 / 0.99982), then `test_full_model` sat >9 min in HF reference loading until the 15-min job budget, on a night when the qb2 pool reads /mnt/MLPerf at ~10x below normal (see #55786). No `reusing legacy` line in either log, so the mesh-only path is taking effect. Failed jobs rerun as attempt 2.
  - **Attempt 2, bh_p300 passed**: [`Gemma-4-E4B e2e tests [bh_p300]`](https://github.com/tenstorrent/tt-metal/actions/runs/34259073850/job/102184322651) — `text_demo` green, `test_lm_head` PCC 0.99995, **`test_full_model` PCC 0.9899 (threshold 0.95) [PASS]**, `2 passed, 2 skipped` in 37 s on a warm mesh-only cache. Same test reads -0.004 on main. Root cause confirmed on hardware. bh_quietbox_2 again ran `text_demo` + `test_lm_head` green and then hit the 15-min job budget inside `test_full_model`'s HF reference load on the slow pool; inconclusive on that SKU only.
  - First dispatch (34258878764) cancelled: the bh_p300 5 → 10 bump exceeded the 8 min tier-3 budget; `.github/time_budget.yaml` +5 added as second commit.
- **bh_quietbox_2, three parallel re-runs (this branch, sku=`bh_quietbox_2` only)**: [34345261594](https://github.com/tenstorrent/tt-metal/actions/runs/34345261594) (qb2-120-p03t01), [34345270852](https://github.com/tenstorrent/tt-metal/actions/runs/34345270852) (qb2-120-p02t08), [34345280638](https://github.com/tenstorrent/tt-metal/actions/runs/34345280638) (qb2-120-p03t03). All three: `text_demo` green (cold mesh-only build into `generated/gemma4_tt_cache/.../tensor_cache_bf16_mesh1x4`, ~3 min), `test_lm_head` green, then `test_full_model[blackhole-1x4]` logs `Warm ttnn weight cache detected`, `built state_dict for 2131 weights`, `KV sharing enabled` and then prints nothing for 11 min until the 15-min job budget kills the step. `pytest --timeout 600` never fired and the 5 s operation-timeout triage never triggered, so the process is blocked in native code, not a device op. That is 6/6 on 4 distinct qb2 runners with this change versus a clean pass on bh_p300, so this is a real 1x4-only hang in the warm mesh-only load path, not pool slowness. Resolved below: root cause is #55957, workaround in commit `e241fabaaab`, final both-SKU run linked below.
- **Working hypothesis for the bh_quietbox_2 hang (code reading, not yet confirmed on hardware):** the warm path is the first time this job loads the mesh-only tensorbins on bh_quietbox_2, and `load_tensor_flatbuffer` mmaps each file `PROT_READ|MAP_PRIVATE` (`ttnn/core/tensor/serialization.cpp:125`) and hands the resulting host-buffer views to `to_device`; transfers above 32 MiB (`tt_metal/impl/tensor/tensor_apis.cpp:40`) go through `PinnedMemoryCache::try_pin` (`tensor_apis.cpp:140`), i.e. the embed and lm_head tensors (1.34 GB each, 335 MB per device on 1x4) are pinned as file-backed read-only pages for device DMA, while the cold path writes the same tensors from anonymous heap memory. The binding holds the GIL, which is why `pytest --timeout` never fired, and no device wait is involved, which is why the dispatch watchdog never fired. Both SKUs report `IOMMU: enabled`; the visible difference is KMD 2.10.0 on the bh_quietbox_2 tiles versus KMD 2.7.0 on bh-gh-07 (bh_p300). Two runs on throwaway branches, bh_quietbox_2 only: [34365458105](https://github.com/tenstorrent/tt-metal/actions/runs/34365458105) A/B with `TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES=0` (memcpy path; if this passes, the hang is in the pinned path), and [34365452713](https://github.com/tenstorrent/tt-metal/actions/runs/34365452713) which dumps the process's native stacks 300 s into the unit invocation and kills it, to see where it is blocked.
- **Confirmed on hardware (09-09 14:56 UTC):** the no-pin A/B run [34365458105](https://github.com/tenstorrent/tt-metal/actions/runs/34365458105/job/102516380204) (qb2-120-p02t07) passed end to end: `text_demo` green, warm `test_full_model[blackhole-1x4]` completes in 7 s with **PCC 0.9846** (threshold 0.95, same test reads 0.0253 on main), job 3m40s. So the bh_quietbox_2 hang is the pinned host-memory write path being fed the mmapped tensorbin, not anything in the cache identity change. Filed as **#55957** for the runtime owners (code chain, evidence table, ask).
- **Root cause confirmed at kernel level (09-09 22:20 UTC):** `sysrq-l` backtrace of the hung thread is `ioctl_pin_pages [tenstorrent] → pin_user_pages_fast → __gup_longterm_locked → __get_user_pages → handle_mm_fault → do_read_fault → filemap_map_pages → do_set_pmd`, i.e. the KMD's long-term pin of the mmapped tensorbin's 2 MB page-cache folios loops forever in GUP because those folios cannot be migrated or long-term pinned. Not a Gemma-4 or weight-cache bug; the `TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES=0` line in this PR is the job-level workaround until tt-metal stops handing file-backed mmaps to the pinned write path (#55957).
- **Commit `e241fabaaab`** adds `export TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES=0` to the E4B job command as the workaround until #55957 is fixed. Final validation of the PR head on both SKUs (`sku=all`): https://github.com/tenstorrent/tt-metal/actions/runs/34367305038. **bh_quietbox_2 PASSED** ([job 102522515328](https://github.com/tenstorrent/tt-metal/actions/runs/34367305038/job/102522515328), qb2-120-p03t03, one of the tiles that hung before): `text_demo` cold mesh-only build 3m27s, warm `test_full_model[blackhole-1x4]` PCC 0.9846, test step 4m06s, job 6 min inside the 15 min SKU timeout. **bh_p300 PASSED** too ([job 102522515162](https://github.com/tenstorrent/tt-metal/actions/runs/34367305038/job/102522515162), bh-gh-08, KMD 2.7.0): `text_demo` 2m26s, warm `test_full_model[blackhole-1x2]` PCC 0.9899, test step 3m42s. **Both SKUs green on the final head `e241fabaaab`.** Still open on the infra side: delete the poisoned legacy `tensor_cache_bf16/` dirs listed above so main's other gemma4 jobs stop reading them.
- Rebased onto main `3f254861838` on 2026-09-10 (clean, no content change). The CI links above were run on the pre-rebase head.
- **Full Gemma-4 set on this head (2026-09-10):** the `cache_layout` tag changes the warm-marker digest for every Gemma-4 model, so on read-only `/mnt/MLPerf` all of them lose the HF-skip fast path until new markers are seeded with an `mlperf-write-access=true` run. Measuring the cost against each job's SKU timeout:
  - Gemma-4-31B e2e wh_llmbox_perf: https://github.com/tenstorrent/tt-metal/actions/runs/34461153275 · bh_quietbox_2: https://github.com/tenstorrent/tt-metal/actions/runs/34461287706
  - Gemma-4-26B-A4B e2e wh_llmbox_perf: https://github.com/tenstorrent/tt-metal/actions/runs/34461172737 · bh_quietbox_2: https://github.com/tenstorrent/tt-metal/actions/runs/34461305029
  - Gemma-4-E2B e2e wh_n150 + bh_p150: https://github.com/tenstorrent/tt-metal/actions/runs/34461190858
  - Gemma-4-31B unit wh_llmbox: https://github.com/tenstorrent/tt-metal/actions/runs/34461209530 · Gemma-4-26B-A4B unit wh_llmbox: https://github.com/tenstorrent/tt-metal/actions/runs/34461228420
  - Gemma-4-E2B unit wh_n150 + bh_p150: https://github.com/tenstorrent/tt-metal/actions/runs/34461248261 · Gemma-4-E4B unit bh_p300: https://github.com/tenstorrent/tt-metal/actions/runs/34461268520
  - Remaining bh_quietbox_2 legs (12B e2e, 31B / 26B / 12B / E4B unit) are dispatched two at a time as the pool frees up; links to follow. The 12B bh_p150 e2e leg cannot be dispatched (the tier-2 e2e workflow does not list `gemma-4-12b`).
  - E4B e2e on both SKUs was already validated on the pre-rebase head (see above).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gemma4-weight-cache-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gemma4-weight-cache-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gemma4-weight-cache-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gemma4-weight-cache-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gemma4-weight-cache-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gemma4-weight-cache-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gemma4-weight-cache-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gemma4-weight-cache-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gemma4-weight-cache-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gemma4-weight-cache-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gemma4-weight-cache-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gemma4-weight-cache-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gemma4-weight-cache-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gemma4-weight-cache-identity)












