### PR TITLE
[Bug fix] reciprocal (float32, Blackhole): use the multiplicative Newton iteration so the correction cannot underflow

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
@@ -294,3 +294,40 @@ def test_atanh(device, h, w):
     # The log1p reformulation makes the fp32 path stable on (-1, 1); the default
     # [0, 1) input exercises the small-x stable region.
     run_unary_test(device, h, w, ttnn.atanh, ulp=2)
+
+
+@pytest.mark.parametrize("exponent", [100, 111, 114, 118, 119, 122, 125])
+def test_reciprocal_fp32_large_magnitude(device, exponent):
+    """1/x must keep its Newton refinement over the whole float32 normal range.
+
+    The Blackhole fp32 path applied the refinement additively, y = y + y*(e + e**2 + e**3) with
+    e = 1 - x*y.  The correction *term* y*(e + ...) is about 2**-8/x, which is below FLT_MIN for
+    |x| >= 2**119, so the SFPU flushed it to zero and the op returned the raw ~7-bit SFPARECIP
+    seed: 0.56% relative error (90,174 ULP) on every value of the seven binades 2**119..2**126,
+    with partial loss from 2**111 up.  2**100 is a control binade that was never affected.
+    """
+    mantissas = 1.0 + torch.arange(256, dtype=torch.float64) / 256.0
+    values = (mantissas * (2.0**exponent)).to(torch.float32)
+    torch_input_tensor = torch.cat([values, -values]).reshape(16, 32)
+    golden = (1.0 / torch_input_tensor.to(torch.float64)).to(torch.float32)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.to_torch(ttnn.reciprocal(input_tensor))
+
+    assert_with_ulp(golden, output_tensor, 2)
+
+
+def test_reciprocal_fp32_special_values(device):
+    """Signs and poles of the fp32 reciprocal: 1/+-0 = +-inf, 1/+-inf = +-0, and exact powers of two."""
+    torch_input_tensor = torch.tensor([[0.0, -0.0, float("inf"), float("-inf"), 1.0, -1.0, 2.0, 0.5]])
+    expected = torch.tensor(
+        [[float("inf"), float("-inf"), 0.0, -0.0, 1.0, -1.0, 0.5, 2.0]],
+        dtype=torch.float32,
+    )
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.to_torch(ttnn.reciprocal(input_tensor))
+
+    assert torch.equal(
+        output_tensor.view(torch.int32), expected.view(torch.int32)
+    ), f"expected {expected}, got {output_tensor}"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
@@ -314,7 +314,7 @@ def test_reciprocal_fp32_large_magnitude(device, exponent):
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.to_torch(ttnn.reciprocal(input_tensor))
 
-    assert_with_ulp(golden, output_tensor, 2)
+    assert_with_ulp(expected_result=golden, actual_result=output_tensor, ulp_threshold=2)
 
 
 def test_reciprocal_fp32_special_values(device):

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -147,68 +147,21 @@ inline void _calculate_reciprocal_fast_8b_3c_(const int iterations) {
 #endif
 }
 
-// FP32 reciprocal, with throughput of 5c/32.
-inline void _calculate_reciprocal_fast_24b_5c_(const int iterations) {
-#ifdef DISABLE_SFPLOADMACRO
+// FP32 reciprocal.
+//
+// The refinement is multiplicative, y = y * (2 - x*y), one Newton-Raphson step per iteration
+// (see sfpu_reciprocal_iter above).  The additive form this replaced -- y = y + y*(e + e**2 + e**3)
+// with e = 1 - x*y -- adds a correction *term* of about 2**-8/x, which is below FLT_MIN and so
+// flushed to zero by the SFPU for |x| >= 2**119: the refinement was silently discarded and the raw
+// ~7-bit SFPARECIP seed returned (up to 90,174 ULP / 0.56% relative error over seven whole binades,
+// partial loss from 2**111 up).  The multiplicative form never forms a subnormal intermediate,
+// because its correction factor 2 - x*y is ~1 for every x.
+inline void _calculate_reciprocal_fast_24b_(const int iterations) {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-        TTI_SFPARECIP(0, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPARECIP_MOD1_RECIP);
-        TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, 1);  // SFPMAD_MOD1_NEGATE_VA
-        TTI_SFPMAD(p_sfpu::LREG2, p_sfpu::LREG2, p_sfpu::LREG2, p_sfpu::LREG3, 0);
-        TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LREG2, p_sfpu::LREG2, p_sfpu::LREG3, 0);
-        TTI_SFPSWAP(0, p_sfpu::LCONST_1, p_sfpu::LREG3, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
-        TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        sfpi::dst_reg[0] = sfpu_reciprocal_iter<2>(sfpi::dst_reg[0]);
+        sfpi::dst_reg++;
     }
