### PR TITLE
[Cleanup] Convert some data_movement DM self-loop DFBs to Scratchpad

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_graph_trace_utils.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_trace_utils.py
@@ -396,17 +396,18 @@ def test_extract_resource_usage_per_core_empty():
     assert usage.peak_total == 0, "Empty trace should have zero total usage"
 
 
-def test_metal2_dataflow_buffers_reach_resource_usage_per_core():
+def test_metal2_scratchpads_reach_resource_usage_per_core():
     """A Metal 2.0 op's L1 scratch must show up in the resource usage, under its own kind.
 
-    Ported ops allocate scratch as dataflow buffers and never call CreateCircularBuffer, so
-    peak_cb came out 0 for all of them and nothing else accounted for the bytes. #51674
+    Ported ops allocate scratch as dataflow buffers or scratchpads and never call
+    CreateCircularBuffer, so peak_cb came out 0 for all of them and nothing else accounted for
+    the bytes. #51674
     """
     with ttnn.manage_device(device_id=0) as device:
         input_tensor = ttnn.from_torch(
             torch.rand(1, 1, 64, 128, dtype=torch.bfloat16),
             dtype=ttnn.bfloat16,
-            # Row major so repeat lands on the interleaved-RM factory, which builds two DFBs.
+            # Row major so repeat lands on the interleaved-RM factory, which builds two scratchpads.
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=device,
             memory_config=ttnn.L1_MEMORY_CONFIG,
@@ -414,30 +415,29 @@ def test_metal2_dataflow_buffers_reach_resource_usage_per_core():
 
         ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NO_DISPATCH)
         # The forced-native entry is load-bearing: ttnn.repeat routes this case to the codegen
-        # path, which uses circular buffers and reports a non-zero peak whether or not DFBs are
-        # recorded.
+        # path, which uses circular buffers and reports a non-zero peak whether or not the native
+        # buffers are recorded.
         ttnn._ttnn.operations.data_movement.repeat_force_native(
             input_tensor, [1, 1, 2, 1], memory_config=ttnn.L1_MEMORY_CONFIG
         )
         captured_graph = ttnn.graph.end_graph_capture()
 
-        # Each DFB is (2 * READ_ALIGNMENT) + page_size = 128 + 256 bytes, and neither is borrowed,
-        # so both are owned L1 that the peak math must count exactly once.
-        dfb_nodes = [node for node in captured_graph if node["node_type"] == "dataflow_buffer_allocate"]
-        assert [int(node["params"]["size"]) for node in dfb_nodes] == [384, 384]
-        assert all(int(node["params"]["borrows_memory"]) == 0 for node in dfb_nodes)
-        # A dataflow buffer is not a circular buffer, and must not be reported as one.
+        # Each scratchpad is (2 * READ_ALIGNMENT) + page_size = 128 + 256 bytes; both are owned,
+        # private L1 that the peak math must count exactly once. (These were self-loop dataflow
+        # buffers until the Quasar self-loop-DFB cleanup converted them to scratchpads.)
+        scratchpad_nodes = [node for node in captured_graph if node["node_type"] == "scratchpad_allocate"]
+        assert [int(node["params"]["size"]) for node in scratchpad_nodes] == [384, 384]
+        # A scratchpad is neither a dataflow buffer nor a circular buffer, and must not be reported as one.
+        assert [node for node in captured_graph if node["node_type"] == "dataflow_buffer_allocate"] == []
         assert [node for node in captured_graph if node["node_type"] == "circular_buffer_allocate"] == []
 
         usage = ttnn.graph.extract_resource_usage_per_core(captured_graph)
 
-        assert (
-            usage.peak_dataflow_buffer == 768
-        ), f"dataflow buffers did not reach the peak, got {usage.peak_dataflow_buffer}"
+        assert usage.peak_scratchpad == 768, f"scratchpads did not reach the peak, got {usage.peak_scratchpad}"
         assert usage.peak_cb == 0, f"a ported op has no circular buffers, got {usage.peak_cb}"
-        assert usage.peak_scratchpad == 0
+        assert usage.peak_dataflow_buffer == 0
         # peak_total is the number an L1 budget check has to use.
-        assert usage.peak_total == usage.peak_dataflow_buffer + usage.peak_l1
+        assert usage.peak_total == usage.peak_scratchpad + usage.peak_l1
 
 
 # Metal 2.0 program-scope L1 comes in three kinds and each is reported under its own node type.

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_default_row_major_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_default_row_major_program_factory.cpp
@@ -101,20 +101,19 @@ ttnn::device_operation::ProgramArtifacts CopyDeviceOperation::DefaultRowMajor::c
     }
 
     // Dataflow buffer identities and tensor parameters.
-    const m2::DFBSpecName INPUT_PAGES{"input_pages"};  // legacy c_0 — reader-private L1 scratchpad (self-loop)
+    const m2::ScratchpadSpecName INPUT_PAGES{"input_pages"};  // reader-private L1 scratchpad
     const m2::DFBSpecName OUTPUT_PAGE{"output_page"};  // legacy c_1 — reader->writer output-page FIFO (double buffered)
     const m2::TensorParamName INPUT{"input"};
     const m2::TensorParamName OUTPUT{"output"};
     const m2::KernelSpecName READER{"reader"};
     const m2::KernelSpecName WRITER{"writer"};
 
