### PR TITLE
[Bug fix] Disable device-read-only host pinning: KMD 2.9.0 can wedge in tt_pin_pages()

### DIFF
--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -434,7 +434,23 @@ experimental::MemoryPinningParameters GetMemoryPinningParameters(distributed::Me
     // Ideally use a 64-bit addresses through the NOC, but otherwise use the iATU to translate 36-bit addresses to 64
     // bit addresses.
     params.can_map_to_noc = true;
-    params.supports_read_only = MetalContext::instance().get_cluster().is_read_only_page_pinning_supported();
+    // Device-read-only pinning is disabled pending a driver-side fix. KMD 2.9.0 -- the version that
+    // introduced the mode, and so far the only one that advertises it -- can wedge inside
+    // tt_pin_pages() when TT_DMA_FLAG_READ_ONLY is set: the ioctl never returns, so the calling
+    // thread sits at 100% CPU with essentially all of it in system time and its
+    // voluntary_ctxt_switches frozen. There is no error, no timeout and no log line, so a caller
+    // that hits it simply hangs until something outside kills it.
+    //
+    // Reporting the capability as unavailable routes callers through the widening path that already
+    // exists for older KMDs: PinnedMemoryCache::try_pin() downgrades the request to ReadWrite, and a
+    // genuinely non-writable mapping (the PROT_READ | MAP_PRIVATE file mapping ttnn.load_tensor()
+    // uses) then fails to pin and falls back to the unpinned copy -- the behaviour from before
+    // read-only pinning landed. It also makes the TT_FATAL in PinnedMemory::Create() reject any
+    // direct ReadOnly request, so no path can reach the wedge.
+    //
+    // Re-enabling is a one-line revert once a known-good KMD version is identified; the version gate
+    // then belongs in UMD's KMD_READ_ONLY_PAGE_PINNING minimum rather than here.
+    params.supports_read_only = false;
     return params;
 }
 

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -434,12 +434,15 @@ experimental::MemoryPinningParameters GetMemoryPinningParameters(distributed::Me
     // Ideally use a 64-bit addresses through the NOC, but otherwise use the iATU to translate 36-bit addresses to 64
     // bit addresses.
     params.can_map_to_noc = true;
-    // Device-read-only pinning is disabled pending a driver-side fix. KMD 2.9.0 -- the version that
-    // introduced the mode, and so far the only one that advertises it -- can wedge inside
-    // tt_pin_pages() when TT_DMA_FLAG_READ_ONLY is set: the ioctl never returns, so the calling
-    // thread sits at 100% CPU with essentially all of it in system time and its
-    // voluntary_ctxt_switches frozen. There is no error, no timeout and no log line, so a caller
-    // that hits it simply hangs until something outside kills it.
+    // Device-read-only pinning is disabled pending a driver-side fix. The mode arrived in KMD 2.9.0;
+    // both 2.9.0 and 2.10.0 can wedge inside tt_pin_pages() when TT_DMA_FLAG_READ_ONLY is set. The
+    // ioctl never returns, so the calling thread sits at 100% CPU with essentially all of it in
+    // system time and its voluntary_ctxt_switches frozen. There is no error, no timeout and no log
+    // line, so a caller that hits it simply hangs until something outside kills it.
+    //
+    // Every KMD version that advertises the mode is affected as far as we have measured, so there is
+    // no known-good version to gate on -- hence disabling the capability rather than raising UMD's
+    // KMD_READ_ONLY_PAGE_PINNING minimum.
     //
     // Reporting the capability as unavailable routes callers through the widening path that already
     // exists for older KMDs: PinnedMemoryCache::try_pin() downgrades the request to ReadWrite, and a
@@ -448,8 +451,8 @@ experimental::MemoryPinningParameters GetMemoryPinningParameters(distributed::Me
     // read-only pinning landed. It also makes the TT_FATAL in PinnedMemory::Create() reject any
     // direct ReadOnly request, so no path can reach the wedge.
     //
-    // Re-enabling is a one-line revert once a known-good KMD version is identified; the version gate
-    // then belongs in UMD's KMD_READ_ONLY_PAGE_PINNING minimum rather than here.
+    // Re-enabling is a one-line revert once a known-good KMD version exists; the version gate then
+    // belongs in UMD's KMD_READ_ONLY_PAGE_PINNING minimum rather than here.
     params.supports_read_only = false;
     return params;
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

`GetMemoryPinningParameters()` now reports `supports_read_only = false`, disabling
device-read-only host pinning (#52893, closes #46132, paired with tenstorrent/tt-umd#3156)
until the driver side is understood.

**Symptom.** On an IOMMU-enabled host whose KMD advertises the read-only pinning mode -- measured
on both 2.9.0 and 2.10.0 -- a host-to-device tensor upload can stop making progress and never
recover. The process sits at ~100% of one core with
essentially all of it in system time (`utime` 28s vs `stime` 368s in one capture),
`voluntary_ctxt_switches` frozen, `/proc/<pid>/syscall` reporting `running`, its mapping count
flat and no file I/O advancing. Nothing fires: no error, no exception, no timeout, no log line.
`TT_METAL_OPERATION_TIMEOUT_SECONDS` does not help because nothing is waiting on the device, so
the only evidence a user gets is a job that eventually gets killed from the outside.

**The same wedge, observed in CI.** A scheduled job that runs each perf case as its own pytest
subprocess under a 3600s watchdog caught it in the act: it killed the
transformer-layer upload case after 3605s with
`TIMEOUT after 3603s (limit 3600s) - killing subprocess. The device is likely wedged; reset it
before trusting later cells.` The subprocess log it captured ends on the weight cache's miss for
the tensor about to be uploaded and then nothing -- the next thing that code does is the
`load_tensor` that requests the read-only pin. Same test function and same cached artifact as the local
reproduction, a different parametrisation. Two things follow:

- The local reproduction and the CI failures are the same defect, not merely similar.
- **Killing the process does not recover the device.** Every one of the five remaining cases in that
  job then failed in ~21s at device init with `Timed out while waiting for active ethernet core
  26-25 to become active` (`RiscFirmwareInitializer::assert_active_ethernet_cores_to_reset`,
  llrt.cpp:594). Only a device reset clears it. So the blast radius is not one hung test: a wedged
  read-only pin takes out the rest of the job, and the follow-on failures look like flaky ethernet
  rather than anything to do with pinning.

**Diagnosis.** An instrumented local build that logs every `PinnedMemory::Create()` before and
after the call shows the trace ending on an unpaired entry:

```
try_pin CREATE addr=0x... size=7833600 access=RO noc=1 ro_supported=1
   <- no matching completion; the preceding ~30 create/complete pairs are all matched
```

So a single `PinnedMemory::Create(..., PinnedMemoryDeviceAccess::ReadOnly)` never returns. That
call reaches `PCIDevice::map_for_dma()`, which sets `TT_DMA_FLAG_READ_ONLY` and issues
`tt_pin_pages()`; the ioctl does not come back. The host-side signature above is consistent with
the thread being stuck inside that one kernel call rather than spinning over syscalls. The buffer
is the `PROT_READ | MAP_PRIVATE` file mapping `ttnn.load_tensor()` creates -- exactly the case
read-only pinning was added for.

Ruled out on the tt-metal side:

- Not the pin cache's bookkeeping. Every loop in `PinnedMemoryCache` is bounded, the process's
  mapping count is flat while it is stuck, and raising
  `TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES` to 64 GB still wedges, so it is not
  limit-driven pin/unpin churn. Setting that variable to `0` avoids the wedge only because it
  makes `try_pin()` bail out before it ever calls `Create()`.
- Not serialization or file content. The same file loads in ~0.05s both before and after the
  commit that introduced read-only pinning when loaded on its own.

**Fix.** Reporting the capability as unavailable routes callers through the widening path that
already exists for KMDs without the mode: `try_pin()` downgrades the request to `ReadWrite`, and
a genuinely non-writable mapping then fails to pin and falls back to the unpinned copy -- the
behaviour from before #52893. `widened_to_read_write` makes that failure return `nullptr`
immediately instead of draining the cache, which is what that flag was written for. It also makes
the `TT_FATAL` in `PinnedMemory::Create()` reject any direct `ReadOnly` request, so no path can
reach the wedge. Writable host buffers keep the pinned fast path.

The cost is the regression #52893 set out to remove: a large file-backed upload is copied instead
of pinned. That is a worse outcome than pinning and a much better one than hanging with no
diagnostic, and it is what every pre-2.9.0 host does today anyway.

**Verification.** Built and run at `d2f4b3a`, not at current `main`; the code in this function is
identical between the two, but I have not rebuilt on `main` HEAD. 8-chip Blackhole host, KMD 2.9.0,
IOMMU active, 4x2 mesh with fabric 2D torus, hybrid L1 allocator, slow dispatch.

A model-layer weight-upload workload that interleaves writable uploads with `ttnn.load_tensor()` of
~8 MB `bfloat8_b` files:

- unpatched `d2f4b3a`: wedged on all 5 attempts (3 on the released wheel, 1 with the pin-cache
  limit raised to 64 GB, 1 on a locally built instrumented library);
- with this change: passes, 85s, no environment overrides;
- separate control on the same instrumented build, forcing `ReadWrite` inside `try_pin()` instead:
  also passes (63s alone, 86s with the preceding test). That control is what identifies the access
  mode as the trigger rather than anything else on that code path.

**Attribution, checked both ways.** I built and ran the same workload at `b4a5f07c7db` itself -- the
commit that adds read-only pinning -- with nothing later applied and the umd submodule pointer
unchanged from it. It wedges there too, with the identical signature: 33 pin creations, 32
completions, the unpaired one being a read-only pin of the same file mapping, and over a 20s sample
`utime` grew 0.13s against `stime` 20.3s with `voluntary_ctxt_switches` frozen. So the change is
sufficient on its own, not merely necessary -- no other commit in the range between it and the
version I originally bisected is needed. (`git log -S` also confirms it is the only commit in that
range introducing `PinnedMemoryDeviceAccess` or a ReadOnly call site.) Only one public header
differs across that range, a `tt::umd::semver_t` -> `tt::umd::SemVer` rename with no layout change,
so mixing that library with the prebuilt ttnn from the later version is ABI-safe; the run also
traced successful read-only pins before the wedge, which rules out the path being skipped.

And the other direction, at the immediate parent `cb8122e29f6`. The strong part is structural, not
statistical: at that commit metal names neither `PinnedMemoryDeviceAccess` nor
`tt::umd::DeviceBufferAccess` anywhere, `map_sysmem_buffer` takes four arguments with no access
parameter, and the only `READ_ONLY` matches in the tree are the `MEM_MAP_READ_ONLY_END` L1 constants
and the watcher's `SANITIZE_READ_ONLY_L1` option. `TT_DMA_FLAG_READ_ONLY` therefore cannot be set,
so the non-returning ioctl is unreachable rather than merely unobserved. Empirically the same
workload then passes 3/3 there (107s, 63s, 63s) while still exercising the pin path hard -- 56
attempted pins per run, 40 succeeding and 16 throwing, which is the read/write pin of a `PROT_READ`
mapping failing exactly as #52893's description says it does, and zero read-only requests. (That
build needed a 5-argument `Create` forwarding shim so the later prebuilt ttnn could link; it
discards the access argument, so the behaviour under test is the parent's.)

The scope of that claim is one failure mode, not the test. A different hang at a different site was
observed before read-only pinning existed, so "without #52893 this test cannot hang" would be false;
"without #52893 a read-only pin cannot be requested, so this particular wedge cannot occur" is what
the code shows.

To be clear about what this does *not* say: the defect is not in this PR's code. Read-only pinning
is a driver capability that does not work; #52893 is the first thing to use it. Reverting the use is
a mitigation, not a fix.

**Known gap, and why this is shaped as a mitigation rather than a real fix.** I could not distil
the wedge into a standalone script. Three shapes all run clean at ~0.045s per read-only load:
`load_tensor` in a loop; writable uploads and file loads alternating with fabric enabled; and 40
read/write pins left live before the first read-only pin. The wedge needs something about the real
workload's pin or allocation state that none of those capture, so it is not simply "any read-only
pin", and whoever picks up the driver side should know that a naive repro will look healthy.

One constraint that may narrow it: in the runs that wedge, it is always the **first** file-backed
load of the process. The runs that get past that one then complete a full suite -- thousands of
further read-only pins on the same mapping pattern -- without trouble. So it looks like a
first-use or cold-state window rather than something that degrades with pin count.

I also checked, and ruled out, the obvious host-capability explanation for why only some runs hang.
A set of hosts that all report the same KMD 2.10.0 and the same `iommu_group/type=DMA-FQ` -- so
`supports_read_only` is true on every one of them -- produces both outcomes: 7 of 9 runs wedged,
2 passed. So this is not "some hosts lack the capability and quietly fall back"; identical hosts
differ run to run, which points at timing or the pin pattern rather than configuration. Every
version that advertises the mode is affected as far as I have measured, so there is currently no
known-good version to raise UMD's `KMD_READ_ONLY_PAGE_PINNING` minimum to.

Given that, this PR deliberately does not try to find a narrower condition to gate on -- there is
nothing safe to probe, because the failure mode is a hang rather than an error. Re-enabling should
be a one-line revert once a KMD version is confirmed good, and the gate then belongs in that UMD
minimum rather than here. Happy to reshape this as a runtime opt-in
flag defaulting to off instead, if the feature owner would rather keep the path exercised on hosts
where it is known to work.
