### PR TITLE
[Bug fix] repeat_bw: size the reduction from the logical shape and sum the repeated blocks on every dim

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_repeat.py
@@ -28,3 +28,31 @@ def test_bw_repeat(input_shapes, sizes, device):
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 17, 37])),  # H and W not tile multiples
+        (torch.Size([1, 1, 7, 7])),
+        (torch.Size([1, 1, 33, 65])),
+        (torch.Size([1, 3, 32, 32])),  # repeated dim with an extent > 1
+    ),
+)
+@pytest.mark.parametrize("sizes", [[4, 1, 1, 1], [1, 3, 1, 1], [1, 1, 2, 1], [1, 1, 1, 3], [1, 1, 1, 1]])
+def test_bw_repeat_all_dims(input_shapes, sizes, device):
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    pyt_y = in_data.repeat(sizes)
+    grad_data, grad_tensor = data_gen_pt_tt(pyt_y.shape, device, True)
+
+    tt_output_tensor_on_device = ttnn.repeat_bw(grad_tensor, input_tensor, sizes)
+
+    golden_function = ttnn.get_golden_function(ttnn.repeat_bw)
+    golden_tensor = golden_function(grad_data, in_data, sizes)
+
+    # one gradient, with the input's shape: compare_pcc iterates over the returned list, so it
+    # passes vacuously on an empty one and never looks at the shape
+    assert len(tt_output_tensor_on_device) == len(golden_tensor)
+    assert list(tt_output_tensor_on_device[0].shape) == list(input_shapes)
+    assert compare_pcc(tt_output_tensor_on_device, golden_tensor)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1596,10 +1596,12 @@ std::vector<Tensor> repeat_bw(
     auto output_memory_config = output_mem_config.value_or(
         input.memory_config());  // TODO: Remove after ternary forward ops migration is completed
 
-    auto shape_wh = input.padded_shape();
+    // moreh_sum validates the preallocated output against the logical dims of the reduction result,
+    // so the required shape has to be built from the logical shape: a padded one rejects every input
+    // whose last two dims are not tile multiples.
+    auto shape_wh = input.logical_shape();
     TT_FATAL(shape_wh[0] == 1, "Input shape[0] must be 1 but got {}", shape_wh[0]);
     auto* ttnn_device = input.device();
-    // input.padded_shape()[0]
     // If repeat shape has 0's, it returns zeros of given input
     if (shape[0] == 0 || shape[1] == 0 || shape[2] == 0 || shape[3] == 0) {
         Tensor zero_tensor = ttnn::zeros_like(input, input.dtype(), input.layout(), std::nullopt, output_memory_config);
@@ -1621,7 +1623,9 @@ std::vector<Tensor> repeat_bw(
         grad_tensor.emplace_back(result);
         return grad_tensor;
     }
-    if (shape[1] > 1) {
+    // moreh_sum reduces the whole axis to one element, which is the gradient of a repeat only when
+    // the axis has a single element to begin with; otherwise fall through to the block sum below.
+    if (shape[1] > 1 && shape_wh[1] == 1) {
         ttsl::SmallVector<int64_t> dim = {1};
         TT_FATAL(shape[0] == 1 && shape[2] == 1 && shape[3] == 1, "repeat[0], [2], [3] should be 1");
         std::array<std::uint32_t, 4> intended_shape_array = {shape_wh[0], 1, shape_wh[2], shape_wh[3]};
@@ -1636,6 +1640,27 @@ std::vector<Tensor> repeat_bw(
         grad_tensor.emplace_back(result);
         return grad_tensor;
     }
+    // Every remaining repeat tiles its axis in blocks of the input's extent, so the gradient is the
+    // sum of those blocks.
+    Tensor result = grad;
+    for (uint32_t dim = 1; dim < 4; dim++) {
+        if (shape[dim] == 1) {
+            continue;
+        }
+        const uint32_t extent = shape_wh[dim];
+        const ttsl::SmallVector<uint32_t> step(4, 1);
+        ttsl::SmallVector<uint32_t> start(4, 0);
+        ttsl::SmallVector<uint32_t> end(result.logical_shape().cbegin(), result.logical_shape().cend());
+        Tensor blocks_sum;
+        for (uint32_t i = 0; i < shape[dim]; i++) {
+            start[dim] = i * extent;
+            end[dim] = (i + 1) * extent;
+            Tensor block = ttnn::slice(result, start, end, step, output_memory_config);
+            blocks_sum = (i == 0) ? block : ttnn::add(blocks_sum, block, std::nullopt, output_memory_config);
+        }
+        result = blocks_sum;
+    }
+    grad_tensor.emplace_back(result);
     return grad_tensor;
 }
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #55799

`repeat_bw` had three in-contract failures, all in the same host composite, all reachable from shapes and `sizes` the forward `ttnn.repeat` accepts:

* It sized the preallocated `moreh_sum` output from `input.padded_shape()`. moreh validates a preallocated output against the **logical** dims of the reduction result (`moreh_helper_functions.cpp:401`), so every input whose last two logical dims are not multiples of 32 aborted with `Input dimension without padding[0] (37) must equal output dimension without padding[0] (64)` — while the forward `ttnn.repeat` is bit-exact on the same tensors. Now built from `input.logical_shape()`.
* It only had branches for `shape[0] > 1` and `shape[1] > 1`; a repeat on dim 2 or dim 3 fell through to the trailing `return grad_tensor;` and came back as an **empty list**, silently, even for a tile-aligned `(1, 1, 32, 32)`.
* Both branches reduce the whole axis. `x.repeat(sizes)` tiles the axis in `sizes[dim]` blocks of the input's extent, so the gradient is the **sum of those blocks**; a full reduction is the same thing only when the extent is 1. Dim 0 is safe (`TT_FATAL(input.shape[0] == 1)` right above it), dim 1 was not: `(1, 3, 32, 32)` with `[1, 2, 1, 1]` silently returned a `(1, 1, 32, 32)` whole-axis sum where `torch` gives `(1, 3, 32, 32)`.

The block sum is `sizes[dim]` slices and `sizes[dim] - 1` adds, and nothing at all for a dim repeated once, so the unit-extent dim 0 / dim 1 path that CI exercises today still dispatches exactly one `moreh_sum` — only the shape of its preallocated output changed. No SFPU work is added; `ttnn::slice` and `ttnn::add` are the same host-composite calls used elsewhere in this file.

bfloat16 (the only dtype `repeat_bw` documents), `TILE_LAYOUT`, ttsim Blackhole v1.10.6, golden = `torch` autograd over `input.repeat(sizes)` in float64. `maxULP` is the bfloat16 ULP distance from that golden, `max rel` the largest absolute error over the largest gradient in the tensor:

| input shape | sizes | before | after | maxULP | max rel |
|---|---|---|---|---|---|
| (1, 1, 32, 32) | [2, 1, 1, 1] | gradient | **gradient** | 1 | 1.8e-03 |
| (1, 1, 32, 64) | [2, 1, 1, 1] | gradient | **gradient** | 1 | 2.5e-03 |
| (1, 1, 17, 32) | [2, 1, 1, 1] | `TT_FATAL` | **gradient** | 1 | 1.7e-03 |
| (1, 1, 32, 17) | [2, 1, 1, 1] | `TT_FATAL` | **gradient** | 1 | 1.7e-03 |
| (1, 1, 33, 32) | [2, 1, 1, 1] | `TT_FATAL` | **gradient** | 1 | 2.9e-03 |
| (1, 1, 32, 33) | [2, 1, 1, 1] | `TT_FATAL` | **gradient** | 1 | 2.9e-03 |
| (1, 1, 17, 37) | [2, 1, 1, 1] | `TT_FATAL` | **gradient** | 1 | 1.3e-03 |
| (1, 1, 7, 7) | [4, 1, 1, 1] | `TT_FATAL` | **gradient** | 16 | 2.8e-03 |
| (1, 1, 33, 65) | [4, 1, 1, 1] | `TT_FATAL` | **gradient** | 15,360 | 5.7e-03 |
| (1, 1, 17, 37) | [1, 3, 1, 1] | `TT_FATAL` | **gradient** | 64 | 3.4e-03 |
| (1, 1, 7, 7) | [1, 24, 1, 1] | `TT_FATAL` | **gradient** | 27 | 1.5e-02 |
| (1, 1, 32, 32) | [1, 1, 2, 1] | `[]` | **gradient** | 1 | 1.8e-03 |
| (1, 1, 32, 32) | [1, 1, 1, 2] | `[]` | **gradient** | 1 | 3.6e-03 |
| (1, 1, 17, 37) | [1, 1, 3, 1] | `[]` | **gradient** | 64 | 3.4e-03 |
| (1, 1, 17, 37) | [1, 1, 1, 3] | `[]` | **gradient** | 15,040 | 4.4e-03 |
| (1, 1, 17, 37) | [1, 1, 2, 3] | `[]` | **gradient** | 14,848 | 6.1e-03 |
| (1, 1, 320, 384) | [1, 1, 1, 2] | `[]` | **gradient** | 1 | 2.6e-03 |
| (1, 1, 7, 7) | [1, 1, 1, 1] | `[]` | **grad** | 0 | 0 |
| (1, 3, 32, 32) | [1, 2, 1, 1] | (1, **1**, 32, 32) | **(1, 3, 32, 32)** | 1 | 3.1e-03 |
| (1, 2, 17, 37) | [1, 3, 1, 1] | `TT_FATAL` | **(1, 2, 17, 37)** | 15,104 | 4.2e-03 |

Every "gradient" after the fix has the input's shape and matches the golden; the two rows with a shape in them are the wrong-shaped whole-axis sums. `TT_FATAL` rows raised, `[]` rows returned an empty list.

### Notes for reviewers

- One file, one function; `repeat_bw` is a host composite, so this covers Wormhole and Blackhole at once.
- `shape_wh` is now the logical shape. Its only other use is `TT_FATAL(shape_wh[0] == 1, ...)`, where logical and padded agree — padding only ever applies to the last two dims — so that check is unchanged.
- The dim-1 `moreh_sum` branch is kept for `input.shape[1] == 1`, where the whole-axis reduction *is* the block sum and costs one dispatch instead of `sizes[1]` slices and adds. That is the shape the nightly test uses (`[1, 24, 1, 1]` and `[1, 3, 1, 1]` over `[1, 1, 32, 32]` and `[1, 1, 320, 384]`), so nothing on the covered path gets slower.
- `sizes = [1, 1, 1, 1]` used to return `[]` as well; it now returns `grad`, which is what the registered golden returns for a no-op repeat. Repeats on two dims at once (`[1, 1, 2, 3]`) are handled by the loop, one dim at a time; they also used to return `[]`.
- ULP is measured against an *exact* float64 sum of the bfloat16 blocks, which overstates the error where blocks cancel: the accumulation is bfloat16, so a partial sum of magnitude `M` carries `M * 2^-8` of rounding and the exact sum of the remaining blocks can be far smaller than that. The four-figure rows are exactly that — for `(1, 1, 17, 37)` `[1, 1, 1, 3]` the worst element is `got = 0` against `want = -0.00146`, in a tensor whose largest gradient is 2.9. Relative to that largest gradient the error stays at or below 1.5 bfloat16 eps wherever the new code runs; the 1.5e-02 row is the pre-existing `moreh_sum` summing 24 blocks.
- `test_bw_repeat_all_dims` covers 5 shapes (tile multiple, sub-tile, ragged H and W, and a dim-1 extent of 3) x 5 `sizes` (one per dim, plus the no-op). It asserts the returned list length and the gradient's shape *before* comparing PCC: `compare_pcc` iterates over the returned list, so an empty gradient list passes it vacuously and a wrong-shaped one is never looked at — that is the second reason CI never saw this. **22 of the 25 cases fail on `main`** (6 `TT_FATAL`, 15 empty lists, 1 wrong shape) and all 25 pass with this change.
- The pre-existing `test_bw_repeat` (8 cases, tile multiples, dims 0 and 1, dim-1 extent 1) passes unchanged: the whole file is 33 passed with the fix, 22 failed / 11 passed on `main`.
- Verified on ttsim Blackhole v1.10.6 (slow dispatch); no silicon.

![repeat_bw before/after](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-repeat-bw.png)
