### PR TITLE
Fix composite LayerNorm variance cancellation

### DIFF
--- a/tt-train/sources/ttml/ops/layernorm_op.cpp
+++ b/tt-train/sources/ttml/ops/layernorm_op.cpp
@@ -131,22 +131,22 @@ autograd::TensorPtr composite_layernorm(
         std::nullopt,
         /* device_compute_kernel_config */ core::ComputeKernelConfig::precise());
 
-    auto tensor_squared = ttnn::square(tensor->get_value());
-    auto mean_squared = core::zeros_like(mean);
+    auto centered_tensor = ttnn::subtract(tensor->get_value(), mean);
+    auto centered_tensor_squared = ttnn::square(centered_tensor);
+    auto variance = core::zeros_like(mean);
     ttnn::moreh_mean(
-        tensor_squared,
+        centered_tensor_squared,
         3,  // last dimension
         true,
         std::nullopt,
-        mean_squared,
+        variance,
         std::nullopt,
         /* device_compute_kernel_config */ core::ComputeKernelConfig::precise());
-    auto variance = ttnn::subtract(mean_squared, ttnn::square(mean));
 
     const float eps = 1e-6F;
     auto rstd = ttnn::rsqrt(ttnn::add(variance, eps));
 
-    auto normalized_tensor = ttnn::multiply(ttnn::subtract(tensor->get_value(), mean), rstd);
+    auto normalized_tensor = ttnn::multiply(centered_tensor, rstd);
 
     auto output = ttnn::multiply(normalized_tensor, gamma->get_value());
     if (beta_opt.has_value()) {

--- a/tt-train/tests/ops/layernorm_composite_test.cpp
+++ b/tt-train/tests/ops/layernorm_composite_test.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <cmath>
+#include <vector>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
@@ -61,6 +63,33 @@ TEST_F(LayerNormOpTest, CompositeLayerNormOp_0) {
 
         EXPECT_NEAR(exp_mean, 0.F, 3e-2);
         EXPECT_NEAR(exp_var, 1.F, 3e-2);
+    }
+}
+
+TEST_F(LayerNormOpTest, CompositeLayerNormIsShiftInvariantForLargeOffset) {
+    using namespace ttml;
+
+    constexpr uint32_t features = 32;
+    std::vector<float> input_data;
+    input_data.reserve(features * 2);
+    input_data.insert(input_data.end(), features / 2, -1.0F);
+    input_data.insert(input_data.end(), features / 2, 1.0F);
+    input_data.insert(input_data.end(), features / 2, 83.5F);
+    input_data.insert(input_data.end(), features / 2, 85.5F);
+
+    auto tensor = autograd::create_tensor(
+        core::from_vector(input_data, ttnn::Shape({1, 1, 2, features}), &autograd::ctx().get_device()));
+    auto gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    auto beta = autograd::create_tensor(core::zeros(ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+
+    auto result = ops::composite_layernorm(tensor, gamma, beta);
+    auto result_data = core::to_vector(result->get_value());
+
+    ASSERT_EQ(result_data.size(), input_data.size());
+    for (std::size_t i = 0; i < result_data.size(); ++i) {
+        ASSERT_TRUE(std::isfinite(result_data[i])) << "Non-finite output at index " << i;
+        const float expected = i % features < features / 2 ? -1.0F : 1.0F;
+        EXPECT_NEAR(result_data[i], expected, 3e-2F) << "Unexpected output at index " << i;
     }
 }
 


### PR DESCRIPTION
Addresses audit finding #3 in tt-train/docs/ops_correctness_audit.md.

Summary:
- Compute composite LayerNorm variance from centered values instead of E[x^2] - E[x]^2, avoiding catastrophic BF16 cancellation.
- Reuse the centered tensor for normalization.
- Add a large-offset shift-invariance regression that previously produced a non-finite or incorrect result.

Verification:
- pre-commit run --files tt-train/sources/ttml/ops/layernorm_op.cpp tt-train/tests/ops/layernorm_composite_test.cpp — passed.
- Exabox Slurm job 80185 on cpu_only: cmake -B build_Release -DCMAKE_DISABLE_PRECOMPILE_HEADERS=OFF followed by CMAKE_BUILD_PARALLEL_LEVEL=4 ./build_metal.sh --enable-ccache --build-tt-train — passed.
- Exabox Slurm job 80234 on bh_lb_single: ./build_Release/tt-train/tests/ttml_tests --gtest_filter=LayerNormOpTest.CompositeLayerNormIsShiftInvariantForLargeOffset — passed (1/1).

Build-environment note:
Current main configures tt-train examples before the ttml_pch provider, so the validation checkout temporarily carried existing commit 414c6421ec7 as an uncommitted CMake ordering workaround. That unrelated CMake change is not part of this PR.