### PR TITLE
ci: Proposal to rework time budget calculations

### DIFF
--- a/.github/instructions/ci-cd.instructions.md
+++ b/.github/instructions/ci-cd.instructions.md
@@ -69,6 +69,6 @@ Flag a test that violates its pipeline's runtime contract (e.g., a 10-minute tes
 - [ ] Runner-routing changes (direct `runs-on:` edits or indirect reorg/`sku_config.yaml` changes) verified against the pipeline reorg tooling
 - [ ] `time_budget.yaml` changes justified
 - [ ] `fetch-depth: 1` unless full history required
-- [ ] Test yaml entries have all required keys (`name`, `cmd`, `sku`, `owner_id`, `team`, `timeout`)
+- [ ] Test yaml entries have all required keys (`name`, `cmd`, `sku`, `owner_id`, `team`, `budget_type`, `timeout`)
 - [ ] `sku` values match `.github/sku_config.yaml`
 - [ ] Tests are in a pipeline level appropriate for their runtime

--- a/.github/scripts/utils/query_time_budget.py
+++ b/.github/scripts/utils/query_time_budget.py
@@ -20,8 +20,9 @@ Key conventions
 ---------------
 * Owner is the entry's `team:` field, not the file name. One file may hold
   several teams' entries, so all files of a test type are scanned and filtered.
-* A file's "test type" is the workflow_name passed to verify_time_budget.py by
-  the workflow that runs it.
+* A test's "test type" is its own `budget_type:` field. An entry may declare a
+  list of them, in which case it is charged to each independently and matches a
+  query for any of them.
 * The models unit/e2e/sweep budgets are tier-split: the plain key covers the
   non-tiered pipelines, while unit_tier<n>/e2e_tier<n>/sweep_tier<n> cover
   models_<testtype>_tests.yaml. Pass --tier to target a tiered budget.
@@ -31,35 +32,37 @@ Key conventions
 
 Usage
 -----
-  query_time_budget.py --team <team> --testtype <type> --machine <sku> [--tier N] [-v]
+  query_time_budget.py --team <team> --budget-type <type> --machine <sku> [--tier N] [-v]
 
 Example
 -------
-  $ query_time_budget.py --team models --testtype unit --machine wh_n150 --tier 1 -v
+  $ query_time_budget.py --team models --budget-type unit --machine wh_n150 --tier 1 -v
   Team 'models' / test type 'unit' / machine 'wh_n150', tier 1
     Files scanned: 1
-         30 min  models_unit_tests.yaml: Llama 3.1-8B unit tests (tier 1)
+         40 min  models_unit_tests.yaml: Llama 3.1-8B unit tests (tier 1)
+          8 min  models_unit_tests.yaml: DeepSeek-V3 module unit tests (host-side) (tier 1)
          10 min  models_unit_tests.yaml: Whisper unit tests (tier 1)
-    Tests matched: 2
-    Allocated:     40 min
-    Budget:        47 min
+         60 min  models_unit_tests.yaml: TT-DiT common unit tests, shared amongst all models. (tier 1)
+    Tests matched: 4
+    Allocated:     118 min
+    Budget:        118 min
     Scheduled pipelines (cron):
          14 runs/wk  models-t1-unit-tests.yaml
-    Est. machine-hours/week: 11.0 h  (47 min x 14 runs/wk / 60)
+    Est. machine-hours/week: 27.5 h  (118 min x 14 runs/wk / 60)
     Note: estimate uses cron schedules only; manual workflow_dispatch runs are NOT counted.
-    [OK] Within budget (7 min headroom).
+    [OK] Within budget (0 min headroom).
 
 
-  $ query_time_budget.py --team runtime --testtype unit --machine wh_n150_civ2
+  $ query_time_budget.py --team runtime --budget-type unit --machine wh_n150_civ2
   Team 'runtime' / test type 'unit' / machine 'wh_n150_civ2'
-    Files scanned: 5
-    Tests matched: 20
-    Allocated:     222 min
-    Budget:        222 min
+    Files scanned: 1
+    Tests matched: 21
+    Allocated:     232 min
+    Budget:        232 min
     Scheduled pipelines (cron):
           7 runs/wk  code-coverage.yaml
           7 runs/wk  runtime-unit-tests.yaml
-    Est. machine-hours/week: 51.8 h  (222 min x 14 runs/wk / 60)
+    Est. machine-hours/week: 54.1 h  (232 min x 14 runs/wk / 60)
     Note: estimate uses cron schedules only; manual workflow_dispatch runs are NOT counted.
     [OK] Within budget (0 min headroom).
 """
@@ -67,7 +70,6 @@ Example
 import argparse
 import glob
 import os
-import re
 import sys
 
 import yaml
@@ -75,126 +77,61 @@ import yaml
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 TESTS_DIR = os.path.join(REPO_ROOT, "tests", "pipeline_reorg")
 DEFAULT_BUDGET_FILE = os.path.join(REPO_ROOT, ".github", "time_budget.yaml")
-TIERED_MODEL_TESTTYPES = {"unit", "e2e", "sweep"}
 WORKFLOWS_DIR = os.path.join(REPO_ROOT, ".github", "workflows")
 
+# Share the bucket-resolution rule with the CI check so the two cannot diverge.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from verify_time_budget import load_tests, resolve_budget_key  # noqa: E402
 
-_TESTS_YAML_RE = re.compile(r"TESTS_YAML_PATH:\s*\S*?([A-Za-z0-9_]+_tests\.yaml)")
+
+def target_budget_key(budgets, team, budget_type, tier):
+    """The budget key this query is asking about."""
+    return resolve_budget_key(budgets, team, budget_type, tier)
 
 
-def build_testtype_map(workflows_dir):
-    """Map each tests YAML (basename) to its budget test type, parsed from workflows.
+def collect_allocations(tests_dir, budgets, team, budget_type, machine, tier=None):
+    """Return (total_minutes, breakdown) for entries charged to this bucket.
 
-    The authoritative test type for a tests YAML is the workflow_name argument
-    passed to verify_time_budget.py in the workflow that runs it -- NOT the file
-    name. We read it live so the mapping tracks pipeline changes (and handles
-    cases where the file name differs from the budget key, e.g. release_tests.yaml
-    -> 'demo').
+    An entry contributes when its team matches, it has a timeout on `machine`,
+    and one of its declared `budget_type` values resolves to the same budget key
+    the query is targeting. breakdown is a list of
+    (file_basename, test_name, timeout, tier) tuples.
     """
-    mapping = {}
-    for path in glob.glob(os.path.join(workflows_dir, "*.y*ml")):
-        try:
-            with open(path, "r") as f:
-                lines = f.read().splitlines()
-        except OSError:
-            continue
-
-        test_files = {m.group(1) for line in lines for m in [_TESTS_YAML_RE.search(line)] if m}
-        if not test_files:
-            continue
-
-        # The workflow_name is the 3rd positional arg to verify_time_budget.py:
-        # the first literal token following the time_budget.yaml path argument.
-        workflow_name = None
-        for i, line in enumerate(lines):
-            if "verify_time_budget.py" not in line:
-                continue
-            for j in range(i + 1, min(i + 8, len(lines))):
-                if "time_budget.yaml" not in lines[j]:
-                    continue
-                for k in range(j + 1, min(j + 4, len(lines))):
-                    arg = lines[k].strip().rstrip("\\").strip().strip("\"'")
-                    if arg and not arg.startswith("${{"):
-                        workflow_name = arg
-                        break
-                break
-            if workflow_name:
-                break
-        if not workflow_name:
-            continue
-
-        for test_file in test_files:
-            mapping[test_file] = workflow_name
-    return mapping
-
-
-def find_test_files(tests_dir, testtype, testtype_map):
-    """Tests YAML paths in tests_dir whose budget test type equals `testtype`."""
-    return sorted(
-        path
-        for path in glob.glob(os.path.join(tests_dir, "*_tests.yaml"))
-        if testtype_map.get(os.path.basename(path)) == testtype
-    )
-
-
-def uses_tiered_model_budget(team, testtype):
-    """Whether this query should use the models-specific tiered budget split."""
-    return team == "models" and testtype in TIERED_MODEL_TESTTYPES
-
-
-def select_files_for_budget(files, team, testtype, tier):
-    """Return the files that correspond to the budget key being queried.
-
-    The models unit/e2e/sweep budgets are split: the plain keys cover non-tiered
-    pipelines, while the <testtype>_tier<n> keys cover models_<testtype>_tests.yaml.
-    """
-    if not uses_tiered_model_budget(team, testtype):
-        return files
-
-    tiered_filename = f"models_{testtype}_tests.yaml"
-    if tier is not None:
-        return [f for f in files if os.path.basename(f) == tiered_filename]
-    return [f for f in files if os.path.basename(f) != tiered_filename]
-
-
-def collect_allocations(files, team, machine, tier=None):
-    """Return (total_minutes, breakdown) for entries matching team/machine.
-
-    breakdown is a list of (file_basename, test_name, timeout, tier) tuples.
-    """
+    wanted = target_budget_key(budgets, team, budget_type, tier)
     total = 0
     breakdown = []
-    for path in files:
-        with open(path, "r") as f:
-            entries = yaml.safe_load(f) or []
+    for basename, entries in load_tests(tests_dir):
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
             if entry.get("team") != team:
                 continue
-            skus = entry.get("skus") or {}
-            sku_cfg = skus.get(machine)
+
+            declared = entry.get("budget_type")
+            budget_types = declared if isinstance(declared, list) else [declared]
+            if budget_type not in budget_types:
+                continue
+
+            sku_cfg = (entry.get("skus") or {}).get(machine)
             if not isinstance(sku_cfg, dict) or "timeout" not in sku_cfg:
                 continue
+
             entry_tier = sku_cfg.get("tier")
             if tier is not None and entry_tier != tier:
                 continue
+            if resolve_budget_key(budgets, team, budget_type, entry_tier) != wanted:
+                continue
+
             timeout = sku_cfg["timeout"]
             total += timeout
-            breakdown.append((os.path.basename(path), entry.get("name", "Unnamed"), timeout, entry_tier))
+            breakdown.append((basename, entry.get("name", "Unnamed"), timeout, entry_tier))
     return total, breakdown
 
 
-def lookup_budget(budget_file, team, testtype, machine, tier=None):
+def lookup_budget(budgets, team, budget_type, machine, tier=None):
     """Return the declared budget, or None if not present."""
-    with open(budget_file, "r") as f:
-        budgets = yaml.safe_load(f) or {}
     try:
-        team_budgets = budgets[team]
-        tiered_key = f"{testtype}_tier{tier}"
-        if tier is not None and tiered_key in team_budgets:
-            return team_budgets[tiered_key][machine]
-        return team_budgets[testtype][machine]
+        return budgets[team][target_budget_key(budgets, team, budget_type, tier)][machine]
     except (KeyError, TypeError):
         return None
 
