### PR TITLE
[Cleanup] Break header include cycles in the kernel compute, LLK, fabric and ethernet headers

### DIFF
--- a/tt_metal/fabric/hw/inc/fabric_direction_table_interface.h
+++ b/tt_metal/fabric/hw/inc/fabric_direction_table_interface.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "hostdevcommon/fabric_common.h"
+// Only included from the bottom of hostdevcommon/fabric_common.h; including it back here would create a cycle.
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/hw/inc/fabric_direction_table_interface.h
+++ b/tt_metal/fabric/hw/inc/fabric_direction_table_interface.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-// Only included from the bottom of hostdevcommon/fabric_common.h; including it back here would create a cycle.
-
 namespace tt::tt_fabric {
 
 // Device-side (HW) inline implementations for direction_table_t

--- a/tt_metal/fabric/hw/inc/fabric_routing_path_interface.h
+++ b/tt_metal/fabric/hw/inc/fabric_routing_path_interface.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "hostdevcommon/fabric_common.h"
-#include "tt_metal/fabric/fabric_edm_packet_header.hpp"
+// Only included from the bottom of hostdevcommon/fabric_common.h, which provides everything used below;
+// including fabric_common.h or fabric_edm_packet_header.hpp back here would create an include cycle.
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/hw/inc/fabric_routing_path_interface.h
+++ b/tt_metal/fabric/hw/inc/fabric_routing_path_interface.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-// Only included from the bottom of hostdevcommon/fabric_common.h, which provides everything used below;
-// including fabric_common.h or fabric_edm_packet_header.hpp back here would create an include cycle.
-
 namespace tt::tt_fabric {
 
 // Device-side compressed decoder function for 2D routing

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -4,7 +4,6 @@
 
 #pragma once
 #include <cstdint>
-#include "chlkc_list.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -4,7 +4,6 @@
 
 #pragma once
 #include <cstdint>
-#include "chlkc_list.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
@@ -4,7 +4,6 @@
 
 #pragma once
 #include <cstdint>
-#include "chlkc_list.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "tensor_shape.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -4,7 +4,6 @@
 
 #pragma once
 #include <cstdint>
-#include "chlkc_list.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -4,7 +4,6 @@
 
 #pragma once
 #include <cstdint>
-#include "chlkc_list.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"

--- a/tt_metal/hw/inc/api/compute/common_globals.h
+++ b/tt_metal/hw/inc/api/compute/common_globals.h
@@ -6,7 +6,7 @@
 
 #define ALWI inline __attribute__((always_inline))
 
-#include "chlkc_list.h"
+// Do not include chlkc_list.h here: it pulls the generated per-kernel body into this shared header
 #include "ckernel.h"
 #include "internal/firmware_common.h"
 #include "ckernel_include.h"

--- a/tt_metal/hw/inc/api/compute/common_globals.h
+++ b/tt_metal/hw/inc/api/compute/common_globals.h
@@ -6,7 +6,6 @@
 
 #define ALWI inline __attribute__((always_inline))
 
-// Do not include chlkc_list.h here: it pulls the generated per-kernel body into this shared header
 #include "ckernel.h"
 #include "internal/firmware_common.h"
 #include "ckernel_include.h"

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "chlkc_list.h"
+// Do not include chlkc_list.h here: it pulls the generated per-kernel body into this shared header
 #include "ckernel.h"
 #ifndef ARCH_QUASAR
 #include "ckernel_globals.h"

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-// Do not include chlkc_list.h here: it pulls the generated per-kernel body into this shared header
 #include "ckernel.h"
 #ifndef ARCH_QUASAR
 #include "ckernel_globals.h"

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "api/compute/common.h"
+#include "api/compute/common_globals.h"
 #include "sanitizer/api.h"
 #include "api/compute/src_order.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/eth_fw_api.h
@@ -55,8 +55,6 @@ struct boot_results_t {
 };
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
-// Only FORCE_INLINE is needed here. Do not include internal/ethernet/erisc.h: it includes this
-// header back (include cycle).
 #include "internal/risc_attribs.h"
 
 FORCE_INLINE bool is_link_up() {

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/eth_fw_api.h
@@ -55,7 +55,9 @@ struct boot_results_t {
 };
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
-#include "internal/ethernet/erisc.h"
+// Only FORCE_INLINE is needed here. Do not include internal/ethernet/erisc.h: it includes this
+// header back (include cycle).
+#include "internal/risc_attribs.h"
 
 FORCE_INLINE bool is_link_up() {
     // Collected when FW/Fabric is idle and context switches to base FW


### PR DESCRIPTION
### What is wrong

clang-tidy's `misc-header-include-cycle` check reported 12 unique findings in the kernel header scan, all of the same shape: header A includes header B, which transitively includes A again. Include guards turn the second include into a silent no-op, so nothing is miscompiled today — but each of these headers only parses because some translation unit happens to enter the cluster through the right door first. Any change of entry point breaks the arrangement (a typical symptom, observed with the `common.h` / `compute_kernel_hw_startup.h` pair, is `error: 'compute_kernel_hw_startup' was not declared in this scope`), and no part of the cluster can be parsed independently of the rest.

### What this PR fixes

**Compute API ↔ `chlkc_list.h`.** `common_globals.h` and `compute_kernel_api.h` both included `chlkc_list.h`, which includes the *generated* per-kernel body — so the shared compute API pulled a generated translation unit into itself, and the generated kernel includes the API back. TRISC translation units always enter through `trisck.cc`, which includes `chlkc_list.h` as one of its first includes, so both edges were dead weight; they are removed. Both headers already include what they actually use on the following lines.

**`common.h` ↔ `compute_kernel_hw_startup.h`.** A true two-node mutual cycle. `common.h` keeps its include (that is how kernels receive the startup function); `compute_kernel_hw_startup.h` needed `common.h` only for the `ALWI`/`MATH`/`PACK`/`UNPACK` macros and now includes `common_globals.h`, which defines them, instead. The `sanitizer/api.h` include that `main` recently added to this header is kept; its include closure was checked and does not reach back into this cluster, so it introduces no new cycle.

**LLK API headers that re-enter the generated body.** `llk_unpack_AB_reduce_custom_api.h` and `llk_unpack_AB_reduce_custom_runtime_api.h` included `chlkc_list.h`; same pattern and same reasoning as above, removed. The scan flagged the wormhole_b0 copies; the blackhole copies carried the identical edge and are fixed too, and quasar's `llk_pack_untilize_api.h` carries the same defect in a file the scan missed (it ran a wormhole configuration) and is fixed as well — quasar's tt-2xx `trisck.cc` likewise includes `chlkc_list.h` directly. The quasar copies of the two experimental headers have no such include and need no change.

**Fabric.** `fabric_common.h` includes `fabric_direction_table_interface.h` and `fabric_routing_path_interface.h` at its bottom (device builds only) to attach device-side template implementations, and those headers included `fabric_common.h` back — plus `fabric_edm_packet_header.hpp`, whose own `fabric_common.h` include closed a second cycle. The interface headers are only reachable through the bottom of `fabric_common.h`, so their back-includes were always no-ops and are removed. The `fabric_edm_packet_header.hpp` include in `fabric_routing_path_interface.h` was unused (everything referenced is defined in `fabric_common.h` itself) and is removed; `fabric_edm_packet_header.hpp`'s genuine include of `fabric_common.h` stays and is now acyclic.

**Wormhole `eth_fw_api.h` ↔ `ethernet/erisc.h`.** `erisc.h` uses symbols from `eth_fw_api.h`, so that direction stays. The wormhole `eth_fw_api.h` used nothing from `erisc.h` except `FORCE_INLINE` and now includes `internal/risc_attribs.h`, which defines it, instead (blackhole and quasar copies already have no `erisc.h` include).

### What this PR defers

**`api/debug/assert.h` ↔ `risc_common.h`** is left alone. That pair is deliberately interleaved — `assert.h` defines `ASSERT` first, includes `risc_common.h` mid-file, then defines `assert_and_hang` using its symbols, and its comments document why the include is load-bearing when the header is entered via `ckernel.h → llk_assert.h`. Removing either edge breaks one of the two real entry orders, and a correct fix means extracting the `ASSERT` macro block into its own small header — a restructuring that cannot be verified as a preprocessing no-op with the replay method below, so it belongs in its own PR.

### How this was verified

Kernel headers are compiled by the JIT at runtime, not by the host build, so this was verified by replaying 17 real production compile commands (TRISC/BRISC/NCRISC kernels and all firmware variants of a production workload) captured from a Blackhole run, with the production PCH force-include stripped so the changes are actually exercised. The verification was performed with the branch based on `951ea267022` (the `main` commit contemporary with the captured compile commands); the branch has since been rebased onto the current `main`, whose only interaction with these changes is the new `sanitizer/api.h` include in `compute_kernel_hw_startup.h`, addressed above. At that base, for all 15 targets that compile from a pristine tree (2 erisc kernel targets fail there for an unrelated reason — their cached generated headers reference a file that does not exist on `main` — and are excluded), every target compiles and its full preprocessed output is **byte-identical** to the unmodified tree, confirming each removed edge was genuinely a no-op for these translation units. The host build (`tt_metal` target, which covers the host-visible fabric headers) also passes.

Not covered locally, left to CI: the wormhole_b0 and quasar LLK copies (including quasar's `llk_pack_untilize_api.h`), the wormhole `eth_fw_api.h` edge, non-Blackhole architectures generally, and device execution. No device tests were run.

### Why beyond the lint

The compute-API cycles (the first two groups above) are what currently prevents parsing the shared compute API ahead of the generated kernel body, which blocks extending the opt-in JIT precompiled-header support (#55230) past the per-kernel body. This PR only breaks the cycles; it changes nothing about the PCH feature itself.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/fix-kernel-include-cycles)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/fix-kernel-include-cycles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/fix-kernel-include-cycles)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/fix-kernel-include-cycles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/fix-kernel-include-cycles)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/fix-kernel-include-cycles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/fix-kernel-include-cycles)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/fix-kernel-include-cycles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/fix-kernel-include-cycles)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/fix-kernel-include-cycles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/fix-kernel-include-cycles)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/fix-kernel-include-cycles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/fix-kernel-include-cycles)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/fix-kernel-include-cycles)