### PR TITLE
[Bug fix]: Act on the rest of the #54992 review

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -189,8 +189,9 @@ INDEXER_K_PCC_THRESHOLD = 0.95
 # Traced and untraced get SEPARATE tables and SEPARATE margins, selected by mode in
 # `kimi_chunked_perf_gate` -- a traced baseline can never gate an untraced run or vice versa. The two
 # are different regimes, not a small delta: traced measures 0.6-0.95 s/chunk (a ramp, since chunk c
-# attends to KV[0:c*CHUNK]) while untraced is a flat ~0.81 s/chunk, host-dispatch bound so the op2op
-# gap swamps the depth ramp entirely.
+# attends to KV[0:c*CHUNK]) while untraced sits near 0.81 s/chunk for most of the run, host-dispatch
+# bound so the op2op gap all but swamps the depth ramp. Only the last chunks show it at all, and
+# whether that tail is real is exactly what the two ungated entries below are waiting on.
 KIMI_TRACED_BASELINE_CHUNK_TIMES_S = {
     # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-traced]
     # (55k / code_debug). These numbers were updated for the K2.6 -> K2.7 weights transition (#54944),
@@ -219,7 +220,7 @@ KIMI_UNTRACED_BASELINE_CHUNK_TIMES_S = {
     # (55k / code_debug), 2026-09-01 on an 8x4 galaxy, per-chunk medians of run 33534897935/job
     # 99949625303.
     #
-    # WITHIN a run the untraced spread is huge -- per-chunk stddev reaches 0.33 s (~30%), because every
+    # WITHIN a run the untraced spread is huge -- per-chunk stddev reaches 0.33 s (~41%), because every
     # iteration re-dispatches every op from host and pays a fresh, variable op2op gap. The MEDIAN of the
     # 9 post-warmup iterations is not: on the previous baseline no chunk median across 32 recorded runs
     # landed further than 3.2% from its median-of-runs value. So the gate is on the median, with
@@ -227,7 +228,14 @@ KIMI_UNTRACED_BASELINE_CHUNK_TIMES_S = {
     #
     # If this goes flaky, re-center on the median over several runs before widening. Widening to 10% is
     # the fallback after that -- a band that needs more than 10% is a regression, not noise.
-    (61, 11, 10): [0.805, 0.808, 0.811, 0.816, 0.808, 0.806, 0.806, 0.805, 0.802, 0.823, 0.854],
+    #
+    # Chunks 9 and 10 are None (record-only) rather than 0.823 and 0.854. Those two came from the tail
+    # of the single run above, where they sit 2% and 6% over the other nine, and the file's own rule is
+    # to cut from the median across several runs. Gating them on one run inverts the test: the band for
+    # chunk 10 is [0.811, 0.897], so a run that comes in flat at 0.806 -- faster than the baseline --
+    # fails as a regression. Re-cut all eleven from 2-3 runs to arm them; if the tail ramp survives
+    # that, it is real and the "near 0.81" note above needs to say so.
+    (61, 11, 10): [0.805, 0.808, 0.811, 0.816, 0.808, 0.806, 0.806, 0.805, 0.802, None, None],
 }
 # Per-mode +/- tolerance band around each baseline chunk median (fraction). Traced replays a captured
 # program, so the device is its only noise source; untraced re-dispatches from host every iteration and
@@ -1276,8 +1284,10 @@ def run_chunked_transformer_updated(
     Perf gate: when `baseline_chunk_times_s` is provided (a per-chunk list of baseline medians pulled
     from a known-good CI run), each chunk's measured median must stay within +/- `perf_margin` of its
     baseline; a single `perf_margin` covers every chunk. The table appends the baseline, tolerance band,
-    and PASS/FAIL per chunk, and the run fails if any chunk is out of band. When no baseline is given the
-    table is record-only (perf-exploration combos)."""
+    and PASS/FAIL per chunk, and the run fails if any chunk is out of band. A None entry in the list
+    leaves that ONE chunk record-only (shown as RECORD) while the others stay gated, for a chunk whose
+    baseline is not yet trustworthy. When no baseline is given at all the whole table is record-only
+    (perf-exploration combos)."""
     if weight_cache_path is None:
         pytest.skip(f"pretrained weights unavailable (set {variant.ttnn_cache_env} + {variant.env_var})")
 
@@ -1319,20 +1329,25 @@ def run_chunked_transformer_updated(
             row = [f"chunk {chunk_idx}", format_duration(median_time), format_duration(stddev_time)]
             if gated:
                 baseline = baseline_chunk_times_s[chunk_idx]
-                low = baseline * (1.0 - margin)
-                high = baseline * (1.0 + margin)
-                ok = low <= median_time <= high
-                row += [
-                    format_duration(baseline),
-                    format_duration(low),
-                    format_duration(high),
-                    "PASS" if ok else "FAIL",
-                ]
-                if not ok:
-                    failures.append(
-                        f"chunk {chunk_idx} median {median_time:.3f}s outside "
-                        f"baseline {baseline:.3f}s +/- {margin * 100:.1f}% band [{low:.3f}s, {high:.3f}s]"
-                    )
+                if baseline is None:
+                    # A None entry means this chunk has no baseline worth gating on yet: record it and
+                    # leave the rest of the table armed.
+                    row += ["-", "-", "-", "RECORD"]
+                else:
+                    low = baseline * (1.0 - margin)
+                    high = baseline * (1.0 + margin)
+                    ok = low <= median_time <= high
+                    row += [
+                        format_duration(baseline),
+                        format_duration(low),
+                        format_duration(high),
+                        "PASS" if ok else "FAIL",
+                    ]
+                    if not ok:
+                        failures.append(
+                            f"chunk {chunk_idx} median {median_time:.3f}s outside "
+                            f"baseline {baseline:.3f}s +/- {margin * 100:.1f}% band [{low:.3f}s, {high:.3f}s]"
+                        )
             rows.append(row)
 
         margin_note = f", baseline gate +/- {margin * 100:.1f}%" if gated else ", record-only (no baseline)"

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -969,12 +969,19 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadCBUpdate) {
             .processor = DataMovementProcessor::RISCV_1,
             .noc = NOC::RISCV_1_default,
             .compile_args = {updated_cb_index}});
+    // The test grows every CB below (num_pages *= 2) and then halves one page size, so the CB region
+    // is at its largest right after the growth. Size the report slot from that footprint and leave a
+    // page of slack, so adding a CB or changing the growth factor cannot land the report inside a
+    // live CB and decide the test for the wrong reason.
+    constexpr uint32_t cb_growth_factor = 2;
+    constexpr uint32_t report_slack_bytes = 4096;
     uint32_t max_cb_region_size = 0;
     for (const auto& cb_config : cb_config_vector) {
-        max_cb_region_size += 2 * cb_config.num_pages * cb_config.page_size;
+        max_cb_region_size += cb_growth_factor * cb_config.num_pages * cb_config.page_size;
     }
     const uint32_t report_addr =
-        mesh_device_->get_devices().front()->allocator()->get_base_allocator_addr(HalMemType::L1) + max_cb_region_size;
+        mesh_device_->get_devices().front()->allocator()->get_base_allocator_addr(HalMemType::L1) + max_cb_region_size +
+        report_slack_bytes;
     SetRuntimeArgs(*program, report_kernel, cr_set, {report_addr});
 
     auto mesh_workload = MeshWorkload();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "gtest/gtest.h"
+#include <numeric>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/distributed.hpp>

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -97,19 +97,13 @@ public:
         }
     }
 