@@ -321,7 +258,14 @@ def discover_scheduled_runs(workflow_index, test_file, tier):
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--team", required=True, help="Team name, e.g. models, llk, runtime")
-    parser.add_argument("--testtype", required=True, help="Test type, e.g. unit, sanity, stress, e2e")
+    # --budget-type matches the tests yaml field; --testtype is the original spelling.
+    parser.add_argument(
+        "--budget-type",
+        "--testtype",
+        dest="testtype",
+        required=True,
+        help="Budget type, e.g. unit, sanity, stress, e2e",
+    )
     parser.add_argument("--machine", required=True, help="SKU/machine name, e.g. wh_n150, wh_llmbox")
     parser.add_argument(
         "--tier", type=int, choices=(1, 2, 3), default=None, help="Optional: only sum entries of this tier"
@@ -334,20 +278,19 @@ def main():
     parser.add_argument("-v", "--verbose", action="store_true", help="Print per-test breakdown")
     args = parser.parse_args()
 
-    testtype_map = build_testtype_map(args.workflows_dir)
-    matching_files = find_test_files(args.tests_dir, args.testtype, testtype_map)
-    files = select_files_for_budget(matching_files, args.team, args.testtype, args.tier)
-    if not matching_files:
-        print(f"[WARN] No tests files map to budget test type '{args.testtype}' (checked {args.workflows_dir})")
-    elif not files:
-        print("[WARN] No files correspond to this budget key after applying model tier split rules")
+    with open(args.budget_file, "r") as f:
+        budgets = yaml.safe_load(f) or {}
 
-    total, breakdown = collect_allocations(files, args.team, args.machine, args.tier)
-    budget = lookup_budget(args.budget_file, args.team, args.testtype, args.machine, args.tier)
+    total, breakdown = collect_allocations(
+        args.tests_dir, budgets, args.team, args.testtype, args.machine, args.tier
+    )
+    budget = lookup_budget(budgets, args.team, args.testtype, args.machine, args.tier)
+    if not breakdown:
+        print(f"[WARN] No tests declare budget_type '{args.testtype}' for team '{args.team}' on '{args.machine}'")
 
     tier_note = f", tier {args.tier}" if args.tier is not None else ""
     print(f"Team '{args.team}' / test type '{args.testtype}' / machine '{args.machine}'{tier_note}")
-    print(f"  Files scanned: {len(files)}")
+    print(f"  Files scanned: {len({fname for fname, _, _, _ in breakdown})}")
     if args.verbose:
         for fname, name, timeout, etier in breakdown:
             tlabel = f" (tier {etier})" if etier is not None else ""

--- a/.github/scripts/utils/query_time_budget.py
+++ b/.github/scripts/utils/query_time_budget.py
@@ -281,9 +281,7 @@ def main():
     with open(args.budget_file, "r") as f:
         budgets = yaml.safe_load(f) or {}
 
-    total, breakdown = collect_allocations(
-        args.tests_dir, budgets, args.team, args.testtype, args.machine, args.tier
-    )
+    total, breakdown = collect_allocations(args.tests_dir, budgets, args.team, args.testtype, args.machine, args.tier)
     budget = lookup_budget(budgets, args.team, args.testtype, args.machine, args.tier)
     if not breakdown:
         print(f"[WARN] No tests declare budget_type '{args.testtype}' for team '{args.team}' on '{args.machine}'")

--- a/.github/scripts/utils/query_time_budget.py
+++ b/.github/scripts/utils/query_time_budget.py
@@ -177,13 +177,42 @@ def cron_runs_per_week(cron):
 
 
 def _workflow_call(job):
-    """Return (impl_basename, tier_value) for a reusable-workflow job, else None."""
+    """Return (impl_basename, tier_value, budget_type) for a reusable-workflow job.
+
+    `budget_type` is the caller's `budget-type:` input, or None when it does not
+    pass one. It says which allowance this particular invocation spends, which the
+    tests yaml cannot express when one list is run by two pipelines.
+    """
     uses = job.get("uses")
     if not isinstance(uses, str) or ".github/workflows/" not in uses:
         return None
     impl = uses.split(".github/workflows/", 1)[1].split("@", 1)[0].strip()
-    tier = (job.get("with") or {}).get("tier")
-    return os.path.basename(impl), tier
+    with_ = job.get("with") or {}
+    return os.path.basename(impl), with_.get("tier"), with_.get("budget-type")
+
+
+def impl_budget_type_defaults(workflows_dir):
+    """{impl_basename: default `budget-type` input} for impls that declare one.
+
+    A caller that omits `budget-type` spends the impl's default, so the default is
+    part of the attribution (pr-gate omits it and gets llk-smoke-impl's pr_gate).
+    """
+    defaults = {}
+    for path in glob.glob(os.path.join(workflows_dir, "*.y*ml")):
+        try:
+            with open(path, "r") as f:
+                data = yaml.safe_load(f)
+        except (yaml.YAMLError, OSError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        triggers = data.get("on", data.get(True)) or {}
+        call = triggers.get("workflow_call") if isinstance(triggers, dict) else None
+        inputs = (call or {}).get("inputs") or {} if isinstance(call, dict) else {}
+        spec = inputs.get("budget-type")
+        if isinstance(spec, dict) and "default" in spec:
+            defaults[os.path.basename(path)] = spec["default"]
+    return defaults
 
 
 def build_workflow_index(workflows_dir):
@@ -229,13 +258,20 @@ def build_workflow_index(workflows_dir):
     return index
 
 
-def discover_scheduled_runs(workflow_index, test_file, tier):
+def discover_scheduled_runs(workflow_index, test_file, tier, budget_type=None, impl_defaults=None):
     """Map a test file to {scheduled_workflow_basename: runs_per_week}.
 
     Walks the reuse graph: a test file is run by the impl whose TESTS_YAML_PATH
     references it, and that impl is triggered by scheduled caller workflows. When
     a tier is queried, callers that pass a non-matching `tier:` input are skipped.
+
+    When the impl takes a `budget-type` input, a caller only counts towards the
+    queried budget_type if that is the allowance it spends (its own input, else the
+    impl's default). Without this a tests yaml that declares several budget_types
+    would credit every one of them with every scheduled consumer -- charging the PR
+    gate with the sanity cron, for instance, when the gate has no cron at all.
     """
+    impl_defaults = impl_defaults or {}
     runner_names = {w["name"] for w in workflow_index if test_file in w["tests_yaml"]}
     runs = {}
     for w in workflow_index:
@@ -246,11 +282,15 @@ def discover_scheduled_runs(workflow_index, test_file, tier):
         if w["name"] in runner_names:
             runs[w["name"]] = weekly
         # A scheduled workflow that calls the impl which runs the test file.
-        for impl, tier_val in w["calls"]:
+        for impl, tier_val, call_budget_type in w["calls"]:
             if impl not in runner_names:
                 continue
             if tier is not None and tier_val is not None and str(tier_val) != str(tier):
                 continue
+            if budget_type is not None and impl in impl_defaults:
+                spends = call_budget_type if call_budget_type is not None else impl_defaults[impl]
+                if str(spends) != str(budget_type):
+                    continue
             runs[w["name"]] = weekly
     return runs
 
@@ -303,10 +343,14 @@ def main():
 
     # --- Estimated weekly machine-hours (cron-scheduled runs only) ---
     workflow_index = build_workflow_index(args.workflows_dir)
+    impl_defaults = impl_budget_type_defaults(args.workflows_dir)
     contributing_files = sorted({fname for fname, _, _, _ in breakdown})
     runs_by_workflow = {}
     for fname in contributing_files:
-        for workflow, weekly in discover_scheduled_runs(workflow_index, fname, args.tier).items():
+        scheduled = discover_scheduled_runs(
+            workflow_index, fname, args.tier, budget_type=args.testtype, impl_defaults=impl_defaults
+        )
+        for workflow, weekly in scheduled.items():
             runs_by_workflow[workflow] = weekly
     total_runs = sum(runs_by_workflow.values())
 

--- a/.github/scripts/utils/verify_time_budget.py
+++ b/.github/scripts/utils/verify_time_budget.py
@@ -442,9 +442,7 @@ def comment_body(problems):
         f"{COMMENT_MARKER} status=fail -->",
         "## :rotating_light: Time budget check failed",
         "",
-        f"pr-gate's `verify-time-budgets` found {len(problems)} {plural}. It reads every "
-        "`tests/pipeline_reorg/*.yaml` at once, because the budget for a "
-        "`(team, budget_type, sku)` bucket is the sum across **all** yamls that charge it.",
+        f"pr-gate's `verify-time-budgets` found {len(problems)} {plural}.",
     ]
 
     overflows = by_kind.pop("overflow", [])
@@ -453,9 +451,7 @@ def comment_body(problems):
             "",
             f"### Budget exceeded ({len(overflows)})",
             "",
-            "A bucket can go over even when no single yaml grew much, since the allowance is "
-            "shared. Trim the timeouts below, or raise the budget in "
-            f"{BUDGET_FILE_LINK} with a justification in the PR description.",
+            f"Trim the timeouts below, or raise the budget in {BUDGET_FILE_LINK} with a justification in the PR description.",
             "",
             "| Budget bucket | Over by | Allocated | Budget | Test yamls charging it |",
             "|---|---:|---:|---:|---|",

--- a/.github/scripts/utils/verify_time_budget.py
+++ b/.github/scripts/utils/verify_time_budget.py
@@ -1,158 +1,245 @@
+#!/usr/bin/env python3
+
+"""Verify every test yaml's timeouts against the team time budgets, repo-wide.
+
+This runs ONCE per PR (the verify-time-budgets job in pr-gate.yaml) over every
+tests/pipeline_reorg/*.yaml at the same time. Seeing all of them together is the
+whole point: several yamls charge the same (team, budget_type, sku) bucket, and
+the budget for that bucket is the sum across all of them. Checking one yaml at a
+time -- which is what this script used to do, with the budget key passed in as a
+CLI argument by each individual workflow -- let every yaml claim the full budget
+independently, so a shared bucket could be spent two or three times over.
+
+Bucket resolution
+-----------------
+Each test entry declares its own bucket coordinates:
+
+    team:        <team>   # which team's allowance to charge
+    budget_type: <key>    # which allowance under that team
+    skus:
+      <sku>:
+        timeout: <min>    # minutes charged to (team, budget_type, sku)
+        tier: <n>         # optional, see below
+
+The budget is budgets[team][budget_type][sku] in .github/time_budget.yaml.
+
+`budget_type` may also be a LIST, for a tests yaml that one pipeline runs against
+one allowance and another pipeline runs against a different one. The timeouts are
+charged to every listed allowance, and each must cover them on its own, because
+each pipeline spends its own budget when it runs. llk_pr_gate_tests.yaml is the
+live case: the PR gate charges llk.pr_gate and sanity-tests charges llk.sanity for
+the same tests, deliberately, so that widening one pipeline's pytest markers cannot
+silently eat the other's allowance.
+
+Tiers: when a sku entry carries `tier: n`, the key becomes "<budget_type>_tier<n>"
+IF the team declares that key, otherwise the plain "<budget_type>" key is used and
+the tiers are pooled. That keeps the split a property of the budget file: to break
+a pooled budget out per tier, add the tiered keys to time_budget.yaml and nothing
+in the test yamls has to change.
+
+Per-test ceiling
+----------------
+The gates additionally cap how long any ONE test may take, so that a single entry
+cannot hold up the whole gate no matter how much budget its team has left. That
+applies to the gate budget types below and is checked here rather than passed in
+per workflow, which is what the old `per-test-timeout` workflow input did.
+"""
+
 import argparse
-import yaml
+import glob
+import os
 import sys
 from collections import defaultdict
 
+import yaml
 
-def verify_timeouts(tests_file, time_budget_file, workflow_name, tier=None, max_per_test_timeout=None):
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+DEFAULT_TESTS_DIR = os.path.join(REPO_ROOT, "tests", "pipeline_reorg")
+DEFAULT_BUDGET_FILE = os.path.join(REPO_ROOT, ".github", "time_budget.yaml")
+
+# Budget types that gate a merge, and the ceiling on any single test entry in them.
+GATE_BUDGET_TYPES = {"pr_gate", "merge_gate"}
+GATE_PER_TEST_CEILING_MINUTES = 15
+
+
+def resolve_budget_key(budgets, team, budget_type, tier):
+    """Bucket key for a sku entry: tiered when the team declares it, else plain."""
+    if tier is None:
+        return budget_type
+    tiered = f"{budget_type}_tier{tier}"
+    team_budgets = budgets.get(team)
+    if isinstance(team_budgets, dict) and tiered in team_budgets:
+        return tiered
+    return budget_type
+
+
+def load_tests(tests_dir):
+    """Yield (basename, entries) for each test-list yaml under tests_dir.
+
+    Files whose top level is not a list (e.g. ttsim-skip-list.yaml) are not test
+    lists and are skipped.
     """
-    Verifies that the SUM of all test timeouts for each (Team, SKU) pair in tests_file
-    is within the total time budget defined in time_budget_file for the given workflow.
-
-    When `tier` is provided, only the SKU entries whose `tier` matches are summed, and
-    the budget is looked up under the per-tier key "<workflow_name>_tier<tier>" (e.g.
-    "unit_tier1"). When `tier` is None the behaviour is unchanged: every SKU entry is
-    summed and the budget is looked up under the plain "<workflow_name>" key.
-
-    When `max_per_test_timeout` is provided, every individual SKU timeout in the tests
-    file must be <= that limit (minutes). Used by smoke/basic to enforce a per-entry
-    ceiling for a given pipeline (e.g. merge_gate).
-    """
-    budget_workflow = workflow_name if tier is None else f"{workflow_name}_tier{tier}"
-
-    print(f"Loading time budgets from: {time_budget_file}")
-    with open(time_budget_file, "r") as f:
-        budgets = yaml.safe_load(f)
-
-    print(f"Loading tests from: {tests_file}")
-    with open(tests_file, "r") as f:
-        tests = yaml.safe_load(f) or []
-
-    if tier is not None:
-        print(f"Filtering tests to tier '{tier}'; budgets looked up under workflow key '{budget_workflow}'.")
-
-    if max_per_test_timeout is not None:
-        print(f"Enforcing max per-test timeout of {max_per_test_timeout} min " f"for pipeline '{workflow_name}'.")
-
-    errors_found = False
-
-    # --- Part 1: Validate test file format and sum timeouts per (Team, SKU) pair ---
-    print("\n--- Summing Test Timeouts per Team and SKU ---")
-
-    # The key will now be a tuple: (team, sku)
-    # e.g., {('ops', 'N300'): 20, ('models', 'N300'): 15}
-    budget_totals = defaultdict(int)
-
-    for test in tests:
-        test_name = test.get("name", "Unnamed Test")
-
-        # Validate that all mandatory keys exist for this test
-        required_keys = ["skus", "team"]
-        missing_keys = [key for key in required_keys if key not in test]
-        if missing_keys:
-            print(
-                f"  [ERROR] Validation FAILED! Test '{test_name}' is missing mandatory keys: {', '.join(missing_keys)}."
-            )
-            errors_found = True
-            continue  # Skip this invalid test
-
-        test_skus = test["skus"]
-        test_team = test["team"]
-
-        if not isinstance(test_skus, dict) or not test_skus:
-            print(
-                f"  [ERROR] Validation FAILED! Test '{test_name}' has invalid 'skus' field. "
-                f"Expected a non-empty mapping of SKU names to their config."
-            )
-            errors_found = True
+    for path in sorted(glob.glob(os.path.join(tests_dir, "*.yaml"))):
+        with open(path, "r") as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, list):
             continue
+        yield os.path.basename(path), data
 
-        for sku_name, sku_config in test_skus.items():
-            if not isinstance(sku_config, dict) or "timeout" not in sku_config:
-                print(f"  [ERROR] Validation FAILED! Test '{test_name}', SKU '{sku_name}' is missing 'timeout'.")
-                errors_found = True
+
+def collect(tests_dir, budgets, errors):
+    """Sum every test's timeouts into its bucket.
+
+    Returns {(team, budget_key, sku): {yaml_basename: minutes}}.
+    """
+    buckets = defaultdict(lambda: defaultdict(int))
+
+    for basename, entries in load_tests(tests_dir):
+        for index, test in enumerate(entries):
+            if not isinstance(test, dict):
+                errors.append(f"{basename}: entry #{index} is not a mapping.")
                 continue
 
-            # When verifying a specific tier, only count SKU entries belonging to it.
-            if tier is not None and str(sku_config.get("tier")) != str(tier):
+            label = f"{basename}: '{test.get('name', f'entry #{index}')}'"
+            missing = [key for key in ("team", "budget_type", "skus") if key not in test]
+            if missing:
+                errors.append(f"{label} is missing mandatory key(s): {', '.join(missing)}.")
                 continue
 
-            test_timeout = sku_config["timeout"]
+            team, skus = test["team"], test["skus"]
+            if not isinstance(skus, dict) or not skus:
+                errors.append(f"{label} has an invalid 'skus' field; expected a non-empty mapping.")
+                continue
 
-            if max_per_test_timeout is not None and float(test_timeout) > float(max_per_test_timeout):
-                print(
-                    f"  [ERROR] Per-test timeout FAILED! Test '{test_name}', SKU '{sku_name}' "
-                    f"has timeout {test_timeout} min, which exceeds the max per-test timeout of "
-                    f"{max_per_test_timeout} min for pipeline '{workflow_name}'."
-                )
-                errors_found = True
+            # A single key or a list of them; charged to each independently.
+            declared = test["budget_type"]
+            budget_types = declared if isinstance(declared, list) else [declared]
+            if not budget_types or not all(isinstance(b, str) for b in budget_types):
+                errors.append(f"{label} has an invalid 'budget_type'; expected a string or list of strings.")
+                continue
+            gated = [b for b in budget_types if b in GATE_BUDGET_TYPES]
 
-            # Use a tuple (team, sku) as the key for summation
-            budget_key = (test_team, sku_name)
-            budget_totals[budget_key] += test_timeout
-            print(f"  Test '{test_name}' (Team: {test_team}, SKU: {sku_name}) adds {test_timeout} min.")
+            for sku, config in skus.items():
+                if not isinstance(config, dict) or "timeout" not in config:
+                    errors.append(f"{label}, SKU '{sku}' is missing 'timeout'.")
+                    continue
 
-    if errors_found:
-        print(f"\nValidation errors in {tests_file}. Please fix the entries above.")
-        sys.exit(1)
+                timeout = config["timeout"]
+                if gated and timeout > GATE_PER_TEST_CEILING_MINUTES:
+                    errors.append(
+                        f"{label}, SKU '{sku}' has timeout {timeout} min, over the "
+                        f"{GATE_PER_TEST_CEILING_MINUTES} min per-test ceiling for "
+                        f"{' and '.join(repr(b) for b in gated)}."
+                    )
 
-    # --- Part 2: Verify Total Time Budget for each (Team, SKU) pair ---
-    print("\n--- Verifying Total Time Budgets ---")
+                for budget_type in budget_types:
+                    key = (team, resolve_budget_key(budgets, team, budget_type, config.get("tier")), sku)
+                    buckets[key][basename] += timeout
 
-    for (team, sku), total_time_requested in budget_totals.items():
+    return buckets
+
+
+def declared_buckets(budgets):
+    """Every (team, budget_type, sku) triple that has a budget declared."""
+    declared = set()
+    for team, budget_types in budgets.items():
+        if not isinstance(budget_types, dict):
+            continue
+        for budget_type, skus in budget_types.items():
+            if isinstance(skus, dict):
+                declared.update((team, budget_type, sku) for sku in skus)
+    return declared
+
+
+def check(buckets, budgets, errors):
+    """Compare each bucket's total against its budget. Returns report rows."""
+    rows = []
+    for key in sorted(buckets, key=lambda k: (k[0] or "", k[1], k[2])):
+        team, budget_type, sku = key
+        contributors = buckets[key]
+        total = sum(contributors.values())
         try:
-            # Navigate the budgets config using team, workflow (or per-tier key), and sku
-            total_time_budget = budgets[team][budget_workflow][sku]
-
-            print(
-                f"Checking total for Team '{team}', SKU '{sku}': Requested = {total_time_requested} min, Budget = {total_time_budget} min"
-            )
-
-            if total_time_requested > total_time_budget:
-                print(
-                    f"  [ERROR] Total Time Budget FAILED for Team '{team}', SKU '{sku}'! "
-                    f"The sum of test timeouts ({total_time_requested} min) exceeds the allocated budget of {total_time_budget} min."
-                )
-                errors_found = True
-            else:
-                print(f"  [OK] Total time for Team '{team}', SKU '{sku}' is within the budget.")
-
+            budget = budgets[team][budget_type][sku]
         except (KeyError, TypeError):
-            print(
-                f"  [ERROR] Configuration FAILED! Could not find a 'time_budget' for Team '{team}', Workflow '{budget_workflow}', SKU '{sku}' in {time_budget_file}."
+            errors.append(
+                f"No budget declared for team '{team}', budget_type '{budget_type}', SKU '{sku}' "
+                f"(charged {total} min by {', '.join(sorted(contributors))})."
             )
-            errors_found = True
+            rows.append((team, budget_type, sku, total, None, contributors))
             continue
 
-    # --- Final Verdict ---
-    if errors_found:
-        print("\nVerification failed.")
-        sys.exit(1)
-    else:
-        print("\nVerification successful.")
-        sys.exit(0)
+        if total > budget:
+            errors.append(
+                f"Over budget: team '{team}', budget_type '{budget_type}', SKU '{sku}' "
+                f"sums to {total} min against a budget of {budget} min (over by {total - budget}). "
+                f"Contributors: {', '.join(f'{f} {m} min' for f, m in sorted(contributors.items()))}."
+            )
+        rows.append((team, budget_type, sku, total, budget, contributors))
+    return rows
+
+
+def render(rows, unused, errors):
+    """Write the full allocation table to stdout and the GitHub step summary."""
+    lines = ["# Time budget report", ""]
+    lines.append(f"{len(rows)} buckets charged. " + ("**FAILED**" if errors else "All within budget."))
+    lines.append("")
+    lines.append("| Team | Budget type | SKU | Allocated | Budget | Headroom | Test yamls |")
+    lines.append("|---|---|---|---|---|---:|---|")
+    for team, budget_type, sku, total, budget, contributors in rows:
+        headroom = "n/a" if budget is None else str(budget - total)
+        flag = " :warning:" if budget is not None and total > budget else ""
+        files = ", ".join(f"{f} ({m})" for f, m in sorted(contributors.items(), key=lambda x: -x[1]))
+        lines.append(
+            f"| {team} | {budget_type} | {sku} | {total} | {'none' if budget is None else budget} "
+            f"| {headroom}{flag} | {files} |"
+        )
+
+    if unused:
+        lines.append("")
+        lines.append(f"## Unused budget entries ({len(unused)})")
+        lines.append("")
+        lines.append("No test charges these, so the capacity they reserve is idle:")
+        lines.append("")
+        for team, budget_type, sku in sorted(unused):
+            lines.append(f"- `{team}` / `{budget_type}` / `{sku}`")
+
+    if errors:
+        lines.append("")
+        lines.append(f"## Errors ({len(errors)})")
+        lines.append("")
+        lines.extend(f"- {error}" for error in errors)
+
+    report = "\n".join(lines)
+    print(report)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a") as f:
+            f.write(report + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--tests-dir", default=DEFAULT_TESTS_DIR, help="Directory of test yamls")
+    parser.add_argument("--budget-file", default=DEFAULT_BUDGET_FILE, help="Path to time_budget.yaml")
+    args = parser.parse_args()
+
+    with open(args.budget_file, "r") as f:
+        budgets = yaml.safe_load(f) or {}
+
+    errors = []
+    buckets = collect(args.tests_dir, budgets, errors)
+    rows = check(buckets, budgets, errors)
+    unused = declared_buckets(budgets) - set(buckets)
+
+    render(rows, unused, errors)
+
+    if errors:
+        for error in errors:
+            print(f"::error::{error}")
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Verify test yaml timeouts against team time budgets (and optional per-test ceiling)."
-    )
-    parser.add_argument("tests_file", help="Path to pipeline_reorg tests yaml")
-    parser.add_argument("time_budget_file", help="Path to time_budget.yaml")
-    parser.add_argument("workflow_name", help="Budget workflow key (e.g. merge_gate, pr_gate, unit)")
-    parser.add_argument(
-        "tier",
-        nargs="?",
-        default=None,
-        help="Optional tier; budgets looked up under <workflow_name>_tier<tier>",
-    )
-    parser.add_argument(
-        "--max-per-test-timeout",
-        type=float,
-        default=None,
-        help="Optional max allowed timeout (minutes) for any individual test SKU entry",
-    )
-    args = parser.parse_args()
-
-    tier_arg = args.tier.strip() if args.tier and args.tier.strip() else None
-    verify_timeouts(args.tests_file, args.time_budget_file, args.workflow_name, tier_arg, args.max_per_test_timeout)
+    sys.exit(main())

--- a/.github/scripts/utils/verify_time_budget.py
+++ b/.github/scripts/utils/verify_time_budget.py
@@ -62,6 +62,12 @@ GATE_BUDGET_TYPES = {"pr_gate", "merge_gate"}
 GATE_PER_TEST_CEILING_MINUTES = 15
 
 
+def problem(kind, message, **fields):
+    """One failure. `message` goes to the log and the annotation; `kind` groups it
+    in the PR comment, where `fields` are rendered into something actionable."""
+    return {"kind": kind, "message": message, **fields}
+
+
 def resolve_budget_key(budgets, team, budget_type, tier):
     """Bucket key for a sku entry: tiered when the team declares it, else plain."""
     if tier is None:
@@ -87,7 +93,7 @@ def load_tests(tests_dir):
         yield os.path.basename(path), data
 
 
-def collect(tests_dir, budgets, errors):
+def collect(tests_dir, budgets, problems):
     """Sum every test's timeouts into its bucket.
 
     Returns {(team, budget_key, sku): {yaml_basename: minutes}}.
@@ -97,39 +103,86 @@ def collect(tests_dir, budgets, errors):
     for basename, entries in load_tests(tests_dir):
         for index, test in enumerate(entries):
             if not isinstance(test, dict):
-                errors.append(f"{basename}: entry #{index} is not a mapping.")
+                problems.append(
+                    problem(
+                        "not_mapping",
+                        f"{basename}: entry #{index} is not a mapping.",
+                        yaml=basename,
+                        test=f"entry #{index}",
+                    )
+                )
                 continue
 
-            label = f"{basename}: '{test.get('name', f'entry #{index}')}'"
+            name = test.get("name", f"entry #{index}")
+            label = f"{basename}: '{name}'"
             missing = [key for key in ("team", "budget_type", "skus") if key not in test]
             if missing:
-                errors.append(f"{label} is missing mandatory key(s): {', '.join(missing)}.")
+                problems.append(
+                    problem(
+                        "missing_field",
+                        f"{label} is missing mandatory key(s): {', '.join(missing)}.",
+                        yaml=basename,
+                        test=name,
+                        missing=missing,
+                    )
+                )
                 continue
 
             team, skus = test["team"], test["skus"]
             if not isinstance(skus, dict) or not skus:
-                errors.append(f"{label} has an invalid 'skus' field; expected a non-empty mapping.")
+                problems.append(
+                    problem(
+                        "bad_skus",
+                        f"{label} has an invalid 'skus' field; expected a non-empty mapping.",
+                        yaml=basename,
+                        test=name,
+                    )
+                )
                 continue
 
             # A single key or a list of them; charged to each independently.
             declared = test["budget_type"]
             budget_types = declared if isinstance(declared, list) else [declared]
             if not budget_types or not all(isinstance(b, str) for b in budget_types):
-                errors.append(f"{label} has an invalid 'budget_type'; expected a string or list of strings.")
+                problems.append(
+                    problem(
+                        "bad_budget_type",
+                        f"{label} has an invalid 'budget_type'; expected a string or list of strings.",
+                        yaml=basename,
+                        test=name,
+                        found=repr(declared),
+                    )
+                )
                 continue
             gated = [b for b in budget_types if b in GATE_BUDGET_TYPES]
 
             for sku, config in skus.items():
                 if not isinstance(config, dict) or "timeout" not in config:
-                    errors.append(f"{label}, SKU '{sku}' is missing 'timeout'.")
+                    problems.append(
+                        problem(
+                            "missing_timeout",
+                            f"{label}, SKU '{sku}' is missing 'timeout'.",
+                            yaml=basename,
+                            test=name,
+                            sku=sku,
+                        )
+                    )
                     continue
 
                 timeout = config["timeout"]
                 if gated and timeout > GATE_PER_TEST_CEILING_MINUTES:
-                    errors.append(
-                        f"{label}, SKU '{sku}' has timeout {timeout} min, over the "
-                        f"{GATE_PER_TEST_CEILING_MINUTES} min per-test ceiling for "
-                        f"{' and '.join(repr(b) for b in gated)}."
+                    problems.append(
+                        problem(
+                            "ceiling",
+                            f"{label}, SKU '{sku}' has timeout {timeout} min, over the "
+                            f"{GATE_PER_TEST_CEILING_MINUTES} min per-test ceiling for "
+                            f"{' and '.join(repr(b) for b in gated)}.",
+                            yaml=basename,
+                            test=name,
+                            sku=sku,
+                            timeout=timeout,
+                            gated=gated,
+                        )
                     )
 
                 for budget_type in budget_types:
@@ -151,92 +204,352 @@ def declared_buckets(budgets):
     return declared
 
 
-def check(buckets, budgets, errors):
+def check(buckets, budgets, problems):
     """Compare each bucket's total against its budget. Returns report rows."""
     rows = []
     for key in sorted(buckets, key=lambda k: (k[0] or "", k[1], k[2])):
         team, budget_type, sku = key
         contributors = buckets[key]
         total = sum(contributors.values())
+        ranked = dict(sorted(contributors.items(), key=lambda x: -x[1]))
         try:
             budget = budgets[team][budget_type][sku]
         except (KeyError, TypeError):
-            errors.append(
-                f"No budget declared for team '{team}', budget_type '{budget_type}', SKU '{sku}' "
-                f"(charged {total} min by {', '.join(sorted(contributors))})."
+            problems.append(
+                problem(
+                    "undeclared",
+                    f"No budget declared for team '{team}', budget_type '{budget_type}', SKU '{sku}' "
+                    f"(charged {total} min by {', '.join(sorted(contributors))}).",
+                    team=team,
+                    budget_type=budget_type,
+                    sku=sku,
+                    allocated=total,
+                    contributors=ranked,
+                )
             )
             rows.append((team, budget_type, sku, total, None, contributors))
             continue
 
         if total > budget:
-            errors.append(
-                f"Over budget: team '{team}', budget_type '{budget_type}', SKU '{sku}' "
-                f"sums to {total} min against a budget of {budget} min (over by {total - budget}). "
-                f"Contributors: {', '.join(f'{f} {m} min' for f, m in sorted(contributors.items()))}."
+            problems.append(
+                problem(
+                    "overflow",
+                    f"Over budget: team '{team}', budget_type '{budget_type}', SKU '{sku}' "
+                    f"sums to {total} min against a budget of {budget} min (over by {total - budget}). "
+                    f"Contributors: {', '.join(f'{f} {m} min' for f, m in sorted(contributors.items()))}.",
+                    team=team,
+                    budget_type=budget_type,
+                    sku=sku,
+                    allocated=total,
+                    budget=budget,
+                    over_by=total - budget,
+                    contributors=ranked,
+                )
             )
         rows.append((team, budget_type, sku, total, budget, contributors))
     return rows
 
 
-def render(rows, unused, errors):
-    """Write the full allocation table to stdout and the GitHub step summary."""
-    lines = ["# Time budget report", ""]
-    lines.append(f"{len(rows)} buckets charged. " + ("**FAILED**" if errors else "All within budget."))
-    lines.append("")
-    lines.append("| Team | Budget type | SKU | Allocated | Budget | Headroom | Test yamls |")
-    lines.append("|---|---|---|---|---|---:|---|")
+HEADERS = ("Team", "Budget type", "SKU", "Allocated", "Budget", "Headroom", "Test yamls")
+# Right-align the three numeric columns; the rest read better left-aligned.
+NUMERIC_COLUMNS = {3, 4, 5}
+
+
+def table_cells(rows):
+    """One list of display strings per row, in HEADERS order."""
+    cells = []
     for team, budget_type, sku, total, budget, contributors in rows:
+        over = budget is not None and total > budget
         headroom = "n/a" if budget is None else str(budget - total)
-        flag = " :warning:" if budget is not None and total > budget else ""
-        files = ", ".join(f"{f} ({m})" for f, m in sorted(contributors.items(), key=lambda x: -x[1]))
-        lines.append(
-            f"| {team} | {budget_type} | {sku} | {total} | {'none' if budget is None else budget} "
-            f"| {headroom}{flag} | {files} |"
+        cells.append(
+            [
+                team,
+                budget_type,
+                sku,
+                str(total),
+                "none" if budget is None else str(budget),
+                headroom + (" !" if over else ""),
+                ", ".join(f"{f} ({m})" for f, m in sorted(contributors.items(), key=lambda x: -x[1])),
+            ]
         )
+    return cells
+
+
+def render_text(rows, unused, errors):
+    """Column-aligned plain text, for reading in the raw job log.
+
+    Padded with spaces rather than tabs: a tab advances to the next 8-column stop,
+    so any cell longer than its stop pushes the rest of the row out of alignment.
+    """
+    cells = table_cells(rows)
+    widths = [max(len(h), *(len(row[i]) for row in cells)) if cells else len(h) for i, h in enumerate(HEADERS)]
+
+    def line(values):
+        padded = [
+            v.rjust(widths[i]) if i in NUMERIC_COLUMNS else v.ljust(widths[i]) for i, v in enumerate(values)
+        ]
+        return "  ".join(padded).rstrip()
+
+    header = line(HEADERS)
+    rule = len(header)
+
+    def section(title):
+        return ["", f"-- {title} ".ljust(rule, "-"), ""]
+
+    out = ["", "=" * rule, "Time budget report", "=" * rule, ""]
+    out.append(f"{len(rows)} buckets charged. " + ("FAILED" if errors else "All within budget."))
+    out.append("")
+    out.append(header)
+    out.append("  ".join("-" * w for w in widths))
+    out.extend(line(row) for row in cells)
 
     if unused:
-        lines.append("")
-        lines.append(f"## Unused budget entries ({len(unused)})")
-        lines.append("")
-        lines.append("No test charges these, so the capacity they reserve is idle:")
-        lines.append("")
-        for team, budget_type, sku in sorted(unused):
-            lines.append(f"- `{team}` / `{budget_type}` / `{sku}`")
+        out += section(f"Unused budget entries ({len(unused)})")
+        out.append("No test charges these, so the capacity they reserve is idle:")
+        out.extend(f"  {team} / {budget_type} / {sku}" for team, budget_type, sku in sorted(unused))
 
     if errors:
-        lines.append("")
-        lines.append(f"## Errors ({len(errors)})")
-        lines.append("")
-        lines.extend(f"- {error}" for error in errors)
+        out += section(f"Errors ({len(errors)})")
+        out.extend(f"  * {error}" for error in errors)
 
-    report = "\n".join(lines)
-    print(report)
+    out.append("")
+    return "\n".join(out)
+
+
+def render_markdown(rows, unused, errors):
+    """Markdown, for the GitHub step summary where it renders as a real table."""
+    out = ["# Time budget report", ""]
+    out.append(f"{len(rows)} buckets charged. " + ("**FAILED**" if errors else "All within budget."))
+    out += ["", "| " + " | ".join(HEADERS) + " |", "|---|---|---|---:|---:|---:|---|"]
+    for row in table_cells(rows):
+        cells = list(row)
+        cells[5] = cells[5].replace(" !", " :warning:")
+        out.append("| " + " | ".join(cells) + " |")
+
+    if unused:
+        out += ["", f"## Unused budget entries ({len(unused)})", ""]
+        out.append("No test charges these, so the capacity they reserve is idle:")
+        out.append("")
+        out.extend(f"- `{team}` / `{budget_type}` / `{sku}`" for team, budget_type, sku in sorted(unused))
+
+    if errors:
+        out += ["", f"## Errors ({len(errors)})", ""]
+        out.extend(f"- {error}" for error in errors)
+
+    return "\n".join(out)
+
+
+def render(rows, unused, errors):
+    """Aligned text to the job log, markdown to the step summary."""
+    print(render_text(rows, unused, errors))
 
     summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary:
         with open(summary, "a") as f:
-            f.write(report + "\n")
+            f.write(render_markdown(rows, unused, errors) + "\n")
+
+
+# Marker the workflow greps for, so repeated pushes update one comment instead
+# of stacking a new one on every run. The trailing status= tells the workflow
+# whether this body is a failure report or the "now passing" note.
+COMMENT_MARKER = "<!-- time-budget-check"
+
+
+def yaml_permalink(basename):
+    """Blob URL for a tests yaml at the commit under test, or None off CI."""
+    server = os.environ.get("GITHUB_SERVER_URL")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    sha = os.environ.get("GITHUB_SHA")
+    if not (server and repo and sha):
+        return None
+    return f"{server}/{repo}/blob/{sha}/tests/pipeline_reorg/{basename}"
+
+
+BUDGET_FILE_LINK = (
+    "[`.github/time_budget.yaml`](https://github.com/tenstorrent/tt-metal/blob/main/.github/time_budget.yaml)"
+)
+
+# Per-kind heading and the explanation of how to fix it. Order sets comment order.
+PROBLEM_KINDS = (
+    (
+        "undeclared",
+        "No budget declared for a bucket",
+        "These tests charge a `(team, budget_type, sku)` bucket that has no budget in "
+        f"{BUDGET_FILE_LINK}. Either add the SKU under that team's `budget_type`, or point "
+        "the test at a `budget_type` the team already has.",
+    ),
+    (
+        "missing_field",
+        "Test entry missing a mandatory key",
+        "Every entry needs `team`, `budget_type` and `skus`. `budget_type` names which of "
+        f"the team's allowances in {BUDGET_FILE_LINK} the test is charged against — the same "
+        "key the pipeline that runs it is budgeted under (e.g. `unit`, `merge_gate`, `e2e`).",
+    ),
+    (
+        "ceiling",
+        "Test over the gate per-test ceiling",
+        f"No single test in a gate may exceed {GATE_PER_TEST_CEILING_MINUTES} min, so that one "
+        "entry cannot hold up the whole gate however much budget its team has left. Split the "
+        "test, or move it to a non-gate pipeline.",
+    ),
+    (
+        "missing_timeout",
+        "SKU entry missing a timeout",
+        "Every SKU under `skus` needs a `timeout` in minutes — that is the number charged "
+        "against the budget.",
+    ),
+    (
+        "bad_budget_type",
+        "Invalid `budget_type`",
+        "`budget_type` must be a string, or a list of strings when one yaml is run by two "
+        "pipelines that charge different allowances.",
+    ),
+    (
+        "bad_skus",
+        "Invalid `skus` field",
+        "`skus` must be a non-empty mapping of SKU name to its config.",
+    ),
+    (
+        "not_mapping",
+        "Entry is not a mapping",
+        "Each item in a tests yaml must be a mapping of fields, not a bare scalar or list.",
+    ),
+)
+
+
+def yaml_link(basename):
+    """Markdown link to a tests yaml, or bare text when the permalink is unavailable."""
+    url = yaml_permalink(basename)
+    return f"[{basename}]({url})" if url else f"`{basename}`"
+
+
+def comment_body(problems):
+    """Markdown PR comment explaining every failure, grouped by kind."""
+    if not problems:
+        return "\n".join(
+            [
+                f"{COMMENT_MARKER} status=pass -->",
+                "## :white_check_mark: Time budget check passed",
+                "",
+                "Every `(team, budget_type, sku)` bucket is within its budget. The full "
+                "allocation table is in the job summary.",
+            ]
+        )
+
+    by_kind = defaultdict(list)
+    for item in problems:
+        by_kind[item["kind"]].append(item)
+
+    plural = "problem" if len(problems) == 1 else "problems"
+    lines = [
+        f"{COMMENT_MARKER} status=fail -->",
+        "## :rotating_light: Time budget check failed",
+        "",
+        f"pr-gate's `verify-time-budgets` found {len(problems)} {plural}. It reads every "
+        "`tests/pipeline_reorg/*.yaml` at once, because the budget for a "
+        "`(team, budget_type, sku)` bucket is the sum across **all** yamls that charge it.",
+    ]
+
+    overflows = by_kind.pop("overflow", [])
+    if overflows:
+        lines += [
+            "",
+            f"### Budget exceeded ({len(overflows)})",
+            "",
+            "A bucket can go over even when no single yaml grew much, since the allowance is "
+            "shared. Trim the timeouts below, or raise the budget in "
+            f"{BUDGET_FILE_LINK} with a justification in the PR description.",
+            "",
+            "| Budget bucket | Over by | Allocated | Budget | Test yamls charging it |",
+            "|---|---:|---:|---:|---|",
+        ]
+        for overflow in overflows:
+            charged = "<br>".join(
+                f"{yaml_link(basename)} ({minutes} min)" for basename, minutes in overflow["contributors"].items()
+            )
+            lines.append(
+                f"| `{overflow['team']}` / `{overflow['budget_type']}` / `{overflow['sku']}` "
+                f"| **{overflow['over_by']} min** | {overflow['allocated']} | {overflow['budget']} "
+                f"| {charged} |"
+            )
+
+    for kind, heading, explanation in PROBLEM_KINDS:
+        items = by_kind.pop(kind, [])
+        if not items:
+            continue
+        lines += ["", f"### {heading} ({len(items)})", "", explanation, ""]
+        for item in items:
+            if kind == "undeclared":
+                charged = ", ".join(yaml_link(b) for b in item["contributors"])
+                lines.append(
+                    f"- `{item['team']}` / `{item['budget_type']}` / `{item['sku']}` — "
+                    f"{item['allocated']} min charged by {charged}"
+                )
+            elif kind == "ceiling":
+                lines.append(
+                    f"- {yaml_link(item['yaml'])} → **{item['test']}** on `{item['sku']}` — "
+                    f"{item['timeout']} min, over the {GATE_PER_TEST_CEILING_MINUTES} min ceiling "
+                    f"for {', '.join(f'`{g}`' for g in item['gated'])}"
+                )
+            elif kind == "missing_field":
+                keys = ", ".join(f"`{k}`" for k in item["missing"])
+                lines.append(f"- {yaml_link(item['yaml'])} → **{item['test']}** — missing {keys}")
+            elif kind == "missing_timeout":
+                lines.append(
+                    f"- {yaml_link(item['yaml'])} → **{item['test']}** — SKU `{item['sku']}` has no `timeout`"
+                )
+            elif kind == "bad_budget_type":
+                lines.append(
+                    f"- {yaml_link(item['yaml'])} → **{item['test']}** — got `{item['found']}`"
+                )
+            else:
+                lines.append(f"- {yaml_link(item['yaml'])} → **{item['test']}**")
+
+    # Anything whose kind predates its entry in PROBLEM_KINDS still gets reported.
+    for kind, items in by_kind.items():
+        lines += ["", f"### {kind} ({len(items)})", ""]
+        lines.extend(f"- {item['message']}" for item in items)
+
+    return "\n".join(lines)
+
+
+def write_comment(problems, path):
+    """Write the PR comment body. Always written, so a fixed PR can clear its comment."""
+    with open(path, "w") as f:
+        f.write(comment_body(problems) + "\n")
+    state = f"{len(problems)} problem(s)" if problems else "pass"
+    print(f"\nWrote PR comment body ({state}) to {path}")
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--tests-dir", default=DEFAULT_TESTS_DIR, help="Directory of test yamls")
     parser.add_argument("--budget-file", default=DEFAULT_BUDGET_FILE, help="Path to time_budget.yaml")
+    parser.add_argument(
+        "--comment-file",
+        default=None,
+        help="Write the PR comment body here. Always written when given: a report of every "
+        "problem found, or a short note that the check passed so a PR that fixed its "
+        "overspend can clear the stale comment.",
+    )
     args = parser.parse_args()
 
     with open(args.budget_file, "r") as f:
         budgets = yaml.safe_load(f) or {}
 
-    errors = []
-    buckets = collect(args.tests_dir, budgets, errors)
-    rows = check(buckets, budgets, errors)
+    problems = []
+    buckets = collect(args.tests_dir, budgets, problems)
+    rows = check(buckets, budgets, problems)
     unused = declared_buckets(budgets) - set(buckets)
 
-    render(rows, unused, errors)
+    render(rows, unused, [item["message"] for item in problems])
 
-    if errors:
-        for error in errors:
-            print(f"::error::{error}")
+    if args.comment_file:
+        write_comment(problems, args.comment_file)
+
+    if problems:
+        for item in problems:
+            print(f"::error::{item['message']}")
         return 1
     return 0
 

--- a/.github/scripts/utils/verify_time_budget.py
+++ b/.github/scripts/utils/verify_time_budget.py
@@ -285,9 +285,7 @@ def render_text(rows, unused, errors):
     widths = [max(len(h), *(len(row[i]) for row in cells)) if cells else len(h) for i, h in enumerate(HEADERS)]
 
     def line(values):
-        padded = [
-            v.rjust(widths[i]) if i in NUMERIC_COLUMNS else v.ljust(widths[i]) for i, v in enumerate(values)
-        ]
+        padded = [v.rjust(widths[i]) if i in NUMERIC_COLUMNS else v.ljust(widths[i]) for i, v in enumerate(values)]
         return "  ".join(padded).rstrip()
 
     header = line(HEADERS)
@@ -395,8 +393,7 @@ PROBLEM_KINDS = (
     (
         "missing_timeout",
         "SKU entry missing a timeout",
-        "Every SKU under `skus` needs a `timeout` in minutes — that is the number charged "
-        "against the budget.",
+        "Every SKU under `skus` needs a `timeout` in minutes — that is the number charged against the budget.",
     ),
     (
         "bad_budget_type",
@@ -495,13 +492,9 @@ def comment_body(problems):
                 keys = ", ".join(f"`{k}`" for k in item["missing"])
                 lines.append(f"- {yaml_link(item['yaml'])} → **{item['test']}** — missing {keys}")
             elif kind == "missing_timeout":
-                lines.append(
-                    f"- {yaml_link(item['yaml'])} → **{item['test']}** — SKU `{item['sku']}` has no `timeout`"
-                )
+                lines.append(f"- {yaml_link(item['yaml'])} → **{item['test']}** — SKU `{item['sku']}` has no `timeout`")
             elif kind == "bad_budget_type":
-                lines.append(
-                    f"- {yaml_link(item['yaml'])} → **{item['test']}** — got `{item['found']}`"
-                )
+                lines.append(f"- {yaml_link(item['yaml'])} → **{item['test']}** — got `{item['found']}`")
             else:
                 lines.append(f"- {yaml_link(item['yaml'])} → **{item['test']}**")
 

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -92,7 +92,7 @@ ttnn:
     bh_galaxy: 40
     bh_p100: 815
     bh_p150b_civ2: 850
-    wh_n150_civ2: 1040
+    wh_n150_civ2: 1000
     wh_n300_civ2: 1190
     bh_p150b_civ2_viommu: 117
     bh_p300: 60

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -92,7 +92,7 @@ ttnn:
     bh_galaxy: 40
     bh_p100: 815
     bh_p150b_civ2: 850
-    wh_n150_civ2: 1000
+    wh_n150_civ2: 1040
     wh_n300_civ2: 1190
     bh_p150b_civ2_viommu: 117
     bh_p300: 60

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -69,7 +69,7 @@ metal_infra:
 
 ttnn:
   pr_gate:
-    wh_n150_civ2: 15
+    wh_n150_civ2: 30
   merge_gate:
     wh_n150_civ2: 45
     wh_n300_civ2: 55
@@ -88,11 +88,11 @@ ttnn:
     sim_bh_p150: 680
   unit:
     wh_llmbox: 50
-    wh_galaxy: 120
+    wh_galaxy: 125
     bh_galaxy: 40
     bh_p100: 815
     bh_p150b_civ2: 850
-    wh_n150_civ2: 1020
+    wh_n150_civ2: 1040
     wh_n300_civ2: 1190
     bh_p150b_civ2_viommu: 117
     bh_p300: 60
@@ -243,7 +243,7 @@ scaleout:
 
 runtime:
   pr_gate:
-    wh_n150_civ2: 15
+    wh_n150_civ2: 30
     github_hosted_cpu: 15
   merge_gate:
     wh_n150_civ2: 45

--- a/.github/workflows/agentic-research-model-tests.yaml
+++ b/.github/workflows/agentic-research-model-tests.yaml
@@ -59,12 +59,6 @@ jobs:
             .github
             tests/pipeline_reorg
       - run: pip3 install PyYAML
-      - name: Validate every tier's time budget
-        run: |
-          for tier in 1 2 3; do
-            python3 .github/scripts/utils/verify_time_budget.py \
-              "$REGISTRY" .github/time_budget.yaml agentic_research "$tier"
-          done
       - name: Resolve hardware
         id: hardware
         run: |
@@ -76,7 +70,9 @@ jobs:
         env:
           MATRIX: ${{ steps.hardware.outputs.matrix }}
         run: |
-          # A missing tier must never bypass its budget check.
+          # Every entry must carry a tier: it selects which of the registry's
+          # agentic_research_tier<N> allowances the entry is charged against, and a
+          # missing one would silently fall back to a budget key that does not exist.
           jq -e 'all(.[]; .tier == 1 or .tier == 2 or .tier == 3)' <<< "$MATRIX"
           selected=$(jq -c --arg model "$MODEL" --arg tier "$TIER" --arg plugin_ref "$VLLM_TT_PLUGIN_REF" '
             [.[] | select(($model == "all" or .model == $model) and

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -21,14 +21,6 @@ on:
         required: true
         type: string
         description: "Comma-separated SKUs to run (must match tests yaml and sku_config.yaml)."
-      per-test-timeout:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Max allowed timeout (minutes) for any individual test SKU entry in the
-          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
-          Empty skips the per-test ceiling check.
       product:
         required: true
         type: string # tt-metalium or tt-nn
@@ -36,12 +28,6 @@ on:
         description: "Enable watcher"
         default: false
         type: boolean
-      test-category:
-        required: false
-        type: string
-        default: merge_gate
-        description: "Time-budget workflow key passed to verify_time_budget.py."
-
 jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
@@ -62,18 +48,6 @@ jobs:
       - name: Install dependencies
         run: pip3 install PyYAML
 
-      - name: Verify test timeouts against budget
-        run: |
-          set -euo pipefail
-          extra=()
-          if [ -n "${{ inputs.per-test-timeout }}" ]; then
-            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
-          fi
-          python3 .github/scripts/utils/verify_time_budget.py \
-            "${{ env.TESTS_YAML_PATH }}" \
-            ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}" \
-            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -44,13 +44,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            e2e
       - name: Build test matrix for enabled SKUs
         id: prepare
         run: |

--- a/.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
@@ -71,13 +71,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sanity"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -72,14 +72,6 @@ jobs:
           fi
           echo "✓ SKU 'bh_${{ inputs.sp-config }}' exists in sku_config.yaml"
 
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "demo"
 
       - name: Build test matrix
         id: build-matrix

--- a/.github/workflows/demo-sp-release-impl.yaml
+++ b/.github/workflows/demo-sp-release-impl.yaml
@@ -46,14 +46,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "demo"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -8,11 +8,6 @@ on:
         type: string
         default: ALL_SKUS_IN_TESTS
         description: "Comma-separated SKUs, or ALL_SKUS_IN_TESTS to run every SKU defined in the tests yaml."
-      test-category:
-        required: false
-        type: string
-        default: merge_gate
-        description: "Time-budget workflow key passed to verify_time_budget.py (merge_gate for merge-gate and N300 fabric)."
       build-artifact-name:
         required: true
         type: string
@@ -36,15 +31,6 @@ on:
         required: false
         type: boolean
         default: false
-      per-test-timeout:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Max allowed timeout (minutes) for any individual test SKU entry in the
-          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
-          Empty skips the per-test ceiling check.
-
 jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
@@ -65,18 +51,6 @@ jobs:
       - name: Install dependencies
         run: pip3 install PyYAML
 
-      - name: Verify test timeouts against budget
-        run: |
-          set -euo pipefail
-          extra=()
-          if [ -n "${{ inputs.per-test-timeout }}" ]; then
-            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
-          fi
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}" \
-            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/fabric-cpu-only-tests-impl.yaml
+++ b/.github/workflows/fabric-cpu-only-tests-impl.yaml
@@ -13,11 +13,6 @@ on:
         type: string
         default: ./tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml
         description: "Pipeline reorg test matrix YAML (e.g. fabric_cpu_only_smoke_merge_gate_tests.yaml for merge gate)."
-      test-category:
-        required: false
-        type: string
-        default: unit
-        description: "Time-budget workflow key passed to verify_time_budget.py (unit for fabric CPU-only tests)."
       build-artifact-name:
         required: true
         type: string
@@ -27,15 +22,6 @@ on:
       wheel-artifact-name:
         required: true
         type: string
-      per-test-timeout:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Max allowed timeout (minutes) for any individual test SKU entry in the
-          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
-          Empty skips the per-test ceiling check.
-
 jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
@@ -54,19 +40,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -euo pipefail
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          extra=()
-          if [ -n "${{ inputs.per-test-timeout }}" ]; then
-            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
-          fi
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}" \
-            "${extra[@]}"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/fabric-multihost-exabox-impl.yaml
+++ b/.github/workflows/fabric-multihost-exabox-impl.yaml
@@ -46,14 +46,6 @@ jobs:
           fi
           echo "✓ SKU 'bh_${{ inputs.sp-config }}' exists in sku_config.yaml"
 
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "e2e"
 
       - name: Build test matrix
         id: build-matrix

--- a/.github/workflows/fabric-sanity-tests-impl.yaml
+++ b/.github/workflows/fabric-sanity-tests-impl.yaml
@@ -63,13 +63,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sanity"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/galaxy-e2e-tests-impl.yaml
+++ b/.github/workflows/galaxy-e2e-tests-impl.yaml
@@ -39,14 +39,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "e2e"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/galaxy-health-impl.yaml
+++ b/.github/workflows/galaxy-health-impl.yaml
@@ -35,14 +35,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "health"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/galaxy-integration-tests-impl.yaml
+++ b/.github/workflows/galaxy-integration-tests-impl.yaml
@@ -39,14 +39,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "integration"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/galaxy-profiler-tests-impl.yaml
+++ b/.github/workflows/galaxy-profiler-tests-impl.yaml
@@ -47,16 +47,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        # "profiler" subheading is temporary while team / test-framework
-        # assignment is being settled, see
-        # https://github.com/tenstorrent/tt-metal/issues/44285
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "profiler"
       - name: Build test matrix
         id: build-matrix
         run: |

--- a/.github/workflows/galaxy-sanity-impl.yaml
+++ b/.github/workflows/galaxy-sanity-impl.yaml
@@ -32,14 +32,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sanity"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/galaxy-stress-tests-impl.yaml
+++ b/.github/workflows/galaxy-stress-tests-impl.yaml
@@ -47,14 +47,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "stress"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -47,14 +47,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "unit"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/llk-bit-exact-impl.yaml
+++ b/.github/workflows/llk-bit-exact-impl.yaml
@@ -52,13 +52,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "bit_exact"
       - name: Build test matrix
         id: build-matrix
         env:

--- a/.github/workflows/llk-e2e-impl.yaml
+++ b/.github/workflows/llk-e2e-impl.yaml
@@ -46,13 +46,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "e2e"
       - name: Build test matrix
         id: build-matrix
         run: |

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -53,13 +53,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "perf"
       - name: Build test matrix
         id: build-matrix
         env:

--- a/.github/workflows/llk-smoke-impl.yaml
+++ b/.github/workflows/llk-smoke-impl.yaml
@@ -16,6 +16,13 @@ on:
         required: false
         type: string
         default: "not perf and not nightly and not quasar"
+      budget-type:
+        required: false
+        type: string
+        default: pr_gate
+        description: >-
+          Which of llk's allowances this run spends. Reporting only: budgets are
+          enforced from the `budget_type` field
       sku-allowlist:
         required: false
         type: string

--- a/.github/workflows/llk-smoke-impl.yaml
+++ b/.github/workflows/llk-smoke-impl.yaml
@@ -16,22 +16,6 @@ on:
         required: false
         type: string
         default: "not perf and not nightly and not quasar"
-      test-category:
-        required: false
-        type: string
-        default: pr_gate
-        description: >-
-          Time-budget workflow key passed to verify_time_budget.py — the pipeline whose
-          hardware allowance this run is charged against (pr_gate for the PR gate, sanity
-          for sanity-tests). Must exist under `llk` in .github/time_budget.yaml.
-      per-test-timeout:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Max allowed timeout (minutes) for any individual test SKU entry in the
-          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
-          Empty skips the per-test ceiling check.
       sku-allowlist:
         required: false
         type: string
@@ -76,18 +60,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -euo pipefail
-          extra=()
-          if [ -n "${{ inputs.per-test-timeout }}" ]; then
-            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
-          fi
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}" \
-            "${extra[@]}"
       - name: Build test matrix
         id: build-matrix
         run: |

--- a/.github/workflows/llk-ttsim-weekly-impl.yaml
+++ b/.github/workflows/llk-ttsim-weekly-impl.yaml
@@ -55,13 +55,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "weekly"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/llk-unit-tests-impl.yaml
+++ b/.github/workflows/llk-unit-tests-impl.yaml
@@ -17,20 +17,12 @@ on:
         required: false
         type: string
         default: unit
-        description: "Time-budget workflow key passed to verify_time_budget.py (e.g. merge_gate for merge-gate, unit for L2 nightly)."
+        description: "Which tests yaml to load: merge_gate for merge-gate, unit for L2 nightly."
       enable-llk-asserts:
         required: false
         type: boolean
         default: true
         description: "Enable LLK asserts"
-      per-test-timeout:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Max allowed timeout (minutes) for any individual test SKU entry in the
-          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
-          Empty skips the per-test ceiling check.
       sku-allowlist:
         required: false
         type: string
@@ -67,19 +59,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -euo pipefail
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          extra=()
-          if [ -n "${{ inputs.per-test-timeout }}" ]; then
-            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
-          fi
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}" \
-            "${extra[@]}"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -311,7 +311,6 @@ jobs:
       cpu-docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
       enabled-skus: ALL_SKUS_IN_TESTS
-      per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml
       product: tt-metalium
       enable-kernel-ccache: true
 
@@ -352,7 +351,6 @@ jobs:
       docker-image: ${{ needs.resolve-docker-pull-refs-asan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
       enabled-skus: ALL_SKUS_IN_TESTS
-      per-test-timeout: 15 # max minutes for any SKU timeout in the basic tests yaml
       product: tt-metalium
 
   # ===========================================================================
@@ -371,7 +369,6 @@ jobs:
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       enabled-skus: ALL_SKUS_IN_TESTS
-      per-test-timeout: 15
 
   # ===========================================================================
   # Team: ttnn
@@ -416,7 +413,6 @@ jobs:
       docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
       enabled-skus: ALL_SKUS_IN_TESTS
-      per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml
       product: tt-nn
       enable-kernel-ccache: true
 
@@ -457,7 +453,6 @@ jobs:
       docker-image: ${{ needs.resolve-docker-pull-refs-asan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
       enabled-skus: ALL_SKUS_IN_TESTS
-      per-test-timeout: 15 # max minutes for any SKU timeout in the basic tests yaml
       product: tt-nn
 
   ttnn-merge-gate-tests:
@@ -473,7 +468,6 @@ jobs:
     with:
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
-      per-test-timeout: 15
 
   # ===========================================================================
   # Team: models
@@ -496,7 +490,6 @@ jobs:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
-      per-test-timeout: 15
 
   # ===========================================================================
   # Team: train
@@ -519,7 +512,6 @@ jobs:
       enabled-skus: ALL_SKUS_IN_TESTS
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
-      per-test-timeout: 15
 
   # ===========================================================================
   # Team: scaleout (fabric)
@@ -538,11 +530,9 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
     with:
-      test-category: merge_gate
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
-      per-test-timeout: 15
 
   # Fabric CPU-only tests removed from merge gate — https://github.com/tenstorrent/tt-metal/pull/47987
   # Scaffolding kept for a future smoke subset (fabric_cpu_only_smoke_merge_gate_tests.yaml).
@@ -555,12 +545,10 @@ jobs:
     uses: ./.github/workflows/fabric-cpu-only-tests-impl.yaml
     with:
       tests-yaml-path: ./tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml
-      test-category: smoke
       runs-on-sku: cpu_medium
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
-      per-test-timeout: 15
 
   # ===========================================================================
   # Team: llk
@@ -617,7 +605,6 @@ jobs:
       test-category: merge_gate
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
-      per-test-timeout: 15
       enabled-skus: ALL_SKUS_IN_TESTS
       # "*" = no allowlist filter; empty = skip all; else CSV of logical SKUs.
       sku-allowlist: ${{

--- a/.github/workflows/models-device-perf-tests-impl.yaml
+++ b/.github/workflows/models-device-perf-tests-impl.yaml
@@ -43,14 +43,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "device_perf"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -80,16 +80,6 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.matrix == '' }}
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        if: ${{ inputs.matrix == '' }}
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "e2e" \
-            "${{ inputs.tier }}"
       - name: Build unified test matrix based on enabled SKUs
         if: ${{ inputs.matrix == '' }}
         id: build-matrix

--- a/.github/workflows/models-sanity-tests-impl.yaml
+++ b/.github/workflows/models-sanity-tests-impl.yaml
@@ -59,14 +59,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sanity"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/models-smoke-tests-impl.yaml
+++ b/.github/workflows/models-smoke-tests-impl.yaml
@@ -25,15 +25,6 @@ on:
         type: boolean
         default: true
         description: "Set to false to allow write access to MLPerf mount"
-      per-test-timeout:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Max allowed timeout (minutes) for any individual test SKU entry in the
-          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
-          Empty skips the per-test ceiling check.
-
 jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
@@ -54,18 +45,6 @@ jobs:
       - name: Install dependencies
         run: pip3 install PyYAML
 
-      - name: Verify test timeouts against budget
-        run: |
-          set -euo pipefail
-          extra=()
-          if [ -n "${{ inputs.per-test-timeout }}" ]; then
-            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
-          fi
-          python3 .github/scripts/utils/verify_time_budget.py \
-            "${{ env.TESTS_YAML_PATH }}" \
-            ./.github/time_budget.yaml \
-            merge_gate \
-            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -51,15 +51,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sweep" \
-            "${{ inputs.tier }}"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -61,15 +61,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "unit" \
-            "${{ inputs.tier }}"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/ops-integration-tests-impl.yaml
+++ b/.github/workflows/ops-integration-tests-impl.yaml
@@ -51,13 +51,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "integration"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/ops-sanity-impl.yaml
+++ b/.github/workflows/ops-sanity-impl.yaml
@@ -79,13 +79,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sanity"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/ops-unit-tests-impl.yaml
+++ b/.github/workflows/ops-unit-tests-impl.yaml
@@ -26,13 +26,6 @@ on:
         type: string
         default: ./tests/pipeline_reorg/ops_unit_tests.yaml
         description: "Test list to load. Pipelines that own a disjoint slice of the ops suites pass their own yaml."
-      budget-subheading:
-        required: false
-        type: string
-        default: "unit"
-        description: "Key under each team in .github/time_budget.yaml to verify against.
-          Pipelines that run this workflow at different frequencies pass different keys so
-          their budgets are tracked separately (e.g. package_and_release vs the nightly unit)."
       enable-llk-asserts:
         required: false
         type: boolean
@@ -65,13 +58,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "${{ inputs.budget-subheading }}"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -208,7 +208,34 @@ jobs:
       - name: Install dependencies
         run: pip3 install PyYAML
       - name: Verify test timeouts against team time budgets
-        run: python3 .github/scripts/utils/verify_time_budget.py
+        run: |
+          python3 .github/scripts/utils/verify_time_budget.py \
+            --comment-file "${{ runner.temp }}/budget-report.md"
+      # Every failure kind gets explained on the PR, not just an over-budget bucket:
+      # a missing budget_type or an undeclared bucket is just as opaque to the author.
+      # One comment is kept up to date across pushes rather than stacking per run, and
+      # a run that passes edits an existing comment to say so instead of leaving a
+      # stale failure behind. A pass with no prior comment posts nothing.
+      - name: Explain a time budget failure on the PR
+        if: ${{ always() && github.event_name == 'pull_request' && hashFiles(format('{0}/budget-report.md', runner.temp)) != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BODY_FILE: ${{ runner.temp }}/budget-report.md
+        run: |
+          set -euo pipefail
+          existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq 'map(select(.body | contains("<!-- time-budget-check"))) | .[-1].id // empty')
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+              -F "body=@$BODY_FILE" >/dev/null
+            echo "Updated existing time-budget comment $existing."
+          elif grep -q "status=fail" "$BODY_FILE"; then
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$BODY_FILE"
+          else
+            echo "Check passed and no existing comment to clear; nothing to post."
+          fi
 
   build-runtime-smoke-image:
     needs: [asan-build, build-docker-images, find-changed-files]

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -217,22 +217,39 @@ jobs:
       # a run that passes edits an existing comment to say so instead of leaving a
       # stale failure behind. A pass with no prior comment posts nothing.
       - name: Explain a time budget failure on the PR
-        if: ${{ always() && github.event_name == 'pull_request' && hashFiles(format('{0}/budget-report.md', runner.temp)) != '' }}
+        if: ${{ always() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
           REPO: ${{ github.repository }}
           BODY_FILE: ${{ runner.temp }}/budget-report.md
         run: |
           set -euo pipefail
+
+          if [ ! -f "$BODY_FILE" ]; then
+            echo "No report was written (the check did not get far enough); nothing to post."
+            exit 0
+          fi
+
+          if [ -z "${PR_NUMBER:-}" ]; then
+            PR_NUMBER=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+              --json number --jq '.[0].number // empty')
+          fi
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "No open PR for '$BRANCH'; nothing to post."
+            exit 0
+          fi
+
           existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq 'map(select(.body | contains("<!-- time-budget-check"))) | .[-1].id // empty')
+            --jq '[.[] | select(.body | contains("<!-- time-budget-check")) | .id] | first // empty')
           if [ -n "$existing" ]; then
             gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
               -F "body=@$BODY_FILE" >/dev/null
-            echo "Updated existing time-budget comment $existing."
+            echo "Updated time-budget comment $existing on PR #$PR_NUMBER."
           elif grep -q "status=fail" "$BODY_FILE"; then
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$BODY_FILE"
+            echo "Posted a new time-budget comment on PR #$PR_NUMBER."
           else
             echo "Check passed and no existing comment to clear; nothing to post."
           fi

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -242,8 +242,7 @@ jobs:
           fi
 
           existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq '[.[] | select(.body | contains("<!-- time-budget-check")) | .id] | first // empty')
-          if [ -n "$existing" ]; then
+              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- time-budget-check"))) | .id] | first // empty')          if [ -n "$existing" ]; then
             gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
               -F "body=@$BODY_FILE" >/dev/null
             echo "Updated time-budget comment $existing on PR #$PR_NUMBER."

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -242,7 +242,8 @@ jobs:
           fi
 
           existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- time-budget-check"))) | .id] | first // empty')          if [ -n "$existing" ]; then
+              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- time-budget-check"))) | .id] | first // empty')
+          if [ -n "$existing" ]; then
             gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
               -F "body=@$BODY_FILE" >/dev/null
             echo "Updated time-budget comment $existing on PR #$PR_NUMBER."

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -190,6 +190,26 @@ jobs:
       - id: find-changes
         uses: ./.github/actions/find-changed-files
 
+  # The ONE place team time budgets are enforced. It has to see every tests yaml
+  # at once: several yamls charge the same (team, budget_type, sku) budget, so the
+  # allowance is the sum across all of them. The per-pipeline checks this replaced
+  # each saw a single yaml, which let every yaml claim the full budget on its own.
+  verify-time-budgets:
+    if: github.event.action != 'destroyed' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 5
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            .github
+            tests/pipeline_reorg
+      - name: Install dependencies
+        run: pip3 install PyYAML
+      - name: Verify test timeouts against team time budgets
+        run: python3 .github/scripts/utils/verify_time_budget.py
+
   build-runtime-smoke-image:
     needs: [asan-build, build-docker-images, find-changed-files]
     if: ${{
@@ -236,7 +256,6 @@ jobs:
       package-artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
       product: tt-metalium
       test-category: pr_gate
-      per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml
       upload-coverage: false
       enable-kernel-ccache: true
   # A second image because the tag reflects build-args, and smoke installs a
@@ -286,7 +305,6 @@ jobs:
       package-artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
       product: tt-nn
       test-category: pr_gate
-      per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml
       upload-coverage: false
       enable-kernel-ccache: true
 
@@ -343,7 +361,6 @@ jobs:
       product: tt-metalium
       build-type: 'ASan'
       enable-kernel-ccache: true
-      per-test-timeout: 15
     secrets: inherit
 
   build-ttnn-examples-image:
@@ -387,7 +404,6 @@ jobs:
       product: tt-nn
       build-type: 'ASan'
       enable-kernel-ccache: true
-      per-test-timeout: 15
     secrets: inherit
 
   # A quick check that parses the models charts in README.md and models/README.md
@@ -534,7 +550,6 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.llk-ci-docker-image }}
-      per-test-timeout: 15
       enabled-skus: ALL_SKUS_IN_TESTS
       # "*" = no allowlist filter; empty = skip all; else CSV of logical SKUs.
       sku-allowlist: ${{
@@ -598,6 +613,7 @@ jobs:
       - build-docs
       - llk-smoke-tests
       - llk-build-quasar
+      - verify-time-budgets
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -607,7 +623,9 @@ jobs:
       - name: Check if all jobs passed
         uses: ./.github/actions/workflow-status
         with:
-          required-jobs: ""
+          # verify-time-budgets is required, not optional: it has no build dependency
+          # and never skips, so a skip would mean it silently stopped gating.
+          required-jobs: "verify-time-budgets"
           optional-jobs: >-
             asan-build, code-analysis,
             runtime-smoke-tests, ttnn-smoke-tests, runtime-examples, ttnn-examples,

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -158,7 +158,6 @@ jobs:
       enabled-skus: wh_n150_civ2,bh_p150b_civ2
       additional_test_categories: ${{ inputs.ops-test-categories }}
       tests-yaml-path: ./tests/pipeline_reorg/ops_pnr_tests.yaml
-      budget-subheading: package_and_release
 
   # ===========================================================================
   # Team: blaze

--- a/.github/workflows/release-demo-tests-impl.yaml
+++ b/.github/workflows/release-demo-tests-impl.yaml
@@ -94,15 +94,6 @@ jobs:
           curl -fsSL "${{ inputs.tests-yaml-gist-url }}" -o "${{ env.TESTS_YAML_PATH }}"
           echo "Downloaded tests YAML:"
           head -n 20 "${{ env.TESTS_YAML_PATH }}"
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "e2e" \
-            "${{ inputs.tier }}"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/runtime-integration-tests-impl.yaml
+++ b/.github/workflows/runtime-integration-tests-impl.yaml
@@ -35,14 +35,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "integration"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/runtime-perf-tests-impl.yaml
+++ b/.github/workflows/runtime-perf-tests-impl.yaml
@@ -16,11 +16,6 @@ on:
         required: false
         type: string
         default: ./tests/pipeline_reorg/runtime_perf_tests.yaml
-      budget-subheading:
-        required: false
-        type: string
-        default: "perf"
-
 jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
@@ -39,14 +34,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "${{ inputs.budget-subheading }}"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/runtime-perf-tests.yaml
+++ b/.github/workflows/runtime-perf-tests.yaml
@@ -109,7 +109,6 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       tests-yaml-path: ./tests/pipeline_reorg/runtime_perf_profiler_tests.yaml
-      budget-subheading: "perf_profiler"
       enabled-skus: >-
         ${{
           github.event_name == 'schedule'

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -63,14 +63,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sanity"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/runtime-unit-tests-impl.yaml
+++ b/.github/workflows/runtime-unit-tests-impl.yaml
@@ -45,14 +45,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "unit"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -706,6 +706,7 @@ jobs:
       # is a separate call about sanity's time budget, not a side effect of wiring it up.
       pytest-markers: "not perf and not nightly and not quasar and not accuracy"
       ref: ${{ needs.resolve-ref.outputs.sha }}
+      budget-type: sanity
 
   # LLK Quasar build check (compile-only, no hardware). Mirrors pr-gate's llk-build-quasar.
   llk-build-quasar:

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -705,11 +705,6 @@ jobs:
       # team already keeps green. Widening it here (dropping `not nightly` / `not accuracy`)
       # is a separate call about sanity's time budget, not a side effect of wiring it up.
       pytest-markers: "not perf and not nightly and not quasar and not accuracy"
-      per-test-timeout: 15
-      # Charge this run against sanity's own allowance (llk.sanity in time_budget.yaml),
-      # as every other sanity impl does, rather than the PR gate's — otherwise widening
-      # one pipeline's markers would silently eat into the other's budget.
-      test-category: sanity
       ref: ${{ needs.resolve-ref.outputs.sha }}
 
   # LLK Quasar build check (compile-only, no hardware). Mirrors pr-gate's llk-build-quasar.

--- a/.github/workflows/sdk-examples.yaml
+++ b/.github/workflows/sdk-examples.yaml
@@ -34,15 +34,6 @@ on:
         description: 'Enable kernel ccache for JIT compilation at runtime'
         default: false
         type: boolean
-      per-test-timeout:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Max allowed timeout (minutes) for any individual test SKU entry in the
-          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
-          Empty skips the per-test ceiling check.
-
 jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
@@ -64,18 +55,6 @@ jobs:
       - name: Install dependencies
         run: pip3 install PyYAML
 
-      - name: Verify test timeouts against budget
-        run: |
-          set -euo pipefail
-          extra=()
-          if [ -n "${{ inputs.per-test-timeout }}" ]; then
-            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
-          fi
-          python3 .github/scripts/utils/verify_time_budget.py \
-            "${{ env.TESTS_YAML_PATH }}" \
-            ./.github/time_budget.yaml \
-            pr_gate \
-            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/single-card-profiler-tests-impl.yaml
+++ b/.github/workflows/single-card-profiler-tests-impl.yaml
@@ -54,16 +54,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        # "profiler" subheading is temporary while team / test-framework
-        # assignment is being settled, see
-        # https://github.com/tenstorrent/tt-metal/issues/44285
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "profiler"
       - name: Build test matrix
         id: build-matrix
         run: |

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -35,14 +35,6 @@ on:
         type: string
         default: ALL_SKUS_IN_TESTS
         description: "Comma-separated SKUs to run, or ALL_SKUS_IN_TESTS to run every SKU in the tests yaml."
-      per-test-timeout:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Max allowed timeout (minutes) for any individual test SKU entry in the
-          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
-          Empty skips the per-test ceiling check.
       product:
         required: true
         type: string # tt-metalium or tt-nn
@@ -62,7 +54,7 @@ on:
         required: false
         type: string
         default: merge_gate
-        description: "Time-budget workflow key passed to verify_time_budget.py (merge_gate or pr_gate)."
+        description: "Which tests yaml to load: the merge_gate or the pr_gate validation list."
 
 jobs:
   load-test-matrix:
@@ -91,18 +83,6 @@ jobs:
       - name: Install dependencies
         run: pip3 install PyYAML
 
-      - name: Verify test timeouts against budget
-        run: |
-          set -euo pipefail
-          extra=()
-          if [ -n "${{ inputs.per-test-timeout }}" ]; then
-            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
-          fi
-          python3 .github/scripts/utils/verify_time_budget.py \
-            "${{ env.TESTS_YAML_PATH }}" \
-            ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}" \
-            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/syseng-didt-tests-impl.yaml
+++ b/.github/workflows/syseng-didt-tests-impl.yaml
@@ -43,14 +43,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "integration"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/t3000-e2e-tests-impl.yaml
+++ b/.github/workflows/t3000-e2e-tests-impl.yaml
@@ -34,14 +34,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "e2e"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/t3000-integration-tests-impl.yaml
+++ b/.github/workflows/t3000-integration-tests-impl.yaml
@@ -38,14 +38,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "integration"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/t3000-profiler-tests-impl.yaml
+++ b/.github/workflows/t3000-profiler-tests-impl.yaml
@@ -47,16 +47,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        # "profiler" subheading is temporary while team / test-framework
-        # assignment is being settled, see
-        # https://github.com/tenstorrent/tt-metal/issues/44285
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "profiler"
       - name: Build test matrix
         id: build-matrix
         run: |

--- a/.github/workflows/t3000-sanity-tests-impl.yaml
+++ b/.github/workflows/t3000-sanity-tests-impl.yaml
@@ -84,13 +84,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sanity"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -38,14 +38,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "unit"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -76,13 +76,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "unit"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -46,13 +46,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "perf"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/triage-tests-impl.yaml
+++ b/.github/workflows/triage-tests-impl.yaml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
         default: unit
-        description: "merge_gate: core triage (merge-gate); unit: hang-report test (L2 nightly). Selects yaml and verify_time_budget.py key."
+        description: "Selects the tests yaml. merge_gate: core triage (merge-gate); unit: hang-report test (L2 nightly)."
       enable-watcher:
         description: "Enable watcher"
         default: false
@@ -32,14 +32,6 @@ on:
         description: "Enable LLK asserts"
         default: false
         type: boolean
-      per-test-timeout:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Max allowed timeout (minutes) for any individual test SKU entry in the
-          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
-          Empty skips the per-test ceiling check.
       summary-scope:
         required: false
         type: string
@@ -68,19 +60,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -euo pipefail
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          extra=()
-          if [ -n "${{ inputs.per-test-timeout }}" ]; then
-            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
-          fi
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}" \
-            "${extra[@]}"
       - name: Build unified test matrix based on enabled SKUs
         id: prepare
         run: |

--- a/.github/workflows/tt-cnn-unit-tests-impl.yaml
+++ b/.github/workflows/tt-cnn-unit-tests-impl.yaml
@@ -52,13 +52,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "unit"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/tt-train-tests.yaml
+++ b/.github/workflows/tt-train-tests.yaml
@@ -55,14 +55,6 @@ on:
         type: string
         default: ''
         description: "Comma-separated category filter. Keep only entries whose `category` field appears in this list."
-      per-test-timeout:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Max allowed timeout (minutes) for any individual test SKU entry in the
-          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
-          Empty skips the per-test ceiling check.
       summary-scope:
         required: false
         type: string
@@ -98,19 +90,6 @@ jobs:
       - name: Install dependencies
         run: pip3 install PyYAML
 
-      - name: Verify test timeouts against budget
-        if: ${{ inputs.timeout-minutes-override == 0 }}
-        run: |
-          set -euo pipefail
-          extra=()
-          if [ -n "${{ inputs.per-test-timeout }}" ]; then
-            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
-          fi
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}" \
-            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/ttnn-integration-tests-impl.yaml
+++ b/.github/workflows/ttnn-integration-tests-impl.yaml
@@ -51,13 +51,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "integration"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/ttnn-model-trace-sweep-validation.yaml
+++ b/.github/workflows/ttnn-model-trace-sweep-validation.yaml
@@ -167,13 +167,6 @@ jobs:
             .github
             tests/pipeline_reorg
           sparse-checkout-cone-mode: true
-      - name: Check budget
-        run: |
-          pip3 install PyYAML > /dev/null 2>&1
-          python3 .github/scripts/utils/verify_time_budget.py \
-            tests/pipeline_reorg/ttnn_sweep_validation_tests.yaml \
-            .github/time_budget.yaml \
-            sweep_validation
 
   run-model-trace-sweep-validation:
     name: Run model trace sweep validation

--- a/.github/workflows/ttnn-run-sweeps-impl.yaml
+++ b/.github/workflows/ttnn-run-sweeps-impl.yaml
@@ -80,7 +80,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     # Single-source-of-truth per-job timeout: compute_sweep_matrix.py stamps
     # matrix.timeout onto every entry from tests/pipeline_reorg/ttnn_sweep_tests.yaml
-    # (checked against .github/time_budget.yaml by verify_time_budget.py). Run types
+    # (checked against .github/time_budget.yaml by pr-gate's verify-time-budgets). Run types
     # not budget-tracked in the yaml (nightly/comprehensive) are stamped with the
     # 60-min default in matrix_runner_config.get_timeout_for, so the value is always
     # present and consumed here directly.

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -1009,14 +1009,6 @@ jobs:
           jq . /tmp/sweep_matrix.pretty.json
           echo "::endgroup::"
 
-      - name: Verify test timeouts against budget
-        shell: bash
-        run: |
-          pip3 install PyYAML > /dev/null 2>&1
-          python3 .github/scripts/utils/verify_time_budget.py \
-            tests/pipeline_reorg/ttnn_sweep_tests.yaml \
-            .github/time_budget.yaml \
-            sweep
 
   ttnn-run-single-sweep:
     name: Run single sweep

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -114,14 +114,6 @@ jobs:
         run: |
           pip3 install PyYAML
 
-      - name: Verify test timeouts against budget
-        if: ${{ inputs.timeout-minutes-override == 0 }}
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sanity"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/ttnn-smoke-tests-impl.yaml
+++ b/.github/workflows/ttnn-smoke-tests-impl.yaml
@@ -42,15 +42,6 @@ on:
         type: boolean
         default: false
         description: "When true, collect LLVM profraw data and upload per-job profdata artifact for coverage aggregation."
-      per-test-timeout:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Max allowed timeout (minutes) for any individual test SKU entry in the
-          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
-          Empty skips the per-test ceiling check.
-
 jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
@@ -77,19 +68,6 @@ jobs:
         run: |
           pip3 install PyYAML
 
-      - name: Verify test timeouts against budget
-        if: ${{ inputs.timeout-minutes-override == 0 }}
-        run: |
-          set -euo pipefail
-          extra=()
-          if [ -n "${{ inputs.per-test-timeout }}" ]; then
-            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
-          fi
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "merge_gate" \
-            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/ttsim-merge-gate-tests-impl.yaml
+++ b/.github/workflows/ttsim-merge-gate-tests-impl.yaml
@@ -66,17 +66,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          # 15 = the merge-gate per-test ceiling; this pipeline must stay under the
-          # workflow's 15-min end-to-end requirement.
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "merge_gate" \
-            --max-per-test-timeout 15
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -47,13 +47,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sanity"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/ttsim-unit-tests-impl.yaml
+++ b/.github/workflows/ttsim-unit-tests-impl.yaml
@@ -54,13 +54,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "unit"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/umd-sanity-tests-impl.yaml
+++ b/.github/workflows/umd-sanity-tests-impl.yaml
@@ -68,13 +68,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sanity"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/vllm-model-tests-impl.yaml
+++ b/.github/workflows/vllm-model-tests-impl.yaml
@@ -68,17 +68,6 @@ jobs:
           sparse-checkout-cone-mode: true
       - name: Install dependencies
         run: pip3 install PyYAML
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          # No tier arg: vLLM Model Tests run every entry at one cadence, so the
-          # budget is summed across all SKU entries under the plain models.vllm key.
-          # (The per-entry `tier` field is classification metadata, not a filter.)
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "vllm"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/models/MIGRATING_TO_TIERED_CI.md
+++ b/models/MIGRATING_TO_TIERED_CI.md
@@ -225,6 +225,7 @@ Use the same shape as the existing entries. Minimal e2e example:
       tier: <1|2|3>
   owner_id: U03XXXXXXXX # <Owner Name>
   team: models
+  budget_type: e2e
 ```
 
 Minimal unit example:
@@ -241,10 +242,18 @@ Minimal unit example:
       tier: <1|2|3>
   owner_id: U03XXXXXXXX # <Owner Name>
   team: models
+  budget_type: unit
 ```
 
 A model can run on multiple SKUs by adding more entries under `skus:`,
 each with its own `timeout` and `tier`.
+
+`budget_type` names which of the team's allowances in
+[`.github/time_budget.yaml`](../.github/time_budget.yaml) the entry is charged
+against — `e2e`, `unit`, `sweep` or `device_perf`, matching the registry you
+added it to. Every entry needs one: pr-gate sums the timeouts per
+(team, budget_type, sku) across all registries and fails if the total exceeds
+the budget.
 
 ### Test conventions
 

--- a/tests/pipeline_reorg/agentic_research_model_tests.yaml
+++ b/tests/pipeline_reorg/agentic_research_model_tests.yaml
@@ -72,3 +72,4 @@
       tier: 3
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
+  budget_type: agentic_research

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -32,6 +32,7 @@
       timeout: 15
   owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
+  budget_type: e2e
 
 # --- perf ---
 - id: bh-fabric-sanity-benchmark
@@ -47,6 +48,7 @@
       timeout: 15
   owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
+  budget_type: e2e
 
 # --- unit ---
 - id: bh-fabric-ttnn-udm-unit
@@ -63,6 +65,7 @@
       timeout: 20
   owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
+  budget_type: e2e
 
 - id: bh-grid-20-cores-ttnn-sharding
   name: ttnn 20-core sharding unit tests
@@ -72,6 +75,7 @@
       timeout: 10
   owner_id: U08ARDXARPF # Ilija Anastasijevic
   team: ttnn
+  budget_type: e2e
 
 # The op gathers over a mesh axis, and a mesh smaller than the box is a submesh, which
 # fabric does not come up on — so the mesh a row asks for is fixed by the box it runs on.
@@ -84,6 +88,7 @@
       timeout: 10
   owner_id: U09LK84G4TF # Nikola Milicevic
   team: ttnn
+  budget_type: e2e
 
 # --- unit (fast) ---
 # Fast multi-card legs that the legacy blackhole-multi-card-unit-tests-impl.yaml
@@ -105,6 +110,7 @@
       timeout: 15
   owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
+  budget_type: e2e
 
 - id: bh-ttnn-ops-fast-unit
   name: ttnn ops fast unit tests (ccl, DRAM prefetcher)
@@ -121,6 +127,7 @@
       timeout: 15
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
+  budget_type: e2e
 
 - id: bh-host-io-fast-unit-viommu
   name: Host IO socket loopback unit tests (slow dispatch, viommu)
@@ -130,6 +137,7 @@
       timeout: 10
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
+  budget_type: e2e
 
 # --- stress (continuous gate) ---
 - id: bh-fabric-stability-stress
@@ -144,6 +152,7 @@
       timeout: 15
   owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
+  budget_type: e2e
 
 - id: bh-ttnn-stress
   name: ttnn stress tests
@@ -153,6 +162,7 @@
       timeout: 45
   owner_id: U084DDYSWCW # Adrian Morrison
   team: ttnn
+  budget_type: e2e
 
 # --- disaggregated prefill ---
 - id: bh-lb-disaggregated-prefill-accuracy
@@ -171,6 +181,7 @@
       timeout: 117
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
+  budget_type: e2e
 
 - id: bh-lb-disaggregated-prefill-sparse-mla
   name: Disaggregated prefill sparse MLA accuracy tests
@@ -189,6 +200,7 @@
       timeout: 10
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
+  budget_type: e2e
 
 - id: bh-lb-disaggregated-prefill-op-tests
   name: Disaggregated prefill op tests
@@ -204,6 +216,7 @@
       timeout: 28
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
+  budget_type: e2e
 
 - id: bh-lb-disaggregated-prefill-perf
   name: Disaggregated prefill perf tests
@@ -221,6 +234,7 @@
       timeout: 35
   owner_id: U09LK84G4TF # Nikola Milicevic
   team: models
+  budget_type: e2e
 
 - id: bh-qb2-disaggregated-prefill-accuracy
   name: Disaggregated prefill accuracy & weight cache tests
@@ -235,6 +249,7 @@
       timeout: 20
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
+  budget_type: e2e
 
 - id: bh-p150-disaggregated-prefill-op-tests
   name: Disaggregated prefill op tests
@@ -248,6 +263,7 @@
       timeout: 8
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
+  budget_type: e2e
 
 - id: bh-qb2-disaggregated-prefill-op-tests
   name: Disaggregated prefill op tests
@@ -261,6 +277,7 @@
       timeout: 60
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
+  budget_type: e2e
 
 - id: bh-qb2-disaggregated-prefill-d2d-socket-sync
   name: Disaggregated prefill D2D socket sync op tests
@@ -277,6 +294,7 @@
       timeout: 10
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
+  budget_type: e2e
 
 - id: bh-lb-kimi-k3-attn-res
   name: bh_lb_Kimi_K3_ATTN_RES
@@ -293,3 +311,4 @@
       timeout: 10
   owner_id: U09LK84G4TF # Nikola Milicevic
   team: models
+  budget_type: e2e

--- a/tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml
@@ -25,6 +25,7 @@
       timeout: 15
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: ttnn
+  budget_type: sanity
 
 - name: Host IO fast unit test (viommu only)
   cmd: TT_METAL_SLOW_DISPATCH_MODE=1 pytest -svv models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
@@ -33,6 +34,7 @@
       timeout: 10
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: sanity
 
 - name: TTNN multi-device CCL, SDPA PERF, and indexer tests (QB2 only)
   cmd: |
@@ -45,3 +47,4 @@
       timeout: 30
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
+  budget_type: sanity

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -668,6 +668,7 @@
       release_ready: false
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -755,6 +756,7 @@
       release_ready: false
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -820,6 +822,7 @@
       timeout: 4
   owner_id: U08SXRPCTJ5  # Janko Mitrovic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -839,6 +842,7 @@
       timeout: 3
   owner_id: U08SXRPCTJ5  # Janko Mitrovic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -962,6 +966,7 @@
       release_ready: false
   owner_id: U08GEEEEC75 # ssalice
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -988,6 +993,7 @@
       release_ready: false
   owner_id: U08GEEEEC75 # ssalice
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -1014,6 +1020,7 @@
       release_ready: false
   owner_id: U08GEEEEC75 # ssalice
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -1034,6 +1041,7 @@
       release_ready: false
   owner_id: U08GEEEEC75 # ssalice
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -1060,6 +1068,7 @@
       release_ready: false
   owner_id: U08GEEEEC75 # ssalice
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -1095,6 +1104,7 @@
       release_ready: false
   owner_id: U08GEEEEC75 # ssalice
   team: models
+  budget_type: demo
   sp_config: sc1
 
 # Trace twin of the entry above: SAME splits, SAME golden, SAME KV bar -- the only difference is that
@@ -1126,6 +1136,7 @@
       release_ready: false
   owner_id: U08GEEEEC75 # ssalice
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -1318,6 +1329,7 @@
       timeout: 35
   owner_id: U0AC4LTJH1P # Jaksa Jovicic
   team: shield
+  budget_type: demo
   sp_config: sc1
 
 
@@ -1338,6 +1350,7 @@
       timeout: 40
   owner_id: U0AC4LTJH1P # Jaksa Jovicic
   team: shield
+  budget_type: demo
   sp_config: sc1
 
 

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -82,6 +82,7 @@
       release_ready: false
   owner_id: U08RL15T4N8 # Danilo Djekic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -107,6 +108,7 @@
       release_ready: false
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -128,6 +130,7 @@
       release_ready: false
   owner_id: U08RL15T4N8 # Danilo Djekic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -149,6 +152,7 @@
       release_ready: false
   owner_id: U08RL15T4N8 # Danilo Djekic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -174,6 +178,7 @@
       release_ready: false
   owner_id: U08RL15T4N8 # Danilo Djekic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 - name: "(Kimi-K2.7-1T) prefill transformer determinism 5k"
@@ -198,6 +203,7 @@
       release_ready: false
   owner_id: U08RL15T4N8 # Danilo Djekic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 - name: "(Kimi-K2.7-1T) chunked prefill padded accuracy 15k@5k no-trace"
@@ -226,6 +232,7 @@
       release_ready: false
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -257,6 +264,7 @@
       release_ready: false
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -294,6 +302,7 @@
       release_ready: false
   owner_id: U08RL15T4N8 # Danilo Djekic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -334,6 +343,7 @@
       release_ready: false
   owner_id: U08RL15T4N8 # Danilo Djekic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -367,6 +377,7 @@
       release_ready: false
   owner_id: U08RL15T4N8 # Danilo Djekic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -391,6 +402,7 @@
       release_ready: false
   owner_id: U09L76N1MAT  # Nenad Babin
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -425,6 +437,7 @@
       release_ready: false
   owner_id: U09L76N1MAT  # Nenad Babin
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -448,6 +461,7 @@
       release_ready: false
   owner_id: U0ACLAM77PS  # Kosta Grujcic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 - name: "(Kimi-K3-2.8T) MLA chunked accuracy 10k@5k + determinism 5k@5k"
@@ -470,6 +484,7 @@
       release_ready: false
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -493,6 +508,7 @@
       release_ready: false
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -517,6 +533,7 @@
       release_ready: false
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -538,6 +555,7 @@
       release_ready: false
   owner_id: U08RL15T4N8 # Danilo Djekic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -567,6 +585,7 @@
       release_ready: false
   owner_id: U09LK84G4TF  # Nikola Milicevic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -589,6 +608,7 @@
       release_ready: false
   owner_id: U09LK84G4TF  # Nikola Milicevic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -618,6 +638,7 @@
       release_ready: false
   owner_id: U09LK84G4TF  # Nikola Milicevic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -678,6 +699,7 @@
       release_ready: false
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -703,6 +725,7 @@
       release_ready: false
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -755,6 +778,7 @@
       release_ready: false
   owner_id: U08SXRPCTJ5  # Janko Mitrovic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -776,6 +800,7 @@
       release_ready: false
   owner_id: U08SXRPCTJ5  # Janko Mitrovic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -851,6 +876,7 @@
       release_ready: false
   owner_id: U08ECJQ848G # Viacheslav Melnykov
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -897,6 +923,7 @@
       release_ready: false
   owner_id: U08ECJQ848G # Viacheslav Melnykov
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -1237,6 +1264,7 @@
       release_ready: true
   owner_id: U0AC4LTJH1P # Jaksa Jovicic
   team: shield
+  budget_type: demo
   sp_config: sc4
 
 
@@ -1268,6 +1296,7 @@
       release_ready: true
   owner_id: U0AC4LTJH1P # Jaksa Jovicic
   team: shield
+  budget_type: demo
   sp_config: sc4
 
 
@@ -1344,6 +1373,7 @@
       release_ready: false
   owner_id: U08RL15T4N8 # Danilo Djekic
   team: models
+  budget_type: demo
   sp_config: sc1
 
 
@@ -1382,4 +1412,5 @@
       release_ready: false
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
+  budget_type: demo
   sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -1182,6 +1182,7 @@
       timeout: 35
   owner_id: U08HM8SL5U4 # Maciek Dragula
   team: models
+  budget_type: demo
   sp_config: sc1
 
 # Same harness/goldens at the variable-chunk small size (PREFILL_CHUNK_SIZE=1024 -> 5 chunks
@@ -1213,6 +1214,7 @@
       timeout: 35
   owner_id: U08HM8SL5U4 # Maciek Dragula
   team: models
+  budget_type: demo
   sp_config: sc1
 
 # Variable-chunk smoke (models/demos/gpt_oss_d_p/tests/variable_chunk_smoke.py):
@@ -1243,6 +1245,7 @@
       timeout: 30
   owner_id: U08HM8SL5U4 # Maciek Dragula
   team: models
+  budget_type: demo
   sp_config: sc1
 
 

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -26,6 +26,7 @@
       timeout: 10
   owner_id: U03HY7MK4BT
   team: models
+  budget_type: demo
 
 - name: "Single Galaxy - Decoder Sweep vs reference (DeepSeek V3 B1)"
   cmd: |
@@ -53,6 +54,7 @@
       timeout: 30
   owner_id: U0ALAR9B78T # Brayden Zhang
   team: models
+  budget_type: demo
 
 - name: "Single Galaxy - Decoder Sweep multi-slot stress (DeepSeek V3 B1)"
   cmd: |
@@ -80,6 +82,7 @@
       timeout: 60
   owner_id: U0ALAR9B78T # Brayden Zhang
   team: models
+  budget_type: demo
 
 # ============================================================================
 # DeepSeek V3 B1 Unit Tests (Blitz) - Blackhole Galaxy
@@ -95,6 +98,7 @@
       timeout: 35
   owner_id: U087S3K319A # Austin Ho
   team: models
+  budget_type: demo
 
 - name: bh_galaxy_DeepSeek_B1_Unit_Tests_PureLocalMatmulExpert
   cmd: |
@@ -106,6 +110,7 @@
       timeout: 75
   owner_id: U06MJ6CVCGZ # Yu Gao
   team: models
+  budget_type: demo
 
 - name: bh_galaxy_DeepSeek_B1_Unit_Tests_PureLocalSingleDeviceRemainder
   cmd: |
@@ -117,6 +122,7 @@
       timeout: 15
   owner_id: U07D5N7QL4U # Joseph Chu
   team: models
+  budget_type: demo
 
 - name: bh_galaxy_DeepSeek_B1_Unit_Tests_SpecialModes
   cmd: |
@@ -129,6 +135,7 @@
       timeout: 15
   owner_id: U08FXFFH7L0 # Abhishek Agarwal
   team: models
+  budget_type: demo
 
 - name: bh_galaxy_DeepSeek_B1_Unit_Tests_Fabric2DHostIO
   cmd: |
@@ -142,6 +149,7 @@
       timeout: 65
   owner_id: U088DBNUKGR # Evan Smal
   team: models
+  budget_type: demo
 
 - name: bh_galaxy_DeepSeek_B1_Unit_Tests_MoreFabric
   cmd: |
@@ -156,3 +164,4 @@
       timeout: 15
   owner_id: U03PUAKE719 # Miguel Tairum
   team: models
+  budget_type: demo

--- a/tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml
+++ b/tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml
@@ -16,6 +16,7 @@
     cpu_medium:
       timeout: 15
   team: scaleout
+  budget_type: unit
   arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song
 
@@ -30,6 +31,7 @@
     cpu_medium:
       timeout: 25
   team: scaleout
+  budget_type: unit
   arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song
 
@@ -50,6 +52,7 @@
       # see https://github.com/tenstorrent/tt-metal/issues/49313.)
       timeout: 15
   team: scaleout
+  budget_type: unit
   arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song
 
@@ -61,6 +64,7 @@
       # 14 fast layout/pipeline-builder combos (SC4 revC subtorus aisleC/aisleD); ~3 min.
       timeout: 15
   team: scaleout
+  budget_type: unit
   arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song
 
@@ -74,6 +78,7 @@
       # run completes in ~40 min, so this shard gets a dedicated 55-min budget for host-variance headroom.
       timeout: 55
   team: scaleout
+  budget_type: unit
   arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song
 
@@ -84,6 +89,7 @@
     cpu_medium:
       timeout: 15
   team: scaleout
+  budget_type: unit
   arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song
 
@@ -96,6 +102,7 @@
     cpu_medium:
       timeout: 15
   team: scaleout
+  budget_type: unit
   arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song
 
@@ -108,6 +115,7 @@
       # 32x4 5-group ring — the slowest CPU-only shard; 15 min timed out on CI.
       timeout: 40
   team: scaleout
+  budget_type: unit
   arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song
 
@@ -120,6 +128,7 @@
       # suite has grown past the old 15-min cap (deterministic timeout on main nightly).
       timeout: 30
   team: scaleout
+  budget_type: unit
   arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song
 
@@ -135,5 +144,6 @@
       # than local (the 4-stage step measured 5m34s on CI). Budgeted from local end-to-end x4 + margin.
       timeout: 45
   team: scaleout
+  budget_type: unit
   arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song

--- a/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
@@ -24,4 +24,5 @@
     wh_n300_civ2:
       timeout: 10
   team: scaleout
+  budget_type: merge_gate
   owner_id: U08RRAU5E15 # Ridvan Song

--- a/tests/pipeline_reorg/fabric_multihost_exabox_tests.yaml
+++ b/tests/pipeline_reorg/fabric_multihost_exabox_tests.yaml
@@ -22,6 +22,7 @@
       timeout: 10
   owner_id: U0845EV7A5U # Umair Cheema
   team: scaleout
+  budget_type: e2e
   sp_config: sc4
 
 - name: "System Health Check (SC4)"
@@ -33,6 +34,7 @@
       timeout: 10
   owner_id: U0845EV7A5U # Umair Cheema
   team: scaleout
+  budget_type: e2e
   sp_config: sc4
 
 - name: "Fabric stability short (SC4)"
@@ -62,6 +64,7 @@
       timeout: 20
   owner_id: U0845EV7A5U # Umair Cheema
   team: scaleout
+  budget_type: e2e
   sp_config: sc4
 
 - name: "DC validation (quad) neighbor exchange"
@@ -122,4 +125,5 @@
       timeout: 20
   owner_id: U0845EV7A5U # Umair Cheema
   team: scaleout
+  budget_type: e2e
   sp_config: sc4

--- a/tests/pipeline_reorg/fabric_perf_tests.yaml
+++ b/tests/pipeline_reorg/fabric_perf_tests.yaml
@@ -32,6 +32,7 @@
     wh_llmbox_perf:
       timeout: 45
   team: scaleout
+  budget_type: perf
   owner_id: U06US5C7M7X # Sean Nijjar
   upload_benchmarks: true
 
@@ -43,6 +44,7 @@
     wh_llmbox_perf:
       timeout: 45
   team: scaleout
+  budget_type: perf
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: T3K ubench - Fabric Mux V2 Throughput
@@ -51,4 +53,5 @@
     wh_llmbox_perf:
       timeout: 45
   team: scaleout
+  budget_type: perf
   owner_id: U06US5C7M7X # Sean Nijjar

--- a/tests/pipeline_reorg/fabric_sanity_tests.yaml
+++ b/tests/pipeline_reorg/fabric_sanity_tests.yaml
@@ -21,6 +21,7 @@
     wh_llmbox_civ2:
       timeout: 30
   team: scaleout
+  budget_type: sanity
   owner_id: U06US5C7M7X # Sean Nijjar
   upload_benchmarks: true
 
@@ -37,6 +38,7 @@
     wh_n300_civ2:
       timeout: 15
   team: scaleout
+  budget_type: sanity
   owner_id: U08RRAU5E15 # Ridvan Song
 
 - name: fabric fast unit tests (1D, 2D, single erisc)
@@ -53,4 +55,5 @@
     bh_p300:
       timeout: 15
   team: scaleout
+  budget_type: sanity
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar

--- a/tests/pipeline_reorg/fabric_tests.yaml
+++ b/tests/pipeline_reorg/fabric_tests.yaml
@@ -27,6 +27,7 @@
     wh_n300_civ2:
       timeout: 15
   team: scaleout
+  budget_type: unit
   owner_id: U08RRAU5E15 # Ridvan Song
 
 # ============================================================================
@@ -44,6 +45,7 @@
     wh_llmbox_civ2:
       timeout: 30
   team: scaleout
+  budget_type: unit
   owner_id: U06US5C7M7X # Sean Nijjar
   upload_benchmarks: true
 
@@ -56,6 +58,7 @@
     wh_llmbox_civ2:
       timeout: 30
   team: scaleout
+  budget_type: unit
   owner_id: U06US5C7M7X # Sean Nijjar
 
 # ============================================================================
@@ -78,6 +81,7 @@
     wh_galaxy:
       timeout: 25
   team: scaleout
+  budget_type: unit
   owner_id: U0845EV7A5U # Umair Cheema
   upload_benchmarks: true
 
@@ -100,6 +104,7 @@
     wh_galaxy:
       timeout: 25
   team: scaleout
+  budget_type: unit
   owner_id: U0845EV7A5U # Umair Cheema
   auto_triage: false
 
@@ -117,6 +122,7 @@
     bh_quietbox_2:
       timeout: 15
   team: scaleout
+  budget_type: unit
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric 2D fixture unit tests
@@ -131,6 +137,7 @@
     bh_quietbox_2:
       timeout: 15
   team: scaleout
+  budget_type: unit
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric mux v2 unit tests
@@ -143,6 +150,7 @@
     bh_quietbox_2:
       timeout: 5
   team: scaleout
+  budget_type: unit
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric UDM mode unit tests
@@ -158,6 +166,7 @@
     bh_quietbox_2:
       timeout: 15
   team: scaleout
+  budget_type: unit
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH ttnn UDM unit tests
@@ -170,6 +179,7 @@
     bh_quietbox_2:
       timeout: 10
   team: scaleout
+  budget_type: unit
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric system health tests
@@ -182,6 +192,7 @@
     bh_quietbox_2:
       timeout: 15
   team: scaleout
+  budget_type: unit
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric stability nightly tests
@@ -195,6 +206,7 @@
     bh_quietbox_2:
       timeout: 30
   team: scaleout
+  budget_type: unit
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH ccl nightly tests
@@ -207,6 +219,7 @@
     bh_quietbox_2:
       timeout: 30
   team: scaleout
+  budget_type: unit
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric infra unit tests
@@ -223,4 +236,5 @@
     bh_quietbox_2:
       timeout: 15
   team: scaleout
+  budget_type: unit
   owner_id: U06US5C7M7X # Sean Nijjar

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -23,6 +23,7 @@
       timeout: 30
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
+  budget_type: e2e
 
 - id: galaxy-fabric-2d-torus-nightly
   name: Galaxy Fabric 2D Torus Nightly Tests
@@ -34,6 +35,7 @@
       timeout: 45
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
+  budget_type: e2e
 
 - id: galaxy-fabric-multi-mesh-4x4-2x4s
   name: Galaxy Fabric Multi-Mesh 4x4 and 2x4s stability tests
@@ -49,6 +51,7 @@
       mgd: tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_split_4x4_2x4_3_mesh.textproto
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
+  budget_type: e2e
 
 - id: galaxy-fabric-multi-mesh-2x8-2x4s
   name: Galaxy Fabric Multi-mesh 2x8 and 2x4s stability tests
@@ -64,6 +67,7 @@
       mgd: tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_split_2x8_2x4_3_mesh.textproto
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
+  budget_type: e2e
 
 # Blackhole Galaxy e2e tests
 - id: bh-galaxy-fabric-torus-stability
@@ -74,6 +78,7 @@
       timeout: 20
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
+  budget_type: e2e
 
 - id: bh-galaxy-socket-pipeline
   name: BH Galaxy Socket Pipeline Single Galaxy
@@ -85,3 +90,4 @@
       timeout: 10
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
+  budget_type: e2e

--- a/tests/pipeline_reorg/galaxy_health_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_health_tests.yaml
@@ -29,6 +29,7 @@
       timeout: 15
   owner_id: U0845EV7A5U # Umair Cheema
   team: scaleout
+  budget_type: health
   arch: wormhole_b0
 
 - name: Galaxy Blackhole health
@@ -40,4 +41,5 @@
       timeout: 10
   owner_id: U0845EV7A5U # Umair Cheema
   team: scaleout
+  budget_type: health
   arch: blackhole

--- a/tests/pipeline_reorg/galaxy_integration_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_integration_tests.yaml
@@ -18,3 +18,4 @@
       timeout: 50
   owner_id: U07D5N7QL4U # Joseph Chu
   team: ttnn
+  budget_type: integration

--- a/tests/pipeline_reorg/galaxy_profiler_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_profiler_tests.yaml
@@ -18,6 +18,7 @@
       timeout: 30
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: runtime
+  budget_type: profiler
 
 - name: Galaxy realtime profiler cross-reference (TG)
   cmd: run_realtime_profiler_cross_reference_tg_test
@@ -26,3 +27,4 @@
       timeout: 15
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: runtime
+  budget_type: profiler

--- a/tests/pipeline_reorg/galaxy_sanity_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_sanity_tests.yaml
@@ -46,4 +46,5 @@
       timeout: 20
   owner_id: U0845EV7A5U # Umair Cheema
   team: scaleout
+  budget_type: sanity
   arch: wormhole_b0

--- a/tests/pipeline_reorg/galaxy_stress_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_stress_tests.yaml
@@ -13,6 +13,7 @@
 - id: galaxy-fabric-stability-stress
   name: Galaxy Fabric Stability Tests
   team: scaleout
+  budget_type: stress
   owner_id: U08FXFFH7L0 # Abhishek Agarwal
   cmd: |
     # 0 disables the metal per-op timeout (overrides setup-job's 5s default), which

--- a/tests/pipeline_reorg/galaxy_unit_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_unit_tests.yaml
@@ -17,6 +17,7 @@
   name: Galaxy UMD unit tests
   model: unit
   team: umd
+  budget_type: unit
   owner_id: U09769N29BN # Aleksa Marković
   # owner: see issue #29677
   auto_triage: true
@@ -29,6 +30,7 @@
   name: UMD API tests
   model: unit
   team: umd
+  budget_type: unit
   owner_id: U09769N29BN # Aleksa Marković
   auto_triage: true
   cmd: ./build/test/umd/api/api_tests
@@ -41,6 +43,7 @@
   name: Galaxy Fabric tests
   model: fabric
   team: scaleout
+  budget_type: unit
   owner_id: U08EE956Q8Z # Allan Liu
   auto_triage: true
   cmd: |
@@ -58,6 +61,7 @@
   name: Galaxy Multi-Process tests
   model: multiprocess
   team: scaleout
+  budget_type: unit
   owner_id: U0709049XNK # Aditya Saigal
   auto_triage: false
   cmd: |
@@ -78,6 +82,7 @@
   name: Galaxy distributed ops tests
   model: distributed-ops
   team: ttnn
+  budget_type: unit
   owner_id: U044T8U8DEF # Johanna Rock
   auto_triage: true
   cmd: |

--- a/tests/pipeline_reorg/llk_bit_exact_tests.yaml
+++ b/tests/pipeline_reorg/llk_bit_exact_tests.yaml
@@ -12,6 +12,7 @@
 - name: llk_bit_exact_wormhole
   split_group: 1
   team: llk
+  budget_type: bit_exact
   coverage: false
   cmd: |
     set -euo pipefail
@@ -29,6 +30,7 @@
 - name: llk_bit_exact_blackhole group 1/2
   split_group: 1
   team: llk
+  budget_type: bit_exact
   coverage: false
   cmd: |
     set -euo pipefail
@@ -47,6 +49,7 @@
 - name: llk_bit_exact_blackhole group 2/2
   split_group: 2
   team: llk
+  budget_type: bit_exact
   coverage: false
   cmd: |
     set -euo pipefail

--- a/tests/pipeline_reorg/llk_e2e_tests.yaml
+++ b/tests/pipeline_reorg/llk_e2e_tests.yaml
@@ -9,6 +9,7 @@
 - name: llk_e2e_wormhole group 1/2
   split_group: 1
   team: llk
+  budget_type: e2e
   coverage: false
   cmd: |
     set -euo pipefail
@@ -26,6 +27,7 @@
 - name: llk_e2e_wormhole group 2/2
   split_group: 2
   team: llk
+  budget_type: e2e
   coverage: false
   cmd: |
     set -euo pipefail
@@ -43,6 +45,7 @@
 - name: llk_e2e_blackhole group 1/2
   split_group: 1
   team: llk
+  budget_type: e2e
   coverage: false
   cmd: |
     set -euo pipefail
@@ -60,6 +63,7 @@
 - name: llk_e2e_blackhole group 2/2
   split_group: 2
   team: llk
+  budget_type: e2e
   coverage: false
   cmd: |
     set -euo pipefail

--- a/tests/pipeline_reorg/llk_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/llk_merge_gate_tests.yaml
@@ -11,6 +11,7 @@
     wh_n150_civ2:
       timeout: 10
   team: llk
+  budget_type: merge_gate
   owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: fd
@@ -23,6 +24,7 @@
     wh_n150_civ2:
       timeout: 10
   team: llk
+  budget_type: merge_gate
   owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: fd
@@ -35,6 +37,7 @@
     wh_n150_civ2:
       timeout: 10
   team: llk
+  budget_type: merge_gate
   owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: fd
@@ -47,6 +50,7 @@
     wh_n150_civ2:
       timeout: 10
   team: llk
+  budget_type: merge_gate
   owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: fd
@@ -59,6 +63,7 @@
     bh_p150b_civ2_viommu:
       timeout: 10
   team: llk
+  budget_type: merge_gate
   owner_id: U09UC143684 # Nemanja Divnic
   arch: blackhole
   dispatch_mode: fd
@@ -71,6 +76,7 @@
     bh_p150b_civ2_viommu:
       timeout: 10
   team: llk
+  budget_type: merge_gate
   owner_id: U09UC143684 # Nemanja Divnic
   arch: blackhole
   dispatch_mode: fd
@@ -84,6 +90,7 @@
     wh_n150_civ2:
       timeout: 10
   team: llk
+  budget_type: merge_gate
   owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: sd
@@ -94,6 +101,7 @@
     bh_p150b_civ2_viommu:
       timeout: 10
   team: llk
+  budget_type: merge_gate
   owner_id: U09UC143684 # Nemanja Divnic
   arch: blackhole
   dispatch_mode: sd

--- a/tests/pipeline_reorg/llk_perf_tests.yaml
+++ b/tests/pipeline_reorg/llk_perf_tests.yaml
@@ -13,6 +13,7 @@
 - name: llk_perf_wormhole group 1/5
   split_group: 1
   team: llk
+  budget_type: perf
   cmd: |
     set -euo pipefail
     ./tests/run_llk_perf_wormhole.sh {split_group} 5
@@ -24,6 +25,7 @@
 - name: llk_perf_wormhole group 2/5
   split_group: 2
   team: llk
+  budget_type: perf
   cmd: |
     set -euo pipefail
     ./tests/run_llk_perf_wormhole.sh {split_group} 5
@@ -35,6 +37,7 @@
 - name: llk_perf_wormhole group 3/5
   split_group: 3
   team: llk
+  budget_type: perf
   cmd: |
     set -euo pipefail
     ./tests/run_llk_perf_wormhole.sh {split_group} 5
@@ -46,6 +49,7 @@
 - name: llk_perf_wormhole group 4/5
   split_group: 4
   team: llk
+  budget_type: perf
   cmd: |
     set -euo pipefail
     ./tests/run_llk_perf_wormhole.sh {split_group} 5
@@ -57,6 +61,7 @@
 - name: llk_perf_wormhole group 5/5
   split_group: 5
   team: llk
+  budget_type: perf
   cmd: |
     set -euo pipefail
     ./tests/run_llk_perf_wormhole.sh {split_group} 5
@@ -68,6 +73,7 @@
 - name: llk_perf_blackhole group 1/5
   split_group: 1
   team: llk
+  budget_type: perf
   cmd: |
     set -euo pipefail
     ./tests/run_llk_perf_blackhole.sh {split_group} 5
@@ -79,6 +85,7 @@
 - name: llk_perf_blackhole group 2/5
   split_group: 2
   team: llk
+  budget_type: perf
   cmd: |
     set -euo pipefail
     ./tests/run_llk_perf_blackhole.sh {split_group} 5
@@ -90,6 +97,7 @@
 - name: llk_perf_blackhole group 3/5
   split_group: 3
   team: llk
+  budget_type: perf
   cmd: |
     set -euo pipefail
     ./tests/run_llk_perf_blackhole.sh {split_group} 5
@@ -101,6 +109,7 @@
 - name: llk_perf_blackhole group 4/5
   split_group: 4
   team: llk
+  budget_type: perf
   cmd: |
     set -euo pipefail
     ./tests/run_llk_perf_blackhole.sh {split_group} 5
@@ -112,6 +121,7 @@
 - name: llk_perf_blackhole group 5/5
   split_group: 5
   team: llk
+  budget_type: perf
   cmd: |
     set -euo pipefail
     ./tests/run_llk_perf_blackhole.sh {split_group} 5

--- a/tests/pipeline_reorg/llk_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/llk_pr_gate_tests.yaml
@@ -2,7 +2,10 @@
 #
 # Merge-gate gtest coverage lives in llk_merge_gate_tests.yaml.
 # PYTEST_MARKERS is set by llk-smoke-impl.yaml / workflow_call inputs.
-# For max allowed timeout refer to .github/time_budget.yaml (llk -> pr_gate).
+# For max allowed timeout refer to .github/time_budget.yaml (llk -> pr_gate and
+# llk -> sanity). Two allowances, because two pipelines run this list: the PR gate
+# charges llk.pr_gate and sanity-tests charges llk.sanity.
+#
 # Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 # Blackhole uses bh_p150b_civ2_viommu (same logical SKU as merge-gate); previously
 # non-prio PR runs used bh_p150b_civ2.
@@ -12,6 +15,7 @@
 - name: llk_smoke_wormhole
   split_group: 1
   team: llk
+  budget_type: [pr_gate, sanity]
   coverage: false
   cmd: |
     set -euo pipefail
@@ -28,6 +32,7 @@
 - name: llk_smoke_blackhole group 1/2
   split_group: 1
   team: llk
+  budget_type: [pr_gate, sanity]
   coverage: false
   cmd: |
     set -euo pipefail
@@ -45,6 +50,7 @@
 - name: llk_smoke_blackhole group 2/2
   split_group: 2
   team: llk
+  budget_type: [pr_gate, sanity]
   coverage: false
   cmd: |
     set -euo pipefail

--- a/tests/pipeline_reorg/llk_ttsim_weekly.yaml
+++ b/tests/pipeline_reorg/llk_ttsim_weekly.yaml
@@ -20,4 +20,5 @@
     sim_quasar_xl:
       timeout: 180
   team: llk
+  budget_type: weekly
   owner_id: U09UC143684 # Nemanja Divnic

--- a/tests/pipeline_reorg/llk_unit_tests.yaml
+++ b/tests/pipeline_reorg/llk_unit_tests.yaml
@@ -17,6 +17,7 @@
     wh_n300_civ2:
       timeout: 40
   team: llk
+  budget_type: unit
   owner_id: U09UC143684 # Nemanja Divnic
   arch: wormhole_b0
   dispatch_mode: sd
@@ -29,6 +30,7 @@
     bh_p100:
       timeout: 40
   team: llk
+  budget_type: unit
   owner_id: U09UC143684 # Nemanja Divnic
   arch: blackhole
   dispatch_mode: sd

--- a/tests/pipeline_reorg/models_device_perf_tests.yaml
+++ b/tests/pipeline_reorg/models_device_perf_tests.yaml
@@ -40,6 +40,7 @@
       hf_model: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
   owner_id: U08GELBB1AP # Ambrose Ling
   team: models
+  budget_type: device_perf
 
 - name: Llama 3.3-70B device perf tests
   cmd: |
@@ -56,6 +57,7 @@
       hf_model: meta-llama/Llama-3.3-70B-Instruct
   owner_id: U08GELBB1AP # Ambrose Ling
   team: models
+  budget_type: device_perf
 
 - name: Qwen3-32B device perf tests
   cmd: |
@@ -72,6 +74,7 @@
       hf_model: Qwen/Qwen3-32B
   owner_id: U08GELBB1AP # Ambrose Ling
   team: models
+  budget_type: device_perf
 
 - name: Stable Diffusion XL device-perf tests
   cmd: |
@@ -88,6 +91,7 @@
       timeout: 60
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: device_perf
 
 - name: ResNet-50 device perf tests
   cmd: |
@@ -104,6 +108,7 @@
       arch_dir: wormhole
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
+  budget_type: device_perf
 
 - name: ResNet-50 e2e model perf tests
   cmd: |
@@ -114,6 +119,7 @@
       timeout: 8
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
+  budget_type: device_perf
 
 - name: DeepSeek-V3 decode device perf tests (Galaxy)
   cmd: |
@@ -128,6 +134,7 @@
       timeout: 20
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
+  budget_type: device_perf
 
 - name: DeepSeek-V3 fused-op device perf tests (Galaxy)
   cmd: |
@@ -179,3 +186,4 @@
       timeout: 45
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
+  budget_type: device_perf

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -1568,6 +1568,7 @@
       release_ready: true
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 - name: TT-DiT Wan2.2-I2V-A14B single galaxy e2e tests
   cmd: |
@@ -1600,6 +1601,7 @@
       release_ready: true
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 # ── LTX-2.3 (Black Hole single galaxy, bh_sc1) ───────────────────
 - name: TT-DiT LTX-2.3 Pro T2V e2e tests

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -1023,6 +1023,7 @@
       release_ready: false
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 - name: TT-DiT Flux.2-dev multihost e2e tests
   cmd: |
@@ -1046,6 +1047,7 @@
       release_ready: false
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 # ── Z-Image ────────────────────────────────────────────────────────
 

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -48,6 +48,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 # bh_p300 runs in LFC mode: per-job impl yaml mounts the host's local-disk
 # cache (/localdev/blackhole_demos/huggingface_data) onto /mnt/MLPerf/huggingface
@@ -75,6 +76,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 # TODO: Move DP tests to sweep pipelines when those come online
 - name: Llama 3.1-8B data-parallel e2e tests
@@ -97,6 +99,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 # TODO: Move DP tests to sweep pipelines when those come online
 - name: Llama 3.1-8B data-parallel e2e tests (Galaxy)
@@ -112,6 +115,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum
   team: models
+  budget_type: e2e
 
 - name: Llama 3.2-1B e2e tests
   cmd: |
@@ -126,6 +130,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Llama 3.2-3B e2e tests
   cmd: |
@@ -142,6 +147,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Llama 3.2-11B Vision e2e tests
   cmd: |
@@ -156,6 +162,7 @@
       release_ready: false
   owner_id: U06UEFWB4P9 # Colman Glagovich
   team: models
+  budget_type: e2e
 
 - name: Llama 3.2-90B-Vision e2e tests
   cmd: |
@@ -170,6 +177,7 @@
       release_ready: false
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: e2e
 
 # Not running on wh_llmbox_perf: performance-ci-eval-32 fails there with
 # "RuntimeError: Timeout waiting for Ethernet core service remote IO request"
@@ -188,6 +196,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 # Issue: The test below is showing bad outputs after some iterations. Need to further investigate. https://github.com/tenstorrent/tt-metal/issues/42469
 # pytest --timeout 1000 models/demos/llama3_70b_galaxy/demo/text_demo.py -k "evals-32"
@@ -205,6 +214,7 @@
       release_ready: false
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
+  budget_type: e2e
 
 # TODO: Move DP tests to sweep pipelines when those come online
 # Disabled: failing with "Could not find any forwarding direction from src (M0, D0) to dst (M0, D19)" — under investigation in https://github.com/tenstorrent/tt-metal/issues/42553
@@ -241,6 +251,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Qwen3-32B e2e tests (Blackhole)
   # The TTTv2 qwen3_32b demo is T3K-only, so the Blackhole (bh_quietbox_2) SKU keeps its TTTv1
@@ -258,6 +269,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Qwen3-32B e2e tests (Galaxy)
   cmd: |
@@ -277,6 +289,7 @@
       release_ready: false
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
+  budget_type: e2e
 
 - name: Qwen3-0.6B e2e tests
   cmd: |
@@ -295,6 +308,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Qwen3-1.7B e2e tests
   cmd: |
@@ -313,6 +327,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Qwen2.5-32B e2e tests
   cmd: |
@@ -332,6 +347,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Qwen2.5-Coder-32B e2e tests
   cmd: |
@@ -347,6 +363,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Qwen2.5-Coder-32B e2e tests (Blackhole)
   cmd: |
@@ -362,6 +379,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Qwen2.5-7B e2e tests
   cmd: |
@@ -376,6 +394,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 # Qwen2.5-72B e2e: still DISABLED. The original TTTv1 leg was disabled because ci-token-matching hung on
 # CI. The TTTv2 qwen25_72b demo below is the staged replacement (T3K parity-verified locally) but stays
@@ -415,6 +434,7 @@
       release_ready: false
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: e2e
 
 - name: Qwen2.5-VL-32B e2e tests
   cmd: |
@@ -434,6 +454,7 @@
       release_ready: false
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: e2e
 
 - name: Qwen3-VL-32B e2e tests
   cmd: |
@@ -449,6 +470,7 @@
       release_ready: false
   owner_id: U08H31YMN4Q # Sanjay Sanjay
   team: models
+  budget_type: e2e
 
 # TODO Top-1/Top-5 test failing with segfaulting.
 # pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
@@ -465,6 +487,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Qwen3.6-27B e2e tests
   cmd: |
@@ -481,6 +504,7 @@
       release_ready: false
   owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models
+  budget_type: e2e
 
 # ── Gemma ──────────────────────────────────────────────────────────
 
@@ -502,6 +526,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Gemma-2-9B e2e tests
   cmd: |
@@ -515,6 +540,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Gemma-3-4B e2e tests
   cmd: |
@@ -530,6 +556,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Gemma-3-27B e2e tests
   cmd: |
@@ -545,6 +572,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 # Gemma-4 e2e tests: one entry per model variant, multiple SKUs per entry.
 # parametrize_mesh_with_fabric() picks the largest mesh shape that fits on each
@@ -581,6 +609,7 @@
       release_ready: false
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: e2e
 
 - name: Gemma-4-E4B e2e tests
   cmd: |
@@ -618,6 +647,7 @@
       release_ready: false
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: e2e
 
 - name: Gemma-4-26B-A4B e2e tests
   cmd: |
@@ -652,6 +682,7 @@
     #   tier: 2
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: e2e
 
 - name: Gemma-4-31B e2e tests
   cmd: |
@@ -683,6 +714,7 @@
     #   tier: 2
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: e2e
 
 - name: Gemma-4-12B e2e tests
   cmd: |
@@ -710,6 +742,7 @@
       release_ready: true
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: e2e
 
 # ── Mistral / Mixtral ──────────────────────────────────────────────
 
@@ -727,6 +760,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Mistral-Small-3.1-24B e2e tests
   cmd: |
@@ -743,6 +777,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 - name: Mixtral-8x7B e2e tests
   cmd: |
@@ -758,6 +793,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 # ── Falcon ─────────────────────────────────────────────────────────
 
@@ -773,6 +809,7 @@
       release_ready: false
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: e2e
 
 - name: Falcon-40B e2e tests
   cmd: |
@@ -786,6 +823,7 @@
       release_ready: false
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
+  budget_type: e2e
 
 # ── GPT-OSS ────────────────────────────────────────────────────────
 
@@ -810,6 +848,7 @@
       release_ready: false
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
+  budget_type: e2e
 
 - name: GPT-OSS 120B e2e tests
   cmd: |
@@ -836,6 +875,7 @@
       release_ready: false
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
+  budget_type: e2e
 
 # ── Whisper ────────────────────────────────────────────────────────
 
@@ -859,6 +899,7 @@
     #   tier: 1
   owner_id: U0491KT8MNY # Mohamed Bahnas
   team: models
+  budget_type: e2e
 
 # ── Phi ────────────────────────────────────────────────────────────
 
@@ -875,6 +916,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 # Phi-4-mini: disabled, asserting with 'assert freqs.shape[-1] == ext_factors.shape[-1]'
 # - name: Phi-4-mini e2e tests
@@ -907,6 +949,7 @@
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: e2e
 
 # ── UNet ───────────────────────────────────────────────────────────
 
@@ -924,6 +967,7 @@
       release_ready: false
   owner_id: U088DBNUKGR # Evan Smal
   team: models
+  budget_type: e2e
 
 - name: TT-DiT Flux.1 schnell e2e tests
   cmd: |
@@ -939,6 +983,7 @@
       release_ready: true
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 - name: TT-DiT Flux.1 dev e2e tests
   cmd: |
@@ -954,6 +999,7 @@
       release_ready: true
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 # ── FLUX.2 (TT-DiT) ────────────────────────────────────────────────
 - name: TT-DiT Flux.2-dev e2e tests
@@ -1015,6 +1061,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 # ── Stable Diffusion XL ────────────────────────────────────────────
 
@@ -1035,6 +1082,7 @@
       release_ready: false
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: e2e
 
 # tensor parralel requires 2 chips, so it is split out to a separate test
 - name: Stable Diffusion XL (base tensor-parallel) e2e tests
@@ -1050,6 +1098,7 @@
       release_ready: false
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: e2e
 
 - name: Stable Diffusion XL (lora) e2e tests
   cmd: |
@@ -1064,6 +1113,7 @@
       release_ready: false
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: e2e
 
 - name: Stable Diffusion XL (base + refiner) e2e tests
   cmd: |
@@ -1082,6 +1132,7 @@
       release_ready: false
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: e2e
 
 - name: Stable Diffusion XL (img2img + inpainting) e2e tests
   cmd: |
@@ -1103,6 +1154,7 @@
       release_ready: false
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: e2e
 
 # ── Stable Diffusion 3.5 Large (TT-DiT) ────────────────────────────
 
@@ -1121,6 +1173,7 @@
       release_ready: false
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 # ── Mochi (TT-DiT) ─────────────────────────────────────────────────
 # test_tt_mochi_pipeline is named explicitly to keep the CPU-only diffusers
@@ -1144,6 +1197,7 @@
       release_ready: false
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 # ── Qwen-Image (TT-DiT) ────────────────────────────────────────────
 - name: TT-DiT Qwen-Image e2e tests
@@ -1161,6 +1215,7 @@
       release_ready: false
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 - name: TT-DiT Motif-Image-6B e2e tests
   cmd: |
@@ -1177,6 +1232,7 @@
       release_ready: false
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 # ── Panoptic DeepLab ───────────────────────────────────────────────
 - name: panoptic-deeplab e2e tests
@@ -1190,6 +1246,7 @@
       release_ready: false
   owner_id: U09LK84G4TF # Nikola Milicevic
   team: shield
+  budget_type: e2e
 
 # ── ViT ────────────────────────────────────────────────────────────
 
@@ -1214,6 +1271,7 @@
       tier: 2
   owner_id: U088413NP0Q # Ashai Reddy Ginuga
   team: models
+  budget_type: e2e
 
 - name: VGGNet e2e tests
   cmd: |
@@ -1226,6 +1284,7 @@
       tier: 3
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
+  budget_type: e2e
 
 - name: BERT-Tiny e2e tests
   cmd: |
@@ -1239,6 +1298,7 @@
       tier: 3
   owner_id: U024A4EFV6U # Brian Liu
   team: ttnn
+  budget_type: e2e
 
 - name: BERT-Large e2e tests
   cmd: |
@@ -1252,6 +1312,7 @@
       tier: 3
   owner_id: U024A4EFV6U # Brian Liu
   team: ttnn
+  budget_type: e2e
 
 - name: DistilBERT e2e tests
   cmd: |
@@ -1265,6 +1326,7 @@
       tier: 3
   owner_id: U087S3K319A # Austin Ho (CODEOWNERS models/**/distilbert/ @tt-aho)
   team: ttnn
+  budget_type: e2e
 
 - name: SqueezeBERT e2e tests
   cmd: |
@@ -1278,6 +1340,7 @@
       tier: 3
   owner_id: U07D5N7QL4U # Joseph Chu
   team: ttnn
+  budget_type: e2e
 
 - name: MNIST MLP e2e tests
   cmd: |
@@ -1290,6 +1353,7 @@
       tier: 3
   owner_id: U088DBNUKGR # Evan Smal
   team: models
+  budget_type: e2e
 
 - name: EfficientDet-D0 e2e tests
   cmd: |
@@ -1302,6 +1366,7 @@
       tier: 3
   owner_id: U07J5E9NA9G # Dalar Vartanians
   team: models
+  budget_type: e2e
 
 - name: MobileNetV3 e2e tests
   cmd: |
@@ -1314,6 +1379,7 @@
       tier: 3
   owner_id: U07J5E9NA9G # Dalar Vartanians
   team: models
+  budget_type: e2e
 
 - name: SSD512 e2e tests
   cmd: |
@@ -1326,6 +1392,7 @@
       tier: 3
   owner_id: U07J5E9NA9G # Dalar Vartanians
   team: models
+  budget_type: e2e
 
 - name: YuNet e2e tests
   cmd: |
@@ -1338,6 +1405,7 @@
       tier: 3
   owner_id: U0978501V8B # CODEOWNERS @tvardhineniTT
   team: models
+  budget_type: e2e
 
 - name: ResNet-50 e2e tests
   cmd: |
@@ -1356,6 +1424,7 @@
       tier: 1
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
+  budget_type: e2e
 
 - name: TT-DiT Wan2.2-T2V-A14B e2e tests
   cmd: |
@@ -1382,6 +1451,7 @@
       release_ready: false
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 # ── WAN 2.2 (Black Hole quad galaxy, bh_sc4 / exabox-multihost-ci-sc4) ──
 - name: TT-DiT Wan2.2-T2V-A14B multihost quad e2e tests
@@ -1425,6 +1495,7 @@
       release_ready: true
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 - name: TT-DiT Wan2.2-I2V-A14B multihost quad e2e tests
   cmd: |
@@ -1467,6 +1538,7 @@
       release_ready: true
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 # ── WAN 2.2 (Black Hole single galaxy, bh_sc1) ───────────────────
 - name: TT-DiT Wan2.2-T2V-A14B single galaxy e2e tests
@@ -1551,6 +1623,7 @@
       release_ready: false
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 - name: TT-DiT LTX-2.3 Fast T2V e2e tests
   cmd: |
@@ -1573,6 +1646,7 @@
       release_ready: false
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 - name: TT-DiT LTX-2.3 Pro I2V e2e tests
   cmd: |
@@ -1596,6 +1670,7 @@
       release_ready: false
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 - name: TT-DiT LTX-2.3 Fast I2V e2e tests
   cmd: |
@@ -1622,6 +1697,7 @@
       release_ready: false
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: e2e
 
 # ── DeepSeek V3 (Wormhole Galaxy / TG) ──
 - name: DeepSeek-V3 decode stress e2e tests (Galaxy)
@@ -1637,6 +1713,7 @@
       release_ready: false
   owner_id: U08H32XUS9W # Yousef Al Rawwash
   team: models
+  budget_type: e2e
 
 # ── DeepSeek V3 B1 (Black Hole supercluster, bh_sc4 / bh_sc16) ──
 # Migrated from demo_sp_multihost_tests.yaml. Launch from empty NFS cwd
@@ -1711,6 +1788,7 @@
       release_ready: true
   owner_id: U08E1JCMAJF
   team: scaleout
+  budget_type: e2e
 
 # TODO: re-enable after SC4 Stress Test when it is fixed
 # - name: Stress Test (DeepSeek V3 B1 Supercluster 4 aka Superpod 1)
@@ -1817,6 +1895,7 @@
       release_ready: true
   owner_id: U08E1JCMAJF
   team: scaleout
+  budget_type: e2e
 # TODO: re-enable after SC16 Stress Test when it is fixed
 # - name: Stress Test (DeepSeek V3 B1 Supercluster 16 aka Superpod 4)
 #   cmd: |
@@ -1868,6 +1947,7 @@
       tier: 2
   owner_id: U082LLYBLSW # Gabriel Tobar (CODEOWNERS @gtobarTT)
   team: models
+  budget_type: e2e
 
 # ── TT-Train (Blackhole Galaxy) ───────────────────────────────────
 
@@ -1886,6 +1966,7 @@
       release_ready: false
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: e2e
 
 # Hanging on bh_sc1, disable until issue is resolved. Maybe related to: https://github.com/tenstorrent/tt-metal/issues/49557
 # - name: Galaxy Llama 8B TP=8 DDP=4 train e2e tests
@@ -1919,6 +2000,7 @@
       release_ready: false
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: e2e
 
 - name: Galaxy Tiny Deepseek v3 DDP=32 train e2e tests
   cmd: |
@@ -1934,6 +2016,7 @@
       release_ready: false
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: e2e
 
 # Unstable on bh_sc1, disable until issue is resolved. Maybe related to: https://github.com/tenstorrent/tt-metal/issues/49557
 # - name: Galaxy Llama 70B TP=8 FSDP=4 train e2e tests

--- a/tests/pipeline_reorg/models_sanity_tests.yaml
+++ b/tests/pipeline_reorg/models_sanity_tests.yaml
@@ -22,4 +22,5 @@
       timeout: 7
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
+  budget_type: sanity
   arch: wormhole_b0

--- a/tests/pipeline_reorg/models_sweep_tests.yaml
+++ b/tests/pipeline_reorg/models_sweep_tests.yaml
@@ -32,6 +32,7 @@
       tier: 1
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: sweep
 
 - name: Llama 3.3-70B prefix-caching benchmark
   cmd: |
@@ -45,6 +46,7 @@
       tier: 1
   owner_id: U09LTAPEU2U # Viktor Pus
   team: models
+  budget_type: sweep
 
 - name: Llama 3.3-70B seqlen sweep (LoudBox)
   cmd: |
@@ -59,6 +61,7 @@
     # bh_quietbox_2 descoped: 70B prefill exceeds Blackhole 4-device L1 (circular-buffer clash). See #48533.
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: sweep
 
 - name: Qwen3-32B seqlen sweep (LoudBox)
   cmd: |
@@ -75,6 +78,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: sweep
 
 - name: Gemma-3-4B seqlen sweep
   cmd: |
@@ -91,6 +95,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: sweep
 
 # Model-independent sampling coverage (temperature / top-k / top-p / seed / penalties /
 # batch isolation) on synthetic logits -- no model weights. In the sweep pipeline rather than
@@ -115,6 +120,7 @@
     # wh_galaxy_perf / bh_galaxy. The (4,8) cases stay in the suite and auto-skip here.
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: sweep
 
 - name: TT-Transformers MLP module sweep
   cmd: HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct pytest --tb=short models/common/tests/modules/mlp
@@ -126,6 +132,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: sweep
 
 - name: TT-Transformers RoPE module sweep
   cmd: HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct pytest --tb=short models/common/tests/modules/rope
@@ -137,6 +144,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: sweep
 
 - name: TT-Transformers RMSNorm module sweep
   cmd: HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct pytest --tb=short models/common/tests/modules/rmsnorm
@@ -148,6 +156,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: sweep
 
 - name: TT-Transformers attention module sweep
   cmd: HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/tttv2/attention_1d pytest --tb=short models/common/tests/modules/attention
@@ -159,6 +168,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: sweep
 
 - name: TT-Transformers embedding module sweep
   cmd: HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/tttv2/embedding_1d pytest --tb=short models/common/tests/modules/embedding
@@ -170,6 +180,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: sweep
 
 - name: TT-Transformers LM head module sweep
   cmd: HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/tttv2/lm_head_1d pytest --tb=short models/common/tests/modules/lm_head
@@ -181,6 +192,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: sweep
 
 - name: DeepSeek-V3 long-sequence module sweep (Galaxy)
   cmd: |
@@ -200,3 +212,4 @@
       tier: 1
   owner_id: U0896VBAKFC
   team: models
+  budget_type: sweep

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1151,6 +1151,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 # Same three test files as the bh_quietbox_2 leg above, on the 4x8 galaxy instead of 2x2.
 - name: TT-DiT Flux.2-dev multihost unit tests
@@ -1179,6 +1180,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 - name: Z-Image-Turbo unit tests
   cmd: |

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -42,6 +42,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Llama 3.2-1B unit tests
   cmd: |
@@ -57,6 +58,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Llama 3.2-3B unit tests
   cmd: |
@@ -72,6 +74,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Llama 3.2-11B Vision unit tests
   cmd: |
@@ -87,6 +90,7 @@
       tier: 3
   owner_id: U06UEFWB4P9 # Colman Glagovich
   team: models
+  budget_type: unit
 
 - name: Llama 3.2-90B-Vision unit tests
   cmd: |
@@ -113,6 +117,7 @@
       tier: 2
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: Llama 3.3-70B unit tests
   cmd: |
@@ -133,6 +138,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Qwen3-32B unit tests
   cmd: |
@@ -152,6 +158,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Qwen2.5-32B unit tests
   cmd: |
@@ -171,6 +178,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Qwen2.5-Coder-32B unit tests
   cmd: |
@@ -190,6 +198,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Qwen3.6 unit tests
   cmd: |
@@ -221,6 +230,7 @@
       tier: 1
   owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models
+  budget_type: unit
 
 - name: Mistral-7B unit tests
   cmd: |
@@ -243,6 +253,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Mistral-Small-3.1-24B vision unit tests
   cmd: |
@@ -272,6 +283,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: ViT unit tests
   cmd: |
@@ -291,6 +303,7 @@
       tier: 2
   owner_id: U088413NP0Q # Ashai Reddy Ginuga
   team: models
+  budget_type: unit
 
 - name: BERT-Large unit tests
   cmd: |
@@ -305,6 +318,7 @@
       tier: 3
   owner_id: U024A4EFV6U # Brian Liu
   team: ttnn
+  budget_type: unit
 
 - name: ResNet-50 unit tests
   cmd: |
@@ -323,6 +337,7 @@
       tier: 1
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
+  budget_type: unit
 
 - name: Gemma-3-4B unit tests
   cmd: |
@@ -336,6 +351,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Gemma-3-27B unit tests
   cmd: |
@@ -349,6 +365,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 # Janus Pro unit tests: Blackhole only (P150).
 - name: Janus Pro-7B unit tests
@@ -363,6 +380,7 @@
       tier: 3
   owner_id: U0B25UFEEAX # Milos Micic
   team: shield
+  budget_type: unit
 
 # Gemma-4 unit tests: one entry per model variant, multiple SKUs per entry.
 # parametrize_mesh_with_fabric() picks the largest mesh shape that fits on each
@@ -388,6 +406,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Gemma-2-9B unit tests
   cmd: |
@@ -403,6 +422,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Gemma-4-E2B unit tests
   cmd: |
@@ -453,6 +473,7 @@
       tier: 3
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: unit
 
 - name: Gemma-4-E4B unit tests
   cmd: |
@@ -484,6 +505,7 @@
       tier: 3
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: unit
 
 - name: Gemma-4-26B-A4B unit tests
   cmd: |
@@ -519,6 +541,7 @@
     #   tier: 2
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: unit
 
 - name: Gemma-4-31B unit tests
   cmd: |
@@ -552,6 +575,7 @@
     #   tier: 2
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: unit
 
 - name: Gemma-4-12B unit tests
   cmd: |
@@ -576,6 +600,7 @@
       tier: 1
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: unit
 
 - name: Shallow UNet unit tests
   cmd: |
@@ -595,6 +620,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Mixtral-8x7B unit tests
   cmd: |
@@ -615,6 +641,7 @@
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Llama 3.3-70B unit tests (Galaxy)
   cmd: |
@@ -637,6 +664,7 @@
       tier: 1
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
+  budget_type: unit
 
 - name: Qwen3-32B unit tests (Galaxy)
   cmd: |
@@ -663,6 +691,7 @@
       tier: 1
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
+  budget_type: unit
 
 # MiniMax-M3 unit tests — random-weight module PCC only (no HF_MODEL / M3_CKPT).
 # test_msa_layer_vs_ref is real-weights and opt-in locally; excluded from CI so Tier-1
@@ -678,6 +707,7 @@
       tier: 1
   owner_id: U08ECJQ848G # Viacheslav Melnykov
   team: models
+  budget_type: unit
 
 - name: MiniMax-M3 unit tests (BH Galaxy 8x4)
   cmd: |
@@ -692,6 +722,7 @@
       tier: 1
   owner_id: U08ECJQ848G # Viacheslav Melnykov
   team: models
+  budget_type: unit
 
 # GPT-OSS unit tests: uses HF config only (no weights). parametrize_mesh_with_fabric()
 # picks the largest fitting mesh shape per SKU when CI=true, so one yaml entry
@@ -717,6 +748,7 @@
       tier: 2
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
+  budget_type: unit
 
 - name: GPT-OSS 120B unit tests
   cmd: |
@@ -762,6 +794,7 @@
       tier: 1
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
+  budget_type: unit
 
 - name: DeepSeek-V3 unit tests
   cmd: |
@@ -782,6 +815,7 @@
       tier: 1
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
+  budget_type: unit
 
 - name: DeepSeek-V3 module unit tests (host-side)
   cmd: |
@@ -798,6 +832,7 @@
       tier: 1
   owner_id: U04N3GWH8F9 # Kartik Paigwar
   team: models
+  budget_type: unit
 
 - name: GPT-OSS-120B (disaggregated prefill) unit tests
   # Single-card PCC units for the gpt_oss_d_p prefill package (standalone: random weights +
@@ -817,6 +852,7 @@
       tier: 2
   owner_id: U08HM8SL5U4 # Maciek Dragula
   team: models
+  budget_type: unit
 
 - name: Whisper unit tests
   cmd: |
@@ -838,6 +874,7 @@
     #   tier: 1
   owner_id: U0491KT8MNY # Mohamed Bahnas
   team: models
+  budget_type: unit
 
 - name: QwQ-32B unit tests
   cmd: |
@@ -853,6 +890,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Falcon-7B unit tests
   cmd: |
@@ -866,6 +904,7 @@
       tier: 3
   owner_id: U07D5N7QL4U # Joseph Chu
   team: models
+  budget_type: unit
 
 - name: Falcon-40B unit tests
   cmd: |
@@ -879,6 +918,7 @@
       tier: 3
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
+  budget_type: unit
 
 - name: Qwen2.5-7B unit tests
   cmd: |
@@ -894,6 +934,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: Qwen2.5-72B unit tests
   cmd: |
@@ -909,6 +950,7 @@
       tier: 3
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
+  budget_type: unit
 
 - name: Qwen2.5-VL-72B unit tests
   cmd: |
@@ -924,6 +966,7 @@
       tier: 2
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: Qwen2.5-VL-32B unit tests
   cmd: |
@@ -939,6 +982,7 @@
       tier: 3
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: Qwen3-VL-32B unit tests
   cmd: |
@@ -954,6 +998,7 @@
       tier: 2
   owner_id: U08H31YMN4Q # Sanjay Sanjay
   team: models
+  budget_type: unit
 
 - name: Phi-3-mini unit tests
   cmd: |
@@ -969,6 +1014,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: TT-DiT common unit tests, shared amongst all models.
   cmd: |
@@ -984,6 +1030,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 - name: TT-DiT encoder unit tests, shared amongst all models.
   cmd: |
@@ -1018,6 +1065,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 # Phi-4-mini: disabled, asserting with 'assert freqs.shape[-1] == ext_factors.shape[-1]'
 # - name: Phi-4-mini unit tests
@@ -1063,6 +1111,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 - name: TT-DiT Flux.1-dev unit tests
   cmd: |
@@ -1081,6 +1130,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 - name: TT-DiT Flux.2-dev unit tests
   cmd: |
@@ -1144,6 +1194,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 - name: Stable Diffusion XL LoRA unit tests
   cmd: |
@@ -1168,6 +1219,7 @@
       tier: 2
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: unit
 
 - name: Stable Diffusion XL refiner unit tests
   cmd: |
@@ -1188,6 +1240,7 @@
       tier: 2
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: unit
 
 - name: Stable Diffusion XL VAE unit tests
   cmd: |
@@ -1208,6 +1261,7 @@
       tier: 2
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: unit
 
 - name: Stable Diffusion XL base unit tests
   cmd: |
@@ -1228,6 +1282,7 @@
       tier: 2
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: unit
 
 - name: Stable Diffusion XL base unet-loop unit tests
   cmd: |
@@ -1251,6 +1306,7 @@
       tier: 2
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: unit
 
 - name: Stable Diffusion XL refiner unet-loop unit tests
   cmd: |
@@ -1274,6 +1330,7 @@
       tier: 2
   owner_id: U08SXRPCTJ5 # Janko Mitrovic
   team: shield
+  budget_type: unit
 
 - name: TT-DiT Stable Diffusion 3.5 Large unit tests
   cmd: |
@@ -1290,6 +1347,7 @@
       tier: 3
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 # ── Mochi (TT-DiT) ─────────────────────────────────────────────────
 - name: TT-DiT Mochi unit tests
@@ -1310,6 +1368,7 @@
       tier: 3
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 # ── Qwen-Image (TT-DiT) ────────────────────────────────────────────
 - name: TT-DiT Qwen-Image unit tests
@@ -1327,6 +1386,7 @@
       tier: 2
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 - name: TT-DiT Motif-Image-6B unit tests
   cmd: |
@@ -1343,6 +1403,7 @@
       tier: 2
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 # ============================================================================
 # Multihost (exabox) model-unit tests
@@ -1377,6 +1438,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 - name: TT-DiT Wan2.2-T2V-A14B unit tests
   cmd: |
@@ -1400,6 +1462,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 - name: TT-DiT Wan2.2-I2V-A14B unit tests
   cmd: |
@@ -1417,6 +1480,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 # ----------------------------------------------------------------------------
 # LTX-2.3 component unit tests (Black Hole single galaxy, bh_sc1)
@@ -1459,6 +1523,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 # ----------------------------------------------------------------------------
 # WAN 2.2 single-galaxy multihost tests (bh_sc1 / exabox-multihost-ci-sc1)
@@ -1558,6 +1623,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 - name: panoptic-deeplab unit tests
   cmd: TT_METAL_WATCHER=30 TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/panoptic_deeplab/tests/pcc/ --timeout=420
@@ -1569,6 +1635,7 @@
       tier: 3
   owner_id: U09LK84G4TF # Nikola Milicevic
   team: shield
+  budget_type: unit
 
 - name: bevformer unit tests
   cmd: TT_METAL_WATCHER=30 TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/bevformer/tests/pcc/ --timeout=660
@@ -1580,6 +1647,7 @@
       tier: 3
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: shield
+  budget_type: unit
 
 - name: EfficientDet-D0 unit tests
   cmd: TT_METAL_WATCHER=30 pytest --timeout 600 models/experimental/efficientdetd0/tests/pcc/test_efficient_det.py
@@ -1591,6 +1659,7 @@
       tier: 3
   owner_id: U07J5E9NA9G # Dalar Vartanians
   team: models
+  budget_type: unit
 
 - name: MobileNetV3 unit tests
   cmd: TT_METAL_WATCHER=30 pytest --timeout 360 models/experimental/mobileNetV3/tests/pcc/test_mobilenetv3.py
@@ -1602,6 +1671,7 @@
       tier: 3
   owner_id: U07J5E9NA9G # Dalar Vartanians
   team: models
+  budget_type: unit
 
 - name: RetinaNet unit tests
   cmd: TT_METAL_WATCHER=30 pytest --timeout 360 models/experimental/retinanet/tests/pcc/test_retinanet.py
@@ -1613,6 +1683,7 @@
       tier: 3
   owner_id: U07J5E9NA9G # Dalar Vartanians
   team: models
+  budget_type: unit
 
 - name: SSD512 unit tests
   cmd: TT_METAL_WATCHER=30 pytest --timeout 300 models/experimental/SSD512/tests/pcc/test_ssd.py
@@ -1624,6 +1695,7 @@
       tier: 3
   owner_id: U07J5E9NA9G # Dalar Vartanians
   team: models
+  budget_type: unit
 
 - name: VAD v2 unit tests
   cmd: TT_METAL_WATCHER=30 pytest --timeout 600 models/experimental/vadv2/tests/pcc/test_tt_vad.py
@@ -1635,6 +1707,7 @@
       tier: 3
   owner_id: U088413NP0Q # Ashai Reddy Ginuga
   team: models
+  budget_type: unit
 
 - name: OpenPDN-MNIST unit tests
   cmd: TT_METAL_WATCHER=30 pytest --timeout 300 tests/ttnn/integration_tests/openpdn_mnist/test_ttnn_openpdn_mnist.py
@@ -1646,6 +1719,7 @@
       tier: 3
   owner_id: U088413NP0Q # Ashai Reddy Ginuga
   team: models
+  budget_type: unit
 
 - name: YuNet unit tests
   cmd: TT_METAL_WATCHER=30 pytest --timeout 300 models/experimental/yunet/tests/pcc/test_pcc.py
@@ -1657,6 +1731,7 @@
       tier: 3
   owner_id: U0978501V8B # CODEOWNERS @tvardhineniTT
   team: models
+  budget_type: unit
 
 - name: BGE-M3 unit tests
   cmd: |
@@ -1678,6 +1753,7 @@
       tier: 2
   owner_id: U082LLYBLSW # Gabriel Tobar (CODEOWNERS @gtobarTT)
   team: models
+  budget_type: unit
 
 - name: On-device sampling unit tests
   cmd: |
@@ -1692,6 +1768,7 @@
       tier: 3
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: unit
 
 - name: TT-Transformers common unit tests
   cmd: |
@@ -1706,6 +1783,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: TT-Transformers MLP module unit tests
   cmd: |
@@ -1728,6 +1806,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: TT-Transformers RMSNorm module unit tests
   cmd: |
@@ -1750,6 +1829,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: TT-Transformers RoPE module unit tests
   cmd: |
@@ -1772,6 +1852,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: TT-Transformers LM head module unit tests
   cmd: |
@@ -1794,6 +1875,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: TT-Transformers attention module unit tests
   cmd: |
@@ -1815,6 +1897,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: TT-Transformers embedding module unit tests
   cmd: |
@@ -1837,6 +1920,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: TT-Transformers sampling module unit tests
   cmd: |
@@ -1871,6 +1955,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: TT-Transformers RMSNorm 2D module unit tests
   cmd: |
@@ -1892,6 +1977,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: TT-Transformers MLP 2D module unit tests
   cmd: |
@@ -1913,6 +1999,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: TT-Transformers auto-compose 2D unit tests
   cmd: |
@@ -1933,6 +2020,7 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: unit
 
 - name: DeepSeek-V3 unit tests (Galaxy)
   cmd: |
@@ -1949,6 +2037,7 @@
       tier: 2
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
+  budget_type: unit
 
 - name: DeepSeek-V3 module tests (Galaxy)
   cmd: |
@@ -1969,6 +2058,7 @@
       tier: 2
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
+  budget_type: unit
 
 - name: DeepSeek-V3 TG MoE tests (Galaxy)
   cmd: |
@@ -1986,3 +2076,4 @@
       tier: 2
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
+  budget_type: unit

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1560,6 +1560,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 - name: TT-DiT Wan2.2-I2V-A14B unit tests (single BH galaxy)
   cmd: |
@@ -1587,6 +1588,7 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+  budget_type: unit
 
 # ----------------------------------------------------------------------------
 # WAN 2.2 multihost quad-galaxy tests (bh_sc4 / exabox-multihost-ci-sc4)

--- a/tests/pipeline_reorg/ops_integration_tests.yaml
+++ b/tests/pipeline_reorg/ops_integration_tests.yaml
@@ -24,4 +24,5 @@
       timeout: 30
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
+  budget_type: integration
   category: ops_docs_check

--- a/tests/pipeline_reorg/ops_pnr_tests.yaml
+++ b/tests/pipeline_reorg/ops_pnr_tests.yaml
@@ -14,6 +14,7 @@
       timeout: 50
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
+  budget_type: package_and_release
   category: matmul
 
 - name: ttnn release fused tests
@@ -25,6 +26,7 @@
       timeout: 65
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
+  budget_type: package_and_release
   category: fused
 
 - name: ttnn release reduction tests
@@ -36,6 +38,7 @@
       timeout: 45
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
+  budget_type: package_and_release
   category: reduction
 
 - name: ttnn release moreh tests
@@ -47,4 +50,5 @@
       timeout: 45
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
+  budget_type: package_and_release
   category: moreh

--- a/tests/pipeline_reorg/ops_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ops_sanity_tests.yaml
@@ -20,6 +20,7 @@
       timeout: 5
   owner_id: U03PUAKE719 # Miguel Tairum
   team: models
+  budget_type: sanity
   slow_dispatch: false
 
 - name: blackhole deepseek blitz op tests (slow dispatch)
@@ -29,6 +30,7 @@
       timeout: 60
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
+  budget_type: sanity
   slow_dispatch: true
 
 - name: blackhole deepseek blitz op tests (fast dispatch)
@@ -38,6 +40,7 @@
       timeout: 30
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
+  budget_type: sanity
   slow_dispatch: false
 
 - name: blackhole deepseek per-core allocation tests (slow dispatch)
@@ -47,6 +50,7 @@
       timeout: 10
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
+  budget_type: sanity
   slow_dispatch: true
 
 - name: blackhole deepseek per-core allocation tests (fast dispatch)
@@ -56,4 +60,5 @@
       timeout: 10
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
+  budget_type: sanity
   slow_dispatch: false

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -32,6 +32,7 @@
       timeout: 150
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
+  budget_type: unit
   category: conv
 
 - name: ttnn nightly matmul tests
@@ -45,6 +46,7 @@
       timeout: 50
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
+  budget_type: unit
   category: matmul
 
 - name: ttnn nightly fused tests
@@ -56,6 +58,7 @@
       timeout: 65
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
+  budget_type: unit
   category: fused
 
 - name: ttnn nightly reduction tests
@@ -69,6 +72,7 @@
       timeout: 45
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
+  budget_type: unit
   category: reduction
 
 - name: ttnn nightly experimental tests (wormhole)
@@ -83,6 +87,7 @@
       timeout: 65
   owner_id: U080FKG7KEU # Utku Aydonat
   team: ttnn
+  budget_type: unit
   category: experimental
 
 - name: ttnn nightly experimental tests (blackhole)
@@ -95,6 +100,7 @@
       timeout: 40
   owner_id: U080FKG7KEU # Utku Aydonat
   team: ttnn
+  budget_type: unit
   category: experimental
 
 - name: ttnn attn_res_weighted_reduce_nc unit tests
@@ -111,6 +117,7 @@
       timeout: 3
   owner_id: U09LK84G4TF # Nikola Milicevic
   team: ttnn
+  budget_type: unit
   category: experimental
 
 - name: ttnn nightly experimental tests (blackhole - viommu)
@@ -127,6 +134,7 @@
       timeout: 7
   owner_id: U09L76N1MAT  # Nenad Babin
   team: ttnn
+  budget_type: unit
   category: experimental
 
 - name: ttnn nightly experimental generalized MoE gate op tests
@@ -138,6 +146,7 @@
       timeout: 10
   owner_id: U07M7QZ0BQA # Camilo Vega
   team: ttnn
+  budget_type: unit
   category: experimental
 
 - name: ttnn nightly pool tests
@@ -153,6 +162,7 @@
       timeout: 90
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
+  budget_type: unit
   category: pool
 
 - name: ttnn kernel-lib eltwise chain tests
@@ -172,6 +182,7 @@
       timeout: 10
   owner_id: U08ADLJ4PLP # Aleksandar Stancov
   team: ttnn
+  budget_type: unit
   category: kernel_lib
 
 - name: ttnn nightly eltwise tests group 1
@@ -185,6 +196,7 @@
       timeout: 75
   owner_id: U09BX3N0N95 # Mateusz Nowak
   team: ttnn
+  budget_type: unit
   category: eltwise
 
 - name: ttnn nightly eltwise tests group 2
@@ -198,6 +210,7 @@
       timeout: 45
   owner_id: U09BX3N0N95 # Mateusz Nowak
   team: ttnn
+  budget_type: unit
   category: eltwise
 
 - name: ttnn nightly eltwise tests group 3
@@ -211,6 +224,7 @@
       timeout: 45
   owner_id: U09BX3N0N95 # Mateusz Nowak
   team: ttnn
+  budget_type: unit
   category: eltwise
 
 - name: ttnn nightly eltwise tests group 4
@@ -224,6 +238,7 @@
       timeout: 55
   owner_id: U09BX3N0N95 # Mateusz Nowak
   team: ttnn
+  budget_type: unit
   category: eltwise
 
 - name: ttnn nightly transformers tests
@@ -239,6 +254,7 @@
       timeout: 30
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: ttnn
+  budget_type: unit
   category: transformers
 
 - name: ttnn nightly moreh tests
@@ -250,6 +266,7 @@
       timeout: 45
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
+  budget_type: unit
   category: moreh
 
 - name: ttnn nightly misc (rand and ssm) tests
@@ -265,6 +282,7 @@
       timeout: 15
   owner_id: U09BX3N0N95 # Mateusz Nowak
   team: ttnn
+  budget_type: unit
   category: misc
 
 - name: ttnn nightly sdpa tests
@@ -284,6 +302,7 @@
       timeout: 90
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
+  budget_type: unit
   category: sdpa
 
 - name: ttnn nightly sdpa stress tests
@@ -300,6 +319,7 @@
       timeout: 55
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
+  budget_type: unit
   category: sdpa
 
 - name: ttnn nightly data_movement tests
@@ -317,6 +337,7 @@
       timeout: 40
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
+  budget_type: unit
   category: data_movement
 
 # The post-commit data_movement / ccl / point_to_point suites are re-run nightly
@@ -346,6 +367,7 @@
       timeout: 80
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
+  budget_type: unit
   category: data_movement
 
 - name: ttnn n300 ccl tests
@@ -359,6 +381,7 @@
       timeout: 10
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
+  budget_type: unit
   category: data_movement
 
 - name: blackhole host to device smoke tests
@@ -370,6 +393,7 @@
       timeout: 10
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
+  budget_type: unit
   category: data_movement
 
 - name: ttnn nightly point_to_point tests (post-commit suite)
@@ -386,6 +410,7 @@
       timeout: 5
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
+  budget_type: unit
   category: data_movement
 
 - name: ccl nightly tests
@@ -406,6 +431,7 @@
       timeout: 60
   owner_id: U07M7QZ0BQA # Camilo Vega
   team: ttnn
+  budget_type: unit
   category: ccl
 
 - name: Galaxy CCL tests
@@ -415,6 +441,7 @@
       timeout: 60
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
+  budget_type: unit
   category: ccl
 
 - name: Galaxy MoE tests
@@ -426,6 +453,7 @@
       timeout: 60
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
+  budget_type: unit
   category: ccl
 
 - name: BH Galaxy CCL tests
@@ -435,6 +463,7 @@
       timeout: 40
   owner_id: U07M7QZ0BQA # Camilo Vega
   team: ttnn
+  budget_type: unit
   category: ccl
 
 - name: ttnn nightly docs examples tests
@@ -451,6 +480,7 @@
       timeout: 20
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
+  budget_type: unit
   category: docs_examples
 
 # --- C++ ttnn unit tests ---
@@ -468,6 +498,7 @@
       timeout: 45
   owner_id: U024A4EFV6U # Brian Liu
   team: ttnn
+  budget_type: unit
   category: cpp_accessor
 
 - name: Nightly TTNN university lab examples
@@ -483,4 +514,5 @@
       timeout: 45
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
+  budget_type: unit
   category: cpp_lab_examples

--- a/tests/pipeline_reorg/runtime_examples_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_examples_pr_gate_tests.yaml
@@ -10,4 +10,5 @@
     wh_n150_civ2:
       timeout: 15
   team: runtime
+  budget_type: pr_gate
   owner_id: U099A7FMKL2 # Manish Sudumbrekar

--- a/tests/pipeline_reorg/runtime_integration_tests.yaml
+++ b/tests/pipeline_reorg/runtime_integration_tests.yaml
@@ -28,6 +28,7 @@
       timeout: 15
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: integration
 
 # --- Sockets (distributed HD socket) ---
 - name: bh_multicard_sockets
@@ -37,6 +38,7 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: integration
 
 # --- Galaxy: Ethernet only (#46302; fabric team owns full galaxy stress) ---
 - name: galaxy_eth
@@ -50,6 +52,7 @@
       timeout: 15
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: integration
 
 # =============================================================================
 # FD Python API Tests (eager ops + sweep)
@@ -65,6 +68,7 @@
       timeout: 45
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: integration
 
 - name: runtime_fd_python_2
   cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 2
@@ -75,6 +79,7 @@
       timeout: 45
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: integration
 
 - name: runtime_fd_python_3
   cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 3
@@ -85,6 +90,7 @@
       timeout: 45
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: integration
 
 - name: runtime_fd_python_4
   cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 4
@@ -95,6 +101,7 @@
       timeout: 45
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: integration
 
 - name: runtime_fd_python_5
   cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 5
@@ -105,6 +112,7 @@
       timeout: 45
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: integration
 
 - name: runtime_fd_python_6
   cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 6
@@ -115,6 +123,7 @@
       timeout: 45
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: integration
 
 - name: runtime_fd_python_7
   cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 7
@@ -125,6 +134,7 @@
       timeout: 45
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: integration
 
 # --- Sweep Tests ---
 # NOTE: erfc filtered — ttnn.erfc dropped fast_and_approximate_mode in #42737 (Apr 24); test still passes the kwarg. Re-enable once test or API is updated.
@@ -137,3 +147,4 @@
       timeout: 45
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: integration

--- a/tests/pipeline_reorg/runtime_perf_profiler_tests.yaml
+++ b/tests/pipeline_reorg/runtime_perf_profiler_tests.yaml
@@ -47,6 +47,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: perf_profiler
 
 # --- Data movement regressions ---
 - name: runtime_perf_data_movement
@@ -68,3 +69,4 @@
       timeout: 20
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: perf_profiler

--- a/tests/pipeline_reorg/runtime_perf_tests.yaml
+++ b/tests/pipeline_reorg/runtime_perf_tests.yaml
@@ -36,6 +36,7 @@
       timeout: 30
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: perf
 
 # --- Dispatch Buffer R/W Bandwidth Benchmark ---
 - name: runtime_perf_rw_buffer
@@ -61,6 +62,7 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: perf
 
 # --- JIT Build (local host compile) Throughput Benchmark ---
 # Adapts DISABLED_TensixCompileStress into a runtime perf gate: real attached
@@ -80,6 +82,7 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: perf
 
 # --- PCIe host/device bandwidth (mem_bench) ---
 # Same command and CIv2 P150b SKU as the former metal-run-microbenchmarks
@@ -95,3 +98,4 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: perf

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -25,6 +25,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: sanity
 
 # --- Dispatch: randomized tensix programs (package-and-release health check) ---
 - name: runtime_release_sanity_dispatch
@@ -36,6 +37,7 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: sanity
 
 # --- Device: init, cluster API, mock API (excluding NIGHTLY) ---
 - name: runtime_sanity_device
@@ -47,6 +49,7 @@
       timeout: 3
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: sanity
 
 # --- API: DRAM R/W + L1 R/W + kernel compile (core API health check) ---
 - name: runtime_sanity_api
@@ -58,6 +61,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: sanity
 
 # --- BH Multi-Card: System Health ---
 - name: bh_multicard_system_health
@@ -67,6 +71,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: sanity
 
 # =============================================================================
 # TTSim simulator coverage for runtime C++ unit tests (sim_* SKUs only, no HW).
@@ -98,6 +103,7 @@
       timeout: 30
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: sanity
 
 # Quasar simulator coverage (ttsim-owned list, full set as originally requested by Matt
 # Craighead). Some of these may fail today due to a known libttsim_qsr.so NOC_API_V2 gap
@@ -129,6 +135,7 @@
       timeout: 30
   owner_id: U08PR765YJ1 # Matt Craighead
   team: ttsim
+  budget_type: sanity
 
 - name: runtime_sim_galaxy_cpp_unit_tests (wormhole_b0)
   cmd: >-
@@ -141,6 +148,7 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: sanity
 
 - name: runtime_sim_galaxy_cpp_unit_tests (blackhole)
   cmd: >-
@@ -153,3 +161,4 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: sanity

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -30,6 +30,7 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 - name: runtime_fast_dispatch_multi_cq
   cmd: TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='UnitMeshMultiCQ*Fixture.*'
@@ -44,6 +45,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 - name: runtime_rt_profiler
   cmd: ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='RealtimeProfiler*'
@@ -54,6 +56,7 @@
       timeout: 6
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Core API Tests (includes kernel path validation) ---
 # Runtime tensor tests were split out of unit_tests_api into their own
@@ -72,6 +75,7 @@
       timeout: 15
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Data Movement Tests ---
 - name: runtime_data_movement
@@ -85,6 +89,7 @@
       timeout: 40
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Context, Device, Misc, JIT Build, NOC ---
 - name: runtime_core
@@ -102,6 +107,7 @@
       timeout: 12
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Integration Tests ---
 - name: runtime_integration
@@ -113,6 +119,7 @@
       timeout: 8
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- LLK + SFPI Tests ---
 # WH/BH timeout raised to 12 min: full LLK+SFPI suite exceeds 8 min wall clock (measured
@@ -132,6 +139,7 @@
       timeout: 12
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Debug Tools (DPrint, Watcher, Inspector, Clean Init, NOC Debugging) ---
 - name: runtime_debug_tools
@@ -149,6 +157,7 @@
       timeout: 12
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 - name: runtime_noc_debugging
   cmd: ./build/test/tt_metal/unit_tests_noc_debugging
@@ -159,6 +168,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Ethernet Tests ---
 - name: runtime_eth
@@ -172,6 +182,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Legacy Tests ---
 - name: runtime_legacy
@@ -183,6 +194,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Distributed / Multi-Device Tests ---
 - name: runtime_distributed
@@ -196,6 +208,7 @@
       timeout: 8
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # NOTE: wh_llmbox is intentionally NOT listed here. The full distributed_unit_tests suite already
 # runs on wh_llmbox (the T3000 8-device box) via the scaleout-owned t3k_ttmetal_tests job
@@ -221,6 +234,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- FD2 Dispatch Tests (prefetcher + dispatcher) ---
 - name: runtime_fd2
@@ -236,6 +250,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # =============================================================================
 # Slow Dispatch Tests (TT_METAL_SLOW_DISPATCH_MODE=1 set per-command)
@@ -259,6 +274,7 @@
       timeout: 15
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Data Movement Tests (SD) ---
 - name: runtime_sd_data_movement
@@ -276,6 +292,7 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Debug Tools, Device, Dispatch (SD) ---
 - name: runtime_sd_debug_tools_device_dispatch
@@ -301,6 +318,7 @@
       timeout: 17
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- LLK Tests (SD) ---
 - name: runtime_sd_llk
@@ -320,6 +338,7 @@
       timeout: 17
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Legacy Tests (SD) ---
 - name: runtime_sd_legacy
@@ -337,6 +356,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Eager C++ Tests (SD) ---
 - name: runtime_sd_eager
@@ -354,6 +374,7 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # =============================================================================
 # Multi-Card Unit Tests (BH + Galaxy) — see #46302 for topology matrix
@@ -371,6 +392,7 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- BH Multi-Card: Dispatch (RandomProgram on multi-card) ---
 - name: bh_multicard_dispatch
@@ -382,6 +404,7 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Galaxy: Dispatch (single-card + multi-CQ fixtures) ---
 - name: galaxy_dispatch
@@ -401,6 +424,7 @@
       timeout: 19
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Galaxy: Device Tests (GalaxyFixture only, SD + FD) ---
 - name: galaxy_device
@@ -414,6 +438,7 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # --- Galaxy: Distributed (DispatchContext SD + remote chip dispatch) ---
 - name: galaxy_distributed
@@ -429,6 +454,7 @@
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit
 
 # Service Core Manager Tests (BH only, SD + FD)
 - name: service_core_manager
@@ -444,3 +470,4 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+  budget_type: unit

--- a/tests/pipeline_reorg/runtime_validation_basic_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_basic_tests.yaml
@@ -12,4 +12,5 @@
     bh_p150b_civ2_viommu:
       timeout: 15
   team: runtime
+  budget_type: merge_gate
   owner_id: U099A7FMKL2 # Manish Sudumbrekar

--- a/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
@@ -18,6 +18,7 @@
     bh_p150b_civ2_viommu:
       timeout: 15
   team: runtime
+  budget_type: merge_gate
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
 
 - name: runtime validation smoke cpu-only
@@ -32,4 +33,5 @@
     github_hosted_cpu:
       timeout: 10
   team: runtime
+  budget_type: merge_gate
   owner_id: U099A7FMKL2 # Manish Sudumbrekar

--- a/tests/pipeline_reorg/runtime_validation_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_pr_gate_tests.yaml
@@ -11,6 +11,7 @@
     wh_n150_civ2:
       timeout: 15
   team: runtime
+  budget_type: pr_gate
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
 
 - name: runtime validation smoke cpu-only
@@ -25,4 +26,5 @@
     github_hosted_cpu:
       timeout: 10
   team: runtime
+  budget_type: pr_gate
   owner_id: U099A7FMKL2 # Manish Sudumbrekar

--- a/tests/pipeline_reorg/single_card_profiler_tests.yaml
+++ b/tests/pipeline_reorg/single_card_profiler_tests.yaml
@@ -24,6 +24,7 @@
       timeout: 5
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: runtime
+  budget_type: profiler
 
 - name: Device profiler regressions
   cmd: run_device_profiler_test
@@ -38,6 +39,7 @@
       timeout: 25
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: runtime
+  budget_type: profiler
 
 - name: Perf op report
   cmd: run_perf_op_report_test
@@ -52,6 +54,7 @@
       timeout: 8
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: ttnn
+  budget_type: profiler
 
 - name: Realtime profiler suite
   cmd: run_realtime_profiler_test
@@ -66,6 +69,7 @@
       timeout: 15
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: runtime
+  budget_type: profiler
 
 - name: L1 accumulate profiler
   cmd: run_accumulate_profiler_test
@@ -80,3 +84,4 @@
       timeout: 6
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: runtime
+  budget_type: profiler

--- a/tests/pipeline_reorg/syseng_didt_tests.yaml
+++ b/tests/pipeline_reorg/syseng_didt_tests.yaml
@@ -24,6 +24,7 @@
       timeout: 2
   owner_id: U08JJGXKWKB # Radomir Djogo
   team: syseng
+  budget_type: integration
 
 - name: didt_ff1_matmul_without_gelu
   cmd: TT_MM_THROTTLE_PERF=0 pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "without_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
@@ -38,6 +39,7 @@
       timeout: 2
   owner_id: U08JJGXKWKB # Radomir Djogo
   team: syseng
+  budget_type: integration
 
 - name: didt_ff1_matmul_with_gelu
   cmd: TT_MM_THROTTLE_PERF=0 pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "with_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
@@ -52,6 +54,7 @@
       timeout: 2
   owner_id: U08JJGXKWKB # Radomir Djogo
   team: syseng
+  budget_type: integration
 
 - name: didt_lm_head_matmul
   cmd: TT_MM_THROTTLE_PERF=1 pytest tests/didt/test_lm_head_matmul.py::test_lm_head_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
@@ -66,6 +69,7 @@
       timeout: 2
   owner_id: U08JJGXKWKB # Radomir Djogo
   team: syseng
+  budget_type: integration
 
 - name: didt_sdxl_conv
   cmd: TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_conv.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
@@ -80,6 +84,7 @@
       timeout: 2
   owner_id: U08JJGXKWKB # Radomir Djogo
   team: syseng
+  budget_type: integration
 
 - name: didt_sdxl_matmul
   cmd: TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_matmul.py::test_sdxl_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
@@ -94,6 +99,7 @@
       timeout: 2
   owner_id: U08JJGXKWKB # Radomir Djogo
   team: syseng
+  budget_type: integration
 
 - name: didt_sdxl_conv_1280x1280_upsample
   cmd: TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_conv_1280x1280_upsample.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
@@ -108,6 +114,7 @@
       timeout: 2
   owner_id: U08JJGXKWKB # Radomir Djogo
   team: syseng
+  budget_type: integration
 
 - name: didt_mla_sdpa
   cmd: pytest tests/didt/test_mla_sdpa.py::test_mla_sdpa -k "all" --didt-workload-iterations 10 --determinism-check-interval 1
@@ -122,6 +129,7 @@
       timeout: 2
   owner_id: U08JJGXKWKB # Radomir Djogo
   team: syseng
+  budget_type: integration
 
 - name: didt_deepseek_v3_128k_matmul
   cmd: TT_MM_THROTTLE_PERF=1 pytest tests/didt/test_deepseek_v3_128k_matmul.py -k "1chips or galaxy" --didt-workload-iterations 10 --determinism-check-interval 1
@@ -136,3 +144,4 @@
       timeout: 2
   owner_id: U08JJGXKWKB # Radomir Djogo
   team: syseng
+  budget_type: integration

--- a/tests/pipeline_reorg/t3000_sanity_tests.yaml
+++ b/tests/pipeline_reorg/t3000_sanity_tests.yaml
@@ -29,3 +29,4 @@
       timeout: 15
   owner_id: U06MJ6CVCGZ # Yu Gao
   team: ttnn
+  budget_type: sanity

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -16,6 +16,7 @@
       timeout: 90
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
+  budget_type: e2e
 
 - name: t3k_ccl_2d_tests
   cmd: pytest tests/nightly/t3000/2d_ccl
@@ -24,6 +25,7 @@
       timeout: 10
   owner_id: U087S3K319A # Austin Ho
   team: scaleout
+  budget_type: e2e
 
 - name: t3k_fabric_unit_tests
   cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*"
@@ -32,6 +34,7 @@
       timeout: 30
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
+  budget_type: e2e
 
 - name: t3k_addrgen_write_tests
   cmd: build/test/tt_metal/tt_fabric/test_addrgen_write
@@ -40,6 +43,7 @@
       timeout: 10
   owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
+  budget_type: e2e
 
 - name: t3k_dispatch_unit_tests
   cmd: build/test/tt_metal/unit_tests_dispatch --gtest_filter="Large*.NIGHTLY_DRAMReadback/*"
@@ -48,6 +52,7 @@
       timeout: 15
   owner_id: U07R05K4WGJ # John Bauman
   team: scaleout
+  budget_type: e2e
 
 - name: t3k_fabric_stability_tests
   # Setting TT_METAL_OPERATION_TIMEOUT_SECONDS=0 to disable test timeouts and let the tests run to completion, as some of the stability tests can take a long time to complete.
@@ -57,3 +62,4 @@
       timeout: 120
   owner_id: U08FXFFH7L0 # Abhishek Agarwal
   team: scaleout
+  budget_type: e2e

--- a/tests/pipeline_reorg/t3k_integration_tests.yaml
+++ b/tests/pipeline_reorg/t3k_integration_tests.yaml
@@ -16,6 +16,7 @@
       timeout: 30
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
+  budget_type: integration
   model-name: tteager
 
 
@@ -26,6 +27,7 @@
       timeout: 30
   owner_id: U0709049XNK # Aditya Saigal
   team: scaleout
+  budget_type: integration
   model-name: trace stress
 
 # - name: t3k_llama3.2-vision_tests

--- a/tests/pipeline_reorg/t3k_profiler_tests.yaml
+++ b/tests/pipeline_reorg/t3k_profiler_tests.yaml
@@ -18,6 +18,7 @@
       timeout: 8
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: runtime
+  budget_type: profiler
 
 - name: T3000 CCL AllGather profiling
   cmd: run_ccl_T3000_test
@@ -26,6 +27,7 @@
       timeout: 10
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: ttnn # Placeholder; see https://github.com/tenstorrent/tt-metal/issues/44285
+  budget_type: profiler
 
 - name: T3000 multi-host tracy smoke
   cmd: run_multi_host_tracy_smoke
@@ -34,6 +36,7 @@
       timeout: 10
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: runtime
+  budget_type: profiler
 
 - name: T3000 device profiler regressions
   cmd: run_device_profiler_test
@@ -42,6 +45,7 @@
       timeout: 25
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: runtime
+  budget_type: profiler
 
 - name: T3000 perf op report
   cmd: run_perf_op_report_test
@@ -50,6 +54,7 @@
       timeout: 8
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: ttnn # Placeholder; see https://github.com/tenstorrent/tt-metal/issues/44285
+  budget_type: profiler
 
 - name: T3000 process_ops_logs
   cmd: run_process_ops_logs_test
@@ -58,6 +63,7 @@
       timeout: 5
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: ttnn # Placeholder; see https://github.com/tenstorrent/tt-metal/issues/44285
+  budget_type: profiler
 
 - name: T3000 tracy wasm gui HTTP integration
   cmd: run_tracy_wasm_gui_http_integration
@@ -66,3 +72,4 @@
       timeout: 8
   owner_id: U03BJ1L3LUQ # Mo Memarian
   team: runtime
+  budget_type: profiler

--- a/tests/pipeline_reorg/t3k_unit_tests.yaml
+++ b/tests/pipeline_reorg/t3k_unit_tests.yaml
@@ -17,6 +17,7 @@
       timeout: 40
   owner_id: U06US5C7M7X # Sean Nijjar
   team: scaleout
+  budget_type: unit
 
 - name: t3k_ttnn_tests
   model-name: t3k_ttnn_tests
@@ -26,6 +27,7 @@
       timeout: 25
   owner_id: U07D5N7QL4U # Joseph Chu
   team: ttnn
+  budget_type: unit
 
 - name: t3k_tt_metal_multiprocess_tests
   cmd: run_t3000_tt_metal_multiprocess_tests
@@ -34,6 +36,7 @@
       timeout: 15
   owner_id: U0709049XNK # Aditya Saigal
   team: scaleout
+  budget_type: unit
 
 - name: t3k_ttnn_udm_tests
   cmd: run_t3000_ttnn_udm_tests
@@ -42,6 +45,7 @@
       timeout: 5
   owner_id: U06MJ6CVCGZ # Yu Gao
   team: ttnn
+  budget_type: unit
 
 - name: t3k_ttnn_multiprocess_slow_tests
   cmd: run_t3000_ttnn_multiprocess_slow_tests
@@ -50,3 +54,4 @@
       timeout: 5
   owner_id: U09BZ5Q33LK # Piotr Stankiewicz
   team: scaleout
+  budget_type: unit

--- a/tests/pipeline_reorg/train_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/train_merge_gate_tests.yaml
@@ -25,6 +25,7 @@
       timeout: 15
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: merge_gate
 
 - name: tt-train cpp merge gate tests (id 1)
   cmd: |
@@ -37,3 +38,4 @@
       timeout: 15
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: merge_gate

--- a/tests/pipeline_reorg/train_perf_tests.yaml
+++ b/tests/pipeline_reorg/train_perf_tests.yaml
@@ -23,6 +23,7 @@
   category: pretraining
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf
 
 - name: "NanoLlama3 Shakespeare"
   cmd: python tt-train/scripts/run_models.py --model_config tt-train/scripts/run_models_configs/single_cards.yaml --filter-filenames "nanollama_shakespeare"
@@ -34,6 +35,7 @@
   category: pretraining
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf
 
 - name: "Nano Deepseek (Char) Shakespeare"
   cmd: python tt-train/scripts/run_models.py --model_config tt-train/scripts/run_models_configs/single_cards.yaml --filter-filenames "nano_deepseek_char_shakespeare"
@@ -45,6 +47,7 @@
   category: pretraining
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf
 
 - name: "Linear Regression"
   cmd: python tt-train/scripts/run_models.py --model_config tt-train/scripts/run_models_configs/single_cards.yaml --filter-filenames "linear_regression"
@@ -56,6 +59,7 @@
   category: pretraining
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf
 
 - name: "TinyLlama Shakespeare"
   cmd: python tt-train/scripts/run_models.py --model_config tt-train/scripts/run_models_configs/single_cards.yaml --filter-filenames "tinyllama_shakespeare"
@@ -65,6 +69,7 @@
   category: pretraining
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf
 
 - name: "Qwen 3 1.7B Shakespeare"
   cmd: python tt-train/scripts/run_models.py --model_config tt-train/scripts/run_models_configs/single_cards.yaml --filter-filenames "qwen3_1.7b_shakespeare"
@@ -74,6 +79,7 @@
   category: pretraining
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf
 
 - name: "Tiny Deepseek (Char) Shakespeare"
   cmd: python tt-train/scripts/run_models.py --model_config tt-train/scripts/run_models_configs/single_cards.yaml --filter-filenames "tiny_deepseek_char_shakespeare"
@@ -83,6 +89,7 @@
   category: pretraining
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf
 
 # C++ models
 - name: "NanoGPT Shakespeare (C++)"
@@ -95,6 +102,7 @@
   category: pretraining
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf
 
 - name: "NanoLlama3 Shakespeare (C++)"
   cmd: python tt-train/scripts/run_models.py --model_config tt-train/scripts/run_models_configs/single_cards.yaml --filter-filenames "nanollama_shakespeare_cpp"
@@ -106,6 +114,7 @@
   category: pretraining
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf
 
 - name: "TinyLlama Shakespeare (C++)"
   cmd: python tt-train/scripts/run_models.py --model_config tt-train/scripts/run_models_configs/single_cards.yaml --filter-filenames "tinyllama_shakespeare_cpp"
@@ -115,6 +124,7 @@
   category: pretraining
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf
 
 # RL Examples
 - name: "Llama 3.2 1B on BoolQ GRPO Training"
@@ -125,6 +135,7 @@
   category: finetuning
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf
 
 - name: "Llama 3.2 1B on BoolQ GRPO Accuracy"
   cmd: python tt-train/sources/examples/grpo/boolq/boolq_accuracy_example.py
@@ -134,3 +145,4 @@
   category: finetuning
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: perf

--- a/tests/pipeline_reorg/train_unit_tests.yaml
+++ b/tests/pipeline_reorg/train_unit_tests.yaml
@@ -23,6 +23,7 @@
       timeout: 40
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: unit
 
 # Non-nightly unit tests
 - name: tt-train cpp non-nightly unit tests
@@ -37,6 +38,7 @@
     # bh_p150b_civ2 is used for merge gate test
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: unit
 
 - name: tt-train python unit tests
   cmd: python -m pytest tt-train/tests/python
@@ -47,3 +49,4 @@
       timeout: 20
   owner_id: U07K00A281X # Kevin Wu
   team: train
+  budget_type: unit

--- a/tests/pipeline_reorg/triage_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/triage_merge_gate_tests.yaml
@@ -13,3 +13,4 @@
       timeout: 11
   owner_id: U09UX6JLA3U # Ognjen Nenezic
   team: triage
+  budget_type: merge_gate

--- a/tests/pipeline_reorg/triage_tests.yaml
+++ b/tests/pipeline_reorg/triage_tests.yaml
@@ -18,3 +18,4 @@
       timeout: 5
   owner_id: U09UX6JLA3U # Ognjen Nenezic
   team: triage
+  budget_type: unit

--- a/tests/pipeline_reorg/tt_cnn_unit_tests.yaml
+++ b/tests/pipeline_reorg/tt_cnn_unit_tests.yaml
@@ -22,6 +22,7 @@
       timeout: 10
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
+  budget_type: unit
   category: cnn_pipeline
 
 - name: tt-cnn builder unit tests
@@ -31,4 +32,5 @@
       timeout: 10
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
+  budget_type: unit
   category: cnn_builder

--- a/tests/pipeline_reorg/ttnn_examples_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_examples_pr_gate_tests.yaml
@@ -10,4 +10,5 @@
     wh_n150_civ2:
       timeout: 15
   team: ttnn
+  budget_type: pr_gate
   owner_id: U076Z1JJUQZ # Artem Yerofieiev

--- a/tests/pipeline_reorg/ttnn_integration_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_integration_tests.yaml
@@ -38,4 +38,5 @@
       timeout: 30
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
+  budget_type: integration
   category: tutorials

--- a/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
@@ -137,4 +137,5 @@
     wh_n300_civ2:
       timeout: 10
   team: ttnn
+  budget_type: merge_gate
   owner_id: U09BX3N0N95 # Mateusz Nowak

--- a/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
@@ -17,6 +17,7 @@
     sim_bh_p150:
       timeout: 15
   team: ttnn
+  budget_type: merge_gate
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
 
 # Codegen-path coverage for every op that has one (untilize, repeat, repeat_interleave and gather
@@ -48,6 +49,7 @@
     wh_n300_civ2:
       timeout: 5
   team: ttnn
+  budget_type: merge_gate
   owner_id: U07M7QZ0BQA # Camilo Vega -- Slack member ID
 
 # Eltwise infra coverage: broadcast classes, tensor-scalar variants and op-dispatch liveness.

--- a/tests/pipeline_reorg/ttnn_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_sanity_tests.yaml
@@ -54,6 +54,7 @@
     sim_bh_p150:
       timeout: 40
   team: ttnn
+  budget_type: sanity
   owner_id: U05ACKAJTHS # Naif Tarafdar
 
 - name: "ttnn eltwise group 1"
@@ -70,6 +71,7 @@
     sim_bh_p150:
       timeout: 40
   team: ttnn
+  budget_type: sanity
   owner_id: U09BX3N0N95 # Mateusz Nowak
 
 - name: "ttnn eltwise group 2"
@@ -86,6 +88,7 @@
     sim_bh_p150:
       timeout: 40
   team: ttnn
+  budget_type: sanity
   owner_id: U09BX3N0N95 # Mateusz Nowak
 
 - name: "ttnn eltwise group 3"
@@ -102,6 +105,7 @@
     sim_bh_p150:
       timeout: 40
   team: ttnn
+  budget_type: sanity
   owner_id: U09BX3N0N95 # Mateusz Nowak
 
 - name: "ttnn eltwise group 4"
@@ -118,6 +122,7 @@
     sim_bh_p150:
       timeout: 40
   team: ttnn
+  budget_type: sanity
   owner_id: U09BX3N0N95 # Mateusz Nowak
 
 - name: "ttnn conv group"
@@ -134,6 +139,7 @@
     sim_bh_p150:
       timeout: 60
   team: ttnn
+  budget_type: sanity
   owner_id: U085GDCAZTN # Pavle Josipovic
 
 - name: "ttnn pool group"
@@ -150,6 +156,7 @@
     sim_bh_p150:
       timeout: 40
   team: ttnn
+  budget_type: sanity
   owner_id: U085GDCAZTN # Pavle Josipovic
 
 - name: "ttnn matmul group"
@@ -166,6 +173,7 @@
     sim_bh_p150:
       timeout: 60
   team: ttnn
+  budget_type: sanity
   owner_id: U084B1CES7M # Borys Bradel
 
 - name: "ttnn fused group 1"
@@ -182,6 +190,7 @@
     sim_bh_p150:
       timeout: 60
   team: ttnn
+  budget_type: sanity
   owner_id: U084B1CES7M # Borys Bradel
 
 - name: "ttnn fused group 2"
@@ -198,6 +207,7 @@
     sim_bh_p150:
       timeout: 60
   team: ttnn
+  budget_type: sanity
   owner_id: U084B1CES7M # Borys Bradel
 
 - name: "ttnn misc ops group"
@@ -214,6 +224,7 @@
     sim_bh_p150:
       timeout: 40
   team: ttnn
+  budget_type: sanity
   owner_id: U08JFM3CFA4 # Gongyu Wang
 
 - name: "ttnn sdpa group"
@@ -230,6 +241,7 @@
     sim_bh_p150:
       timeout: 40
   team: ttnn
+  budget_type: sanity
   owner_id: U085GDCAZTN # Pavle Josipovic
 
 # indexer_score is Blackhole-only (the nightly suite has the full coverage); this reuses the accuracy
@@ -249,6 +261,7 @@
     sim_bh_p150:
       timeout: 40
   team: ttnn
+  budget_type: sanity
   owner_id: U085GDCAZTN # Pavle Josipovic
 
 - name: "ttnn reduce group"
@@ -265,6 +278,7 @@
     sim_bh_p150:
       timeout: 40
   team: ttnn
+  budget_type: sanity
   owner_id: U084B1CES7M # Borys Bradel
 
 - name: "ttnn llk helper library tests"
@@ -282,6 +296,7 @@
     bh_p150b_civ2:
       timeout: 20
   team: ttnn
+  budget_type: sanity
   owner_id: U0BCCPS862F # Milan Alimpic
 
 - name: "core ttnn unit test group"
@@ -304,6 +319,7 @@
     sim_bh_p150:
       timeout: 40
   team: ttnn
+  budget_type: sanity
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
 
 - name: "trace allocation tracker"
@@ -317,4 +333,5 @@
     sim_wh_n150:
       timeout: 15
   team: ttnn
+  budget_type: sanity
   owner_id: U076Z1JJUQZ # Artem Yerofieiev

--- a/tests/pipeline_reorg/ttnn_sweep_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_sweep_tests.yaml
@@ -74,6 +74,7 @@
       timeout: 150
   owner_id: U08T3JQEB36 # stevendae
   team: ttnn
+  budget_type: sweep
   category: sweep
 
 - name: ttnn sweeps model traced
@@ -111,4 +112,5 @@
       timeout: 720   # 20 batches, computed 681
   owner_id: U08T3JQEB36 # stevendae
   team: ttnn
+  budget_type: sweep
   category: sweep

--- a/tests/pipeline_reorg/ttnn_sweep_validation_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_sweep_validation_tests.yaml
@@ -18,4 +18,5 @@
       timeout: 120
   owner_id: U08T3JQEB36 # stevendae
   team: ttnn
+  budget_type: sweep_validation
   category: sweep_validation

--- a/tests/pipeline_reorg/ttnn_validation_basic_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_validation_basic_tests.yaml
@@ -12,4 +12,5 @@
     bh_p150b_civ2_viommu:
       timeout: 15
   team: ttnn
+  budget_type: merge_gate
   owner_id: U076Z1JJUQZ # Artem Yerofieiev

--- a/tests/pipeline_reorg/ttnn_validation_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_validation_merge_gate_tests.yaml
@@ -16,4 +16,5 @@
     bh_p150b_civ2_viommu:
       timeout: 15
   team: ttnn
+  budget_type: merge_gate
   owner_id: U076Z1JJUQZ # Artem Yerofieiev

--- a/tests/pipeline_reorg/ttnn_validation_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_validation_pr_gate_tests.yaml
@@ -9,4 +9,5 @@
     wh_n150_civ2:
       timeout: 15
   team: ttnn
+  budget_type: pr_gate
   owner_id: U076Z1JJUQZ # Artem Yerofieiev

--- a/tests/pipeline_reorg/ttsim_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttsim_merge_gate_tests.yaml
@@ -39,3 +39,4 @@
       timeout: 15
   owner_id: U08PR765YJ1 # Matt Craighead
   team: ttsim
+  budget_type: merge_gate

--- a/tests/pipeline_reorg/ttsim_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttsim_sanity_tests.yaml
@@ -37,4 +37,5 @@
     sim_bh_p150:
       timeout: 30
   team: ttsim
+  budget_type: sanity
   owner_id: U08PR765YJ1 # Matt Craighead

--- a/tests/pipeline_reorg/umd_sanity_tests.yaml
+++ b/tests/pipeline_reorg/umd_sanity_tests.yaml
@@ -19,4 +19,5 @@
     bh_p150b_civ2_viommu:
       timeout: 15
   team: umd
+  budget_type: sanity
   owner_id: U09769N29BN # Aleksa Marković

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -48,6 +48,7 @@
   owner_id: U08E1JCDVNX # Pavle Petrovic
   co-owner-2-id: U08BH66EXAL # Radoica Draskic
   team: models
+  budget_type: vllm
 
 - name: "Gemma3-27B DP=4"
   model: google/gemma-3-27b-it
@@ -67,6 +68,7 @@
   owner_id: U08E1JCDVNX # Pavle Petrovic
   co-owner-2-id: U08BH66EXAL # Radoica Draskic
   team: models
+  budget_type: vllm
 
 # ── Gemma 4 ────────────────────────────────────────────────────────
 
@@ -85,6 +87,7 @@
       tier: 3
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
+  budget_type: vllm
 
 # Product path on QB2: 256k + chunked prefill + B=32.
 - name: "Gemma4-12B"
@@ -103,6 +106,7 @@
       tier: 1
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
+  budget_type: vllm
 
 # tp=8 coverage on the 8-chip BH LoudBox (P150x8) — the flagship 12B config.
 # Serving knobs mirror the QB2 leg; the impl workflow additionally exports the
@@ -169,6 +173,7 @@
       tier: 1
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
+  budget_type: vllm
 
 # Serve 16k with chunked prefill=2048 (12 GB/ASIC); do not mirror BH 256k.
 #
@@ -223,6 +228,7 @@
       tier: 2
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
+  budget_type: vllm
 
 - name: "Gemma4-31B"
   model: google/gemma-4-31B-it
@@ -240,6 +246,7 @@
       tier: 1
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
+  budget_type: vllm
 
 # ── Qwen 3.6 ───────────────────────────────────────────────────────
 
@@ -260,6 +267,7 @@
       tier: 1
   owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models
+  budget_type: vllm
 
 - name: "Qwen3.6-27B (batch=8)"
   model: Qwen/Qwen3.6-27B
@@ -278,6 +286,7 @@
       tier: 1
   owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models
+  budget_type: vllm
 
 # ── GPT-OSS ────────────────────────────────────────────────────────
 
@@ -304,6 +313,7 @@
   owner_id: U08TJ70UFRT # Harry Andrews
   co-owner-2-id: U06F3ER8X9A # Stuti Raizada
   team: models
+  budget_type: vllm
 
 - name: "GPT-OSS-120B (high-throughput)"
   model: openai/gpt-oss-120b
@@ -327,6 +337,7 @@
   owner_id: U08TJ70UFRT # Harry Andrews
   co-owner-2-id: U06F3ER8X9A # Stuti Raizada
   team: models
+  budget_type: vllm
 
 # ── Llama ──────────────────────────────────────────────────────────
 
@@ -350,6 +361,7 @@
   owner_id: U08E1JCDVNX # Pavle Petrovic
   co-owner-2-id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: vllm
 
 - name: "Llama-3.1-8B-Instruct (prefix caching)"
   model: meta-llama/Llama-3.1-8B-Instruct
@@ -373,6 +385,7 @@
   owner_id: U08E1JCDVNX # Pavle Petrovic
   co-owner-2-id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: vllm
 
 - name: "Llama-3.1-8B-Instruct"
   model: meta-llama/Llama-3.1-8B-Instruct
@@ -391,6 +404,7 @@
       tier: 2
   owner_id: U08GELBB1AP # Ambrose Ling
   team: models
+  budget_type: vllm
 
 - name: "Llama-3.1-8B-Instruct with sampling-tests"
   model: meta-llama/Llama-3.1-8B-Instruct
@@ -415,6 +429,7 @@
       tier: 2
   owner_id: U08GELBB1AP # Ambrose Ling
   team: models
+  budget_type: vllm
 
 - name: "Llama-3.1-8B-Instruct (chunked prefill)"
   model: meta-llama/Llama-3.1-8B-Instruct
@@ -444,6 +459,7 @@
   owner_id: U08E1JCDVNX # Pavle Petrovic
   co-owner-2-id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: vllm
 
 - name: "Llama-3.1-8B-Instruct DP=4"
   model: meta-llama/Llama-3.1-8B-Instruct
@@ -468,6 +484,7 @@
   owner_id: U08E1JCDVNX # Pavle Petrovic
   co-owner-2-id: U08BH66EXAL # Radoica Draskic
   team: models
+  budget_type: vllm
 
 - name: "Llama-3.3-70B-Instruct device with sampling-tests (prefix caching)"
   model: meta-llama/Llama-3.3-70B-Instruct
@@ -488,6 +505,7 @@
   owner_id: U08E1JCDVNX # Pavle Petrovic
   co-owner-2-id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: vllm
 
 # ── Qwen 3 ─────────────────────────────────────────────────────────
 
@@ -508,6 +526,7 @@
       tier: 1
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
+  budget_type: vllm
 
 - name: "Qwen3-32B device (BH Galaxy)"
   model: Qwen/Qwen3-32B
@@ -531,6 +550,7 @@
       tier: 1
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
+  budget_type: vllm
 
 # ── Qwen VL ────────────────────────────────────────────────────────
 
@@ -551,6 +571,7 @@
       tier: 2
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+  budget_type: vllm
 
 - name: "Qwen3-VL-32B-Instruct"
   model: Qwen/Qwen3-VL-32B-Instruct
@@ -570,6 +591,7 @@
       tier: 2
   owner_id: U08H31YMN4Q # Sarva Sanjay
   team: models
+  budget_type: vllm
 
 # ── Infra / overhead ───────────────────────────────────────────────
 
@@ -589,6 +611,7 @@
       tier: 1
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
+  budget_type: vllm
 
 # ── Disabled entries (preserved for re-enable) ─────────────────────
 #

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -132,6 +132,7 @@
       tier: 1
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: vllm
 
 # 31B tp=8 on the BH LoudBox. Unlike 12B, 31B keeps the gated (traced
 # sequential prefill) default — it is immune to the 12B 1x8 wedge and this is
@@ -156,6 +157,7 @@
       tier: 1
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
+  budget_type: vllm
 
 - name: "Gemma4-26B-A4B"
   model: google/gemma-4-26B-A4B-it


### PR DESCRIPTION
### PR Category

Feature

### Summary

Team time budgets were not additive. `verify_time_budget.py` took the budget key as a CLI argument and ran against a single tests yaml at a time, inside each pipeline's `load-test-matrix` step. Where two yamls charge the same `(team, budget_type, sku)` bucket, each was independently allowed the **full** budget, so a bucket could be spent twice or more and still pass.

Summing properly across all yamls, 9 buckets are shared by more than one yaml and 4 of them were already over budget:

| bucket | sum | old budget | over | contributors |
|---|---|---|---|---|
| `runtime/pr_gate/wh_n150_civ2` | 30 | 15 | +15 | `runtime_examples_pr_gate` (15), `runtime_validation_pr_gate` (15) |
| `ttnn/pr_gate/wh_n150_civ2` | 30 | 15 | +15 | `ttnn_examples_pr_gate` (15), `ttnn_validation_pr_gate` (15) |
| `ttnn/unit/wh_n150_civ2` | 1040 | 1020 | +20 | `ops_unit` (1020), `tt_cnn_unit` (20) |
| `ttnn/unit/wh_galaxy` | 125 | 120 | +5 | `ops_unit` (120), `galaxy_unit` (5) |

This PR makes the budget a property of the test rather than of the workflow running it, and enforces it in one place that can see everything at once.

**1. Each test declares its own budget bucket.** New required `budget_type:` field alongside `team:`, on all 555 reorg tests across 68 matrices. The budget is `budgets[team][budget_type][sku]`. Previously ~23 registries got their key from `${{ inputs.test-category }}` / `budget-subheading`, so their bucket was invisible to any static tool — `query_time_budget.py` was reading `per-test-timeout:` as the key for `llk_pr_gate_tests.yaml` and `${extra[@]}` for `fabric_merge_gate_tests.yaml`.

**2. One `verify-time-budgets` job in pr-gate replaces 61 per-pipeline steps.** It globs every registry, sums per bucket across all of them, and fails on an over-budget total, a missing `budget_type`, an undeclared bucket, or a gate ceiling breach. Added to `workflow-status`'s `required-jobs:` instead of optional since a skip here should not count as a pass.

**3. Budgets corrected.** The four buckets above are raised to their true sums. The machine time is already being spent every run; the budget numbers were wrong, not the tests.

### Notes for reviewers

**`budget_type` accepts a list, for one real case.** `llk-smoke-impl.yaml` hardcodes `llk_pr_gate_tests.yaml` and varies only the budget key: pr-gate takes the input default (`pr_gate`), sanity-tests overrode it to `sanity`. A single-valued field cannot express it, so `budget_type: [pr_gate, sanity]` charges each allowance independently. Both are now charged and within budget (15/40 and 30/40); without this `llk.sanity` would have silently gone unallocated. 

**The per-test ceiling moved into the checker** `--max-per-test-timeout` and the `per-test-timeout` workflow input (11 impls, 17 caller lines) are gone. The ceiling is now a constant applied to gate budget types:

```python
GATE_BUDGET_TYPES = {"pr_gate", "merge_gate"}
GATE_PER_TEST_CEILING_MINUTES = 15
```

Deliberate behaviour change: `sanity` is not a gate type, so `sanity-tests.yaml`'s `per-test-timeout: 15` is dropped and sanity is no longer ceiling-checked.

**What the scheduled pipelines give up.** Nightly and dispatch runs no longer re-verify their own budgets. Every registry edit lands through pr-gate, and pr-gate is the only place that can see all registries at once, so a single gate is sufficient — but `workflow_dispatch` runs with hand-set inputs won't re-check.

**Tiers are resolved from the budget file, not composed blindly.** `_tier<n>` is appended only when the team declares that key, else the plain key is used and tiers pool. This preserves today's behaviour for `vllm_model_tests.yaml`, which carries per-sku `tier:` values while its caller passes no tier arg — composing unconditionally would have exploded it into 8 nonexistent buckets. Splitting a pooled budget by tier is now a `time_budget.yaml`-only edit.

### Test Plan
 - [x] Ensure all time budget checks pass on PR Gate (run: https://github.com/tenstorrent/tt-metal/actions/runs/34269833803)
  - [x] Check error comment raised on invalid budget (run: https://github.com/tenstorrent/tt-metal/actions/runs/34280961574)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tdowdall/time-budget-upgrades)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tdowdall/time-budget-upgrades)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tdowdall/time-budget-upgrades)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tdowdall/time-budget-upgrades)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tdowdall/time-budget-upgrades)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tdowdall/time-budget-upgrades)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tdowdall/time-budget-upgrades)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tdowdall/time-budget-upgrades)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tdowdall/time-budget-upgrades)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tdowdall/time-budget-upgrades)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tdowdall/time-budget-upgrades)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tdowdall/time-budget-upgrades)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tdowdall/time-budget-upgrades)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tdowdall/time-budget-upgrades)