### PR TITLE
[Performance] Make JIT kernel debug info opt-in

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -161,6 +161,9 @@ runs:
         TRIAGE_SENTINEL=generated/.tt_triage_already_ran
         echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=mkdir -p generated; if [ -e $TRIAGE_SENTINEL ]; then echo 'Triage already ran in this job; skipping — device is not reset between tests, so subsequent triage is unreliable' >&2; else touch $TRIAGE_SENTINEL; $HANG_REPORT; $TRIAGE 2>&1 | tee $TT_TRIAGE_OUTPUT_PATH 1>&2; $HANG_REPORT --update; fi" >> $GITHUB_ENV
         echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=${{ inputs.hang-detection-timeout }}" >> $GITHUB_ENV
+        # tt-triage symbolizes kernel ELFs, so it needs DWARF. Debug info is opt-in and triage runs
+        # post-mortem, so this has to be set before the workload builds its kernels.
+        echo "TT_METAL_RISCV_DEBUG_INFO=1" >> $GITHUB_ENV
         echo "TT_TRIAGE_ENABLE_AGGREGATED_CALLSTACKS=1" >> $GITHUB_ENV
         echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1" >> $GITHUB_ENV
         echo "TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH=$TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH" >> $GITHUB_ENV

--- a/.github/actions/setup-multihost-job/action.yml
+++ b/.github/actions/setup-multihost-job/action.yml
@@ -237,6 +237,10 @@ runs:
         {
           echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=$TRIAGE_CMD"
           echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=$HANG_DETECTION_TIMEOUT"
+          # tt-triage symbolizes kernel ELFs, so it needs DWARF. Debug info is opt-in and triage runs
+          # post-mortem, so this has to be set before the workload builds its kernels. tt-run
+          # propagates it to every rank via the TT_ passthrough prefix.
+          echo "TT_METAL_RISCV_DEBUG_INFO=1"
           echo "TT_TRIAGE_ENABLE_AGGREGATED_CALLSTACKS=1"
           echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1"
         } >> "$GITHUB_ENV"

--- a/docs/source/tt-metalium/tools/inspector.rst
+++ b/docs/source/tt-metalium/tools/inspector.rst
@@ -22,7 +22,8 @@ Configure the Inspector by setting the following environment variables:
    export TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS=localhost:50051 # optional: set the address of the Inspector RPC server. Default is `localhost:50051`.
    export TT_METAL_INSPECTOR_RPC=1                              # optional: enable/disable the Inspector RPC server. Default is `1` (enabled).
 
-Enabling the Inspector will override `TT_METAL_RISCV_DEBUG_INFO` and debugging info will be generated for riscv elfs.
+The Inspector no longer turns on `TT_METAL_RISCV_DEBUG_INFO`. Debug info for riscv elfs is opt-in, so set
+`TT_METAL_RISCV_DEBUG_INFO=1` when you need tooling that reads DWARF (for example ``tt-triage`` or ``dump-consts.py``).
 You can also use unix sockets for the RPC server by setting `TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS` to a unix socket path,
 e.g. `unix:/tmp/inspector_socket`.
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -1410,13 +1410,14 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             break;
 
         // TT_METAL_RISCV_DEBUG_INFO
