### PR TITLE
[Cleanup] Remove iostream from fabric EDM types public header

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_edm_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_edm_types.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <cstdint>
-#include <iostream>
 
 namespace tt::tt_fabric {
 
@@ -15,8 +14,6 @@ enum class Topology { NeighborExchange = 0, Linear = 1, Ring = 2, Mesh = 3, Toru
 constexpr bool is_2D_topology(Topology topology) { return topology == Topology::Mesh || topology == Topology::Torus; }
 
 constexpr bool is_ring_or_torus(Topology topology) { return topology == Topology::Ring || topology == Topology::Torus; }
-
-std::ostream& operator<<(std::ostream& os, const Topology& topology);
 
 struct WorkerXY {
     uint16_t x;

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 #include <map>
+#include <ostream>
 #include <algorithm>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
`fabric_edm_types.hpp` pulls `<iostream>` into every consumer, including runtime RISC-V kernel compilations, solely to declare the `Topology` stream operator. Remove that include and declaration from the public header. Retain the existing operator definition in `fabric_context.cpp` and include `<ostream>` explicitly there.

### Notes for reviewers
No direct callers of the operator were found in the checkout. Removing the public declaration can affect external consumers that stream `Topology`; the existing out-of-line definition is retained.

Validation:
- Passed standalone header compilation with local Clang in C++20 mode, with warnings treated as errors, for host mode and with `KERNEL_BUILD` / `FW_BUILD` defined. These checks also exercise topology helpers, `WorkerXY` packing, and structure size assertions.
- Confirmed the header's include tree contains neither `<iostream>` nor `<ostream>` after the change. Local Clang preprocessing fell from 83,789 to 447 lines; this is not a runtime compilation performance measurement.
- `git diff --check` passed.
- **Full build unverified:** `.github/scripts/copilot-build.sh` failed because Docker was unavailable (daemon not running). Actual RISC-V kernel compilation and device execution were not tested. Defining the build macros in local Clang does not substitute for the RISC-V toolchain.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/remove-fabric-edm-iostream)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/remove-fabric-edm-iostream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/remove-fabric-edm-iostream)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/remove-fabric-edm-iostream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/remove-fabric-edm-iostream)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/remove-fabric-edm-iostream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/remove-fabric-edm-iostream)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/remove-fabric-edm-iostream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/remove-fabric-edm-iostream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/remove-fabric-edm-iostream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/remove-fabric-edm-iostream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/remove-fabric-edm-iostream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/remove-fabric-edm-iostream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/remove-fabric-edm-iostream)