-    bool enabled() const { return enabled_; }
-
-    void record(ChipId device_id, uint64_t runtime_id, SubDeviceId sub_device_id) const {
-        tt::RecordProgramSubDevice(
-            context_id_, device_id, manager_id_, runtime_id, sub_device_id, num_available_worker_cores_);
-    }
-
     void record(const std::vector<IDevice*>& devices, uint64_t runtime_id, SubDeviceId sub_device_id) const {
         if (!enabled_) {
             return;
         }
         for (const auto* device : devices) {
-            record(device->id(), runtime_id, sub_device_id);
+            tt::RecordProgramSubDevice(
+                context_id_, device->id(), manager_id_, runtime_id, sub_device_id, num_available_worker_cores_);
         }
     }
 
@@ -448,8 +442,11 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         TT_FATAL(!blocking, "Blocking is not supported when recording a trace.");
         trace_nodes_.push_back(MeshTraceNode{});
         auto& trace_node = trace_nodes_.back();
-        bool use_prefetcher_cache =
-            mesh_workload.impl().get_finalized_metadata().max_program_kernels_sizeB <= this->prefetcher_cache_sizeB_;
+        // Reuse what generate_dispatch_commands() resolved (it runs immediately before this, in
+        // EnqueueMeshWorkload). Recomputing it here dropped the "has any kernels at all" term, so a
+        // kernel-less workload captured a trace node claiming the prefetcher cache and then
+        // dereferenced its null kernels buffer.
+        bool use_prefetcher_cache = mesh_workload.impl().use_prefetcher_cache_;
         for (auto& [device_range, program] : mesh_workload.get_programs()) {
             trace_node.trace_nodes.push_back(std::pair<MeshCoordinateRange, TraceNode>(
                 device_range,
@@ -541,7 +538,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     const CoreCoord dispatch_core = this->virtual_program_dispatch_core();
     const SubDeviceRecorder sub_device_recorder(mesh_device_, sub_device_id);
 #if defined(TRACY_ENABLE)
-    const bool tag_tracy_zones = !tt::tt_metal::getDeviceProfilerState();
+    const bool tag_tracy_zones = !tt::tt_metal::getDeviceProfilerState(extract_context_id(mesh_device_));
 #endif
 
     // Iterate over all programs. Update dispatch commands per program to reflect
@@ -926,13 +923,9 @@ void FDMeshCommandQueue::increment_num_entries_in_completion_queue() {
 }
 
 void FDMeshCommandQueue::submit_memcpy_request(
-    std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
-    bool blocking,
-    std::vector<MemoryPin> memory_pins) {
+    std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking, std::vector<MemoryPin> memory_pins) {
     completion_queue_reads_.push(std::make_shared<MeshCompletionReaderVariant>(
-        std::in_place_type<MeshBufferReadDescriptor>,
-        std::move(num_txns_per_device),
-        std::move(memory_pins)));
+        std::in_place_type<MeshBufferReadDescriptor>, std::move(num_txns_per_device), std::move(memory_pins)));
 
     this->increment_num_entries_in_completion_queue();
 
@@ -1626,13 +1619,11 @@ void FDMeshCommandQueue::record_end() {
                 std::pair<bool, int>(mesh_node.unicast_go_signals, num_virtual_eth_cores),
                 static_cast<uint8_t>(this->id()));
 
+            // Per node, not hoisted above the loop: sub_device_id, and so num_available_worker_cores,
+            // is per node.
             const SubDeviceRecorder trace_sub_device_recorder(mesh_device_, sub_device_id);
-            if (trace_sub_device_recorder.enabled()) {
-                for_each_local(mesh_device_, range, [&](const MeshCoordinate& coord) {
-                    trace_sub_device_recorder.record(
-                        mesh_device_->impl().get_device(coord)->id(), node.program_runtime_id, sub_device_id);
-                });
-            }
+            trace_sub_device_recorder.record(
+                mesh_device_->impl().get_local_devices(range), node.program_runtime_id, sub_device_id);
 
             // Issue dispatch commands for this program
             program_dispatch::write_program_command_sequence(

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -105,13 +105,8 @@ void MeshWorkloadImpl::set_finalized(uint32_t max_program_kernels_sizeB) {
             metadata.program_config_sizes = program_config_sizes;
         } else {
             TT_FATAL(
-                metadata.program_config_sizes.size() == program_config_sizes.size(),
+                metadata.program_config_sizes == program_config_sizes,
                 "Expected config sizes to be identical across all programs in a MeshWorkload.");
-            for (size_t i = 0; i < metadata.program_config_sizes.size(); i++) {
-                TT_FATAL(
-                    metadata.program_config_sizes[i] == program_config_sizes[i],
-                    "Expected config sizes to be identical across all programs in a MeshWorkload.");
-            }
         }
 
         if (!program_impl.get_per_core_cross_node_dfbs().empty()) {
@@ -340,15 +335,18 @@ const std::vector<uint64_t>& MeshWorkloadImpl::get_cross_node_program_ids() {
 
 const std::unordered_set<SubDeviceId>& MeshWorkloadImpl::determine_sub_device_ids(MeshDevice* mesh_device) {
     auto& sub_device_ids_by_manager = sub_device_ids_by_mesh_and_manager_[mesh_device->id()];
-    auto [entry, inserted] = sub_device_ids_by_manager.try_emplace(*mesh_device->get_active_sub_device_manager_id());
-    auto& sub_device_ids = entry->second;
-    if (inserted) {
-        for (auto& [device_range, program] : programs_) {
-            auto sub_devices_for_program = program.impl().determine_sub_device_ids(mesh_device);
-            sub_device_ids.insert(sub_devices_for_program.begin(), sub_devices_for_program.end());
-        }
+    const uint64_t manager_id = *mesh_device->get_active_sub_device_manager_id();
+    if (auto entry = sub_device_ids_by_manager.find(manager_id); entry != sub_device_ids_by_manager.end()) {
+        return entry->second;
     }
-    return sub_device_ids;
+    // Collect before inserting: a program that raises partway through would otherwise leave the
+    // programs walked so far cached as the whole workload's sub-device set.
+    std::unordered_set<SubDeviceId> sub_device_ids;
+    for (auto& [device_range, program] : programs_) {
+        auto sub_devices_for_program = program.impl().determine_sub_device_ids(mesh_device);
+        sub_device_ids.insert(sub_devices_for_program.begin(), sub_devices_for_program.end());
+    }
+    return sub_device_ids_by_manager.emplace(manager_id, std::move(sub_device_ids)).first->second;
 }
 
 ProgramCommandSequence& MeshWorkloadImpl::get_dispatch_cmds_for_program(Program& program, uint64_t command_hash) {
@@ -455,6 +453,12 @@ void MeshWorkloadImpl::finalize_offsets(MeshDevice* mesh_device) {
         semaphores_getter,
         programs);
 
+    // The programs were laid out jointly above, so each one is finalized. Say so: finalize_offsets()
+    // and LaunchProgram() both re-lay out a program that still reports unfinalized, which would
+    // replace these joint offsets with standalone ones while dispatch keeps using the snapshot.
+    for (auto* program_impl : program_impls) {
+        program_impl->set_finalized();
+    }
     set_finalized(max_program_kernels_sizeB);
 }
 

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -105,6 +105,16 @@ inline bool is_watcher_assert_enabled(const MetalContext& metal_ctx) {
     return metal_ctx.rtoptions().get_watcher_enabled() && !metal_ctx.rtoptions().watcher_assert_disabled();
 }
 
+// A CB config payload carries the local configs from the front, indexed by buffer index, and the
+// remote configs from the back, so a remote buffer index counts down from max_cbs. Both return an
+// offset in uint32 words from the start of the payload.
+constexpr uint32_t local_cb_config_slot(uint32_t buffer_index) {
+    return UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * buffer_index;
+}
+constexpr uint32_t remote_cb_config_slot(uint32_t remote_offset_index, uint32_t max_cbs, uint32_t buffer_index) {
+    return remote_offset_index + (max_cbs - 1 - buffer_index) * UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG;
+}
+
 struct CommandConstants {
     NOC noc_index;
     uint32_t max_prefetch_command_size;
@@ -1573,7 +1583,7 @@ public:
                     for (const auto& buffer_index : cb->local_buffer_indices()) {
                         // 1 cmd for all 32 buffer indices, populate with real data for specified indices
                         // cb config payload
-                        const uint32_t base_index = UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * buffer_index;
+                        const uint32_t base_index = local_cb_config_slot(buffer_index);
                         cb_config_payload[base_index] = cb_address;
                         cb_config_payload[base_index + 1] = cb_size;
                         cb_config_payload[base_index + 2] = cb->num_pages(buffer_index);
@@ -1581,9 +1591,7 @@ public:
                         max_index = std::max(max_index, base_index + UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG);
                     }
                     for (const auto& buffer_index : cb->remote_buffer_indices()) {
-                        const uint32_t base_index =
-                            remote_offset_index +
-                            ((max_cbs - 1 - buffer_index) * UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
+                        const uint32_t base_index = remote_cb_config_slot(remote_offset_index, max_cbs, buffer_index);
                         cb_config_payload[base_index] = cb->config_address();
                         cb_config_payload[base_index + 1] = cb->page_size(buffer_index);
                         max_index = std::max(max_index, base_index + UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
@@ -2688,8 +2696,7 @@ void assemble_device_commands(
         metal_ctx, mesh_device, constants, program, batched_transfers, absolute_cross_node_config_transfers);
 
     PrefetcherPipeCommandGenerator prefetcher_pipe_command_generator;
-    prefetcher_pipe_command_generator.construct_commands(
-        metal_ctx, mesh_device, constants, program, batched_transfers);
+    prefetcher_pipe_command_generator.construct_commands(metal_ctx, mesh_device, constants, program, batched_transfers);
 
     BatchedTransferGenerator batched_transfer_generator;
     batched_transfer_generator.construct_commands(metal_ctx, batched_transfers, program_config_buffer_calculator);
@@ -2723,15 +2730,12 @@ void assemble_device_commands(
         for (const auto& circular_buffer : program_command_sequence.circular_buffers_on_core_ranges[range_index]) {
             for (const uint32_t buffer_index : circular_buffer->local_buffer_indices()) {
                 local_cb_updates.push_back(
-                    {circular_buffer.get(),
-                     payload + UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * buffer_index,
-                     buffer_index});
+                    {circular_buffer.get(), payload + local_cb_config_slot(buffer_index), buffer_index});
             }
             for (const uint32_t buffer_index : circular_buffer->remote_buffer_indices()) {
                 remote_cb_updates.push_back(
                     {circular_buffer.get(),
-                     payload + remote_offset_index +
-                         (max_cbs - 1 - buffer_index) * UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG,
+                     payload + remote_cb_config_slot(remote_offset_index, max_cbs, buffer_index),
                      buffer_index});
             }
         }
@@ -2829,11 +2833,7 @@ void assemble_device_commands(
             tt::LogDispatch,
             "Runtime Args Commands:    {} commands",
             program_command_sequence.runtime_args_command_sequences.size());
-        uint32_t total_rta_size = 0;
-        for (const auto& cmd : program_command_sequence.runtime_args_command_sequences) {
-            total_rta_size += cmd.size_bytes();
-        }
-        log_trace(tt::LogDispatch, "Runtime Args Total Size:  {} bytes", total_rta_size);
+        log_trace(tt::LogDispatch, "Runtime Args Total Size:  {} bytes", program_command_sequence.runtime_args_sizeB);
         log_trace(
             tt::LogDispatch,
             "Program Config Buffer:    {} bytes",
@@ -2850,7 +2850,8 @@ void assemble_device_commands(
             tt::LogDispatch,
             "Go Signal:                {} bytes",
             program_command_sequence.go_msg_command_sequence.size_bytes());
-        uint32_t total_size = program_command_sequence.preamble_command_sequence.size_bytes() + total_rta_size +
+        uint32_t total_size = program_command_sequence.preamble_command_sequence.size_bytes() +
+                              program_command_sequence.runtime_args_sizeB +
                               program_command_sequence.program_config_buffer_command_sequence.size_bytes() +
                               program_command_sequence.program_binary_command_sequence.size_bytes() +
                               program_command_sequence.launch_msg_command_sequence.size_bytes() +
@@ -3553,19 +3554,20 @@ TraceNode create_trace_node(
                 // 1 cmd for all 32 buffer indices, populate with real data for specified indices
 
                 // cb config payload
-                uint32_t base_index = UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * buffer_index;
+                uint32_t base_index = local_cb_config_slot(buffer_index);
                 cb_config_payload[base_index] = cb_address;
                 cb_config_payload[base_index + 1] = cb_size;
                 cb_config_payload[base_index + 2] = cb->num_pages(buffer_index);
                 cb_config_payload[base_index + 3] = cb->page_size(buffer_index);
-                first_unused_index = std::max(first_unused_index, base_index + 4);
+                first_unused_index =
+                    std::max(first_unused_index, base_index + UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG);
             }
             for (const auto& buffer_index : cb->remote_buffer_indices()) {
-                const uint32_t base_index = remote_offset_index + ((max_cbs - 1 - buffer_index) *
-                                                                   UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
+                const uint32_t base_index = remote_cb_config_slot(remote_offset_index, max_cbs, buffer_index);
                 cb_config_payload[base_index] = cb->config_address();
                 cb_config_payload[base_index + 1] = cb->page_size(buffer_index);
-                first_unused_index = std::max(first_unused_index, base_index + 2);
+                first_unused_index =
+                    std::max(first_unused_index, base_index + UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
             }
         }
         cb_config_payload.resize(first_unused_index);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Relates to #52756. Stacked on #55792 (`jbauman/mesh-device-property-caches`).

#54992 merged with thirteen unresolved review threads from @ayerofieiev-tt. Three were about the mesh device property caches and are handled in #55792. This PR takes the other ten.

**Two are wrong answers, not untidy ones.**

Trace capture recomputed `use_prefetcher_cache` instead of reading what `generate_dispatch_commands()` had resolved moments earlier, and the recomputation dropped that expression's `max_program_kernels_sizeB and` term. A workload with no kernels (which `load_binaries` documents as valid) therefore captured a trace node claiming the prefetcher cache, and `assemble_device_commands` went on to call `->address()` on its null kernels buffer. The enqueue path never hit this because it uses the guarded value. Now both read the same field.

The untraced Kimi chunk perf gate is two-sided at 5%, and chunks 9 and 10 were cut from the tail of a single run, sitting 2% and 6% above the other nine. Chunk 10's band works out to [0.811, 0.897], so a run coming in flat at 0.806 — *faster* than the baseline — failed as a regression. A baseline entry may now be `None`, which records that chunk and leaves the other nine armed; chunks 9 and 10 take it until all eleven are re-cut across several runs, which is what the file's own header already instructs. Two comments describing the pre-recut table are corrected: the untraced run is not flat any more, and 0.33 s of a 0.81 s chunk is 41%, not 30%.

**The rest are lost guards and duplication.** `MeshWorkloadImpl::finalize` laid every program out jointly but left each reporting unfinalized, so `finalize_offsets` or `LaunchProgram` would re-lay one out standalone while dispatch kept using the joint snapshot. `determine_sub_device_ids` cached its map entry before filling it, so a program raising mid-loop left a partial set cached as the whole workload's. The Tracy zone tag read the profiler state from the default context while the rest of its function used the mesh's own. The two CB config slot formulas were spelled out at three sites — the assemble-time fill, the update descriptors, and `create_trace_node` — which is exactly where eager and traced replay would drift apart, so they get one definition each. The command summary log re-added the runtime-arg sizes by hand next to the field that now holds that total. Trace replay hand-rolled the recorder loop that `SubDeviceRecorder`'s vector overload already provides, which is the only thing the single-device overload and `enabled()` existed for. `test_prefetcher.cpp` used `std::accumulate` with no `<numeric>`. The `MeshWorkloadCBUpdate` report slot sat exactly at the end of the grown CB region with zero slack.

### Testing

Local, single p100a (Blackhole): `distributed_unit_tests` 188 passed / 0 failed, `unit_tests_api` 1611 passed / 0 failed. `MeshWorkloadCBUpdate` is among them, which is the test that reads CB configs back off the device, so it covers both the CB slot helpers and the moved report slot.

The python gate change is checked by construction rather than by a run (the config needs an 8x4 Galaxy): the table parses to 11 entries, 9 gated and 2 record-only, and `black`/`isort` pass.

Everything shape-dependent skips on a one-board host, so this needs a T3K or Galaxy before leaving draft — in particular the kernel-less trace-capture path from the first bug and the Kimi chunked prefill job.

### Notes for reviewers

One thread is deliberately not acted on: recording program metadata unconditionally at trace-capture time, so that a trace captured while the gate is off is still annotated. The reasoning in the thread is sound — the gate has no re-sync, so it is a latent trap — but the gate lives *inside* `RecordProgramMetadata` rather than at its call sites, so bypassing it for capture means adding a second un-gated entry point into the data collector. That is a wider change than the thread's one-line framing suggests, for a configuration that cannot occur today (the real-time profiler only starts inside `MeshDevice::create`, before any enqueue). Happy to do it if you would rather have it now.

The `finalize` fix is the one with the widest blast radius: marking the programs finalized makes `ProgramImpl::finalize_offsets()` and `ProgramCompileGroup::finalize_offsets()` correctly skip a standalone re-layout, which is the intended effect but does change behavior for any caller that was relying on the re-layout happening. No in-tree caller does.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/glm-dispatch-review-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/glm-dispatch-review-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/glm-dispatch-review-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/glm-dispatch-review-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/glm-dispatch-review-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/glm-dispatch-review-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/glm-dispatch-review-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/glm-dispatch-review-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/glm-dispatch-review-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/glm-dispatch-review-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/glm-dispatch-review-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/glm-dispatch-review-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/glm-dispatch-review-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/glm-dispatch-review-followups)