### PR TITLE
[skip ci] Allow DeepSeek decode profiling to finish in CI

### DIFF
--- a/tests/pipeline_reorg/models_device_perf_tests.yaml
+++ b/tests/pipeline_reorg/models_device_perf_tests.yaml
@@ -116,6 +116,8 @@
 - name: DeepSeek-V3 decode device perf tests (Galaxy)
   cmd: |
     export MESH_DEVICE=TG
+    # Device timings come from CSV; omit the large device-event stream from Tracy.
+    export TT_METAL_PROFILER_DISABLE_PUSH_TO_TRACY=1
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
     pytest --timeout=1200 models/demos/deepseek_v3/demo/test_decode_demo_perf.py
   model: deepseek-v3-tg

--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -443,8 +443,10 @@ def main():
                 logger.error(f"{testCommand} exited with a non-zero return code")
                 sys.exit(4)
 
+            # Large model traces can take over 15 seconds to save after the test exits.
+            capture_timeout = 120
             try:
-                captureProcess.communicate(timeout=15)
+                captureProcess.communicate(timeout=capture_timeout)
                 # Copy the generated .tracy file to the server's traces folder with a unique name
                 import datetime
 
@@ -496,7 +498,8 @@ def main():
                 captureProcess.terminate()
                 captureProcess.communicate()
                 logger.error(
-                    f"No profiling data could be captured. Please make sure you are on a Tracy-enabled build (default)."
+                    f"Tracy capture did not finish within {capture_timeout} seconds after the test exited. "
+                    "Run with -v to see capture output."
                 )
                 sys.exit(1)
 


### PR DESCRIPTION
Codex: The DeepSeek decode model test passes, but Tracy needs more than 15 seconds to save its large host trace. The wrapper kills capture too early and reports a misleading build error. Allow 120 seconds after the test exits, and report a capture timeout if that limit is reached.

Also disable device-event upload to Tracy for this decode CI job. This avoids the separate 32K source-location overflow. Device CSV timings, host operation data, and all performance assertions remain enabled.

Fixes #54872.

## Testing

- `pre-commit run --files tests/pipeline_reorg/models_device_perf_tests.yaml tools/tracy/__main__.py` passed. Python and YAML only; no local native build required.
- [Galaxy diagnostic job](https://github.com/tenstorrent/tt-metal/actions/runs/34283193312/job/102255479463): capture connected, received 62,079,822 zones, and saved a 1365.4 MB trace. Saving took about 50 seconds; capture finished about 57 seconds after device shutdown. With a 120-second wait and the device-event flag, the complete decode perf test passed on `g03glx04`. Kernel time: 10155.56 µs; op-to-op latency: 135.32 µs; E2E: 10290.88 µs. All three existing assertions passed. That diagnostic used temporary verbose output; it is not part of this PR.
- **Final PR head `25ac1ac7a8b6f6c6b97cbadf26c8f501b41eee0a`: [Tier 1 Galaxy decode passed](https://github.com/tenstorrent/tt-metal/actions/runs/34286500407/job/102273165819)** on `OM1-01A02-STGWH01`, with no temporary diagnostics. All required checks passed or were skipped as expected. Two earlier decode attempts were interrupted by a device hang and a runner connection loss; this passing attempt used the same commit and build artifacts.
- The Tier 1 workflow remains red because its separate [fused-op job failed during device setup](https://github.com/tenstorrent/tt-metal/actions/runs/34286500407/job/102268629123): `Query mappings failed on device 17: No such device`, repeated once on `OM1-01A02-STGWH02`. It failed before the model or changed capture wait. The fused-op model also has the independent grid issue #54873. No fused-op model code changed in this PR.

## CI

[![(Tier 1) Models Device Perf Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-device-perf-tests.yaml/badge.svg?branch=yieldthought%2Fdeepseek-decode-csv-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-device-perf-tests.yaml?query=branch%3Ayieldthought%2Fdeepseek-decode-csv-profiler)