-    // The DFB that stores input pages (a reader-private scratchpad, single entry).
-    const auto input_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    m2::DataflowBufferSpec input_pages_dfb{
+    // Reader-private scratchpad for staging input pages (single entry). Formerly a self-loop DFB:
+    // the reader both filled and drained it, so the FIFO machinery synchronized nothing — a shape
+    // Quasar rejects. Converted to Scratchpad.
+    m2::ScratchpadSpec input_pages_scratch{
         .unique_id = INPUT_PAGES,
-        .entry_size = input_page_size,
-        .num_entries = 1,
-        .data_format_metadata = input_data_format,
+        .size_per_node = input_page_size * 1,  // entry_size * num_entries
     };
 
     // The DFB that stores output pages. This one is double buffered, since it is shared between the reader
@@ -132,24 +131,18 @@ ttnn::device_operation::ProgramArtifacts CopyDeviceOperation::DefaultRowMajor::c
     m2::KernelSpec reader{
         .unique_id = READER,
         .source = KERNEL_READER,
-        // input_pages is touched by the reader alone (fill + drain) — self-loop, one accessor name.
         .dfb_bindings =
             {
-                m2::DFBBinding{
-                    .dfb_spec_name = INPUT_PAGES,
-                    .accessor_name = "in0",
-                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
-                },
-                m2::DFBBinding{
-                    .dfb_spec_name = INPUT_PAGES,
-                    .accessor_name = "in0",
-                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
-                },
                 m2::DFBBinding{
                     .dfb_spec_name = OUTPUT_PAGE,
                     .accessor_name = "in1",
                     .endpoint_type = m2::DFBEndpointType::PRODUCER,
                 },
+            },
+        // input_pages is touched by the reader alone (fill + drain): a private scratchpad.
+        .scratchpad_bindings =
+            {
+                m2::ScratchpadBinding{.scratchpad_spec_name = INPUT_PAGES, .accessor_name = "in0"},
             },
         .tensor_bindings =
             {
@@ -226,7 +219,8 @@ ttnn::device_operation::ProgramArtifacts CopyDeviceOperation::DefaultRowMajor::c
     m2::ProgramSpec spec{
         .name = "copy_default_row_major",
         .kernels = {std::move(reader), std::move(writer)},
-        .dataflow_buffers = {std::move(input_pages_dfb), std::move(output_page_dfb)},
+        .dataflow_buffers = {std::move(output_page_dfb)},
+        .scratchpads = {std::move(input_pages_scratch)},
         .tensor_parameters =
             {
                 m2::TensorParameter{.unique_id = INPUT, .spec = input.tensor_spec()},

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/redistribute_pages_row_major_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/redistribute_pages_row_major_reader.cpp
@@ -35,7 +35,9 @@ void kernel_main() {
     Noc noc;
     // scratch::in0 is a reader-private L1 scratchpad: the reader stages input pages in it.
     // dfb::in1 is the reader->writer output-page FIFO.
-    Scratchpad<std::uint32_t> in0(scratch::in0);
+    // uint8_t view: the kernel only takes the base address; a byte element type keeps the
+    // Scratchpad size%sizeof(T) invariant valid for any page size (UINT8/FP8, odd RM widths).
+    Scratchpad<std::uint8_t> in0(scratch::in0);
     DataflowBuffer dfb_in1(dfb::in1);
 
     const auto accessor_src = TensorAccessor(tensor::src);

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/redistribute_pages_row_major_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/redistribute_pages_row_major_reader.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "api/scratchpad.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
@@ -32,16 +33,15 @@ void kernel_main() {
     constexpr auto bytes_per_output_subblock = get_arg(args::bytes_per_output_subblock);
 
     Noc noc;
-    // dfb::in0 is a reader-private L1 scratchpad (self-loop): the reader both fills and
-    // drains it. dfb::in1 is the reader->writer output-page FIFO.
-    DataflowBuffer dfb_in0(dfb::in0);
+    // scratch::in0 is a reader-private L1 scratchpad: the reader stages input pages in it.
+    // dfb::in1 is the reader->writer output-page FIFO.
+    Scratchpad<std::uint32_t> in0(scratch::in0);
     DataflowBuffer dfb_in1(dfb::in1);
 
     const auto accessor_src = TensorAccessor(tensor::src);
 
     const std::uint32_t elements_per_output_subblock = bytes_per_output_subblock / bytes_per_element;
     const std::uint32_t elements_per_input_subblock = bytes_per_input_subblock / bytes_per_element;
-    dfb_in0.reserve_back(1);
 
     // To help understand the logic of this kernel, here is a visualization of what a subblock looks like in the
     // input/output tensor: When the tensor page is not too large (i.e., does not cause a DFB OOM error), the subblock
@@ -60,7 +60,7 @@ void kernel_main() {
     // Thus, the start of a page will always align with the start of a subblock. This is required to guarantee
     // aligned noc reads/writes.
 
-    const std::uint32_t input_l1_write_addr = dfb_in0.get_write_ptr();
+    const std::uint32_t input_l1_write_addr = in0.get_base_address();
 
     for (std::uint32_t row = start_row; row < start_row + num_rows_to_process; ++row) {
         std::uint32_t input_start_column = 0;
@@ -182,8 +182,4 @@ void kernel_main() {
             }
         }
     }
-
-    dfb_in0.push_back(1);
-    dfb_in0.wait_front(1);
-    dfb_in0.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.cpp
@@ -51,34 +51,29 @@ ttnn::device_operation::ProgramArtifacts FillRMProgramFactory::create_program_ar
 
     // Resource names
     const KernelSpecName READER{"reader"};
-    const DFBSpecName IN0{"in0"};
-    const DFBSpecName IN1{"in1"};
+    const ScratchpadSpecName IN0{"in0"};
+    const ScratchpadSpecName IN1{"in1"};
     const TensorParamName OUT{"out"};
 
-    // Two single-toucher DFBs (the reader FIFO-produces each and uses it as the NoC write source; no
-    // separate consumer), so each is bound self-loop: the reader is both PRODUCER and CONSUMER.
-    DataflowBufferSpec dfb_in0{
+    // Two single-toucher scratchpads: the reader fills each and uses it as the NoC write source.
+    // (Formerly self-loop DFBs; a single DM kernel filled and drained each, so the FIFO machinery
+    // synchronized nothing. Converted to Scratchpad for Quasar, which rejects DM self-loop DFBs.)
+    ScratchpadSpec sp_in0{
         .unique_id = IN0,
-        .entry_size = single_tile_size,
-        .num_entries = num_cb_tiles,
-        .data_format_metadata = cb_data_format,
+        .size_per_node = single_tile_size * num_cb_tiles,
     };
-    DataflowBufferSpec dfb_in1{
+    ScratchpadSpec sp_in1{
         .unique_id = IN1,
-        .entry_size = single_tile_size,
-        .num_entries = num_cb_tiles,
-        .data_format_metadata = cb_data_format,
+        .size_per_node = single_tile_size * num_cb_tiles,
     };
 
     KernelSpec reader{
         .unique_id = READER,
         .source = "ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp",
-        .dfb_bindings =
+        .scratchpad_bindings =
             {
-                DFBBinding{.dfb_spec_name = IN0, .accessor_name = "in0", .endpoint_type = DFBEndpointType::PRODUCER},
-                DFBBinding{.dfb_spec_name = IN0, .accessor_name = "in0", .endpoint_type = DFBEndpointType::CONSUMER},
-                DFBBinding{.dfb_spec_name = IN1, .accessor_name = "in1", .endpoint_type = DFBEndpointType::PRODUCER},
-                DFBBinding{.dfb_spec_name = IN1, .accessor_name = "in1", .endpoint_type = DFBEndpointType::CONSUMER},
+                ScratchpadBinding{.scratchpad_spec_name = IN0, .accessor_name = "in0"},
+                ScratchpadBinding{.scratchpad_spec_name = IN1, .accessor_name = "in1"},
             },
         .tensor_bindings =
             {
@@ -94,7 +89,7 @@ ttnn::device_operation::ProgramArtifacts FillRMProgramFactory::create_program_ar
     ProgramSpec spec{
         .name = "fill_rm",
         .kernels = {reader},
-        .dataflow_buffers = {dfb_in0, dfb_in1},
+        .scratchpads = {sp_in0, sp_in1},
         .tensor_parameters =
             {
                 TensorParameter{.unique_id = OUT, .spec = output_mesh_tensor.tensor_spec()},

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/scratchpad.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -29,25 +29,19 @@ void kernel_main() {
     const auto s0 = TensorAccessor(tensor::out);
 
     // DPRINT("fill_rm_8bank: NC={} H={} W={} fillH={} fillW={}\n", NC, H, W, fillH, fillW);
-    DataflowBuffer dfb_in0(dfb::in0);
-    DataflowBuffer dfb_in1(dfb::in1);
+    Scratchpad<uint16_t> in0(scratch::in0);
+    Scratchpad<uint16_t> in1(scratch::in1);
 
-    dfb_in0.reserve_back(16);
-    dfb_in1.reserve_back(16);
-    std::uint32_t l1_w_addr = dfb_in0.get_write_ptr();
-    std::uint32_t l1_zeros_addr = dfb_in1.get_write_ptr();
     std::uint32_t w;
     for (w = 0; w < fillW; w++) {
-        reinterpret_cast<std::uint16_t*>(l1_w_addr)[w] = val_hi;
+        in0[w] = val_hi;
     }
     for (w = fillW; w < W; w++) {
-        reinterpret_cast<std::uint16_t*>(l1_w_addr)[w] = val_lo;
+        in0[w] = val_lo;
     }
     for (w = 0; w < W; w++) {
-        reinterpret_cast<std::uint16_t*>(l1_zeros_addr)[w] = val_lo;
+        in1[w] = val_lo;
     }
-    dfb_in0.push_back(16);
-    dfb_in1.push_back(16);
 
     Noc noc;
     std::uint32_t nch_dst = 0;
@@ -56,10 +50,10 @@ void kernel_main() {
         for (std::uint32_t h = 0; h < H; h++) {
             if (h < fillH) {
                 noc.async_write(
-                    dfb_in0, s0, (W << 1), {.offset_bytes = 0}, {.page_id = nch_dst});  // TODO(AP): segment this write
+                    in0, s0, (W << 1), {.offset_bytes = 0}, {.page_id = nch_dst});  // TODO(AP): segment this write
             } else {
                 noc.async_write(
-                    dfb_in1, s0, (W << 1), {.offset_bytes = 0}, {.page_id = nch_dst});  // TODO(AP): segment this write
+                    in1, s0, (W << 1), {.offset_bytes = 0}, {.page_id = nch_dst});  // TODO(AP): segment this write
             }
             noc.async_write_barrier();
             nch_dst++;

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp
@@ -43,6 +43,16 @@ void kernel_main() {
         in1[w] = val_lo;
     }
 
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    // Quasar DM: the fills above are CPU stores that land in the RISC's L1 D$/L2, not shared L1, and
+    // the NoC below reads shared L1 directly. Flush the filled range (W bf16 elements = W<<1 bytes)
+    // so the NoC writes see the fills. No-op on WH/BH (CPU stores are coherent to the NoC there and
+    // flush_l2_cache_range is tt-2xx-only). #51763 fixed this for the tt_memmove fallback but not for
+    // direct scratchpad stores like these.
+    flush_l2_cache_range(static_cast<uintptr_t>(in0.get_base_address()), static_cast<size_t>(W << 1));
+    flush_l2_cache_range(static_cast<uintptr_t>(in1.get_base_address()), static_cast<size_t>(W << 1));
+#endif
+
     Noc noc;
     std::uint32_t nch_dst = 0;
     // input is NCH(Wt*32) unpadded RM

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_interleaved.cpp
@@ -9,7 +9,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/scratchpad.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
@@ -42,9 +42,9 @@ void kernel_main() {
     const auto d = TensorAccessor(tensor::dst);
 
     Noc noc;
-    // dfb::in0 and dfb::in1 are each 1 page of size: 128 + page_size_bytes.
-    DataflowBuffer dfb0(dfb::in0);
-    DataflowBuffer dfb1(dfb::in1);
+    // scratch::in0 and scratch::in1 are each 1 page of size: 128 + page_size_bytes.
+    Scratchpad<uint8_t> dfb0(scratch::in0);
+    Scratchpad<uint8_t> dfb1(scratch::in1);
 
     // Alignment pre-calculations.
     constexpr uint64_t r_mask_to_use = decltype(s)::is_dram ? MASK_64 : MASK_16;
@@ -54,12 +54,8 @@ void kernel_main() {
     const uint64_t w_mask_to_use = MASK_16;
     const uint64_t w_offset_to_use = OFFSET_16;
 
-    dfb0.reserve_back(1);
-    dfb1.reserve_back(1);
-    uint32_t input_buffer = dfb0.get_write_ptr();
-    uint32_t alignment_buffer = dfb1.get_write_ptr();
-    dfb1.push_back(1);
-    dfb0.push_back(1);
+    uint32_t input_buffer = dfb0.get_base_address();
+    uint32_t alignment_buffer = dfb1.get_base_address();
 
     alignment_buffer = align_address<w_alignment_requirement>(alignment_buffer, w_mask_to_use);  // aligned for writes
     input_buffer = align_address<r_alignment_requirement>(input_buffer, r_mask_to_use);          // aligned for reads

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_sharded.cpp
@@ -8,7 +8,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/scratchpad.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -35,10 +35,8 @@ void kernel_main() {
     const auto s = TensorAccessor(tensor::src);
     const auto d = TensorAccessor(tensor::dst);
 
-    DataflowBuffer dfb(dfb::in0);
-    dfb.reserve_back(1);
-    const uint32_t cb_slot = dfb.get_write_ptr();
-    dfb.push_back(1);
+    Scratchpad<uint8_t> dfb(scratch::in0);
+    const uint32_t cb_slot = dfb.get_base_address();
 
     Noc noc;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_tile.cpp
@@ -8,7 +8,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/scratchpad.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
@@ -37,11 +37,7 @@ void kernel_main() {
     const auto d = TensorAccessor(tensor::dst);
 
     Noc noc;
-    DataflowBuffer dfb(dfb::in0);
-    dfb.reserve_back(1);
-    const uint32_t cb_slot = dfb.get_write_ptr();
-    dfb.push_back(1);
-    const CoreLocalMem<uint32_t> cb_mem(cb_slot);
+    Scratchpad<uint32_t> cb_mem(scratch::in0);
 
     for (uint32_t h = higher_dim_start; h < higher_dim_end; h++) {
         const uint32_t h_offset = h * LOWER_DIMS_TIMES_REP_DIM;

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_interleaved.cpp
@@ -9,7 +9,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/scratchpad.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
@@ -37,14 +37,14 @@ void kernel_main() {
     const auto d = TensorAccessor(tensor::dst);
 
     Noc noc;
-    // dfb::in0 and dfb::in1 are each 1 page; size depends on alignment:
+    // scratch::in0 and scratch::in1 are each 1 page; size depends on alignment:
     //   multiple of 16 -> original_page_size_bytes + 128
     //   multiple of  8 -> original_page_size_bytes * 2  + 128
     //   multiple of  4 -> original_page_size_bytes * 4  + 128
     //   multiple of  2 -> original_page_size_bytes * 8  + 128
     //   odd            -> original_page_size_bytes * 16 + 128
-    DataflowBuffer dfb0(dfb::in0);
-    DataflowBuffer dfb1(dfb::in1);
+    Scratchpad<uint8_t> dfb0(scratch::in0);
+    Scratchpad<uint8_t> dfb1(scratch::in1);
 
     // Number of times we must double the input page to make it write-aligned.
     constexpr uint32_t num_doublings = ((original_page_size_bytes % 16) == 0)  ? 0
@@ -55,12 +55,8 @@ void kernel_main() {
     // Max write size after doublings; used as template parameter to enable fast path.
     constexpr uint32_t max_write_size = original_page_size_bytes << num_doublings;
 
-    dfb0.reserve_back(1);
-    dfb1.reserve_back(1);
-    uint32_t input_buffer = dfb0.get_write_ptr();
-    uint32_t alignment_buffer = dfb1.get_write_ptr();
-    dfb1.push_back(1);
-    dfb0.push_back(1);
+    uint32_t input_buffer = dfb0.get_base_address();
+    uint32_t alignment_buffer = dfb1.get_base_address();
 
     constexpr uint64_t r_mask_to_use = decltype(s)::is_dram ? MASK_64 : MASK_16;
     constexpr uint64_t r_offset_to_use = decltype(s)::is_dram ? OFFSET_64 : OFFSET_16;

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_sharded.cpp
@@ -8,7 +8,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/scratchpad.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -29,10 +29,8 @@ void kernel_main() {
     const auto s = TensorAccessor(tensor::src);
     const auto d = TensorAccessor(tensor::dst);
 
-    DataflowBuffer dfb(dfb::in0);
-    dfb.reserve_back(1);
-    const uint32_t cb_slot = dfb.get_write_ptr();
-    dfb.push_back(1);
+    Scratchpad<uint8_t> dfb(scratch::in0);
+    const uint32_t cb_slot = dfb.get_base_address();
 
     Noc noc;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
@@ -27,7 +27,6 @@ ttnn::device_operation::ProgramArtifacts RepeatProgramFactoryHigherDim::create_p
     const auto& output = tensor_return_value;
     const uint32_t num_repeats = operation_attributes.m_num_repeats;
     // get datum size
-    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const uint32_t data_size = input.element_size();
     IDevice* device = input.device();
     // Multi device pre-computation
@@ -77,39 +76,32 @@ ttnn::device_operation::ProgramArtifacts RepeatProgramFactoryHigherDim::create_p
     // Metal 2.0 named resource ids. Declared function-local so the unity build (both repeat factory
     // .cpp files land in one translation unit) sees no duplicate anonymous-namespace symbols.
     const KernelSpecName READER{"reader"};
-    const DFBSpecName SRC0{"src0"};
-    const DFBSpecName SRC1{"src1"};
+    const ScratchpadSpecName SRC0{"src0"};
+    const ScratchpadSpecName SRC1{"src1"};
     const TensorParamName INPUT{"input"};
     const TensorParamName OUTPUT{"output"};
 
-    // Dataflow buffers: one page each, staging a page for the read-repeat-write. Each is a single-toucher
-    // scratchpad the reader fills and drains itself, so it self-loops (reader bound PRODUCER + CONSUMER).
-    Group<DataflowBufferSpec> dataflow_buffers;
-    dataflow_buffers.push_back(DataflowBufferSpec{
+    // One page each, staging a page for the read-repeat-write. Each is a reader-private scratchpad the
+    // reader fills and drains itself. (Formerly self-loop DFBs; a single DM kernel filled and drained
+    // each, so the FIFO synchronized nothing — a shape Quasar rejects.)
+    Group<ScratchpadSpec> scratchpads;
+    scratchpads.push_back(ScratchpadSpec{
         .unique_id = SRC0,
-        .entry_size = cb_size_bytes,
-        .num_entries = 1,
-        .data_format_metadata = cb_data_format,
+        .size_per_node = cb_size_bytes,  // entry_size * num_entries (1)
     });
     // Second buffer only for interleaved RM (write-alignment scratchpad).
     if (needs_alignment_cb) {
-        dataflow_buffers.push_back(DataflowBufferSpec{
+        scratchpads.push_back(ScratchpadSpec{
             .unique_id = SRC1,
-            .entry_size = cb_size_bytes,
-            .num_entries = 1,
-            .data_format_metadata = cb_data_format,
+            .size_per_node = cb_size_bytes,
         });
     }
 
-    // Self-loop the DFBs: bind the reader as both PRODUCER and CONSUMER of each (one accessor name each).
-    Group<DFBBinding> dfb_bindings = {
-        DFBBinding{.dfb_spec_name = SRC0, .accessor_name = "in0", .endpoint_type = DFBEndpointType::PRODUCER},
-        DFBBinding{.dfb_spec_name = SRC0, .accessor_name = "in0", .endpoint_type = DFBEndpointType::CONSUMER}};
+    // The reader privately fills and drains each scratchpad (one accessor name each).
+    Group<ScratchpadBinding> scratchpad_bindings = {
+        ScratchpadBinding{.scratchpad_spec_name = SRC0, .accessor_name = "in0"}};
     if (needs_alignment_cb) {
-        dfb_bindings.push_back(
-            DFBBinding{.dfb_spec_name = SRC1, .accessor_name = "in1", .endpoint_type = DFBEndpointType::PRODUCER});
-        dfb_bindings.push_back(
-            DFBBinding{.dfb_spec_name = SRC1, .accessor_name = "in1", .endpoint_type = DFBEndpointType::CONSUMER});
+        scratchpad_bindings.push_back(ScratchpadBinding{.scratchpad_spec_name = SRC1, .accessor_name = "in1"});
     }
 
     std::filesystem::path kernel_source;
@@ -125,7 +117,7 @@ ttnn::device_operation::ProgramArtifacts RepeatProgramFactoryHigherDim::create_p
     KernelSpec reader{
         .unique_id = READER,
         .source = kernel_source,
-        .dfb_bindings = dfb_bindings,
+        .scratchpad_bindings = scratchpad_bindings,
         .tensor_bindings =
             {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"},
              TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
@@ -204,7 +196,7 @@ ttnn::device_operation::ProgramArtifacts RepeatProgramFactoryHigherDim::create_p
     ProgramSpec spec{
         .name = "repeat_higher_dim",
         .kernels = {reader},
-        .dataflow_buffers = dataflow_buffers,
+        .scratchpads = scratchpads,
         .tensor_parameters =
             {TensorParameter{.unique_id = INPUT, .spec = input.tensor_spec()},
              TensorParameter{.unique_id = OUTPUT, .spec = output.tensor_spec()}},

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
@@ -28,7 +28,6 @@ ttnn::device_operation::ProgramArtifacts RepeatProgramFactoryLastDim::create_pro
     const auto& output = tensor_return_value;
     const uint32_t num_repeats = operation_attributes.m_num_repeats;
     // get datum size
-    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const uint32_t data_size = input.element_size();
     IDevice* device = input.device();
     // Multi device pre-computation
@@ -67,39 +66,32 @@ ttnn::device_operation::ProgramArtifacts RepeatProgramFactoryLastDim::create_pro
     // Metal 2.0 named resource ids. Declared function-local so the unity build (both repeat factory
     // .cpp files land in one translation unit) sees no duplicate anonymous-namespace symbols.
     const KernelSpecName READER{"reader"};
-    const DFBSpecName SRC0{"src0"};
-    const DFBSpecName SRC1{"src1"};
+    const ScratchpadSpecName SRC0{"src0"};
+    const ScratchpadSpecName SRC1{"src1"};
     const TensorParamName INPUT{"input"};
     const TensorParamName OUTPUT{"output"};
 
-    // Dataflow buffers: one page each. Each is a single-toucher scratchpad the reader fills and drains
-    // itself, so it self-loops (reader bound PRODUCER + CONSUMER).
-    Group<DataflowBufferSpec> dataflow_buffers;
-    dataflow_buffers.push_back(DataflowBufferSpec{
+    // One page each. Each is a reader-private scratchpad the reader fills and drains itself.
+    // (Formerly self-loop DFBs; a single DM kernel filled and drained each, so the FIFO synchronized
+    // nothing — a shape Quasar rejects.)
+    Group<ScratchpadSpec> scratchpads;
+    scratchpads.push_back(ScratchpadSpec{
         .unique_id = SRC0,
-        .entry_size = cb_size_bytes,
-        .num_entries = 1,
-        .data_format_metadata = cb_data_format,
+        .size_per_node = cb_size_bytes,  // entry_size * num_entries (1)
     });
     // Second buffer only for interleaved RM.
     if (needs_alignment_cb) {
-        dataflow_buffers.push_back(DataflowBufferSpec{
+        scratchpads.push_back(ScratchpadSpec{
             .unique_id = SRC1,
-            .entry_size = cb_size_bytes,
-            .num_entries = 1,
-            .data_format_metadata = cb_data_format,
+            .size_per_node = cb_size_bytes,
         });
     }
 
-    // Self-loop the DFBs: bind the reader as both PRODUCER and CONSUMER of each (one accessor name each).
-    Group<DFBBinding> dfb_bindings = {
-        DFBBinding{.dfb_spec_name = SRC0, .accessor_name = "in0", .endpoint_type = DFBEndpointType::PRODUCER},
-        DFBBinding{.dfb_spec_name = SRC0, .accessor_name = "in0", .endpoint_type = DFBEndpointType::CONSUMER}};
+    // The reader privately fills and drains each scratchpad (one accessor name each).
+    Group<ScratchpadBinding> scratchpad_bindings = {
+        ScratchpadBinding{.scratchpad_spec_name = SRC0, .accessor_name = "in0"}};
     if (needs_alignment_cb) {
-        dfb_bindings.push_back(
-            DFBBinding{.dfb_spec_name = SRC1, .accessor_name = "in1", .endpoint_type = DFBEndpointType::PRODUCER});
-        dfb_bindings.push_back(
-            DFBBinding{.dfb_spec_name = SRC1, .accessor_name = "in1", .endpoint_type = DFBEndpointType::CONSUMER});
+        scratchpad_bindings.push_back(ScratchpadBinding{.scratchpad_spec_name = SRC1, .accessor_name = "in1"});
     }
 
     std::filesystem::path kernel_source;
@@ -113,7 +105,7 @@ ttnn::device_operation::ProgramArtifacts RepeatProgramFactoryLastDim::create_pro
     KernelSpec reader{
         .unique_id = READER,
         .source = kernel_source,
-        .dfb_bindings = dfb_bindings,
+        .scratchpad_bindings = scratchpad_bindings,
         .tensor_bindings =
             {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"},
              TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
@@ -151,7 +143,7 @@ ttnn::device_operation::ProgramArtifacts RepeatProgramFactoryLastDim::create_pro
     ProgramSpec spec{
         .name = "repeat_last_dim",
         .kernels = {reader},
-        .dataflow_buffers = dataflow_buffers,
+        .scratchpads = scratchpads,
         .tensor_parameters =
             {TensorParameter{.unique_id = INPUT, .spec = input.tensor_spec()},
              TensorParameter{.unique_id = OUTPUT, .spec = output.tensor_spec()}},

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "api/scratchpad.h"
 
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/operations/data_movement/reshape_view/device/hostdevcommon/common.hpp"
@@ -26,11 +27,10 @@ void kernel_main() {
     Noc noc;
     DataflowBuffer dfb_mapping(dfb::mapping);  // scratch: mapping-page FIFO (consumer)
     DataflowBuffer dfb_in_tiles(dfb::in_tiles);  // input-tile FIFO (consumer)
-    DataflowBuffer dfb_working(dfb::working);  // L1 scratch page (self-loop producer+consumer)
+    Scratchpad<uint8_t> working(scratch::working);  // writer-private L1 scratch page
     // loop over output (reshaped) pages this core is responsible for
     bool first = true;
-    dfb_working.reserve_back(1);
-    const uint32_t working_write_addr = dfb_working.get_write_ptr();
+    const uint32_t working_write_addr = working.get_base_address();
     for (uint32_t output_page_idx = start_output_page; output_page_idx < end_output_page; ++output_page_idx) {
         dfb_mapping.wait_front(1);
         const uint32_t map_addr = dfb_mapping.get_read_ptr();
@@ -75,5 +75,4 @@ void kernel_main() {
         noc.async_write_barrier();
         dfb_in_tiles.pop_front(1);
     }
-    dfb_working.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
@@ -344,7 +344,7 @@ ttnn::device_operation::ProgramArtifacts ReshapeViewTiledProgramFactory::create_
     const DFBSpecName MAPPING{"mapping"};  // reader-produces / writer-consumes mapping-page FIFO
     const DFBSpecName IN_TILES{"in_tiles"};  // reader-produces / writer-consumes input-tile FIFO
                                              // (distinct from tensor::input, the input tensor)
-    const DFBSpecName WORKING{"working"};  // writer-only L1 scratch page (self-loop)
+    const ScratchpadSpecName WORKING{"working"};  // writer-private L1 scratch page
     const TensorParamName INPUT_T{"input"};
     const TensorParamName MAPPING_T{"map"};  // the op-owned page-mapping tensor
     const TensorParamName OUTPUT_T{"output"};
@@ -353,8 +353,9 @@ ttnn::device_operation::ProgramArtifacts ReshapeViewTiledProgramFactory::create_
     spec.name = "reshape_view_tiled";
 
     // DFBs (placement derived from bindings; no core_ranges). The mapping metadata DFB stages
-    // mapping pages on the fly; the input DFB stages input tiles; the output/working DFB is an L1
-    // scratch page the writer both fills and drains (self-loop).
+    // mapping pages on the fly; the input DFB stages input tiles. The working buffer is a
+    // writer-private L1 scratch page (formerly a self-loop DFB the writer filled and drained;
+    // that FIFO synchronized nothing and is rejected on Quasar) — now a Scratchpad.
     spec.dataflow_buffers = {
         DataflowBufferSpec{
             .unique_id = MAPPING,
@@ -368,11 +369,11 @@ ttnn::device_operation::ProgramArtifacts ReshapeViewTiledProgramFactory::create_
             .num_entries = reader_dfb_len,
             .data_format_metadata = input_dfb_data_format,
         },
-        DataflowBufferSpec{
+    };
+    spec.scratchpads = {
+        ScratchpadSpec{
             .unique_id = WORKING,
-            .entry_size = output_tile_size_bytes,
-            .num_entries = 1,
-            .data_format_metadata = output_dfb_data_format,
+            .size_per_node = output_tile_size_bytes,  // entry_size * num_entries (1)
         },
     };
 
@@ -409,10 +410,10 @@ ttnn::device_operation::ProgramArtifacts ReshapeViewTiledProgramFactory::create_
                     .dfb_spec_name = MAPPING, .accessor_name = "mapping", .endpoint_type = DFBEndpointType::CONSUMER},
                 DFBBinding{
                     .dfb_spec_name = IN_TILES, .accessor_name = "in_tiles", .endpoint_type = DFBEndpointType::CONSUMER},
-                DFBBinding{
-                    .dfb_spec_name = WORKING, .accessor_name = "working", .endpoint_type = DFBEndpointType::PRODUCER},
-                DFBBinding{
-                    .dfb_spec_name = WORKING, .accessor_name = "working", .endpoint_type = DFBEndpointType::CONSUMER},
+            },
+        .scratchpad_bindings =
+            {
+                ScratchpadBinding{.scratchpad_spec_name = WORKING, .accessor_name = "working"},
             },
         .tensor_bindings =
             {

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
@@ -5,6 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "api/scratchpad.h"
 #include "api/numeric/bfloat16.h"
 #include "experimental/kernel_args.h"
 #include "../common.hpp"
@@ -44,7 +45,7 @@ FORCE_INLINE void scatter_along_chunk(
     const DataflowBuffer& index_dfb,
     const DataflowBuffer& source_dfb,
     const DataflowBuffer& output_dfb,
-    const DataflowBuffer& fp32_temp_dfb,
+    const Scratchpad<volatile float>& fp32_temp,
     const uint32_t& input_stick_size,
     const index_type& input_offset,
     const uint32_t& input_chunk_size,
@@ -54,7 +55,6 @@ FORCE_INLINE void scatter_along_chunk(
     const uint32_t index_l1_read_addr = index_dfb.get_read_ptr();
     const uint32_t source_l1_read_addr = source_dfb.get_read_ptr();
     const uint32_t output_l1_write_addr = output_dfb.get_write_ptr();
-    const uint32_t fp32_temp_l1_write_addr = fp32_temp_dfb.get_write_ptr();
     volatile tt_l1_ptr uint16_t* input_l1_read_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(input_l1_read_addr);
     volatile tt_l1_ptr index_type* index_l1_read_ptr =
         reinterpret_cast<volatile tt_l1_ptr index_type*>(index_l1_read_addr);
@@ -62,8 +62,6 @@ FORCE_INLINE void scatter_along_chunk(
         reinterpret_cast<volatile tt_l1_ptr uint16_t*>(source_l1_read_addr);
     volatile tt_l1_ptr uint16_t* output_l1_write_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint16_t*>(output_l1_write_addr);
-    volatile tt_l1_ptr float* fp32_temp_l1_write_ptr =
-        reinterpret_cast<volatile tt_l1_ptr float*>(fp32_temp_l1_write_addr);
 
     // each index from the index chunk is checked whether it points
     // to any of the elements in the current output range (defined by
@@ -78,35 +76,28 @@ FORCE_INLINE void scatter_along_chunk(
         }
         volatile uint16_t& source_value = source_l1_read_ptr[index_in_index_chunk];
         const index_type& output_index = index_value - input_offset;
-        fp32_temp_l1_write_ptr[output_index] =
-            perform_reduction(fp32_temp_l1_write_ptr[output_index], source_value, scatter_reduction_type);
+        fp32_temp[output_index] = perform_reduction(fp32_temp[output_index], source_value, scatter_reduction_type);
     }
 }
 
 // copies source stick to destination stick (first phase of scatter)
 FORCE_INLINE void copy_input_to_fp32_temp(
-    const DataflowBuffer& input_dfb, const DataflowBuffer& fp32_temp_dfb, uint32_t input_chunk_size) {
+    const DataflowBuffer& input_dfb, const Scratchpad<volatile float>& fp32_temp, uint32_t input_chunk_size) {
     const uint32_t input_l1_read_addr = input_dfb.get_read_ptr();
-    const uint32_t fp32_temp_l1_write_addr = fp32_temp_dfb.get_write_ptr();
     volatile tt_l1_ptr uint16_t* input_l1_read_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(input_l1_read_addr);
-    volatile tt_l1_ptr float* fp32_temp_l1_write_ptr =
-        reinterpret_cast<volatile tt_l1_ptr float*>(fp32_temp_l1_write_addr);
     for (uint32_t index_in_input_chunk = 0; index_in_input_chunk < input_chunk_size; ++index_in_input_chunk) {
-        fp32_temp_l1_write_ptr[index_in_input_chunk] = bf16_to_fp32(input_l1_read_ptr[index_in_input_chunk]);
+        fp32_temp[index_in_input_chunk] = bf16_to_fp32(input_l1_read_ptr[index_in_input_chunk]);
     }
 }
 
 FORCE_INLINE void copy_fp32_temp_to_output(
-    const DataflowBuffer& fp32_temp_dfb, const DataflowBuffer& output_dfb, uint32_t chunk_size) {
-    const uint32_t fp32_temp_l1_read_addr = fp32_temp_dfb.get_read_ptr();
+    const Scratchpad<volatile float>& fp32_temp, const DataflowBuffer& output_dfb, uint32_t chunk_size) {
     const uint32_t output_l1_write_addr = output_dfb.get_write_ptr();
-    volatile tt_l1_ptr float* fp32_temp_l1_read_ptr =
-        reinterpret_cast<volatile tt_l1_ptr float*>(fp32_temp_l1_read_addr);
     volatile tt_l1_ptr uint16_t* output_l1_write_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint16_t*>(output_l1_write_addr);
 
     for (uint32_t copy_i = 0; copy_i < chunk_size; ++copy_i) {
-        output_l1_write_ptr[copy_i] = fp32_to_bf16(fp32_temp_l1_read_ptr[copy_i]);
+        output_l1_write_ptr[copy_i] = fp32_to_bf16(fp32_temp[copy_i]);
     }
 }
 
@@ -147,7 +138,7 @@ void kernel_main() {
     std::array<uint32_t, N> coord{from_id<N>(start_stick_id, input_dims)};
 
     DataflowBuffer input_dfb(dfb::input);
-    DataflowBuffer fp32_temp_dfb(dfb::fp32_temp);
+    Scratchpad<volatile float> fp32_temp(scratch::fp32_temp);
     DataflowBuffer output_dfb(dfb::output);
     DataflowBuffer index_dfb(dfb::index);
     DataflowBuffer source_dfb(dfb::source);
@@ -167,9 +158,8 @@ void kernel_main() {
                 input_chunk_length * sizeof(input_std_type),
                 input_stick_id);
             input_dfb.wait_front(ONE_PAGE);
-            fp32_temp_dfb.reserve_back(ONE_PAGE);
 
-            copy_input_to_fp32_temp(input_dfb, fp32_temp_dfb, input_chunk_length);
+            copy_input_to_fp32_temp(input_dfb, fp32_temp, input_chunk_length);
 
             if (in_bounds<N>(coord, index_dims)) {
                 const uint32_t index_stick_id = to_id<N>(coord, index_strides);
@@ -203,7 +193,7 @@ void kernel_main() {
                         index_dfb,
                         source_dfb,
                         output_dfb,
-                        fp32_temp_dfb,
+                        fp32_temp,
                         input_stick_size,
                         input_offset,
                         input_chunk_length,
@@ -215,13 +205,10 @@ void kernel_main() {
             }
 
             input_dfb.pop_front(ONE_PAGE);
-            fp32_temp_dfb.push_back(ONE_PAGE);
-            fp32_temp_dfb.wait_front(ONE_PAGE);
             output_dfb.reserve_back(ONE_PAGE);
 
             // third phase: push to the output dfb with fp32->bf16 conversion
-            copy_fp32_temp_to_output(fp32_temp_dfb, output_dfb, input_chunk_length);
-            fp32_temp_dfb.pop_front(ONE_PAGE);
+            copy_fp32_temp_to_output(fp32_temp, output_dfb, input_chunk_length);
             output_dfb.push_back(ONE_PAGE);
         }
         next_inplace<N>(coord, input_dims);

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.cpp
@@ -117,8 +117,8 @@ ttnn::device_operation::ProgramArtifacts ScatterReduceBfloat16ProgramFactory::cr
         make_dfb(DST_DFB, output_tensor.dtype(), output_page_size_bytes),
     };
 
-    // The reader alone fills and drains INPUT/INDEX/SRC and the FP32_TEMP scratch (self-loop: bound
-    // PRODUCER + CONSUMER); it produces DST, which the writer consumes.
+    // The reader alone fills and drains INPUT/INDEX/SRC (self-loop: bound PRODUCER + CONSUMER) and
+    // privately fills/drains the FP32_TEMP scratchpad; it produces DST, which the writer consumes.
     KernelSpec reader{
         .unique_id = READER,
         .source = reader_kernel_path,

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.cpp
@@ -80,7 +80,6 @@ ttnn::device_operation::ProgramArtifacts ScatterReduceBfloat16ProgramFactory::cr
                 ? tt::tt_metal::split_work_to_cores(*args.sub_core_grid, work_units)
                 : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, work_units);
 
-    const auto fp32_temp_dtype = DataType::FLOAT32;
     const auto farthest_x_y =
         args.sub_core_grid.has_value() ? args.sub_core_grid->bounding_box().end_coord : compute_with_storage_grid_size;
     const uint32_t all_cores_in_bounding_box = (farthest_x_y.x + 1) * (farthest_x_y.y + 1);
@@ -91,7 +90,7 @@ ttnn::device_operation::ProgramArtifacts ScatterReduceBfloat16ProgramFactory::cr
     const DFBSpecName INDEX_DFB{"index"};
     const DFBSpecName SRC_DFB{"source"};
     const DFBSpecName DST_DFB{"output"};
-    const DFBSpecName FP32_TEMP_DFB{"fp32_temp"};
+    const ScratchpadSpecName FP32_TEMP_SCRATCH{"fp32_temp"};
     const TensorParamName INPUT_TENSOR{"input"};
     const TensorParamName INDEX_TENSOR{"index"};
     const TensorParamName SRC_TENSOR{"source"};
@@ -116,7 +115,6 @@ ttnn::device_operation::ProgramArtifacts ScatterReduceBfloat16ProgramFactory::cr
         make_dfb(INDEX_DFB, index_tensor.dtype(), index_page_size_bytes),
         make_dfb(SRC_DFB, src_tensor.dtype(), source_page_size_bytes),
         make_dfb(DST_DFB, output_tensor.dtype(), output_page_size_bytes),
-        make_dfb(FP32_TEMP_DFB, fp32_temp_dtype, fp32_temp_page_size_bytes),
     };
 
     // The reader alone fills and drains INPUT/INDEX/SRC and the FP32_TEMP scratch (self-loop: bound
@@ -139,15 +137,11 @@ ttnn::device_operation::ProgramArtifacts ScatterReduceBfloat16ProgramFactory::cr
                 DFBBinding{
                     .dfb_spec_name = SRC_DFB, .accessor_name = "source", .endpoint_type = DFBEndpointType::CONSUMER},
                 DFBBinding{
-                    .dfb_spec_name = FP32_TEMP_DFB,
-                    .accessor_name = "fp32_temp",
-                    .endpoint_type = DFBEndpointType::PRODUCER},
-                DFBBinding{
-                    .dfb_spec_name = FP32_TEMP_DFB,
-                    .accessor_name = "fp32_temp",
-                    .endpoint_type = DFBEndpointType::CONSUMER},
-                DFBBinding{
                     .dfb_spec_name = DST_DFB, .accessor_name = "output", .endpoint_type = DFBEndpointType::PRODUCER},
+            },
+        .scratchpad_bindings =
+            {
+                ScratchpadBinding{.scratchpad_spec_name = FP32_TEMP_SCRATCH, .accessor_name = "fp32_temp"},
             },
         .tensor_bindings =
             {
@@ -253,6 +247,9 @@ ttnn::device_operation::ProgramArtifacts ScatterReduceBfloat16ProgramFactory::cr
     spec.name = "scatter_reduce_bfloat16";
     spec.kernels = {reader, writer};
     spec.dataflow_buffers = std::move(dataflow_buffers);
+    spec.scratchpads = {
+        ScratchpadSpec{.unique_id = FP32_TEMP_SCRATCH, .size_per_node = fp32_temp_page_size_bytes},
+    };
     spec.tensor_parameters = {
         TensorParameter{.unique_id = INPUT_TENSOR, .spec = input_tensor.tensor_spec()},
         TensorParameter{.unique_id = INDEX_TENSOR, .spec = index_tensor.tensor_spec()},


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
A DM self-loop DataflowBuffer is a DFB bound as both PRODUCER and CONSUMER by one data-movement kernel. On a single DM kernel the FIFO machinery synchronizes nothing, so the buffer is really private scratch — and the shape is Gen1-only: Quasar rejects DM self-loop DFBs. This converts them to `Scratchpad` in five `data_movement` ops, removing that Quasar-uplift blocker.

Behaviour-preserving: same reads/writes, same order, same remote addresses. Every buffer here is single-entry, so the FIFO calls drop and the buffer is indexed from base (no stride/wrap).

Ops converted:
- `copy` — INPUT_PAGES (DefaultRowMajor reader)
- `fill_rm` — IN0, IN1
- `reshape_view` — WORKING (tiled writer)
- `repeat` — SRC0/SRC1 in both factories
- `scatter` — FP32_TEMP (bf16-reduction reader) **only**; its other self-loop DFBs make FIFO calls through a shared helper / consult `get_dataformat`, which the conversion does not cover, so they are left as-is.

Follows the post-port DM self-loop recipe (`docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/post_port/semantic/dm_self_loop_dfbs.md`).

Relates to #55526.

### Notes for reviewers
- Verified on Wormhole (n150), same sentinel green before and after each conversion: `copy` test_copy.py (542 passed), `fill_rm` test_fill_rm.py (2), `reshape_view` test_reshape.py (334), `repeat` test_repeat.py (127) + test_universal_input_tm_repeat.py (96), `scatter` test_scatter.py -k reduction (19). Sentinels were chosen to actually select the edited factory (e.g. copy's row-major sharded cases hit DefaultRowMajor; scatter's bf16+reduction cases hit the edited factory).
- `Scratchpad` handed directly to `noc.async_*` where the DFB was a NOC operand (copy reader, repeat tile, fill_rm); `get_base_address()` where a raw address was needed (repeat sharded/interleaved, reshape writer). `volatile` carried into `T` where the old pointer had it (scatter fp32_temp).
- Also deletes now-dead data-format locals the removed DFB specs consumed (`input_data_format` / `cb_data_format` / `fp32_temp_dtype`) — required under `-Werror=unused-variable`.
- `scatter` is a partial conversion by design; its remaining self-loop DFBs need an API decision (no `ScratchpadSpec` counterpart for `data_format_metadata`; FIFO calls hidden in `load_to_dfb`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/55526/dm-self-loop-dfb-data_movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/55526/dm-self-loop-dfb-data_movement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/55526/dm-self-loop-dfb-data_movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/55526/dm-self-loop-dfb-data_movement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/55526/dm-self-loop-dfb-data_movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/55526/dm-self-loop-dfb-data_movement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gchoudhary/55526/dm-self-loop-dfb-data_movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gchoudhary/55526/dm-self-loop-dfb-data_movement)