-#else
-    // Pseudocode:
-    //
-    // y = arecip(x)
-    // e = 1 - x*y
-    // t = e * e + e
-    // t2 = t * e + e    # e**3 + e**2 + e
-    // t2 = min(t2, 1.0) # replace NaN with 1.0
-    // y = t2 * y + y    # y = y * (e**3 + e**2 + e + 1)
-    //                   # if y = ±0 or ±inf, then y = y+y
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    //   | Load | Simple                 | MAD                     | Store   |
-    // - | -----| ---------------------- | ----------------------- |-------- |
-    // 0 | [y]  |                        |                         |         |
-    // 1 |      | [y] = arecip(y)        |                         |         |
-    // 2 | [e]  |                        |                         |         |
-    // 3 |      | [e] L16 = arecip(e)    | e = mad(-e, y, 1.0)     |         |
-    // 4 |      |                        |                         |         |
-    // 0 |      |                        | [e] = mad(e, e, e)      | [e]     |
-    // 1 | [t2] |                        |                         |         |
-    // 2 |      |                        | [t2] = mad(t2, e, t2)   | [y] L16 |
-    // 3 |      |                        |                         |         |
-    // 4 | [z]  | [t2] = swap(t2, 1.0)   |                         |         |
-    // 0 |      |                        |                         |         |
-    // 1 |      |                        | [z] L16 = mad(t2, z, z) |         |
-    // 2 |      |                        |                         |         |
-    // 3 |      |                        |                         | [z] L16 |
-
-    lltt::replay(0, 4);
-    TTI_SFPLOAD(7, 0, ADDR_MOD_6, 0);
-
-#pragma GCC unroll 7
-    for (int d = 0; d < iterations - 1; d++) {
-        lltt::replay(0, 5);
-    }
-
-    TTI_SFPNOP;
-    lltt::replay(1, 1);
-    TTI_SFPNOP;
-    lltt::replay(3, 2);
-
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 // ~7b precision; 1c/element
@@ -278,87 +231,6 @@ inline void _init_reciprocal_fast_8b_3c_() {
 #endif
 }
 
