### PR TITLE
[LLK][Quasar] Reduce TRISC_ID to the per-Neo thread id

### DIFF
--- a/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_add_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_add_quasar_test.cpp
@@ -103,7 +103,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<p_pacr::PACK1, false /*EN_32BIT_DEST*/>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
 
     // Implied math format disable for SrcS (unpacker). Load/store decode uses explicit sfpmem.
-    cfg[DISABLE_IMPLIED_SRCS_FORMAT_ADDR32 + TRISC_ID] = !IMPLIED_MATH_FORMAT;
+    cfg_rmw(DISABLE_IMPLIED_SRCS_FORMAT_RMW, !IMPLIED_MATH_FORMAT);
 
     // SFPU load reads what UNP_S wrote; store writes what PACK1 will read.
     const std::uint32_t load_sfpmem  = _sfpu_sfpmem_type_(static_cast<DataFormat>(formats.unpack_S_dst));

--- a/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_square_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_square_quasar_test.cpp
@@ -92,7 +92,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<p_pacr::PACK1, false /*EN_32BIT_DEST*/>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
 
     // Implied math format disable for SrcS (unpacker). Load/store decode uses explicit sfpmem.
-    cfg[DISABLE_IMPLIED_SRCS_FORMAT_ADDR32 + TRISC_ID] = !IMPLIED_MATH_FORMAT;
+    cfg_rmw(DISABLE_IMPLIED_SRCS_FORMAT_RMW, !IMPLIED_MATH_FORMAT);
 
     // SFPU load reads what UNP_S wrote; store writes what PACK1 will read.
     const std::uint32_t load_sfpmem  = _sfpu_sfpmem_type_(static_cast<DataFormat>(formats.unpack_S_dst));

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_add_parallel_matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_add_parallel_matmul_quasar_test.cpp
@@ -151,7 +151,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _configure_buf_desc_table_(buf_desc_id_pack, bd_pack);
     _llk_pack_hw_configure_<p_pacr::PACK1, false /*EN_32BIT_DEST*/>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
 
