### PR TITLE
[LLK][BH] Acquire the source banks on the math class in the topk_xl transpose guards

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
@@ -1644,7 +1644,10 @@ inline void _topk_xl_local_sort_(const std::uint32_t dst_index, const bool ascen
     enter_transpose_cfg_block();
 
     // ── Phase 6 — length 512 ───────────────────────────────────────────────
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
+    // The face moves write SrcA/SrcB, which hardware arbitration does not gate: hold the math
+    // class until both banks are math-owned, their in-flight consumers have drained, and the
+    // preceding vector-unit Dest writes are ordered ahead of the moves.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
     transpose_8_faces<true, 256, /*manage_outer_cfg=*/false>();
 
     // Stride-2 (load + TRANSP + sort_4 + store<2, 16>), N = 8.
@@ -1919,8 +1922,11 @@ inline void _topk_xl_local_sort_generic_(const std::uint32_t dst_index, const bo
     // transpose CFG block and pass `manage_outer_cfg=false` to each
     // `transpose_N_faces` call. Saves a handful of CFG writes per
     // transposed phase.
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
     enter_transpose_cfg_block();
+    // The face moves write SrcA/SrcB, which hardware arbitration does not gate: hold the math
+    // class until both banks are math-owned, their in-flight consumers have drained, and the
+    // preceding vector-unit Dest writes are ordered ahead of the moves.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
 
     // ── build bitonic sequences of len=(K/4) ──────────────────────────────
     transpose_N_faces</*N*/ row_scale_factor * 2, /*fused=*/true, /*indices_offset=*/256, /*manage_outer_cfg=*/false>();
@@ -2143,8 +2149,11 @@ inline void _topk_xl_rebuild_(const std::uint32_t dst_index, const bool ascendin
         // ── Fused path ─────────────────────────────────────────────────────
         // One CFG block wraps both transposes since the bitonic work between
         // them doesn't touch the transpose CFG bits.
-        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
         enter_transpose_cfg_block();
+        // The face moves write SrcA/SrcB, which hardware arbitration does not gate: hold the math
+        // class until both banks are math-owned, their in-flight consumers have drained, and the
+        // preceding vector-unit Dest writes are ordered ahead of the moves.
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
         transpose_8_faces<true, 256, /*manage_outer_cfg=*/false>();
 
         // Length-2048 build phase via the 5-slot MOP template.
@@ -2198,8 +2207,11 @@ inline void _topk_xl_rebuild_(const std::uint32_t dst_index, const bool ascendin
         // sitting at offset +128 inside each value region (vs +256 in the
         // older non-distributed-topk unfused path).
         constexpr int indices_offset = 2 * 64; // 128
-        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
         enter_transpose_cfg_block();
+        // The face moves write SrcA/SrcB, which hardware arbitration does not gate: hold the math
+        // class until both banks are math-owned, their in-flight consumers have drained, and the
+        // preceding vector-unit Dest writes are ordered ahead of the moves.
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
         transpose_8_faces<fused, indices_offset, /*manage_outer_cfg=*/false>();
 
         // Stride-8 (load + sort_16_alt<false> + store<8, 16>), N = 8 per
@@ -2447,8 +2459,11 @@ inline void _topk_xl_rebuild_generic_(const std::uint32_t dst_index, const bool 
 
     if constexpr (fused)
     {
-        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
         enter_transpose_cfg_block();
+        // The face moves write SrcA/SrcB, which hardware arbitration does not gate: hold the math
+        // class until both banks are math-owned, their in-flight consumers have drained, and the
+        // preceding vector-unit Dest writes are ordered ahead of the moves.
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
         transpose_N_faces</*N*/ row_scale_factor * 2, /*fused=*/true, /*indices_offset=*/256, /*manage_outer_cfg=*/false>();
 
         // ── stride-2 + sort_16_alt build phase ─────────────────────────
@@ -2495,8 +2510,11 @@ inline void _topk_xl_rebuild_generic_(const std::uint32_t dst_index, const bool 
     else
     {
         constexpr int indices_offset = num_tiles_per_sequence * 64;
-        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
         enter_transpose_cfg_block();
+        // The face moves write SrcA/SrcB, which hardware arbitration does not gate: hold the math
+        // class until both banks are math-owned, their in-flight consumers have drained, and the
+        // preceding vector-unit Dest writes are ordered ahead of the moves.
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
         transpose_N_faces</*N*/ row_scale_factor * 2, fused, indices_offset, /*manage_outer_cfg=*/false>();
 
         // ── stride-8 + sort_16_alt build phase (both columns) ──────────


### PR DESCRIPTION
Closes #55881.

Each of the six face-transpose blocks in `ckernel_sfpu_topk_xl.h` was guarded by

```c
TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
enter_transpose_cfg_block();
transpose_N_faces<..., /*manage_outer_cfg=*/false>();
```

Two problems. The stall mask names the config class, but the `SRCA_VLD | SRCB_VLD` conditions it carries are the source-bank acquisition for `transpose_dest_face_32b`, whose source-register writes — `MOVD2B` into SrcB (8 per face) and `MOVB2A` into SrcA (4 per face), 96 per 8-face block — are math class. And there is no math drain, so an in-flight math consumer of either bank is not drained before those writes land on it. `MOVD2B` has no hardware source gate and the unpacker's SrcB fill is not held off while it runs, so both halves are software's responsibility.

The change is one `STALLWAIT` per call site — the same count as before — moved behind the config block, stalling the math class, with the math drain added:

```c
enter_transpose_cfg_block();
TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
transpose_N_faces<..., /*manage_outer_cfg=*/false>();
```

### Why one gate per call site

Bank ownership is acquired once and persists: nothing in the transpose body clears SrcB data-valid, and within each function every `TTI_SETRWC` spanning the transpose calls is `CLR_NONE` — the `CLR_AB` comes after the last one. So the later transpose calls in the same function need no second acquisition. Their Dest dependency on the preceding vector-unit work is carried by the hardware Dest client arbitration, which holds a matrix-unit access to a bank while another client's writes to it are still pending.

`p_stall::WAIT_SFPU` is retained. On the current reading it is redundant — see the next section for the config side, and the Dest side is covered by the arbitration described above — but removing a shipped guard belongs in its own change with its own justification, not in a correctness fix.

### Why the config writes no longer need to be gated

The gate used to sit in front of `enter_transpose_cfg_block()`; it now sits behind it, so those three config writes are no longer held by anything. That is safe because the ALU control registers this block writes — the implied-SrcA-format bit and the two zero-flag bits, plus the SrcA format and `Fp32_enabled` rewritten per face — are sampled in the cycle their consuming instruction is issued and carried with it down the pipeline. The datapath consumes that carried copy, not a live read. A thread exposes one instruction at a time and the sample happens as the instruction is taken, so a later same-thread write cannot be applied before an earlier math or SFPU instruction has taken its copy. There is no window to close.

The tree already relies on this, in the very body being guarded: `transpose_dest_face_32b` rewrites `ALU_FORMAT_SPEC_REG0_SrcA` and `ALU_ACC_CTRL_Fp32_enabled` **five times per face**, interleaved with the `MOVD2B` / `MOVB2A` / `MOVB2D` / `MOVA2D` moves that consume them, with no `STALLWAIT` anywhere inside it — 40 undrained config rewrites per 8-face block. If a config write in this position needed a drain, that body would be broken 8 to 16 times per block no matter what the entry gate did. The same shape ships in `llk_math_transpose_dest.h` and `llk_math_eltwise_unary_datacopy.h`.

Both writers here are Tensix instructions (`TTI_SETC16`, and `cfg_reg_rmw_tensix` which expands to `TT_RMWCIB0..3`), which is what makes the in-order argument apply. A RISC MMIO config write does not travel through the instruction stream and would need the drain — so this reasoning does not transfer to a plain `cfg_rmw` writer.

### Cost

Lower than before, not higher. The wait no longer holds `enter_transpose_cfg_block()`'s three config writes, so they overlap the unpacker's per-call dummy `SrcB` publication instead of queuing behind it. Same instruction count as shipped.

### Scope

Blackhole only. Wormhole has no counterpart of this file.

### Verification

Blackhole p100a silicon:

| suite | result |
|---|---|
| `test_topk_xl.py` | 136 passed |
| `test_topk_xl_unfused_macro.py` | 18 passed |

All six changed sites execute in that set: `_topk_xl_local_sort_` / `_topk_xl_rebuild_` route K != 2048 to their `_generic_` variants, and the suites cover K ∈ {512, 1024, 2048} × {fused, unfused}, reaching both branches of both rebuild functions and both local-sort functions.

**This is a hardening change, not a live-failure repair.** No shipped-code failure reproduces: the old mask reached the moves because the instruction behind it happened to be config class and per-thread issue is in order. What the change buys is that the guard no longer depends on that, and that the math drain is present. There is accordingly no fail-without/pass-with test; the tests above prove no regression across every variant that reaches the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)