### PR TITLE
[Cleanup] Include stdbool.h only for C in Wormhole noc.h

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc/noc.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc/noc.h
@@ -6,7 +6,9 @@
 #define _NOC_H_
 
 #include <stdint.h>
+#ifndef __cplusplus
 #include <stdbool.h>
+#endif
 
 //////
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Avoid including `<stdbool.h>` in C++ consumers of `tt_metal/hw/inc/internal/tt-1xx/wormhole/noc/noc.h`.

An unconditional deletion is incorrect: this header declares `bool` parameters and is included first by `hw/firmware/src/tt-1xx/wormhole/noc.c`. Keep `<stdbool.h>` for C and skip it in C++, where `bool` is a keyword.

### Notes for reviewers
This is one independent change from a kernel include audit, based directly on `main`; it does not depend on the other audit PRs. No runtime compilation speedup is claimed. Removing a redundant direct include does not necessarily eliminate that library header from the complete translation unit.

Validation:
- Before/after preprocessing with local Clang, C++20, and representative Wormhole kernel defines passed. The resulting preprocessed tokens are identical after ignoring line directives and whitespace.
- Local Clang C11 and C++20 syntax checks passed with the guard. A negative check confirmed that unconditional deletion fails C11 with unknown type `bool`; the original header passes both languages.
- Changed-line formatting with `git-clang-format --style=file 89e1256c98` and `git diff --check` passed.
- **Full build unverified:** `.github/scripts/copilot-build.sh` was attempted and failed because Docker is unavailable (daemon not running). The Tenstorrent RISC-V compiler, complete kernel configuration matrix, and device execution were not tested. The reported translation-unit agreement counts were not independently reproduced.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/trim-noc-stdbool-h)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/trim-noc-stdbool-h)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/trim-noc-stdbool-h)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/trim-noc-stdbool-h)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/trim-noc-stdbool-h)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/trim-noc-stdbool-h)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/trim-noc-stdbool-h)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/trim-noc-stdbool-h)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/trim-noc-stdbool-h)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/trim-noc-stdbool-h)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/trim-noc-stdbool-h)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/trim-noc-stdbool-h)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/trim-noc-stdbool-h)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/trim-noc-stdbool-h)