### PR TITLE
[Cleanup] Use direct STL dependencies in Wormhole NoC API

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include <stdint.h>
-#include <limits>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
 #include "noc_parameters.h"
 #include "hostdev/dev_msgs.h"
 #include "noc_overlay_parameters.h"


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Replace the unused `<limits>` include in `tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h` with headers for the facilities used by that file.

The NoC API does not use `std::numeric_limits`. Replace `<limits>` with explicit headers for the facilities it does use: `<cstddef>` for `offsetof`, `<type_traits>` for `std::underlying_type_t`, and `<utility>` for `std::declval`.

### Notes for reviewers
This is one independent change from a kernel include audit, based directly on `main`; it does not depend on the other audit PRs. No runtime compilation speedup is claimed. Removing a redundant direct include does not necessarily eliminate that library header from the complete translation unit.

Validation:
- Before/after preprocessing with local Clang, C++20, and representative Wormhole kernel defines passed. This checks include resolution and macro expansion; it is not a kernel compilation or link test.
- Changed-line formatting with `git-clang-format --style=file 89e1256c98` and `git diff --check` passed.
- **Full build unverified:** `.github/scripts/copilot-build.sh` was attempted and failed because Docker is unavailable (daemon not running). The Tenstorrent RISC-V compiler, complete kernel configuration matrix, and device execution were not tested. The reported translation-unit agreement counts were not independently reproduced.
