### PR TITLE
[Cleanup] Remove unused cstddef from dprint_common.h

### DIFF
--- a/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
@@ -22,8 +22,6 @@ using CommonDataFormat = tt::DataFormat;
 using CommonDataFormat = DataFormat;
 #endif
 
-#include <cstddef>
-
 #if !defined(ENV_LLK_INFRA)
 // Deprecated buffer size from old DPRINT implementation. Used only to verify that buffers are still the same size.
 constexpr static std::uint32_t DPRINT_BUFFER_SIZE = 204;  // per thread


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Remove an unnecessary direct standard-library include from `tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h`.

The shared debug-print structures use fixed-width integer types and no `size_t`, `ptrdiff_t`, `offsetof`, or other `<cstddef>` facilities.

### Notes for reviewers
This is one independent change from a kernel include audit, based directly on `main`; it does not depend on the other audit PRs. No runtime compilation speedup is claimed. Removing a redundant direct include does not necessarily eliminate that library header from the complete translation unit.

Validation:
- Before/after preprocessing with local Clang, C++20, and representative Wormhole kernel defines passed. This checks include resolution and macro expansion; it is not a kernel compilation or link test.
- Local Clang C++20 syntax check of the modified header with `TENSIX_FIRMWARE` and `ENV_LLK_INFRA` defined passed.
- Changed-line formatting with `git-clang-format --style=file 89e1256c98` and `git diff --check` passed.
- **Full build unverified:** `.github/scripts/copilot-build.sh` was attempted and failed because Docker is unavailable (daemon not running). The Tenstorrent RISC-V compiler, complete kernel configuration matrix, and device execution were not tested. The reported translation-unit agreement counts were not independently reproduced.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/trim-dprint-common-cstddef)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/trim-dprint-common-cstddef)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/trim-dprint-common-cstddef)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/trim-dprint-common-cstddef)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/trim-dprint-common-cstddef)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/trim-dprint-common-cstddef)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/trim-dprint-common-cstddef)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/trim-dprint-common-cstddef)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/trim-dprint-common-cstddef)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/trim-dprint-common-cstddef)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/trim-dprint-common-cstddef)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/trim-dprint-common-cstddef)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/trim-dprint-common-cstddef)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/trim-dprint-common-cstddef)