### PR TITLE
Fix SwiGLU flattening for padded sequence dimensions

### DIFF
--- a/tt-train/sources/ttml/ops/swiglu_op.cpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.cpp
@@ -17,6 +17,7 @@
 #include "ops/linear_op.hpp"
 #include "ops/unary_ops.hpp"
 #include "ttnn/operations/creation/creation.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -28,7 +29,7 @@ namespace {
 // Zero-copy flatten of all dims except the last into a single leading dim: [B,N,S,D] -> [B*N*S, D]
 ttnn::Tensor flatten_leading(const ttnn::Tensor& t) {
     const auto vol = t.logical_volume() / static_cast<uint64_t>(t.logical_shape()[-1]);
-    return t.reshape(ttnn::Shape({static_cast<uint32_t>(vol), t.logical_shape()[-1]}));
+    return ttnn::reshape(t, ttnn::Shape({static_cast<uint32_t>(vol), t.logical_shape()[-1]}));
 }
 
 bool force_swiglu_composite() {

--- a/tt-train/tests/ops/swiglu_op_test.cpp
+++ b/tt-train/tests/ops/swiglu_op_test.cpp
@@ -467,6 +467,9 @@ TEST_F(SwiGLUBackwardTest, BackwardAccuracy_2x1x32x128) {
 TEST_F(SwiGLUBackwardTest, BackwardAccuracy_4x1x64x256) {
     CompareSwiGLUBackwardAgainstReference({4, 1, 64, 256}, 256);
 }
+TEST_F(SwiGLUBackwardTest, BackwardAccuracy_MultiBatchNonAlignedSequence) {
+    CompareSwiGLUBackwardAgainstReference({2, 1, 48, 32}, 32);
+}
 TEST_F(SwiGLUBackwardTest, NIGHTLY_BackwardAccuracy_2x1x128x512) {
     CompareSwiGLUBackwardAgainstReference({2, 1, 128, 512}, 512);
 }


### PR DESCRIPTION
## Summary
- use padding-aware `ttnn::reshape` when flattening SwiGLU activations and gradients
- add a backward regression with `B*N > 1` and `S % 32 != 0`

## Validation
- `pre-commit run --files tt-train/sources/ttml/ops/swiglu_op.cpp tt-train/tests/ops/swiglu_op_test.cpp`
- Exabox `cpu_only`: `CMAKE_BUILD_PARALLEL_LEVEL=4 ./build_metal.sh --enable-ccache --build-tt-train` (Slurm 80242, passed)
- Exabox Blackhole: `./build_Release/tt-train/tests/ttml_tests --gtest_filter=SwiGLUBackwardTest.BackwardAccuracy_MultiBatchNonAlignedSequence` (Slurm 80264, 1/1 passed)

## Exabox notes
The validation checkout carried two uncommitted build-only workarounds that are not part of this PR: the existing tt-train CMake target-order fix from `414c6421ec7`, and deferred GoogleTest discovery (`PRE_TEST`) after an earlier build compiled the test binary but hit CMake's default 5-second discovery timeout.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmalone/fix-swiglu-flatten-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmalone/fix-swiglu-flatten-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmalone/fix-swiglu-flatten-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmalone/fix-swiglu-flatten-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmalone/fix-swiglu-flatten-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmalone/fix-swiglu-flatten-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmalone/fix-swiglu-flatten-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmalone/fix-swiglu-flatten-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmalone/fix-swiglu-flatten-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmalone/fix-swiglu-flatten-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmalone/fix-swiglu-flatten-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmalone/fix-swiglu-flatten-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmalone/fix-swiglu-flatten-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmalone/fix-swiglu-flatten-padding)