### PR TITLE
[Cleanup] Remove unused cstdint from llk_io.h

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io.h
@@ -3,6 +3,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <cstdint>
 
 #include "internal/circular_buffer_interface.h"


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Remove an unnecessary direct standard-library include from `tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io.h`.

This forwarding header contains no declarations of its own. Its only project include, `internal/circular_buffer_interface.h`, directly includes `<cstdint>` before using integer types.

### Notes for reviewers
This is one independent change from a kernel include audit, based directly on `main`; it does not depend on the other audit PRs. No runtime compilation speedup is claimed. Removing a redundant direct include does not necessarily eliminate that library header from the complete translation unit.

Validation:
- Before/after preprocessing with local Clang, C++20, and representative Wormhole kernel defines passed. The resulting preprocessed tokens are identical after ignoring line directives and whitespace.
- Changed-line formatting with `git-clang-format --style=file 89e1256c98` and `git diff --check` passed.
- **Full build unverified:** `.github/scripts/copilot-build.sh` was attempted and failed because Docker is unavailable (daemon not running). The Tenstorrent RISC-V compiler, complete kernel configuration matrix, and device execution were not tested. The reported translation-unit agreement counts were not independently reproduced.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/trim-llk-io-cstdint)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/trim-llk-io-cstdint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/trim-llk-io-cstdint)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/trim-llk-io-cstdint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/trim-llk-io-cstdint)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/trim-llk-io-cstdint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/trim-llk-io-cstdint)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/trim-llk-io-cstdint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/trim-llk-io-cstdint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/trim-llk-io-cstdint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/trim-llk-io-cstdint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/trim-llk-io-cstdint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/trim-llk-io-cstdint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/trim-llk-io-cstdint)