-    cfg[DISABLE_IMPLIED_SRCS_FORMAT_ADDR32 + TRISC_ID] = !IMPLIED_MATH_FORMAT;
+    cfg_rmw(DISABLE_IMPLIED_SRCS_FORMAT_RMW, !IMPLIED_MATH_FORMAT);
 
     // SFPU load reads what UNP_S wrote; store writes what PACK1 will read.
     const std::uint32_t load_sfpmem  = _sfpu_sfpmem_type_(static_cast<DataFormat>(formats.unpack_S_dst));

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -216,6 +216,8 @@ constexpr std::uint32_t get_dest_max_tiles()
 template <std::uint8_t TRISC_ID>
 inline void _set_dest_section_base_(const std::uint32_t base_addr)
 {
+    static_assert(TRISC_ID < 4, "_set_dest_section_base_ takes a per-Neo thread id in [0, 3]");
+
     if constexpr (TRISC_ID == 0)
     {
         cfg[DEST_TARGET_REG_CFG_MATH_SEC0_Offset_ADDR32] = base_addr;
@@ -228,7 +230,7 @@ inline void _set_dest_section_base_(const std::uint32_t base_addr)
     {
         cfg[DEST_TARGET_REG_CFG_MATH_SEC2_Offset_ADDR32] = base_addr;
     }
-    else
+    else if constexpr (TRISC_ID == 3)
     {
         cfg[DEST_TARGET_REG_CFG_MATH_SEC3_Offset_ADDR32] = base_addr;
     }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_id.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_id.h
@@ -23,6 +23,13 @@
 namespace ckernel
 {
 
-constexpr std::uint32_t TRISC_ID = COMPILE_FOR_TRISC;
+// COMPILE_FOR_TRISC is the cluster-GLOBAL processor id (NEO_n_COMPUTE_m = n*4 + m, 0..15); the
+// per-Neo thread id this indexes config by is that id modulo 4. See the ThreadId enum note in
+// ckernel_defs.h, and the same reduction in ckernel.h's mailbox self-checks.
+constexpr std::uint32_t TRISC_ID = COMPILE_FOR_TRISC % 4;
+
+// Validates the define itself: the id must name a compute processor of the 4-Neo cluster. (Asserting
+// TRISC_ID < 4 would be vacuous - the reduction above already guarantees it.)
+static_assert(COMPILE_FOR_TRISC < 16, "COMPILE_FOR_TRISC must be a Quasar compute processor id in [0, 15]");
 
 } // namespace ckernel


### PR DESCRIPTION
Closes #55817 — both findings.

`COMPILE_FOR_TRISC` is the cluster-**global** compute processor id, but `TRISC_ID` is used to index
4-entry per-thread config groups. It needs that id modulo 4.

- `hal_2xx_common.cpp` bakes the define straight from the processor id:
  `defines.push_back(fmt::format("COMPILE_FOR_TRISC={}", params.processor_id));`
- `QuasarComputeProcessor` is a 16-value enum — `NEO_n_COMPUTE_m = n*4 + m`, so **0..15**.
- The role dispatch in that same function shows the intent is modulo 4: `NEO_0/1/2/3_COMPUTE_1` all
  map to `UCK_CHLKC_MATH`, `..._COMPUTE_0` all to `UNPACK`, `..._COMPUTE_2` all to `PACK`.

The tree already says so and already does it elsewhere: `ckernel_defs.h` notes beside the `ThreadId`
enum that the define "only agrees with this enum modulo 4", and `ckernel.h` applies
`COMPILE_FOR_TRISC % 4` in three mailbox self-checks.

Without the reduction, any id from 4 up walks its indexed writes out of the intended group — the
section-indexed implied-format writes leave `SEC0..SEC3`, `addr_mod_t::set` indexes the shared
addrmod region by the wrong thread, and `_set_dest_section_base_` falls into its bare `else` and
programs the isolate-SFPU section. It also invalidates the software per-thread partition of the
shared counter file, which is the argument that makes those accesses safe.

### Verification

Compiling the constant at every processor id:

| | ids 0–3 (Neo 0) | ids 4–15 (Neos 1–3) |
|---|---|---|
| with this change | pass | **pass** |
| without it | pass | **fail** |

So the defect is exactly "every Neo but the first", and the reduction is what closes it. An
out-of-range define (16) is now rejected at compile time. The Quasar harness still compiles clean —
322 variants across the three isolate-SFPU / parallel-matmul tests.

**Why there is no runtime test.** The tt-llk harness passes `-DCOMPILE_FOR_TRISC=` from
`KERNEL_COMPONENTS.index(name)`, i.e. 0..3 only, so the entire test surface sits in the range where
`% 4` is a no-op — which is why this survived. Only the metal path produces ids above 3. The
`static_assert(TRISC_ID < 4)` added to `_set_dest_section_base_` is the regression guard instead:
dropping the reduction again fails the build on a Neo 1+ target rather than silently misindexing.

Note the `static_assert` in `ckernel_trisc_id.h` deliberately checks `COMPILE_FOR_TRISC < 16` and not
`TRISC_ID < 4` — the latter is vacuous once the modulo is applied.

## Second commit — three test sources, and this is the part that needs your simulator

`DISABLE_IMPLIED_SRCS_FORMAT` is a single-bit field at a **single** address (`ADDR32 7`,
`SHAMT 19`, `MASK 0x80000`) with **no per-section replication**. The three isolate-SFPU /
parallel-matmul sources index it by `TRISC_ID`, so two things go wrong in one statement:

1. the write walks onto config words 8..10, which belong to unrelated registers;
2. it is a full-word store of a masked single-bit field, so whichever word it reaches is clobbered
   wholesale.

Note (2) bites **even at `TRISC_ID == 0`**, where the address is right: the field is at bit 19
(`0x80000`), but the statement stores a 0/1 value across the whole word. `IMPLIED_MATH_FORMAT` false
gives `!false == 1` -> `0x00000001`, setting bit **0**; true gives `0` -> the word is zeroed. Either
way **bit 19 is never asserted, on any thread, for either parameter value** — so `ImpliedMathFormat`
has been inert for SrcS in these three tests, and an unrelated word was clobbered as collateral. Fixed by writing the field through its own RMW triple —
`cfg_rmw(DISABLE_IMPLIED_SRCS_FORMAT_RMW, !IMPLIED_MATH_FORMAT)` — which is how masked fields are
written elsewhere in the tree.

(Contrast the library's `DISABLE_IMPLIED_SRCA_FMT_SEC0_Base`, which genuinely is replicated at
244/245/246/247, so indexing *that* by the thread id is correct.)

**⚠ This changes what those three tests program.** They have only ever run with implied SrcS format
*enabled*, whatever the parameter said; the fix starts honouring it. If the golden model assumed the
bit was being set, these were passing for the wrong reason and may now shift — that is the specific
thing a simulator run would settle. It is compile-clean (322 variants) but I could not run it: a single simulator variant
is ~15 minutes here, and there are 58/58/206 of them. **If someone on the Quasar side can run these
three files on the simulator before merge, that is the one outstanding check on this PR.** The first
commit does not depend on it and is independently verified.

Introduced by #49790, which ported a 3-thread assumption.