### PR TITLE
[Cleanup]: Pimplify PrefetcherPipe

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -25,7 +25,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include "tests/tt_metal/tt_metal/common/device_fixture.hpp"
 #include "impl/context/metal_context.hpp"
-#include "impl/dataflow_buffer/prefetcher_pipe.hpp"
+#include <tt-metalium/experimental/prefetcher_pipe.hpp>
 #include "tt_metal/distributed/hd_socket_descriptor.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
 #include "tt_metal/llrt/tt_cluster.hpp"

--- a/tests/tt_metal/tt_metal/api/prefetcher_pipe_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/api/prefetcher_pipe_test_utils.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "cross_node_dfb_test_utils.hpp"
-#include "impl/dataflow_buffer/prefetcher_pipe.hpp"
+#include <tt-metalium/experimental/prefetcher_pipe.hpp>
 
 namespace tt::tt_metal::prefetcher_pipe_test {
 

--- a/tests/tt_metal/tt_metal/api/test_prefetcher_pipe.cpp
+++ b/tests/tt_metal/tt_metal/api/test_prefetcher_pipe.cpp
@@ -24,6 +24,7 @@
 #include <tt-metalium/sub_device.hpp>
 
 #include "impl/dataflow_buffer/cross_node_dfb.hpp"
+#include <tt-metalium/experimental/prefetcher_pipe.hpp>
 #include "impl/dataflow_buffer/prefetcher_pipe.hpp"
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
@@ -31,7 +31,7 @@
 #include <tt-metalium/mesh_buffer.hpp>
 #include "tt_metal/distributed/trace_allocation_tracker.hpp"
 
-#include "tt_metal/impl/dataflow_buffer/prefetcher_pipe.hpp"
+#include <tt-metalium/experimental/prefetcher_pipe.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/experimental/prefetcher_pipe.hpp
+++ b/tt_metal/api/tt-metalium/experimental/prefetcher_pipe.hpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Experimental: no API-stability guarantee. Everything in this header may change or be removed.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+
+namespace tt::tt_metal {
+
+class Program;
+
+namespace distributed {
+class MeshDevice;
+}  // namespace distributed
+
+namespace experimental {
+
+class PrefetcherPipeImpl;
+
+/**
+ * Host object for a durable cross-program remote DFB.
+ *
+ * Lifetime: construction allocates the data ring + config page from persistent L1
+ * pages once, and this handle owns them. Keep it alive for the entire time any program
+ * Attaches / uses it; destroying it frees the ring and config, and an attached Program
+ * holds a non-owning reference that does not keep either alive. The runtime does not
+ * fence peers; only destroy (or let it go out of scope) after every peer program has
+ * Finished.
+ *
+ * The handle is a movable value. An Attach records the implementation object behind it, and a
+ * move leaves that object where it is, so a pipe can be handed to a new owner or kept in a
+ * container without orphaning an attachment. Moving from a pipe empties it, and an empty pipe
+ * is only good for destruction or assignment; move-assigning onto a live pipe destroys the pipe
+ * that was there, with the same effect on its attachments as letting it go out of scope.
+ *
+ * Host programming model:
+ *   auto pipe = CreatePrefetcherPipe(device, sender_core, receiver_cores, ring_size);
+ *   AttachPrefetcherPipe(program, pipe, sender_cores, entry_size);  // or all receivers
+ *   // optional relay to TRISC: CreatePrefetcherPipeRelayDataflowBuffer(program, receivers, cfg, id),
+ *   //   declared in impl/dataflow_buffer/prefetcher_pipe.hpp with the DFB config it takes.
+ *
+ * Device kernel flows (sender / receiver / relay) are documented on the device API:
+ *   tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
+ */
+class PrefetcherPipe {
+public:
+    PrefetcherPipe(
+        distributed::MeshDevice* device,
+        CoreCoord sender_core,
+        const CoreRangeSet& receiver_cores,
+        uint32_t ring_size,
+        BufferType buffer_type = BufferType::L1);
+
+    // Movable, not copyable. A handle is a pointer to the implementation object that owns the
+    // durable L1, and a Program's attachment points at that object rather than at the handle, so
+    // relocating a handle keeps every attachment valid. Copying would leave two handles freeing
+    // one ring.
+    PrefetcherPipe(const PrefetcherPipe&) = delete;
+    PrefetcherPipe& operator=(const PrefetcherPipe&) = delete;
+    PrefetcherPipe(PrefetcherPipe&&) noexcept;
+    PrefetcherPipe& operator=(PrefetcherPipe&&) noexcept;
+    ~PrefetcherPipe();
+
+    // Base address of the data ring. Every core of the pipe holds its slice at this address.
+    uint32_t buffer_address() const;
+    // Base address of the config pages. Each core of the pipe holds its own page at this address.
+    uint32_t config_address() const;
+    uint32_t ring_size() const;
+    uint32_t config_page_size() const;
+    // The credit counters within a config page, as a byte range relative to config_address(). Zeroing
+    // it returns the pipe to its just-created credit state.
+    uint32_t credit_reset_offset() const;
+    uint32_t credit_reset_size() const;
+
+    CoreCoord sender_core() const;
+    const CoreRangeSet& sender_cores() const;
+    const CoreRangeSet& receiver_cores() const;
+    const CoreRangeSet& all_cores() const;
+    distributed::MeshDevice* get_device() const;
+
+    // Internal (host runtime, tests): the implementation object this pipe owns.
+    PrefetcherPipeImpl& impl() { return *pimpl_; }
+    const PrefetcherPipeImpl& impl() const { return *pimpl_; }
+
+private:
+    std::unique_ptr<PrefetcherPipeImpl> pimpl_;
+};
+
+/**
+ * @brief Create a PrefetcherPipe host object with an arena-backed data ring and config page.
+ *
+ * Config pages are written to device L1 at Create (safe-point initial write).
+ * Caller keeps the returned pipe alive for cross-program persistence; Attach wires programs
+ * to the same ring/config addresses.
+ */
+PrefetcherPipe CreatePrefetcherPipe(
+    distributed::MeshDevice* device,
+    CoreCoord sender_core,
+    const CoreRangeSet& receiver_cores,
+    uint32_t ring_size,
+    BufferType buffer_type = BufferType::L1);
+
+/**
+ * @brief Attach a PrefetcherPipe to `program` on the given cores (non-owning).
+ *
+ * `cores` must be a non-empty role-complete subset of the PrefetcherPipe's mapping
+ * cores: the sender role is this pipe's one sender, while the receiver role contains
+ * every receiver. This prevents one PrefetcherPipe role from being split across Programs.
+ * Returns an independent prefetcher_pipe_id in [0, 255).
+ *
+ * WH/BH: on each sender core, only one DM (BRISC or NCRISC) may own PrefetcherPipe
+ * credit / resize / push for that Attach. Both DMs can run on the same physical
+ * core, but dual-DM ownership races on local sent counters and the checkpoint
+ * cursor. Host binding / kernel placement should pin a single sender DM owner
+ * until Attach can enforce this.
+ *
+ * @param entry_size Dense entry size for this Program execution epoch.
+ */
+uint8_t AttachPrefetcherPipe(
+    Program& program, PrefetcherPipe& prefetcher_pipe, const CoreRangeSet& cores, uint32_t entry_size);
+
+}  // namespace experimental
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/prefetcher_pipe.cpp
+++ b/tt_metal/impl/buffers/prefetcher_pipe.cpp
@@ -7,6 +7,7 @@
 #include <buffer_types.hpp>
 #include <core_coord.hpp>
 #include <device.hpp>
+#include <tt-metalium/experimental/prefetcher_pipe.hpp>
 #include "impl/dataflow_buffer/prefetcher_pipe.hpp"
 #include "impl/allocator/allocator.hpp"
 #include "impl/context/metal_context.hpp"
@@ -17,6 +18,8 @@
 #include <algorithm>
 #include <cstdint>
 #include <limits>
+#include <memory>
+#include <type_traits>
 #include <variant>
 #include <vector>
 
@@ -75,7 +78,7 @@ PrefetcherPipeConfigPageLayout compute_prefetcher_pipe_config_page_layout(
 
 }  // namespace
 
-PrefetcherPipe::PrefetcherPipe(
+PrefetcherPipeImpl::PrefetcherPipeImpl(
     distributed::MeshDevice* device,
     CoreCoord sender_core,
     const CoreRangeSet& receiver_cores,
@@ -91,7 +94,7 @@ PrefetcherPipe::PrefetcherPipe(
     }
 }
 
-void PrefetcherPipe::build_config_pages() {
+void PrefetcherPipeImpl::build_config_pages() {
     TT_FATAL(config_address_ != 0, "PrefetcherPipe config allocation must exist before building pages");
     TT_FATAL(data_address_ != 0, "PrefetcherPipe data address must be set before building config pages");
 
@@ -147,7 +150,7 @@ void PrefetcherPipe::build_config_pages() {
     }
 }
 
-void PrefetcherPipe::write_config_to_device() {
+void PrefetcherPipeImpl::write_config_to_device() {
     TT_FATAL(device_ != nullptr, "PrefetcherPipe device cannot be null");
     for (const auto& [core, page] : config_pages_) {
         for (IDevice* target_device : device_->get_devices()) {
@@ -161,7 +164,7 @@ void PrefetcherPipe::write_config_to_device() {
     }
 }
 
-void PrefetcherPipe::setup_buffers(BufferType buffer_type) {
+void PrefetcherPipeImpl::setup_buffers(BufferType buffer_type) {
     validate_ring_geometry(device_, ring_size_, buffer_type);
 
     const auto context_id = extract_context_id(device_);
@@ -206,9 +209,9 @@ void PrefetcherPipe::setup_buffers(BufferType buffer_type) {
     write_config_to_device();
 }
 
-PrefetcherPipe::~PrefetcherPipe() { release_allocations(); }
+PrefetcherPipeImpl::~PrefetcherPipeImpl() { release_allocations(); }
 
-void PrefetcherPipe::release_allocations() noexcept {
+void PrefetcherPipeImpl::release_allocations() noexcept {
     if (device_ == nullptr || !device_->is_initialized()) {
         config_allocation_id_ = 0;
         data_allocation_id_ = 0;
@@ -227,21 +230,66 @@ void PrefetcherPipe::release_allocations() noexcept {
     data_allocation_id_ = 0;
 }
 
-uint32_t PrefetcherPipe::buffer_address() const { return data_address_; }
+uint32_t PrefetcherPipeImpl::buffer_address() const { return data_address_; }
 
-uint32_t PrefetcherPipe::config_address() const { return config_address_; }
+uint32_t PrefetcherPipeImpl::config_address() const { return config_address_; }
 
-const std::vector<uint32_t>& PrefetcherPipe::config_page(const CoreCoord& core) const {
+const std::vector<uint32_t>& PrefetcherPipeImpl::config_page(const CoreCoord& core) const {
     auto it = config_pages_.find(core);
     TT_FATAL(it != config_pages_.end(), "PrefetcherPipe has no host config page for core {}", core.str());
     return it->second;
 }
 
-const CoreRangeSet& PrefetcherPipe::sender_cores() const { return sender_cores_; }
+const CoreRangeSet& PrefetcherPipeImpl::sender_cores() const { return sender_cores_; }
 
-const CoreRangeSet& PrefetcherPipe::receiver_cores() const { return receiver_cores_; }
+const CoreRangeSet& PrefetcherPipeImpl::receiver_cores() const { return receiver_cores_; }
 
-const CoreRangeSet& PrefetcherPipe::all_cores() const { return all_cores_; }
+const CoreRangeSet& PrefetcherPipeImpl::all_cores() const { return all_cores_; }
+
+PrefetcherPipe::PrefetcherPipe(
+    distributed::MeshDevice* device,
+    CoreCoord sender_core,
+    const CoreRangeSet& receiver_cores,
+    uint32_t ring_size,
+    BufferType buffer_type) :
+    pimpl_(std::make_unique<PrefetcherPipeImpl>(device, sender_core, receiver_cores, ring_size, buffer_type)) {}
+
+PrefetcherPipe::PrefetcherPipe(PrefetcherPipe&&) noexcept = default;
+
+// Defined here rather than in the header because assigning over a pipe destroys the
+// PrefetcherPipeImpl it held, which needs the complete type.
+PrefetcherPipe& PrefetcherPipe::operator=(PrefetcherPipe&&) noexcept = default;
+
+PrefetcherPipe::~PrefetcherPipe() = default;
+
+// A Program records an Attach by pointing at the PrefetcherPipeImpl, so relocating a handle has to
+// leave that object alone; holding it behind a pointer is what makes that true. Containers relocate
+// on growth, and a throwing move there would strand the ring, so require the move to be noexcept.
+static_assert(
+    std::is_nothrow_move_constructible_v<PrefetcherPipe> && !std::is_copy_constructible_v<PrefetcherPipe>,
+    "PrefetcherPipe must move without throwing and must not copy: two handles would free one ring");
+
+uint32_t PrefetcherPipe::buffer_address() const { return pimpl_->buffer_address(); }
+
+uint32_t PrefetcherPipe::config_address() const { return pimpl_->config_address(); }
+
+uint32_t PrefetcherPipe::ring_size() const { return pimpl_->ring_size(); }
+
+uint32_t PrefetcherPipe::config_page_size() const { return pimpl_->config_page_size(); }
+
+uint32_t PrefetcherPipe::credit_reset_offset() const { return pimpl_->credit_reset_offset(); }
+
+uint32_t PrefetcherPipe::credit_reset_size() const { return pimpl_->credit_reset_size(); }
+
+CoreCoord PrefetcherPipe::sender_core() const { return pimpl_->sender_core(); }
+
+const CoreRangeSet& PrefetcherPipe::sender_cores() const { return pimpl_->sender_cores(); }
+
+const CoreRangeSet& PrefetcherPipe::receiver_cores() const { return pimpl_->receiver_cores(); }
+
+const CoreRangeSet& PrefetcherPipe::all_cores() const { return pimpl_->all_cores(); }
+
+distributed::MeshDevice* PrefetcherPipe::get_device() const { return pimpl_->get_device(); }
 
 PrefetcherPipe CreatePrefetcherPipe(
     distributed::MeshDevice* device,
@@ -254,7 +302,7 @@ PrefetcherPipe CreatePrefetcherPipe(
 
 uint8_t AttachPrefetcherPipe(
     Program& program, PrefetcherPipe& prefetcher_pipe, const CoreRangeSet& cores, uint32_t entry_size) {
-    return program.impl().add_prefetcher_pipe_attachment(prefetcher_pipe, cores, entry_size);
+    return program.impl().add_prefetcher_pipe_attachment(prefetcher_pipe.impl(), cores, entry_size);
 }
 
 uint32_t CreatePrefetcherPipeRelayDataflowBuffer(
@@ -262,7 +310,7 @@ uint32_t CreatePrefetcherPipeRelayDataflowBuffer(
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& receiver_core_spec,
     const dfb::DataflowBufferConfig& config,
     uint8_t prefetcher_pipe_id) {
-    const PrefetcherPipe& pipe = program.impl().get_prefetcher_pipe_attachment(prefetcher_pipe_id);
+    const PrefetcherPipeImpl& pipe = program.impl().get_prefetcher_pipe_attachment(prefetcher_pipe_id);
 
     CoreRangeSet receiver_cores;
     if (std::holds_alternative<CoreCoord>(receiver_core_spec)) {

--- a/tt_metal/impl/dataflow_buffer/prefetcher_pipe.hpp
+++ b/tt_metal/impl/dataflow_buffer/prefetcher_pipe.hpp
@@ -24,37 +24,28 @@ class MeshDevice;
 
 namespace experimental {
 
-class PrefetcherPipe {
+// Implementation of the PrefetcherPipe host object declared in
+// tt-metalium/experimental/prefetcher_pipe.hpp: it owns the persistent L1 allocations, composes
+// each core's config page and stamps those pages onto the device. A PrefetcherPipe holds one of
+// these and forwards to it, and the host runtime records an Attach by pointing at one. That
+// pointer is only as good as the handle: destroying the PrefetcherPipe destroys this object and
+// frees the ring, which is why the handle must outlive every Program attached to it. Moving a
+// handle hands this object to the new owner without relocating it, so destruction is the only
+// way to get there.
+class PrefetcherPipeImpl {
 public:
-    /**
-     * Host object for a durable cross-program remote DFB.
-     *
-     * Lifetime: Create allocates the data ring + config page from persistent L1
-     * pages once. Keep this object alive for the entire time any program Attaches / uses
-     * it, destroying it frees the ring and config. The runtime does not fence peers;
-     * only destroy (or let it go out of scope) after every peer program has Finished.
-     *
-     * Host programming model:
-     *   auto pipe = CreatePrefetcherPipe(device, sender_core, receiver_cores, ring_size);
-     *   AttachPrefetcherPipe(program, pipe, sender_cores, entry_size);  // or all receivers
-     *   // optional: CreatePrefetcherPipeRelayDataflowBuffer(program, receivers, cfg, id);
-     *
-     * Device kernel flows (sender / receiver / relay) are documented on the device API:
-     *   tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
-     *
-     */
-    PrefetcherPipe(
+    PrefetcherPipeImpl(
         distributed::MeshDevice* device,
         CoreCoord sender_core,
         const CoreRangeSet& receiver_cores,
         uint32_t ring_size,
         BufferType buffer_type = BufferType::L1);
 
-    PrefetcherPipe(const PrefetcherPipe&) = delete;
-    PrefetcherPipe& operator=(const PrefetcherPipe&) = delete;
-    PrefetcherPipe(PrefetcherPipe&&) = delete;
-    PrefetcherPipe& operator=(PrefetcherPipe&&) = delete;
-    ~PrefetcherPipe();
+    PrefetcherPipeImpl(const PrefetcherPipeImpl&) = delete;
+    PrefetcherPipeImpl& operator=(const PrefetcherPipeImpl&) = delete;
+    PrefetcherPipeImpl(PrefetcherPipeImpl&&) = delete;
+    PrefetcherPipeImpl& operator=(PrefetcherPipeImpl&&) = delete;
+    ~PrefetcherPipeImpl();
 
     uint32_t buffer_address() const;
     uint32_t config_address() const;
@@ -94,44 +85,14 @@ private:
 };
 
 /**
- * @brief Create a PrefetcherPipe host object with an arena-backed data ring and config page.
- *
- * Config pages are written to device L1 at Create (safe-point initial write).
- * Caller keeps the object alive for cross-program persistence; Attach wires programs
- * to the same ring/config addresses.
- */
-PrefetcherPipe CreatePrefetcherPipe(
-    distributed::MeshDevice* device,
-    CoreCoord sender_core,
-    const CoreRangeSet& receiver_cores,
-    uint32_t ring_size,
-    BufferType buffer_type = BufferType::L1);
-
-/**
- * @brief Attach a PrefetcherPipe to `program` on the given cores (non-owning).
- *
- * `cores` must be a non-empty role-complete subset of the PrefetcherPipe's mapping
- * cores: the sender role is this pipe's one sender, while the receiver role contains
- * every receiver. This prevents one PrefetcherPipe role from being split across Programs.
- * Returns an independent prefetcher_pipe_id in [0, 255).
- *
- * WH/BH: on each sender core, only one DM (BRISC or NCRISC) may own PrefetcherPipe
- * credit / resize / push for that Attach. Both DMs can run on the same physical
- * core, but dual-DM ownership races on local sent counters and the checkpoint
- * cursor. Host binding / kernel placement should pin a single sender DM owner
- * until Attach can enforce this.
- *
- * @param entry_size Dense entry size for this Program execution epoch.
- */
-uint8_t AttachPrefetcherPipe(
-    Program& program, PrefetcherPipe& prefetcher_pipe, const CoreRangeSet& cores, uint32_t entry_size);
-
-/**
  * @brief Create and register the local DFB used to relay a PrefetcherPipe to TRISC.
  *
  * The local DFB borrows the PrefetcherPipe data ring. `prefetcher_pipe_id` must already be
  * Attached on `receiver_core_spec`. Relay entry_size / depth must match this Attach's
  * dense entry_size and `ring_size / entry_size`.
+ *
+ * Declared here rather than alongside the rest of the host API because it takes a DFB config,
+ * which has no public header yet.
  *
  * @return Program-unique host DFB id (distinct from `prefetcher_pipe_id`).
  */

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1368,7 +1368,7 @@ uint8_t detail::ProgramImpl::add_cross_node_dfb(experimental::CrossNodeDFB gdfb)
 }
 
 uint8_t detail::ProgramImpl::add_prefetcher_pipe_attachment(
-    experimental::PrefetcherPipe& prefetcher_pipe, const CoreRangeSet& cores, uint32_t entry_size) {
+    experimental::PrefetcherPipeImpl& prefetcher_pipe, const CoreRangeSet& cores, uint32_t entry_size) {
     TT_FATAL(this->compiled_.empty(), "Cannot attach PrefetcherPipe to an already compiled program {}", this->id);
 
     for (const auto& [core, remote_bits] : per_core_remote_cb_indices_) {
@@ -1440,7 +1440,7 @@ uint8_t detail::ProgramImpl::add_prefetcher_pipe_attachment(
     return prefetcher_pipe_id;
 }
 
-const experimental::PrefetcherPipe& detail::ProgramImpl::get_prefetcher_pipe_attachment(
+const experimental::PrefetcherPipeImpl& detail::ProgramImpl::get_prefetcher_pipe_attachment(
     uint8_t prefetcher_pipe_id) const {
     auto it = prefetcher_pipe_attachments_.find(prefetcher_pipe_id);
     TT_FATAL(
@@ -1466,7 +1466,7 @@ void detail::ProgramImpl::register_prefetcher_pipe_relay_dfb(
     TT_FATAL(
         this->compiled_.empty(), "Cannot register a PrefetcherPipe relay on an already compiled program {}", this->id);
 
-    const experimental::PrefetcherPipe& pipe = get_prefetcher_pipe_attachment(prefetcher_pipe_id);
+    const experimental::PrefetcherPipeImpl& pipe = get_prefetcher_pipe_attachment(prefetcher_pipe_id);
 
     auto relay_dfb = get_dataflow_buffer(relay_dfb_host_id);
     TT_FATAL(relay_dfb != nullptr, "Relay DFB host id {} does not exist", relay_dfb_host_id);

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -62,7 +62,7 @@ class MeshWorkloadImpl;
 namespace experimental {
 class GlobalCircularBuffer;
 class CrossNodeDFB;
-class PrefetcherPipe;
+class PrefetcherPipeImpl;
 }  // namespace experimental
 
 namespace program_dispatch {
@@ -367,9 +367,9 @@ public:
     uint8_t num_prefetcher_pipe_slots() const { return next_prefetcher_pipe_slot_; }
 
     uint8_t add_prefetcher_pipe_attachment(
-        experimental::PrefetcherPipe& prefetcher_pipe, const CoreRangeSet& cores, uint32_t entry_size);
+        experimental::PrefetcherPipeImpl& prefetcher_pipe, const CoreRangeSet& cores, uint32_t entry_size);
 
-    const experimental::PrefetcherPipe& get_prefetcher_pipe_attachment(uint8_t prefetcher_pipe_id) const;
+    const experimental::PrefetcherPipeImpl& get_prefetcher_pipe_attachment(uint8_t prefetcher_pipe_id) const;
     std::optional<uint8_t> get_prefetcher_pipe_id_for_relay(uint32_t relay_dfb_host_id) const;
 
     // Mark a normal local DFB as the typed relay for a PrefetcherPipe this core participates in.
@@ -587,7 +587,7 @@ private:
     uint8_t next_cross_node_dfb_slot_ = 0;
 
     std::unordered_map<CoreCoord, std::vector<PrefetcherPipeParticipant>> per_core_prefetcher_pipes_;
-    std::unordered_map<uint8_t, experimental::PrefetcherPipe*> prefetcher_pipe_attachments_;
+    std::unordered_map<uint8_t, experimental::PrefetcherPipeImpl*> prefetcher_pipe_attachments_;
     // Optional typed relay: prefetcher_pipe_id → local DFB host id (from CreatePrefetcherPipeRelayDataflowBuffer).
     std::unordered_map<uint8_t, uint32_t> prefetcher_pipe_relay_host_ids_;
     uint8_t next_prefetcher_pipe_slot_ = 0;

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -88,6 +88,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/per_core_allocation/buffer.hpp
     api/tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp
     api/tt-metalium/experimental/pinned_memory.hpp
+    api/tt-metalium/experimental/prefetcher_pipe.hpp
     api/tt-metalium/experimental/profiler.hpp
     api/tt-metalium/experimental/program_descriptor_patching.hpp
     api/tt-metalium/experimental/sockets/d2h_socket.hpp


### PR DESCRIPTION
### PR Category

  Cleanup

  ### Summary

  Expose `PrefetcherPipe` through the public experimental header
  `tt-metalium/experimental/prefetcher_pipe.hpp`, so callers outside `tt_metal`
  can own and use a pipe without including implementation headers.

  The public class delegates to `PrefetcherPipeImpl`, which retains the persistent
  L1 allocations, config pages, and device writes.

  - `CreatePrefetcherPipe` returns a `PrefetcherPipe` by value, so existing call sites
    are unchanged.
  - The handle is movable and non-copyable. A program attachment records the
    `PrefetcherPipeImpl`, which a move leaves in place, so pipes can be kept in a
    container or handed to a new owner with every attachment still valid.
  - Update program attachments to reference the implementation, and point the existing
    tests' includes at the public header.
  - Keep `CreatePrefetcherPipeRelayDataflowBuffer` internal because its
    `DataflowBufferConfig` parameter has no public header.

  ### Lifetime contract

  Program attachments remain non-owning. The caller must keep the pipe alive for every
  attached program and wait for all users to finish before destroying it. Destruction
  releases the persistent L1 allocations; move-assigning onto a live pipe destroys the
  pipe that was there, with the same effect. A moved-from pipe is empty and only good
  for destruction or assignment.

  Device behavior is unchanged.

  ### Validation

  On a p100a (Blackhole, 7 DRAM banks), firmware 19.12.0.0:

  - `unit_tests_api --gtest_filter='*PrefetcherPipe*'`: 29 tests passed.
  - Two persistent-pipe sub-device tests in `unit_tests_dispatch` passed.
  - `unit_tests_per_core_allocation`: 11 tests passed with slow dispatch.
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/prefetcher-pipe-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/prefetcher-pipe-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/prefetcher-pipe-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/prefetcher-pipe-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/prefetcher-pipe-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/prefetcher-pipe-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/prefetcher-pipe-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/prefetcher-pipe-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/prefetcher-pipe-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/prefetcher-pipe-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/prefetcher-pipe-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/prefetcher-pipe-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/prefetcher-pipe-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/prefetcher-pipe-pimpl)