-        // Enable RISC-V debug info. Defaults to inspector setting, override with 0/1.
-        // Default: Inherits from inspector setting
+        // Emit DWARF debug info (-g) for JIT-compiled kernels. Opt in: DWARF dominates the size of
+        // every kernel ELF and adds to JIT build time, so it is off unless explicitly requested.
+        // Default: false
         // Usage: export TT_METAL_RISCV_DEBUG_INFO=1  # or =0 to disable
         case EnvVarID::TT_METAL_RISCV_DEBUG_INFO: {
-            bool enable_riscv_debug_info = this->get_inspector_enabled();  // Default from inspector
+            bool enable_riscv_debug_info = false;
             if (value) {
-                enable_riscv_debug_info = true;  // Default to true if set
+                enable_riscv_debug_info = true;
                 if (strcmp(value, "0") == 0) {
                     enable_riscv_debug_info = false;  // Only "0" = false
                 }
@@ -1848,7 +1849,7 @@ void RunTimeOptions::InitializeFromEnvVars() {
     // Set inspector log path
     this->inspector_settings.log_path = std::filesystem::path(this->get_logs_dir()) / "generated/inspector";
 
-    // TT_METAL_RISCV_DEBUG_INFO: Inherit from inspector if not explicitly set
+    // TT_METAL_RISCV_DEBUG_INFO: Apply the default when not explicitly set
     if (std::getenv("TT_METAL_RISCV_DEBUG_INFO") == nullptr) {
         HandleEnvVar(EnvVarID::TT_METAL_RISCV_DEBUG_INFO, nullptr);
     }


### PR DESCRIPTION
### PR Category
Performance

### Summary
`TT_METAL_RISCV_DEBUG_INFO` defaults to the Inspector's enabled state, and the Inspector ships enabled, so **every JIT kernel build currently passes `-g`** unless you explicitly set the variable to `0`. Debug tooling should be opt in, not opt out.

(`set_riscv_debug_info_enabled(env_str != nullptr)`). The Inspector PR #22614 changed that line to inherit from `get_inspector_enabled()`, and because `InspectorSettings::enabled = true`, kernel DWARF became on-by-default as a side effect. The later rtoptions refactor (#31885) preserved it mechanically. This restores the original behaviour.

The payoff, measured on a TRISC target:

| | with `-g` | without |
|---|---|---|
| kernel ELF size | 1481 KB | 21 KB |
| per-target JIT build time | baseline | ~18% faster |

DWARF is ~98% of each kernel ELF, which is several GB written per full run. `.text` and `.data` are byte-identical either way, so generated code is unaffected.

**Nothing on the runtime path consumes kernel DWARF.** The ELF loader (`tt_elffile.cpp`) has no debug-section handling; the Inspector only records the flag's value and publishes ELF *paths*; and the device profiler resolves zone source locations from the compiler's `.o.log` files. The two tools that do read DWARF, `tools/triage` and `dump-consts.py`, already instruct the user to set `TT_METAL_RISCV_DEBUG_INFO=1`, so this fails loudly with an actionable message rather than silently.

CI behaviour is unchanged: the second commit opts the auto-triage jobs back in, so hang triage keeps its symbols.

### Notes for reviewers
The subtle part is the CI commit. `tt-triage` runs **post-mortem** on a workload that has already compiled its kernels, so the variable has to be exported before the workload starts, not when triage fires. It is therefore set in the same conditional block that installs the triage hook in `setup-job` and `setup-multihost-job` — which scopes it to exactly the jobs that can run triage. `auto-triage` defaults to `true`, so this covers essentially all of CI; the two legs that disable it (watcher-enabled ttnn smoke/sanity) do not read DWARF.

For multihost, the variable reaches each rank through tt-run's existing passthrough: `TT_` is in `ENV_PASSTHROUGH_PREFIXES` and the variable is not in `ENV_BLOCKLIST`, so it is forwarded as `-x TT_METAL_RISCV_DEBUG_INFO=1`.

`docs/source/tt-metalium/tools/inspector.rst` explicitly promised the old coupling ("Enabling the Inspector will override `TT_METAL_RISCV_DEBUG_INFO`"), so it is updated here.

Verification so far is static plus a compile of the `llrt` unity object containing `rtoptions.cpp`. I have **not** yet confirmed on hardware that `-g` disappears from the emitted JIT compile line; that needs a device run and is worth a reviewer sanity check or a follow-up before this leaves draft.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/jit-debug-info-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/jit-debug-info-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/jit-debug-info-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/jit-debug-info-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/jit-debug-info-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/jit-debug-info-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/jit-debug-info-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/jit-debug-info-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/jit-debug-info-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/jit-debug-info-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/jit-debug-info-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/jit-debug-info-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/jit-debug-info-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/jit-debug-info-opt-in)