### PR TITLE
fix(sfpu): compute softplus bf16 tail so softplus(t) is nonzero for t < -5 (#51866)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -138,10 +138,15 @@ inline void calculate_softplus_body(const float beta, const float beta_reciproca
             SOFTPLUS_BF16_POLY_C5,
             SOFTPLUS_BF16_POLY_C6);
 
-        // Tail: the degree-6 poly diverges past its [0, 5] fit domain, while the true
-        // residual < exp(-5) = 0.0067 there. Clamping to 0 keeps softplus(t>0) = t within
-        // bf16 rounding and avoids the ~8-op exp tail on every element.
-        v_if(a > SOFTPLUS_POLY_BOUNDARY) { residual = 0.0f; }
+        // Tail: f(a) = ln(1+exp(-a)) ~ exp(-a) for a > 5, computed the same way as the fp32
+        // branch above. It must NOT be clamped to 0: for t < -5 this residual is the entire
+        // result (softplus(t) = f(|t|) ~ e^t), so clamping collapses the (0, inf) range to
+        // exactly 0 all the way down to the bf16 normal floor. Only the a > 5 lanes pay the exp.
+        sfpi::vFloat neg_a = sfpi::setsgn(a, 1);
+        v_if(a > SOFTPLUS_POLY_BOUNDARY) {
+            sfpi::vFloat e = softplus_exp_negative(neg_a);
+            residual = e * (1.0f + e * (-0.5f + e * 0.333333343f));
+        }
         v_endif;
 #endif
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -138,10 +138,15 @@ inline void calculate_softplus_body(const float beta, const float beta_reciproca
             SOFTPLUS_BF16_POLY_C5,
             SOFTPLUS_BF16_POLY_C6);
 
-        // Tail: the degree-6 poly diverges past its [0, 5] fit domain, while the true
-        // residual < exp(-5) = 0.0067 there. Clamping to 0 keeps softplus(t>0) = t within
-        // bf16 rounding and avoids the ~8-op exp tail on every element.
-        v_if(a > SOFTPLUS_POLY_BOUNDARY) { residual = 0.0f; }
+        // Tail: f(a) = ln(1+exp(-a)) ~ exp(-a) for a > 5, computed the same way as the fp32
+        // branch above. It must NOT be clamped to 0: for t < -5 this residual is the entire
+        // result (softplus(t) = f(|t|) ~ e^t), so clamping collapses the (0, inf) range to
+        // exactly 0 all the way down to the bf16 normal floor. Only the a > 5 lanes pay the exp.
+        sfpi::vFloat neg_a = sfpi::setsgn(a, 1);
+        v_if(a > SOFTPLUS_POLY_BOUNDARY) {
+            sfpi::vFloat e = softplus_exp_negative(neg_a);
+            residual = e * (1.0f + e * (-0.5f + e * 0.333333343f));
+        }
         v_endif;
 #endif
 


### PR DESCRIPTION
## Summary

Fixes #51866: `ttnn.softplus` on the bf16 path returns exactly `0.0` for every input below `-5.03125`, down to `x = -87` where the correct result is still a normal bf16 value. This breaks the `(0, inf)` range of softplus. @fplavecTT reproduced the same behavior on Wormhole.

## Root cause

In `calculate_softplus_body`, softplus is reconstructed from the abs-symmetry identity `softplus(t) = max(0, t) + f(|t|)`, with `f(a) = ln(1 + e^{-a})`. The residual `f(a)` is a `[0, 5]` polynomial plus a tail for `a > 5`.

The **bf16** branch clamps the tail to zero:

```cpp
v_if(a > SOFTPLUS_POLY_BOUNDARY) { residual = 0.0f; }
```

Because `a = |t|`, this fires for `t < -5` as well as `t > 5`. For the positive tail it is harmless — `max(0, t) = t` carries the result. But for the **negative** tail the residual **is** the entire result (`softplus(t) = f(|t|) ≈ e^t`), so `max(0, t) + 0` collapses to exactly `0`. The **fp32** branch of the same function does not have this — it computes the exp tail.

## Fix

Make the bf16 tail compute `f(a) ≈ e^{-a}` the same way the fp32 branch already does (`softplus_exp_negative` + the 3-term `ln(1+e)` correction), instead of clamping to `0`. The `[0, 5]` polynomial path is unchanged, so nothing outside `|t| > 5` moves. Only the `a > 5` lanes pay the exp.

Applied to `wormhole_b0` and `blackhole` (byte-identical here).

## Verification

Emulated the exact bf16 control flow (real poly coefficients, the Cody-Waite `softplus_exp_negative`, bf16 store rounding) against a float64 reference on CPU. The fix matches the reference bit-for-bit on the tail, and the current code (clamp) reproduces the reported `0`:

| x | current (bf16) | fixed (bf16) | float64 → bf16 |
|---|---|---|---|
| -5.03125 | 0.0 | 6.500244e-03 | 6.500244e-03 |
| -6 | 0.0 | 2.471924e-03 | 2.471924e-03 |
| -10 | 0.0 | 4.529953e-05 | 4.529953e-05 |
| -50 | 0.0 | 1.927331e-22 | 1.927331e-22 |
| -87 | 0.0 | 1.643855e-38 | 1.643855e-38 |

No regression: `current == fixed` for `x ∈ {0, 0.5, 1, 3, 5, 6, 10}` (the fix only touches the `a > 5` branch, and for `t > 5` the tiny `e^{-a}` rounds away in bf16).

## Note on Quasar

`quasar/.../ckernel_sfpu_softplus.h` has the same latent clamp in its bf16 branch, but a different structure (no `softplus_exp_negative`; its fp32 tail uses `_sfpu_exp_fp32_accurate_`). Left out of this PR since it targets the shipping arches; happy to follow up with the analogous fix there if wanted.

---

*Disclosure: this fix was prepared with offline AI assistance; the analysis, kernel patch, and the numerical verification above were reviewed by me before submitting.*
