### PR TITLE
[Cleanup] Use cstdint instead of climits in mod_div_lib.h

### DIFF
--- a/tt_metal/hw/inc/internal/mod_div_lib.h
+++ b/tt_metal/hw/inc/internal/mod_div_lib.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <climits>
+#include <cstdint>
 
 inline __attribute__((always_inline)) unsigned int mulsi3(unsigned int a, unsigned int b) { return a * b; }
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Replace the unused `<climits>` include in `tt_metal/hw/inc/internal/mod_div_lib.h` with headers for the facilities used by that file.

The division helpers do not use integer-limit macros, but they do use `uint32_t` and `uint64_t`. Replace `<climits>` with `<cstdint>` so the header declares its actual dependency and can compile on its own.

### Notes for reviewers
This is one independent change from a kernel include audit, based directly on `main`; it does not depend on the other audit PRs. No runtime compilation speedup is claimed. Removing a redundant direct include does not necessarily eliminate that library header from the complete translation unit.

Validation:
- Before/after preprocessing with local Clang, C++20, and representative Wormhole kernel defines passed. This checks include resolution and macro expansion; it is not a kernel compilation or link test.
- Local Clang C++20 syntax check of the modified header in host mode passed.
- Changed-line formatting with `git-clang-format --style=file 89e1256c98` and `git diff --check` passed.
- **Full build unverified:** `.github/scripts/copilot-build.sh` was attempted and failed because Docker is unavailable (daemon not running). The Tenstorrent RISC-V compiler, complete kernel configuration matrix, and device execution were not tested. The reported translation-unit agreement counts were not independently reproduced.
