### PR TITLE
[Bug fix] softplus (float32): clamp the exponential's argument at the exp underflow limit

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -258,6 +258,41 @@ def test_softplus_threshold_boundary(device, beta, threshold):
     run_softplus_boundary_test(device, beta, threshold)
 
 
+# The affected band is exactly two binades of ``beta * x`` wide, so promoting every bfloat16 bit
+# pattern to float32 lands ~128 inputs inside it for any beta; a float32-only sweep is what is
+# needed, the bfloat16 path clamps its residual to zero and never reaches the tail.
+@pytest.mark.parametrize("beta", [0.5, 1, 2, 10, 100])
+def test_softplus_fp32_deep_negative_tail_all_bitpatterns(device, beta):
+    """Every bfloat16 bit pattern promoted to float32, checking the deep negative tail.
+
+    Once ``beta * x`` is far enough below zero the true softplus is smaller than the smallest
+    normal float and the kernel must return exactly ``0``. The float32 tail range-reduces with
+    ``_sfpu_round_to_nearest_int32_``, whose ``2**23 + 2**22`` magic constant is only valid while
+    ``|beta * x * log2(e)| <= 2**22``. Past that the integer part came back with the wrong sign,
+    the flush-to-zero guard on the reconstructed exponent never fired, and softplus returned
+    ``+-inf``, ``NaN`` or values up to ``FLT_MAX`` where the answer is ``0``.
+    """
+    threshold = 20.0
+    torch_input_tensor = flush_subnormal_values_to_zero(generate_all_bfloat16_bitpatterns(torch.float32))
+    reference = torch.nn.functional.softplus(torch_input_tensor.to(torch.float64), beta=beta, threshold=threshold)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    result = ttnn.to_torch(ttnn.softplus(input_tensor, beta=beta, threshold=threshold))
+
+    finite = torch.isfinite(torch_input_tensor)
+    assert torch.isfinite(result[finite]).all(), f"softplus produced non-finite output for finite input (beta={beta})"
+
+    # softplus(x) -> exp(beta*x)/beta as x -> -inf, so the deep tail underflows all the way to
+    # zero; the reference is evaluated in float64 so that only inputs whose exact result is far
+    # below the float32 subnormal range are asserted on.
+    underflowed = finite & (reference == 0)
+    assert underflowed.any()
+    assert (result[underflowed] == 0).all(), (
+        f"softplus returned a non-zero value where the exact result underflows to zero "
+        f"(beta={beta}, worst |result| = {result[underflowed].abs().max().item():g})"
+    )
+
+
 def test_tanhshrink_ulp(device):
     """ULP regression guard for the dedicated tanhshrink SFPU op (issue #45520).
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -62,6 +62,18 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
     constexpr float LN2_HI = -0.6931152343750000f;
     constexpr float LN2_LO = -3.19461832987e-05f;
 
+    // exp(x) underflows to zero below x = ln(2^-126) = -87.3365, so clamping the argument
+    // does not change any representable result.  It is required for correctness: the range
+    // reduction below uses _sfpu_round_to_nearest_int32_, whose 2^23 + 2^22 magic constant
+    // is only valid while |z| <= 2^22 (z = x * INV_LN2).  Past that, k_int comes back a large
+    // POSITIVE integer, so the `new_exp > 0` flush-to-zero guard no longer fires and setexp
+    // writes garbage into the exponent field, returning Inf/NaN/up to FLT_MAX where the true
+    // result is 0.  Every other caller of that helper clamps for the same reason
+    // (ckernel_sfpu_xielu.h, ckernel_sfpu_unary_power.h, ckernel_sfpu_binary_pow.h).
+    // At the clamp the reduced exponent is already <= 0, so the guard returns 0 as it should.
+    constexpr float EXP_UNDERFLOW_LIMIT = -88.0f;
+    x = sfpi::max(x, EXP_UNDERFLOW_LIMIT);
+
     // Range reduction: x = k*ln(2) + r
     sfpi::vFloat z = x * INV_LN2;
     sfpi::vInt k_int;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -62,6 +62,18 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
     constexpr float LN2_HI = -0.6931152343750000f;
     constexpr float LN2_LO = -3.19461832987e-05f;
 
+    // exp(x) underflows to zero below x = ln(2^-126) = -87.3365, so clamping the argument
+    // does not change any representable result.  It is required for correctness: the range
+    // reduction below uses _sfpu_round_to_nearest_int32_, whose 2^23 + 2^22 magic constant
+    // is only valid while |z| <= 2^22 (z = x * INV_LN2).  Past that, k_int comes back a large
+    // POSITIVE integer, so the `new_exp > 0` flush-to-zero guard no longer fires and setexp
+    // writes garbage into the exponent field, returning Inf/NaN/up to FLT_MAX where the true
+    // result is 0.  Every other caller of that helper clamps for the same reason
+    // (ckernel_sfpu_xielu.h, ckernel_sfpu_unary_power.h, ckernel_sfpu_binary_pow.h).
+    // At the clamp the reduced exponent is already <= 0, so the guard returns 0 as it should.
+    constexpr float EXP_UNDERFLOW_LIMIT = -88.0f;
+    x = sfpi::max(x, EXP_UNDERFLOW_LIMIT);
+
     // Range reduction: x = k*ln(2) + r
     sfpi::vFloat z = x * INV_LN2;
     sfpi::vInt k_int;


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #55798

`softplus_exp_negative` computes `z = -a * INV_LN2` and hands it to
`_sfpu_round_to_nearest_int32_` unclamped. That helper's Hacker's-Delight magic constant
`c231 = 0x4B400000` (`2^23 + 2^22`) is only valid while `z + c231` stays inside `c231`'s own binade,
i.e. `|z| <= 2^22`. Below that, `as<vInt>(tmp) - as<vInt>(c231)` comes back a large **positive**
integer, so

```cpp
sfpi::vInt new_exp = p_exp + k_int;
v_if(new_exp > 0) { result = sfpi::setexp(poly, new_exp); }
```

writes it straight into the 8-bit exponent field — the flush-to-zero guard cannot fire because
`k_int` has the wrong sign. `ttnn.softplus` therefore returned `±inf`, `NaN` and finite values up to
`3.28e38` over two full binades of `beta * x` where the exact result is `0`.

Every other caller of that helper already clamps for exactly this reason — `xielu`
(`z = sfpi::max(z, -126.5f)`, added as the fix for #54046), `unary_power` and `binary_pow`
(`sfpi::max(z, -0x7e.ffff8p0f)`) — and `gelu` / `tanh_derivative` only reach it on bounded branches.
`softplus` was the one caller with no bound.

The clamp goes on the argument rather than on `z`, so the Cody-Waite reduction below stays
consistent with the value that was rounded: `r = k * LN2_HI + x` uses `x`, and clamping only `z`
would leave a huge `r` feeding the Taylor polynomial. `exp(x)` underflows below
`x = ln(2^-126) = -87.3365`, so `sfpi::max(x, -88.0f)` changes no representable result, and at the
clamp the reconstructed exponent is already `<= 0`, which makes the existing guard return `0` — the
right answer.

All 65,536 bfloat16 bit patterns promoted to `float32` on ttsim Blackhole, `threshold = 20`, golden
in `float64`, counting only inputs whose exact `softplus` underflows to `0`:

| beta | nonzero where the answer is 0 | of which `inf` | max finite \|got\| |
|---|---|---|---|
| 1 | 128 → **0** | 44 → **0** | 4.566e37 → **—** |
| 0.5 | 128 → **0** | 44 → **0** | 9.132e37 → **—** |
| 2 | 128 → **0** | 44 → **0** | 2.283e37 → **—** |
| 10 | 126 → **0** | 46 → **0** | 6.928e34 → **—** |
| 100 | 125 → **0** | 44 → **0** | 4.560e33 → **—** |

Dense per-binade `float32` scan, 8,192 mantissa samples per binade, `beta = 1`:

| x | nonzero (before → after) | inf | NaN | max \|got\| |
|---|---|---|---|---|
| -[2^23, 2^24) | 7,856 / 8,192 → **0** | 2,625 → **0** | 62 → **0** | 3.28092e38 → **0** |
| -[2^24, 2^25) | 326 / 8,192 → **0** | 109 → **0** | 2 → **0** | 6.11954e37 → **0** |
| -[2^21, 2^23), -[2^25, 2^30) | 0 → 0 | 0 | 0 | 0 |

Nothing outside the affected band moves. Restricted to `|beta * x| <= 4e6` the two builds report the
same numbers to the last digit: max 7,315 ULP / mean 579.06967 over 38,122 inputs at `beta = 1`, and
max 3,698 ULP / mean 731.44636 over 36,410 inputs at `beta = 100`.

![softplus fp32 tail before/after](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-softplus.png)

### Notes for reviewers

- Both archs, one file each; `ckernel_sfpu_softplus.h` is byte-identical between `wormhole_b0` and
  `blackhole` before and after.
- **Cost: one SFPU operation.** `sfpi::max` lowers to a single `SFPSWAP` (plus the loop-invariant
  `SFPLOADI` of the constant), and it sits inside `softplus_exp_negative`, which is only reached on
  the already-predicated `a > SOFTPLUS_POLY_BOUNDARY` tail branch. The polynomial path for
  `|beta * x| <= 5` is untouched.
- `-88.0f` rather than the exactly-rounded `ln(2^-126) = -87.33654` so that the clamp engages a
  little after the true underflow point rather than a little before it; the sweep confirms nothing
  above it changed. `|z|` at the clamp is 126.97, comfortably inside the helper's `2^22` domain.
- Special values are unchanged, measured on both builds: `softplus(NaN) = NaN`,
  `softplus(+inf) = +inf`, `softplus(-inf) = 0` (`z = -inf` already produced a large negative
  `k_int`, so the guard did fire there), `softplus(±0) = 0.6931056`. Only the deep negative tail
  moves — at `x = -1e7` the result goes from `+inf` to `0`.
- The bfloat16 branch is not touched: it clamps its residual to `0` past `SOFTPLUS_POLY_BOUNDARY`
  and never calls `softplus_exp_negative`. Open PR #51868 names this same `|z| <= 2^22` limit in a
  comment while bounding only the bfloat16 branch it adds, so the two changes are complementary and
  do not overlap in the code they touch.
- Two pre-existing residuals are visible in the sweep and are **not** introduced or changed by this
  PR: `beta = 0.5` still returns `0` for 2 inputs whose exact result is a normal float
  (`beta_reciprocal` is applied *after* the residual has already underflowed — same count before and
  after), and the accuracy of the degree-8 polynomial on `[0, 5]` is #54673.
- `test_softplus_fp32_deep_negative_tail_all_bitpatterns` sweeps every bfloat16 bit pattern promoted
  to `float32` at five `beta` values and asserts that no finite input yields a non-finite output and
  that every input whose exact result underflows to zero returns exactly `0`. It fails all 5 cases
  on `main` (`AssertionError: softplus produced non-finite output for finite input`) and passes all
  5 with the fix.
- `tests/ttnn/unit_tests/operations/eltwise/test_activation.py`: 111 passed, 3 skipped.
  `test_eltwise_softplus_inf.py` was not runnable in this environment (its import chain needs
  `transformers`, and its 6x6x192x224 stimulus is far past what the simulator can execute).
- Verified on ttsim Blackhole v1.10.6 (slow dispatch); no silicon.
