### PR TITLE
Re-enable watcher for Qwen-Image

### DIFF
--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1250,7 +1250,7 @@
 - name: TT-DiT Qwen-Image unit tests
   cmd: |
     unset HF_HUB_OFFLINE
-    unset TT_METAL_WATCHER  # blocked by #50886
+    export TT_METAL_WATCHER=30
     export TT_DIT_CACHE_DIR=/tmp/TT_DIT_CACHE
     pytest --timeout 1500 models/tt_dit/tests/encoders/qwen25vl/test_qwen25vl.py::test_qwen25vl_encoder_pair
     pytest --timeout 900 models/tt_dit/tests/models/qwenimage/test_transformer_qwenimage.py -k "not not_traced"

--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -225,7 +225,7 @@ def test_embedding_tiled_input_qwen_like_shapes(
     """TILE UINT32 indices + RM weights + TILE output; shapes from Qwen-Image text encoder (TP-sharded hidden)."""
     torch.manual_seed(1234)
 
-    torch_input_tensor = torch.randint(0, vocabulary_size - 1, (batch_size, sentence_size))
+    torch_input_tensor = torch.randint(0, vocabulary_size, (batch_size, sentence_size))
     torch_weights = torch_random((vocabulary_size, hidden_embedding_dim), -0.1, 0.1, dtype=torch.bfloat16)
     torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -215,6 +215,44 @@ def test_embedding_tiled_input(
     assert_equal(torch_output_tensor, output_tensor)
 
 
+@pytest.mark.parametrize("batch_size", [2])
+@pytest.mark.parametrize("sentence_size", [640])
+@pytest.mark.parametrize("hidden_embedding_dim", [1792])
+@pytest.mark.parametrize("vocabulary_size", [512])
+def test_embedding_tiled_input_qwen_like_shapes(
+    device, batch_size, sentence_size, hidden_embedding_dim, vocabulary_size
+):
+    """TILE UINT32 indices + RM weights + TILE output; shapes from Qwen-Image text encoder (TP-sharded hidden)."""
+    torch.manual_seed(1234)
+
+    torch_input_tensor = torch.randint(0, vocabulary_size - 1, (batch_size, sentence_size))
+    torch_weights = torch_random((vocabulary_size, hidden_embedding_dim), -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
+
+    input_tensor = ttnn.to_device(
+        ttnn.from_torch(torch_input_tensor, dtype=ttnn.uint32, layout=ttnn.TILE_LAYOUT),
+        device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    weights = ttnn.to_device(
+        ttnn.from_torch(torch_weights, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT),
+        device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    output_tensor = ttnn.embedding(
+        input_tensor,
+        weights,
+        embeddings_type=ttnn.EmbeddingsType.GENERIC,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_equal(torch_output_tensor, output_tensor)
+
+
 def reverse_embedding_output(output_tensor, weights_tensor):
     """
     Reverse the embedding operation by finding the indices of rows in the output tensor

--- a/ttnn/cpp/ttnn/operations/embedding/device/embeddings_tilized_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embeddings_tilized_indices_program_factory.cpp
@@ -117,10 +117,13 @@ ttnn::device_operation::ProgramArtifacts EmbeddingsTilizedIndicesProgramFactory:
         .data_format_metadata = weights_data_format,
     });
 
-    uint32_t index_page_size = round_up_to_mul32(input_element_size_bytes);
+    // The reader loads one full TILE page of indices (`input.get_aligned_page_size()`) into this
+    // scratch buffer, then decodes faces via face_offset. Size it to that page, not a single face:
+    // a face-sized CB overflows Watcher NOC sanitize (UINT32 TILE page is 4096 B).
+    uint32_t index_tile_page_size = tt::align(TILE_HW * input_element_size_bytes, alignment);
     spec.dataflow_buffers.push_back(DataflowBufferSpec{
         .unique_id = INDEX_SCRATCH,
-        .entry_size = FACE_HEIGHT * index_page_size,
+        .entry_size = index_tile_page_size,
         .num_entries = 1,
         .data_format_metadata = input_data_format,
     });

--- a/ttnn/cpp/ttnn/operations/embedding/device/embeddings_tilized_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embeddings_tilized_indices_program_factory.cpp
@@ -117,10 +117,9 @@ ttnn::device_operation::ProgramArtifacts EmbeddingsTilizedIndicesProgramFactory:
         .data_format_metadata = weights_data_format,
     });
 
-    // The reader loads one full TILE page of indices (`input.get_aligned_page_size()`) into this
-    // scratch buffer, then decodes faces via face_offset. Size it to that page, not a single face:
-    // a face-sized CB overflows Watcher NOC sanitize (UINT32 TILE page is 4096 B).
-    uint32_t index_tile_page_size = tt::align(TILE_HW * input_element_size_bytes, alignment);
+    // The reader loads one full input page of indices (`input.get_aligned_page_size()`) into this scratch buffer,
+    // then decodes faces via face_offset. Size it to the input's aligned page size to avoid Watcher NOC sanitize overflows.
+    uint32_t index_tile_page_size = a.buffer()->aligned_page_size();
     spec.dataflow_buffers.push_back(DataflowBufferSpec{
         .unique_id = INDEX_SCRATCH,
         .entry_size = index_tile_page_size,

--- a/ttnn/cpp/ttnn/operations/embedding/device/embeddings_tilized_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embeddings_tilized_indices_program_factory.cpp
@@ -40,7 +40,6 @@ ttnn::device_operation::ProgramArtifacts EmbeddingsTilizedIndicesProgramFactory:
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
 
-    uint32_t input_element_size_bytes = a.element_size();
     uint32_t weights_element_size_bytes = weights.element_size();
     uint32_t output_element_size_bytes = output.element_size();
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Re-enable watcher for Qwen-Image

Relates to https://github.com/tenstorrent/tt-metal/issues/50886

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
Pipeline runs:
- https://github.com/tenstorrent/tt-metal/actions/runs/34288625066
- https://github.com/tenstorrent/tt-metal/actions/runs/34524618638

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=50886-re-enable-watcher-for-qwenimage)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:50886-re-enable-watcher-for-qwenimage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=50886-re-enable-watcher-for-qwenimage)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:50886-re-enable-watcher-for-qwenimage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=50886-re-enable-watcher-for-qwenimage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:50886-re-enable-watcher-for-qwenimage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=50886-re-enable-watcher-for-qwenimage)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:50886-re-enable-watcher-for-qwenimage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=50886-re-enable-watcher-for-qwenimage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:50886-re-enable-watcher-for-qwenimage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=50886-re-enable-watcher-for-qwenimage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:50886-re-enable-watcher-for-qwenimage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=50886-re-enable-watcher-for-qwenimage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:50886-re-enable-watcher-for-qwenimage)