### PR TITLE
[Bug Fix: Nightly L2 Failure] Fix cliff-row runtime args on core 0 in block tilize/untilize factories

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -1234,8 +1234,8 @@ def test_tilize_block_two_pair_program_cache_addr_change(device, tensor_shape):
 
 # Blackhole sends non-sharded uint8 tilize to the block factory, the only way a 1-tile-wide tensor
 # reaches it. These get a single reader/writer pair: 2048/4096 rows build only full_set, 5120 rows
-# only cliffrow_set. Checks that lone pair is still re-pointed on a cache hit. 4160 rows is to check
-# the case where row is narrower than a block case.
+# only cliffrow_set. Checks that lone pair is still re-pointed on a cache hit. 4160 rows makes the
+# row narrower than one block (full_cores_per_row == 0), which puts core 0 in the cliff-row set.
 @run_for_blackhole()
 @pytest.mark.parametrize("shape", [(1, 1, 2048, 32), (1, 1, 4096, 32), (1, 1, 4160, 32), (1, 1, 5120, 32)])
 def test_tilize_uint8_tall_narrow_program_cache_addr_change(device, shape):

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -1234,9 +1234,10 @@ def test_tilize_block_two_pair_program_cache_addr_change(device, tensor_shape):
 
 # Blackhole sends non-sharded uint8 tilize to the block factory, the only way a 1-tile-wide tensor
 # reaches it. These get a single reader/writer pair: 2048/4096 rows build only full_set, 5120 rows
-# only cliffrow_set. Checks that lone pair is still re-pointed on a cache hit.
+# only cliffrow_set. Checks that lone pair is still re-pointed on a cache hit. 4160 rows is to check
+# the case where row is narrower than a block case.
 @run_for_blackhole()
-@pytest.mark.parametrize("shape", [(1, 1, 2048, 32), (1, 1, 4096, 32), (1, 1, 5120, 32)])
+@pytest.mark.parametrize("shape", [(1, 1, 2048, 32), (1, 1, 4096, 32), (1, 1, 4160, 32), (1, 1, 5120, 32)])
 def test_tilize_uint8_tall_narrow_program_cache_addr_change(device, shape):
     torch.manual_seed(0)
     device.enable_program_cache()

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -260,7 +260,7 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
             single_block_size_col_arg = single_block_size_cliff_col;
             single_sub_block_size_row_arg = single_block_size_cliff_row;
 
-        } else if (has_cliff_row && i != 0 && ((i + 1) % (full_cores_per_row + 1)) == 0) {
+        } else if (has_cliff_row && ((i + 1) % (full_cores_per_row + 1)) == 0) {
             single_block_size_row_arg = single_block_size_cliff_row;
             single_block_size_col_arg = single_block_size;
             single_sub_block_size_row_arg = single_block_size_cliff_row;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
@@ -252,7 +252,7 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
             single_block_size_col_arg = single_block_size_cliff_col;
             single_sub_block_size_row_arg = single_block_size_cliff_row;
 
-        } else if (has_cliff_row && i != 0 && ((i + 1) % (full_cores_per_row + 1)) == 0) {
+        } else if (has_cliff_row && ((i + 1) % (full_cores_per_row + 1)) == 0) {
             single_block_size_row_arg = single_block_size_cliff_row;
             single_block_size_col_arg = single_block_size;
             single_sub_block_size_row_arg = single_block_size_cliff_row;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
@@ -251,7 +251,7 @@ ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
             single_block_size_col_arg = single_block_size_cliff_col;
             single_sub_block_size_row_arg = single_block_size_cliff_row;
 
-        } else if (has_cliff_row && i != 0 && ((i + 1) % (full_cores_per_row + 1)) == 0) {
+        } else if (has_cliff_row && ((i + 1) % (full_cores_per_row + 1)) == 0) {
             single_block_size_row_arg = single_block_size_cliff_row;
             single_block_size_col_arg = single_block_size;
             single_sub_block_size_row_arg = single_block_size_cliff_row;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -254,7 +254,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
             single_block_size_col_arg = single_block_size_cliff_col;
             single_sub_block_size_row_arg = single_block_size_cliff_row;
 
-        } else if (has_cliff_row && i != 0 && ((i + 1) % (full_cores_per_row + 1)) == 0) {
+        } else if (has_cliff_row && ((i + 1) % (full_cores_per_row + 1)) == 0) {
             single_block_size_row_arg = single_block_size_cliff_row;
             single_block_size_col_arg = single_block_size;
             single_sub_block_size_row_arg = single_block_size_cliff_row;


### PR DESCRIPTION
### Problem description
https://github.com/tenstorrent/tt-metal/actions/runs/34232429559/job/102087813466#step:6:18928
`test_tilize_uint8_tall_narrow_program_cache_addr_change[shape=(1, 1, 4096, 32)]` fails on BH with `Core 0-0 is fed a sub-block of 2 tiles but the buffers on it hold 1`. A row narrower than one block leaves `full_cores_per_row` at 0. The split gives every core the cliff-row block, but the `i != 0` guard on the cliff-row branch sent core 0 to the full-block case and fed it a width its buffers were not sized for.

Latest Failing Run: https://github.com/tenstorrent/tt-metal/actions/runs/35066000834/job/104698889032#step:6:20867

### What's changed
Dropped the `i != 0` guard in all four block factories (tilize, tilize_with_val_padding, untilize, untilize_with_unpadding).  It was redundant in every other case: with at least one full core per row the modulus already excludes `i == 0`, since `1 % (n + 1)` is never 0 for `n >= 1`. BH routes non-sharded UINT8 there regardless of width or L1, the other three were latent.

Not scoped to `experimental/quasar/`

### Checks
Modelled the split and arg loop over 12,880 grid/shape configs: 146 mismatches before, 0 after, and 0 configs where the old form was already correct and the args change. 
Added `(1, 1, 4160, 32)` to `test_tilize_uint8_tall_narrow_program_cache_addr_change` so the regression is caught on a full grid too. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anasuya/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anasuya/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anasuya/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anasuya/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anasuya/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anasuya/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anasuya/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anasuya/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anasuya/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anasuya/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anasuya/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anasuya/tilize_fix)