### PR TITLE
[Performance] ttnn: reduce tensor-bounds clamp/clip from 7 to 3 device kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -239,18 +239,13 @@ Tensor clamp(
             output_memory_config,
             output_tensor);
     }
+    // y = max(min(x, max), lo) with lo = min(min, max).
+    // torch.clamp defines the degenerate case min > max as "every element becomes max"; clamping the
+    // lower bound to the upper bound first folds that case into the plain two-op form, so the whole
+    // tensor-bounds path is three device kernels instead of seven (issue #49996).
+    Tensor lo = ttnn::minimum(min.value(), max.value(), std::nullopt, output_memory_config);
     Tensor a_max = ttnn::minimum(input_a, max.value(), std::nullopt, output_memory_config);
-    Tensor temp = ttnn::where(
-        ttnn::eq(min.value(), 0.0f, std::nullopt, output_memory_config),
-        ttnn::relu(a_max, output_memory_config),
-        ttnn::maximum(a_max, min.value(), std::nullopt, output_memory_config),
-        output_memory_config);
-    return ttnn::where(
-        ttnn::gt(min.value(), max.value(), std::nullopt, output_memory_config),
-        max.value(),
-        temp,
-        output_memory_config,
-        output_tensor);
+    return ttnn::maximum(a_max, lo, std::nullopt, output_memory_config, output_tensor);
 }
 
 // Gated Linear Unit activation: matmul(split[0],sigmoid(split[1]))


### PR DESCRIPTION
### PR Category
Performance

### Summary
Relates to #49996

The tensor-`min`/`max` overload of `ttnn::clamp` (which `ttnn::clip` forwards to) dispatched **7 device kernels**: `minimum, eq, relu, maximum, where, gt, where`. Two of those pieces are redundant:

- `where(eq(min, 0), relu(a_max), maximum(a_max, min))` — `relu(x) == maximum(x, min)` whenever `min == 0`, so the `eq`/`relu`/`where` trio is a no-op.
- `where(gt(min, max), max, ...)` implements torch's degenerate rule ("if `min > max`, every element becomes `max`"). That folds into the plain two-op form by clamping the lower bound to the upper bound first.

New form, **3 kernels**:

```
lo = minimum(min, max)
y  = maximum(minimum(x, max), lo)
```

Measured on Blackhole P150b (bf16, tile, DRAM, Tracy device kernel duration, avg of 3 calls):

| Shape | Before (7 kernels) | After (3 kernels) | Speedup |
|---|---|---|---|
| 1×1×32×32 | 12.09 µs | 4.61 µs | 2.6× |
| 1×1×1024×1024 | 110.5 µs | 46.7 µs | 2.4× |

### Notes for reviewers
- Only the tensor-bounds overload changes. The scalar path (`clamp_tss`) and `clip` (which just forwards to `clamp`) are untouched; `clip` picks up the win automatically.
- Result is bit-exact against `torch.clamp`, including elements where `min > max` (verified with `torch.equal` on inputs with ~48% degenerate elements). The bare `maximum(minimum(x, max), min)` two-kernel form was rejected because it returns `min` instead of `max` in that case.
- `output_tensor` is still honoured (passed to the final `maximum`), so the #55334 regression test still passes.
- `tests/ttnn/unit_tests/operations/eltwise/test_composite.py -k "clamp or clip"`: 138 passed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aswinmcw/clamp-tensor-bounds-3-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aswinmcw/clamp-tensor-bounds-3-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aswinmcw/clamp-tensor-bounds-3-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aswinmcw/clamp-tensor-bounds-3-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aswinmcw/clamp-tensor-bounds-3-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aswinmcw/clamp-tensor-bounds-3-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aswinmcw/clamp-tensor-bounds-3-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aswinmcw/clamp-tensor-bounds-3-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aswinmcw/clamp-tensor-bounds-3-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aswinmcw/clamp-tensor-bounds-3-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aswinmcw/clamp-tensor-bounds-3-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aswinmcw/clamp-tensor-bounds-3-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aswinmcw/clamp-tensor-bounds-3-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aswinmcw/clamp-tensor-bounds-3-kernels)
- **Special values** (exhaustive 13³ sweep over `{NaN, ±inf, ±0.0, ±1, ±3, ±bf16_max, ±bf16_tiny}` for input/min/max, old vs new vs `torch.clamp`): no differences for any NaN-free combination, including ±inf bounds and `min > max`. Signed-zero sign (`-0.0` vs `+0.0`) differs from torch in 179 combos identically for old and new (pre-existing SFPU behaviour). NaN is **not propagated** by either old or new (SFPU `minimum`/`maximum` don't propagate it: `minimum(nan, 1) = 1`, `maximum(nan, 1) = inf`); both fail the same 469 NaN combos vs torch, with a different non-NaN value in 143 of them when `max` is NaN. Not a regression, but not fixable by rearranging min/max — it needs NaN-aware kernels.