-inline void _init_reciprocal_fast_24b_5c_() {
-#ifndef DISABLE_SFPLOADMACRO
-    constexpr int e = p_sfpu::LREG0;
-    constexpr int t2 = p_sfpu::LREG1;
-    constexpr int z = p_sfpu::LREG2;
-    constexpr int y = p_sfpu::LREG3;
-
-    // InstructionTemplate[0]
-    TTI_SFPARECIP(0, 0, 12, sfpi::SFPARECIP_MOD1_RECIP);
-
-    // InstructionTemplate[1]
-    TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG0, 0, 13, 0);
-
-    // InstructionTemplate[2]
-    // SFPMAD(VA=t2, VB=0 or VD, VC=VD or z)
-    TTI_SFPMAD(t2, p_sfpu::LREG0, z, 14, 0);
-
-    // InstructionTemplate[3]
-    TTI_SFPSWAP(0, p_sfpu::LCONST_1, 15, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
-
-    // Macro 0: [y]
-    {
-        constexpr std::uint32_t simple_bits = 0x00 | 0x00 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (6 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4, 0);
-    }
-
-    // Macro 1: [e]
-    {
-        constexpr std::uint32_t simple_bits = 0x00 | 0x40 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0x00 | 0x00 | (2 << 3) | (4 + 1);
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x00 | (2 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 1, 0);
-    }
-
-    // Macro 2: [t2]
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (2 << 3) | (4 + 3);
-        constexpr std::uint32_t mad_bits = 0x00 | 0x00 | (0 << 3) | (4 + 2);
-
-        TTI_SFPCONFIG((mad_bits << 8) | simple_bits, 4 + 2, 1);
-    }
-
-    // Macro 3: [z]
-    {
-        constexpr std::uint32_t simple_bits = 0;
-        constexpr std::uint32_t mad_bits = 0x80 | 0x40 | (1 << 3) | (4 + 2);
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (3 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 3, 0);
-    }
-
-    // Misc: {UsesLoadMod0ForStore=1, WaitForElapsedInstructions=1} for all macros.
-    TTI_SFPCONFIG(0xff0, 8, 1);
-
-    constexpr std::uint32_t prev_offset = -2 & 0x3ff;
-    constexpr std::uint32_t offset = 0;
-
-    load_replay_buf(0, 6, [e, t2, z, y, offset, prev_offset] {
-        TTI_SFPLOADMACRO((0 << 2) | (y & 3), 0, ADDR_MOD_7, offset | (y >> 2));
-        TTI_SFPLOADMACRO((2 << 2) | (t2 & 3), 0, ADDR_MOD_7, prev_offset | (t2 >> 2));
-        TTI_SFPLOADMACRO((1 << 2) | (e & 3), 0, ADDR_MOD_7, offset | (e >> 2));
-        TTI_SFPMAD(p_sfpu::LREG0, y, p_sfpu::LCONST_1, 0, 1);  // SFPMAD_MOD1_NEGATE_VA
-        TTI_SFPLOADMACRO((3 << 2) | (z & 3), 0, ADDR_MOD_6, prev_offset | (z >> 2));
-        TTI_SFPLOADMACRO((3 << 2) | (z & 3), 0, ADDR_MOD_7, prev_offset | (z >> 2));
-    });
-#endif
-}
-
 template <bool APPROXIMATE = false, bool save_reg = true /* Unused. Enough registers available. */>
 sfpi_inline vFloat sfpu_reciprocal(const vFloat in) {
     return sfpu_reciprocal_iter<APPROXIMATE ? 0 : 2>(in);
@@ -378,7 +250,7 @@ inline void calculate_reciprocal() {
     } else if constexpr (APPROXIMATION_MODE) {
         _calculate_reciprocal_fast_7b_(ITERATIONS);
     } else if constexpr (is_fp32_dest_acc_en) {
-        _calculate_reciprocal_fast_24b_5c_(ITERATIONS);
+        _calculate_reciprocal_fast_24b_(ITERATIONS);
     } else {
         _calculate_reciprocal_fast_8b_3c_(ITERATIONS);
     }
@@ -398,9 +270,7 @@ void recip_init() {
         sfpu_reciprocal_init<false>();  // set vConstFloatPrgm0 for sfpu_reciprocal_iter
         if constexpr (APPROXIMATION_MODE) {
             _init_reciprocal_fast_7b_();
-        } else if constexpr (is_fp32_dest_acc_en) {
-            _init_reciprocal_fast_24b_5c_();
-        } else {
+        } else if constexpr (!is_fp32_dest_acc_en) {
             _init_reciprocal_fast_8b_3c_();
         }
     }


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #55797

The Blackhole float32 reciprocal (`_calculate_reciprocal_fast_24b_5c_`, selected by `recip_tile<false>` whenever fp32 dest accumulation is on) refined the `SFPARECIP` seed **additively**:

```
e  = 1 - x*y
t  = e*e + e
t2 = t*e + e        # e + e^2 + e^3
y  = t2*y + y       # y * (1 + e + e^2 + e^3)
```

`t2` is the seed's relative error (`~2^-8`) and `y` is `~1/x`, so the refinement **term** `t2*y` is `~2^-8/x`. For `|x| >= 2^119` it is below `FLT_MIN`, the SFPU flushes it to zero, the MAD adds nothing, and the raw ~7-bit seed is returned: 90,174 ULP / 0.56 % relative error on 100 % of the seven binades `2^119 .. 2^126` (117,440,512 float32 bit patterns), with partial loss from `2^111` up.

The float32 path now uses `sfpu_reciprocal_iter<2>` — the same refinement `ttnn.div`, `ttnn.rdiv` and `ttnn.pow` already take on this architecture. Its multiplicative form `y = y*(2 - x*y)` never forms a subnormal intermediate, because the correction *factor* is `~1` for every `x`, and its NaN guard keeps `1/±0 = ±inf` and `1/±inf = ±0` with the sign intact.

The correction cannot be reassociated in place inside the `SFPLOADMACRO` schedule. The fixed last step needs the final MAD's addend to become `0` while the second MAD keeps its addend, but both MADs are driven by instruction template 2 — one `lreg_src_c` field for both — and all four programmable instruction templates are already in use, so there is no fifth template to split them. Rather than ship a re-scheduled macro pipeline that cannot be executed here at all (ttsim does not implement `SFPLOADMACRO`), this PR drops to a plain per-element sequence — in the same spirit as #45660, which took the macro store-and-reload pipeline off the bf16 reciprocal on this arch.

ttsim Blackhole v1.10.6, 256 bfloat16-spaced mantissas per binade, both signs, golden `1/x` in float64:

| binade of \|x\| | mantissas wrong by >4 ULP (before → after) | max ULP (before → after) | max rel. err (before → after) |
|---|---|---|---|
| 2^100 .. 2^110 | 0/256 → **0/256** | 1 → **1** | 1.19e-07 → **1.19e-07** |
| 2^111 | 2/256 → **0/256** | 396 → **1** | 3.05e-05 → **1.19e-07** |
| 2^114 | 16/256 → **0/256** | 3,219 → **1** | 2.44e-04 → **1.19e-07** |
| 2^117 | 136/256 → **0/256** | 29,700 → **1** | 1.92e-03 → **1.19e-07** |
| 2^118 | 210/256 → **0/256** | 51,067 → **1** | 3.66e-03 → **1.19e-07** |
| 2^119 .. 2^125 | 256/256 → **0/256** | 90,174 → **1** | 5.58e-03 → **1.19e-07** |

Over all 65,536 bfloat16 bit patterns promoted to float32 (subnormal inputs excluded, `±2^126` excluded — that is #54513's separate seed-returns-zero cliff):

| | before | after |
|---|---|---|
| max ULP, \|x\| in 2^111 .. 2^126 | 90,174 | **1** |
| mean ULP, \|x\| in 2^111 .. 2^126 | 16,318.87 | **0.336** |
| inputs wrong by >4 ULP there | 2,162 / 3,840 | **0 / 3,840** |
| max ULP, \|x\| < 2^111 | 1 | **1** |
| agrees bit-for-bit with `ttnn.rdiv(x, 1)` | 42,934 / 65,536 | **65,536 / 65,536** |

Downstream, at `x = 1.5 · 2^122` (exact `1/x = 1.253860641e-37`): `ttnn.div_bw` (grad-wrt-a arm) and `ttnn.log_bw` go from `1.248962748e-37` (3.906e-03) to `1.253860678e-37` (2.98e-08), matching `ttnn.div` / `rdiv` / `pow`, which were already correct.

![fp32 reciprocal before/after](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-recip-fp32.png)

### Notes for reviewers

- **Blackhole only, float32 only.** bfloat16 keeps `_calculate_reciprocal_fast_8b_3c_` (max 0 ULP over all 64,512 normal-in / normal-out patterns, unchanged by this PR), `APPROXIMATE` keeps `_calculate_reciprocal_fast_7b_`, and `legacy_compat` (the `recip_tile()` default, i.e. the moreh / softmax / sampling / deepseek callers) is untouched. Wormhole has no `_fast_*` paths and normalises the mantissa before applying the exponent, so it never had this bug.
- **Instruction count (measured, corrected).** An earlier version of this bullet said "one extra SFPU instruction"; that compared against the non-macro fallback, not against what ships. Counted from the `math.elf` the tt-llk MATH_ISOLATE perf test builds, Tensix instructions issued per 32 datums: **5** before with SFPLOADMACRO on (`ttreplay 0,5`, the shipping path), 8 before with `-DDISABLE_SFPLOADMACRO`, **10** after this change (`ttreplay 0,10`). So against the shipping macro schedule this is 2x the issued instructions, not one extra.
  I cannot give cycles: the tt-llk harness runs here only on ttsim, whose cycle counts are not physical (Sqrt, Rsqrt and the patched Reciprocal all report an identical 0.367 cycles/tile, below the 32 cycles/tile floor for 1024 datums over 32 lanes), and tt-llk's own `run_ttsim_regression.sh` deselects `-m perf`. ttsim also requires `TT_METAL_DISABLE_SFPLOADMACRO=1`, so its "before" is the fallback rather than the macro schedule this PR removes.
  Please run MATH_ISOLATE on Blackhole for `mathop:Reciprocal, Float32->Float32, dest_acc:Yes`. If the 2x is real I would rather rework this into a hand-scheduled fast path than land it; the arithmetic that has to end up there is `y*(2 - x*y)`, equivalently `y*(1 + e + e^2 + e^3)`, never `y + y*(...)`.
- **Accuracy trade, stated plainly**: below `2^111` the old additive form was correctly rounded (mean 0.0078 ULP) and the new one is faithfully rounded (mean 0.336 ULP, max 1 ULP, unchanged worst case). That is inherent, not incidental: an additive last step is exactly what underflows, so the last operation must be a multiply by a factor of magnitude ~1, and rounding that factor to float32 costs up to `2^-25`. The same trade is already accepted for `ttnn.div` / `rdiv` / `pow`, and after this PR `ttnn.reciprocal` returns bit-identical results to them on all 65,536 patterns instead of on 42,934.
- **Poles and signs are unchanged**: `1/+0 = +inf`, `1/-0 = -inf`, `1/+inf = +0`, `1/-inf = -0`, `1/1 = 1`, `1/2 = 0.5` exactly, before and after — `sfpu_reciprocal_iter`'s `v_if (t < 0)` guard leaves the seed untouched when `x*y` is NaN. `test_reciprocal_fp32_special_values` pins this (it passes on `main` too, deliberately — it guards the rewrite).
- `reciprocal(±2^126) -> ±0` is **not** fixed here and is not made worse: there `SFPARECIP` itself returns zero and no refinement can rescue a zero seed. That is #54513 / #52094 / #55128, and PR #54514 addresses it; the two are independent and the changes do not overlap.
- **Tests**: `test_reciprocal_fp32_large_magnitude` sweeps 256 bfloat16-spaced mantissas of a binade in both signs and asserts ≤ 2 ULP against a float64 reference. On `main` it fails for exponents 111 / 114 / 118 / 119 / 122 / 125 (396, 3,219, 51,067, 90,174, 90,174, 90,174 ULP) and passes for the 100 control; with the fix all 7 parametrisations pass. Whole file: `test_unary_fp32.py` 31 passed; `test_math.py -k recip` 6 passed; `test_unary_category1_bfloat16.py -k reciprocal` 1 passed.
- Verified on ttsim Blackhole v1.10.6 (slow dispatch, `TT_METAL_DISABLE_SFPLOADMACRO=1`); no silicon. Since this PR removes the `SFPLOADMACRO` variant of this one function, the code that ships is now exactly the code that was measured.

