### PR TITLE
[skip ci] Add include-what-you-use, and unversioned clang names, to the CI images

### DIFF
--- a/.github/scripts/compute-tool-tags.sh
+++ b/.github/scripts/compute-tool-tags.sh
@@ -22,6 +22,7 @@ CCACHE_VERSION=$(grep -E "^ARG CCACHE_VERSION=" dockerfile/Dockerfile.tools | he
 MOLD_VERSION=$(grep -E "^ARG MOLD_VERSION=" dockerfile/Dockerfile.tools | head -1 | cut -d= -f2)
 DOXYGEN_VERSION=$(grep -E "^ARG DOXYGEN_VERSION=" dockerfile/Dockerfile.tools | head -1 | cut -d= -f2)
 CLANGBUILDANALYZER_VERSION=$(grep -E "^ARG CLANGBUILDANALYZER_VERSION=" dockerfile/Dockerfile.tools | head -1 | cut -d= -f2)
+IWYU_VERSION=$(grep -E "^ARG IWYU_VERSION=" dockerfile/Dockerfile.tools | head -1 | cut -d= -f2)
 GDB_VERSION=$(grep -E "^ARG GDB_VERSION=" dockerfile/Dockerfile.tools | head -1 | cut -d= -f2)
 CMAKE_VERSION=$(grep -E "^ARG CMAKE_VERSION=" dockerfile/Dockerfile.tools | head -1 | cut -d= -f2)
 YQ_VERSION=$(grep -E "^ARG YQ_VERSION=" dockerfile/Dockerfile.tools | head -1 | cut -d= -f2)
@@ -39,8 +40,12 @@ for tool in ccache mold doxygen clangbuildanalyzer gdb cmake yq zstd curl oras; 
     declare "$hash_var=$(cat "dockerfile/scripts/install-${tool}.sh" | sha1sum | cut -d' ' -f1 | head -c 12)"
 done
 
-# Handle special cases (sfpi and openmpi) separately
+# Handle special cases (sfpi, openmpi and iwyu) separately
 SFPI_HASH=$(cat dockerfile/scripts/install-sfpi.sh tt_metal/sfpi-version | sha1sum | cut -d' ' -f1 | head -c 12)
+# iwyu is bound to a Clang major version that the builder stage needs as an ARG,
+# so it lives in Dockerfile.tools as well as the script. Both feed the hash, or
+# bumping the Clang major alone would silently reuse the old image.
+IWYU_HASH=$({ cat dockerfile/scripts/install-iwyu.sh; grep -E "^ARG IWYU_LLVM_MAJOR=" dockerfile/Dockerfile.tools; } | sha1sum | cut -d' ' -f1 | head -c 12)
 OPENMPI_HASH=$(cat dockerfile/scripts/install-openmpi.sh .github/scripts/install-slurm.sh | sha1sum | cut -d' ' -f1 | head -c 12)
 # syft-scanner and dockerfile-frontend have no install script of their own
 # (single-stage passthroughs of an upstream image - see Dockerfile.tools) -
@@ -55,6 +60,7 @@ jq -n \
   --arg mold "${BASE}/mold:${MOLD_VERSION}-${MOLD_HASH}" \
   --arg doxygen "${BASE}/doxygen:${DOXYGEN_VERSION}-${DOXYGEN_HASH}" \
   --arg clangbuildanalyzer "${BASE}/clangbuildanalyzer:${CLANGBUILDANALYZER_VERSION}-${CLANGBUILDANALYZER_HASH}" \
+  --arg iwyu "${BASE}/iwyu:${IWYU_VERSION}-${IWYU_HASH}" \
   --arg gdb "${BASE}/gdb:${GDB_VERSION}-${GDB_HASH}" \
   --arg cmake "${BASE}/cmake:${CMAKE_VERSION}-${CMAKE_HASH}" \
   --arg yq "${BASE}/yq:${YQ_VERSION}-${YQ_HASH}" \
@@ -70,6 +76,7 @@ jq -n \
     "mold-tag": $mold,
     "doxygen-tag": $doxygen,
     "clangbuildanalyzer-tag": $clangbuildanalyzer,
+    "iwyu-tag": $iwyu,
     "gdb-tag": $gdb,
     "cmake-tag": $cmake,
     "yq-tag": $yq,

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -201,6 +201,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zstd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# The LLVM packages install versioned names only. CodeChecker resolves the
+# unversioned ones, and consults ClangSA.analyzer_binary() even when only
+# clang-tidy runs, where a None crashes compilation-database parsing. Three
+# workflows each fixed that up themselves before running it; do it once here.
+# Nothing in the build picks a compiler by bare name: build_metal.sh passes an
+# explicit path, CMakePresets pins clang-tidy-20, and CMake's own default probe
+# looks for cc/c++.
+RUN for tool in clang clang++ clang-tidy; do \
+        update-alternatives --install "/usr/bin/$tool" "$tool" "/usr/bin/${tool}-20" 100; \
+    done && \
+    clang --version && clang-tidy --version
+
 #############################################################
 # CI Build image
 #############################################################

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -250,12 +250,19 @@ RUN curl -fsSL -o /usr/local/bin/tt-smi \
 
 # include-what-you-use. Here rather than with the other tools in ci-build-light
 # because nothing in the build needs it: this is the first stage shared by the
-# CI test images and the dev images, which are the two consumers. It carries its
-# own copy of Clang's builtin headers, since the LLVM apt packages install only
-# versioned names and IWYU's default lookup wants a plain `clang` on PATH.
+# CI test images and the dev images, which are the two consumers.
+#
+# IWYU reads Clang's builtin headers from the LLVM prefix it was built against,
+# which is the same /usr/lib/llvm-<major> the apt packages above install. The
+# check below analyzes a file that needs those headers, so that coupling breaks
+# the image build rather than the first analysis run.
 COPY --from=iwyu-layer --link /install/ /usr/local/
 RUN test -x /usr/local/bin/include-what-you-use || \
-    { echo "ERROR: include-what-you-use not found in iwyu-layer" >&2; exit 1; }
+      { echo "ERROR: include-what-you-use not found in iwyu-layer" >&2; exit 1; }; \
+    printf '#include <stddef.h>\nsize_t f(void) { return 0; }\n' > /tmp/iwyu-check.c; \
+    include-what-you-use -xc /tmp/iwyu-check.c 2>&1 | grep -q 'has correct #includes' || \
+      { echo "ERROR: include-what-you-use cannot find Clang's builtin headers" >&2; exit 1; }; \
+    rm -f /tmp/iwyu-check.c
 
 # Create directories for infra (needed even with pre-built venv for requirements file reference)
 RUN mkdir -p ${TT_METAL_INFRA_DIR}/tt-metal/docs/ && \

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -64,6 +64,7 @@ FROM scratch AS ccache-layer
 FROM scratch AS mold-layer
 FROM scratch AS doxygen-layer
 FROM scratch AS clangbuildanalyzer-layer
+FROM scratch AS iwyu-layer
 FROM scratch AS gdb-layer
 FROM scratch AS cmake-layer
 FROM scratch AS yq-layer
@@ -247,6 +248,15 @@ RUN curl -fsSL -o /usr/local/bin/tt-smi \
     chmod a+rx /usr/local/bin/tt-smi && \
     tt-smi --version | grep -q "${TT_SMI_VERSION}"
 
+# include-what-you-use. Here rather than with the other tools in ci-build-light
+# because nothing in the build needs it: this is the first stage shared by the
+# CI test images and the dev images, which are the two consumers. It carries its
+# own copy of Clang's builtin headers, since the LLVM apt packages install only
+# versioned names and IWYU's default lookup wants a plain `clang` on PATH.
+COPY --from=iwyu-layer --link /install/ /usr/local/
+RUN test -x /usr/local/bin/include-what-you-use || \
+    { echo "ERROR: include-what-you-use not found in iwyu-layer" >&2; exit 1; }
+
 # Create directories for infra (needed even with pre-built venv for requirements file reference)
 RUN mkdir -p ${TT_METAL_INFRA_DIR}/tt-metal/docs/ && \
     mkdir -p ${TT_METAL_INFRA_DIR}/tt-metal/tests/sweep_framework/ && \
@@ -358,10 +368,6 @@ ENV VIRTUAL_ENV="$PYTHON_ENV_DIR"
 # permissions verbatim. Do NOT add --chmod: it disables the --link fast path.
 COPY --from=ci-test-venv-layer --link /install/venv /opt/venv
 RUN echo "source $PYTHON_ENV_DIR/bin/activate" >> /etc/bash.bashrc
-
-# IWYU (Include What You Use) could be useful to developers.
-# Not currently included; install script ready at dockerfile/scripts/install-iwyu.sh
-# To add: create iwyu tool target in Dockerfile.tools using install-iwyu.sh
 
 #############################################################
 # Release image

--- a/dockerfile/Dockerfile.tools
+++ b/dockerfile/Dockerfile.tools
@@ -27,6 +27,12 @@ ARG DOXYGEN_SHA256=a56f885d37e3aae08a99f638d17bbb381224c03a878d9e2dda4f9fa4baf1d
 ARG CLANGBUILDANALYZER_VERSION=1.6.0
 ARG CLANGBUILDANALYZER_SHA256=868a8d34ecb9b65da4e5874342062a12c081ce4385c7ddd6ce7d557a0c5c292d
 
+# IWYU links against Clang's internals, so the release and the LLVM major
+# version are a matched pair: 0.24 is the clang-20 release.
+ARG IWYU_VERSION=0.24
+ARG IWYU_SHA256=897b4c864a983f493c8efef4a1a9a2d429fd7ead1011f7a41743ed7b6dbe8c2e
+ARG IWYU_LLVM_MAJOR=20
+
 ARG GDB_VERSION=14.2
 ARG GDB_SHA256=2d4dd8061d8ded12b6c63f55e45344881e8226105f4d2a9b234040efa5ce7772
 
@@ -203,6 +209,43 @@ LABEL org.opencontainers.image.description="ClangBuildAnalyzer - Clang build tim
 LABEL org.opencontainers.image.licenses="Unlicense"
 LABEL org.opencontainers.image.version="${CLANGBUILDANALYZER_VERSION}"
 COPY --from=clangbuildanalyzer-builder /install/ /install/
+
+#############################################################
+# include-what-you-use - requires the matching Clang to build and to run
+# Outputs: /install/bin/include-what-you-use, /install/lib/clang/<major>/include
+#############################################################
+
+FROM ubuntu:22.04 AS iwyu-builder
+ARG IWYU_VERSION
+ARG IWYU_SHA256
+ARG IWYU_LLVM_MAJOR
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Enforce strict error handling: exit on error, unset vars, pipe failures
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget gnupg ca-certificates cmake build-essential \
+    && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${IWYU_LLVM_MAJOR} main" \
+       > /etc/apt/sources.list.d/llvm-${IWYU_LLVM_MAJOR}.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    clang-${IWYU_LLVM_MAJOR} libclang-${IWYU_LLVM_MAJOR}-dev llvm-${IWYU_LLVM_MAJOR}-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY dockerfile/scripts/install-iwyu.sh /tmp/install-iwyu.sh
+RUN IWYU_VERSION=${IWYU_VERSION} \
+    IWYU_SHA256=${IWYU_SHA256} \
+    IWYU_LLVM_MAJOR=${IWYU_LLVM_MAJOR} \
+    INSTALL_PREFIX=/install \
+    /bin/bash /tmp/install-iwyu.sh
+
+FROM scratch AS iwyu
+ARG IWYU_VERSION
+LABEL org.opencontainers.image.source="https://github.com/include-what-you-use/include-what-you-use"
+LABEL org.opencontainers.image.description="include-what-you-use - include analysis for C/C++"
+LABEL org.opencontainers.image.licenses="NCSA"
+LABEL org.opencontainers.image.version="${IWYU_VERSION}"
+COPY --from=iwyu-builder /install/ /install/
 
 #############################################################
 # GDB - requires configure/make to build

--- a/dockerfile/docker-bake.hcl
+++ b/dockerfile/docker-bake.hcl
@@ -124,6 +124,13 @@ target "clangbuildanalyzer" {
   tags       = ["tool-clangbuildanalyzer:local"]
 }
 
+target "iwyu" {
+  context    = "."
+  dockerfile = "dockerfile/Dockerfile.tools"
+  target     = "iwyu"
+  tags       = ["tool-iwyu:local"]
+}
+
 target "gdb" {
   context    = "."
   dockerfile = "dockerfile/Dockerfile.tools"
@@ -199,7 +206,7 @@ target "dockerfile-frontend" {
 }
 
 group "tools" {
-  targets = ["ccache", "clangbuildanalyzer", "cmake", "curl", "dockerfile-frontend", "doxygen", "gdb", "mold", "openmpi", "oras", "sfpi", "syft-scanner", "yq", "zstd"]
+  targets = ["ccache", "clangbuildanalyzer", "cmake", "curl", "dockerfile-frontend", "doxygen", "gdb", "iwyu", "mold", "openmpi", "oras", "sfpi", "syft-scanner", "yq", "zstd"]
 }
 
 # =============================================================================
@@ -263,6 +270,7 @@ target "_main-common" {
     mold-layer               = "target:mold"
     doxygen-layer            = "target:doxygen"
     clangbuildanalyzer-layer = "target:clangbuildanalyzer"
+    iwyu-layer               = "target:iwyu"
     gdb-layer                = "target:gdb"
     cmake-layer              = "target:cmake"
     yq-layer                 = "target:yq"

--- a/dockerfile/scripts/README.md
+++ b/dockerfile/scripts/README.md
@@ -26,6 +26,7 @@ The Docker build system uses **pre-built tool images** stored in GHCR (GitHub Co
    | mold | Fast linker |
    | doxygen | Documentation generator |
    | clangbuildanalyzer | ClangBuildAnalyzer for build profiling |
+   | iwyu | include-what-you-use; include analysis. Pinned to the Clang major version |
    | gdb | GNU Debugger |
    | cmake | Build system generator |
    | yq | YAML processor |
@@ -78,7 +79,7 @@ docker buildx bake -f dockerfile/docker-bake.hcl tools
 | `install-curl.sh` | Build and install curl from source |
 | `install-doxygen.sh` | Build and install doxygen from source |
 | `install-gdb.sh` | Build and install GDB from source |
-| `install-iwyu.sh` | Build and install Include What You Use (not currently in Docker image) |
+| `install-iwyu.sh` | Build and install include-what-you-use |
 | `install-mold.sh` | Install mold linker binary release |
 | `install-openmpi.sh` | Build and install OpenMPI with ULFM support |
 | `install-sfpi.sh` | Install SFPI compiler tools |

--- a/dockerfile/scripts/compute-hashes.sh
+++ b/dockerfile/scripts/compute-hashes.sh
@@ -54,7 +54,9 @@ curl -fsSL -o "$TMPDIR/clangbuildanalyzer.tar.gz" \
 echo "CLANGBUILDANALYZER_SHA256=$($SHA_CMD "$TMPDIR/clangbuildanalyzer.tar.gz" | cut -d' ' -f1)"
 echo ""
 
-# include-what-you-use
+# include-what-you-use. The version is half of a pin: IWYU_LLVM_MAJOR in
+# Dockerfile.tools has to move with it (0.24 is the clang-20 release), and it
+# feeds the tool tag hash in compute-tool-tags.sh, so bump the two together.
 IWYU_VERSION="${IWYU_VERSION:-0.24}"
 echo "Downloading include-what-you-use ${IWYU_VERSION}..."
 curl -fsSL -o "$TMPDIR/iwyu.tar.gz" \

--- a/dockerfile/scripts/compute-hashes.sh
+++ b/dockerfile/scripts/compute-hashes.sh
@@ -54,6 +54,14 @@ curl -fsSL -o "$TMPDIR/clangbuildanalyzer.tar.gz" \
 echo "CLANGBUILDANALYZER_SHA256=$($SHA_CMD "$TMPDIR/clangbuildanalyzer.tar.gz" | cut -d' ' -f1)"
 echo ""
 
+# include-what-you-use
+IWYU_VERSION="${IWYU_VERSION:-0.24}"
+echo "Downloading include-what-you-use ${IWYU_VERSION}..."
+curl -fsSL -o "$TMPDIR/iwyu.tar.gz" \
+    "https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${IWYU_VERSION}.tar.gz"
+echo "IWYU_SHA256=$($SHA_CMD "$TMPDIR/iwyu.tar.gz" | cut -d' ' -f1)"
+echo ""
+
 # GDB
 GDB_VERSION="${GDB_VERSION:-14.2}"
 echo "Downloading GDB ${GDB_VERSION}..."

--- a/dockerfile/scripts/install-iwyu.sh
+++ b/dockerfile/scripts/install-iwyu.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Install include-what-you-use from source
+set -euo pipefail
+
+# IWYU links against Clang's internals, so a release only works with the
+# matching Clang major version. 0.24 is the clang-20 release; bumping one
+# without the other fails to configure.
+IWYU_VERSION="${IWYU_VERSION:-0.24}"
+IWYU_LLVM_MAJOR="${IWYU_LLVM_MAJOR:-20}"
+# SHA256 for the include-what-you-use 0.24 source tarball
+# Verified by downloading and computing hash with compute-hashes.sh
+IWYU_SHA256="${IWYU_SHA256:-897b4c864a983f493c8efef4a1a9a2d429fd7ead1011f7a41743ed7b6dbe8c2e}"
+
+INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
+IWYU_LLVM_PREFIX="${IWYU_LLVM_PREFIX:-/usr/lib/llvm-${IWYU_LLVM_MAJOR}}"
+DOWNLOAD_URL="https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${IWYU_VERSION}.tar.gz"
+TMPDIR="/tmp/iwyu"
+CLANG_RESOURCE_DIR="${IWYU_LLVM_PREFIX}/lib/clang/${IWYU_LLVM_MAJOR}"
+
+echo "Installing include-what-you-use ${IWYU_VERSION} (LLVM ${IWYU_LLVM_MAJOR})..."
+
+# Create temp directory
+mkdir -p "${TMPDIR}"
+
+# Download (use curl if wget not available)
+if command -v wget &> /dev/null; then
+    wget -q -O "${TMPDIR}/iwyu.tar.gz" "${DOWNLOAD_URL}"
+else
+    curl -fsSL -o "${TMPDIR}/iwyu.tar.gz" "${DOWNLOAD_URL}"
+fi
+
+# Verify hash
+if ! echo "${IWYU_SHA256}  ${TMPDIR}/iwyu.tar.gz" | sha256sum -c - ; then
+    echo "[ERROR] SHA256 checksum verification failed for iwyu.tar.gz. Aborting." >&2
+    exit 1
+fi
+
+# Extract
+tar -xzf "${TMPDIR}/iwyu.tar.gz" -C "${TMPDIR}" --strip-components=1
+
+# Create install prefix directory
+mkdir -p "${INSTALL_PREFIX}"
+
+# Build with CMake.
+#
+# IWYU needs Clang's builtin headers (stddef.h and friends) at runtime. Its
+# default is to locate them next to a `clang` on PATH, but the LLVM apt
+# packages install only versioned names, so there is no `clang` to find. Point
+# the lookup at IWYU's own tree instead and ship the headers there, which is
+# the packaging mode IWYU documents for exactly this case.
+cmake -S "${TMPDIR}" -B "${TMPDIR}/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+    -DCMAKE_PREFIX_PATH="${IWYU_LLVM_PREFIX}" \
+    -DIWYU_RESOURCE_RELATIVE_TO=iwyu \
+    -DIWYU_RESOURCE_DIR="../lib/clang/${IWYU_LLVM_MAJOR}"
+cmake --build "${TMPDIR}/build" -j"$(nproc)"
+cmake --install "${TMPDIR}/build"
+
+# Ship the builtin headers at the path configured above. Only include/ is
+# needed; the rest of Clang's resource dir is compiler-rt runtime libraries.
+mkdir -p "${INSTALL_PREFIX}/lib/clang/${IWYU_LLVM_MAJOR}"
+cp -r "${CLANG_RESOURCE_DIR}/include" "${INSTALL_PREFIX}/lib/clang/${IWYU_LLVM_MAJOR}/include"
+
+# Cleanup
+rm -rf "${TMPDIR}"
+
+# Verify installation, including that the builtin headers resolve without a
+# `clang` on PATH.
+"${INSTALL_PREFIX}/bin/include-what-you-use" --version
+printf '#include <stddef.h>\nsize_t f(void) { return 0; }\n' > /tmp/iwyu-check.c
+env -i PATH=/usr/bin:/bin "${INSTALL_PREFIX}/bin/include-what-you-use" -xc /tmp/iwyu-check.c 2>&1 \
+    | grep -q 'has correct #includes' \
+    || { echo "[ERROR] iwyu cannot find its builtin headers. Aborting." >&2; exit 1; }
+rm -f /tmp/iwyu-check.c
+echo "include-what-you-use ${IWYU_VERSION} installed successfully"

--- a/dockerfile/scripts/install-iwyu.sh
+++ b/dockerfile/scripts/install-iwyu.sh
@@ -15,7 +15,6 @@ INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
 IWYU_LLVM_PREFIX="${IWYU_LLVM_PREFIX:-/usr/lib/llvm-${IWYU_LLVM_MAJOR}}"
 DOWNLOAD_URL="https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${IWYU_VERSION}.tar.gz"
 TMPDIR="/tmp/iwyu"
-CLANG_RESOURCE_DIR="${IWYU_LLVM_PREFIX}/lib/clang/${IWYU_LLVM_MAJOR}"
 
 echo "Installing include-what-you-use ${IWYU_VERSION} (LLVM ${IWYU_LLVM_MAJOR})..."
 
@@ -43,24 +42,18 @@ mkdir -p "${INSTALL_PREFIX}"
 
 # Build with CMake.
 #
-# IWYU needs Clang's builtin headers (stddef.h and friends) at runtime. Its
-# default is to locate them next to a `clang` on PATH, but the LLVM apt
-# packages install only versioned names, so there is no `clang` to find. Point
-# the lookup at IWYU's own tree instead and ship the headers there, which is
-# the packaging mode IWYU documents for exactly this case.
+# The resource dir is left at IWYU's default, which bakes in the LLVM prefix it
+# was built against. IWYU then finds Clang's builtin headers (stddef.h and
+# friends) under that prefix with no `clang` on PATH, so the consuming image
+# needs LLVM at the same prefix. That holds because both come from the same LLVM
+# apt packages, and if it ever stops holding IWYU says "fatal error: 'stddef.h'
+# file not found" rather than failing quietly.
 cmake -S "${TMPDIR}" -B "${TMPDIR}/build" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-    -DCMAKE_PREFIX_PATH="${IWYU_LLVM_PREFIX}" \
-    -DIWYU_RESOURCE_RELATIVE_TO=iwyu \
-    -DIWYU_RESOURCE_DIR="../lib/clang/${IWYU_LLVM_MAJOR}"
+    -DCMAKE_PREFIX_PATH="${IWYU_LLVM_PREFIX}"
 cmake --build "${TMPDIR}/build" -j"$(nproc)"
 cmake --install "${TMPDIR}/build"
-
-# Ship the builtin headers at the path configured above. Only include/ is
-# needed; the rest of Clang's resource dir is compiler-rt runtime libraries.
-mkdir -p "${INSTALL_PREFIX}/lib/clang/${IWYU_LLVM_MAJOR}"
-cp -r "${CLANG_RESOURCE_DIR}/include" "${INSTALL_PREFIX}/lib/clang/${IWYU_LLVM_MAJOR}/include"
 
 # Cleanup
 rm -rf "${TMPDIR}"


### PR DESCRIPTION
## What

Adds `include-what-you-use` as a tool image, alongside ClangBuildAnalyzer and the rest.

The Dockerfile has carried a note that IWYU "could be useful to developers", pointing at `dockerfile/scripts/install-iwyu.sh` — a script that was never written. The README rows referencing it were aspirational too. This makes them true.

## Why these choices

**Built from source, not apt.** IWYU links against Clang's internals, so a release only works with the matching Clang major version. The apt package is clang-13 based; there is no upstream binary release. 0.24 is the clang-20 release, matching the `clang-20` already installed in the image. The version pairing is stated at both declaration sites.

**It reads Clang's builtin headers from the LLVM prefix it was built against**, which is the same `/usr/lib/llvm-20` the image installs from the same apt packages. No `clang` on PATH is needed, and none exists — the LLVM apt packages install only versioned names. The consuming stage analyzes a file that needs those headers, so if that coupling ever breaks it fails the image build rather than the first analysis run.

**Placed in `ci-test-light`,** rather than with the other tools in `ci-build-light`. Nothing in the build needs it, and `ci-test-light` is the first stage shared by the CI test images and the dev images, which are the two consumers.

**The tool tag hash covers the Clang major version** as well as the install script. It has to live in `Dockerfile.tools` as an ARG for the builder's apt line, so without this, bumping the major alone would silently reuse the old image.

## Verified

- `docker buildx bake iwyu` builds clean; image is 9.5 MB.
- The packaged binary, extracted from the built image and run with no `clang` on PATH, analyzes a real captured kernel translation unit (riscv32 target, SFPI headers, generated JIT sources) and produces a verdict with no missing-header errors.
- The builtin-header check passes on a healthy image and aborts the build when the LLVM resource dir is removed.
- `compute-tool-tags.sh` emits `iwyu-tag`, and the tool list derived from the bake group picks `iwyu` up automatically.
- pre-commit passes.

## Follow-up

This only puts the tool in the image; nothing runs it yet. The intended consumer is the kernel clang-tidy workflow (#55421), where a per-leg IWYU pass would report on device headers. `misc-include-cleaner` cannot do this: it only judges the main file of a translation unit, which for JIT kernels is always one of five firmware wrappers. On one captured leg, IWYU produced verdicts for 194 files where include-cleaner produced 1.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/iwyu-docker-image)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/iwyu-docker-image)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/iwyu-docker-image)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/iwyu-docker-image)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/iwyu-docker-image)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/iwyu-docker-image)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/iwyu-docker-image)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/iwyu-docker-image)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/iwyu-docker-image)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/iwyu-docker-image)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/iwyu-docker-image)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/iwyu-docker-image)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/iwyu-docker-image)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/iwyu-docker-image)