### PR TITLE
[doc] Replace legacy vLLM fork references with plugin info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ The Models team is focused on developing the following models, optimizing them f
 
 Blackhole software optimization is under active development.  Please join us in shaping the future of open source AI! <br> [\[Discord\]](https://discord.gg/tenstorrent) [\[Developer Hub\]](https://tenstorrent.com/developers)
 
-For more information regarding vLLM installation and environment creation visit the [Tenstorrent vLLM TT plugin README](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/README.md).
+For more information regarding vLLM installation and environment creation visit the [Tenstorrent vLLM TT plugin README](https://github.com/tenstorrent/vllm-tt-plugin).
+Note that the previously maintained [vLLM TT fork](https://github.com/tenstorrent/vllm)
+is deprecated.
 
 ## Model Updates
 

--- a/models/README.md
+++ b/models/README.md
@@ -37,7 +37,7 @@
 > - The t/s/u reported is the throughput of the first token generated after prefill, i.e. 1 / inter token latency.
 > - Performance numbers were collected using the tt-metal model demos (accessible via the model links). If running with a vLLM inference server, performance may be different.
 > - \* Blackhole software optimization is under active development.  Please join us in shaping the future of open source AI! <br> [\[Discord\]](https://discord.gg/tenstorrent) [\[Developer Hub\]](https://tenstorrent.com/developers)
-> - For more information regarding vLLM installation and environment creation visit the [Tenstorrent vLLM TT plugin README](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/README.md).
+> - For more information regarding vLLM installation and environment creation visit the [Tenstorrent vLLM TT plugin README](https://github.com/tenstorrent/vllm-tt-plugin).
 
 ## Speech-to-Text
 

--- a/models/common/llm_runtime/tttv2_demo_to_vllm_integration_skill.md
+++ b/models/common/llm_runtime/tttv2_demo_to_vllm_integration_skill.md
@@ -10,6 +10,13 @@ Treat demo success as tensor-model evidence only, not proof of the executor,
 lifecycle, façade, policy, KV, DP, registration, or serving contracts. Audit
 first, publish the gap report, then implement the smallest missing layer.
 
+*__Important:__ this document still references the deprecated
+[vLLM TT Fork](https://github.com/tenstorrent/vllm/tree/dev) instead of
+[vLLM TT Plugin](https://github.com/tenstorrent/vllm-tt-plugin). Normally, only the paths to
+modules and scripts in the snippets above require fixes (i.e., from
+`plugins/vllm-tt-plugin/{src,examples}/` to `{src,examples}/`, assuming you're in the plugin
+directory), but further clarifications might be needed.*
+
 ## Eligibility gate
 
 Use this skill only for a model that already has a working TTTv2 demo

--- a/models/common/llm_runtime/tttv2_demo_to_vllm_integration_skill.md
+++ b/models/common/llm_runtime/tttv2_demo_to_vllm_integration_skill.md
@@ -13,7 +13,7 @@ first, publish the gap report, then implement the smallest missing layer.
 *__Important:__ this document still references the deprecated
 [vLLM TT Fork](https://github.com/tenstorrent/vllm/tree/dev) instead of
 [vLLM TT Plugin](https://github.com/tenstorrent/vllm-tt-plugin). Normally, only the paths to
-modules and scripts in the snippets above require fixes (i.e., from
+modules and scripts in the snippets below require fixes (i.e., from
 `plugins/vllm-tt-plugin/{src,examples}/` to `{src,examples}/`, assuming you're in the plugin
 directory), but further clarifications might be needed.*
 

--- a/models/demos/deepseek_v3/README.md
+++ b/models/demos/deepseek_v3/README.md
@@ -300,6 +300,8 @@ output = MLP.forward_prefill(input_tensor, run_config) # or forward_decode(input
 
 ## VLLM Server (TT backend)
 
+See the vLLM installation instructions [here](https://github.com/tenstorrent/vllm/tree/dev). **Important**: these snippets were tested for this fork, while the TT-specific development is now in [vLLM TT Plugin](https://github.com/tenstorrent/vllm-tt-plugin).
+
 To run the DeepSeek-V3 model via vLLM with the TT device backend, configure the environment and launch the server as shown below. Adjust the paths for your workspace.
 
 ```bash

--- a/models/demos/llama3_70b_galaxy/PERF.md
+++ b/models/demos/llama3_70b_galaxy/PERF.md
@@ -43,7 +43,7 @@ Similarly, if you want to run a different input prompt file with different lengt
 
 ### vLLM Runs
 
-For vLLM runs, you'll need to install [Tenstorrent's vLLM fork and TT plugin](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/README.md).
+For vLLM runs, install the standalone [Tenstorrent vLLM TT plugin](https://github.com/tenstorrent/vllm-tt-plugin).
 
 Historical note: the measurements in this section were captured before the
 single-process Galaxy lane switch. The commands below reflect the current
@@ -52,12 +52,16 @@ re-baselined for that path.
 
 vLLM offline run command:
 ```
-MESH_DEVICE=TG TT_LLAMA_TEXT_VER=llama3_70b_galaxy VLLM_RPC_TIMEOUT=100000 python plugins/vllm-tt-plugin/examples/offline_inference_tt.py --model meta-llama/Llama-3.3-70B-Instruct --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 95693824}}' --greedy_sampling --num_repeat_prompts 2 --async_engine
+VLLM_TT_PLUGIN_ROOT=/path/to/vllm-tt-plugin
+cd "$VLLM_TT_PLUGIN_ROOT"
+MESH_DEVICE=TG TT_LLAMA_TEXT_VER=llama3_70b_galaxy VLLM_RPC_TIMEOUT=100000 python examples/offline_inference_tt.py --model meta-llama/Llama-3.3-70B-Instruct --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 95693824}}' --greedy_sampling --num_repeat_prompts 2 --async_engine
 ```
 
 vLLM server run command:
 ```
-MESH_DEVICE=TG TT_LLAMA_TEXT_VER=llama3_70b_galaxy VLLM_RPC_TIMEOUT=900000 python plugins/vllm-tt-plugin/examples/server_example_tt.py --model "meta-llama/Llama-3.3-70B-Instruct" --data_parallel_size 4 --max_num_seqs 8 --async-scheduling --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 220000000}}'
+VLLM_TT_PLUGIN_ROOT=/path/to/vllm-tt-plugin
+cd "$VLLM_TT_PLUGIN_ROOT"
+MESH_DEVICE=TG TT_LLAMA_TEXT_VER=llama3_70b_galaxy VLLM_RPC_TIMEOUT=900000 python examples/server_example_tt.py --model "meta-llama/Llama-3.3-70B-Instruct" --data_parallel_size 4 --max_num_seqs 8 --async-scheduling --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 220000000}}'
 ```
 
 To send requests to vLLM the server, you will need [TT-Inference-Server](https://github.com/tenstorrent/tt-inference-server/tree/dev).

--- a/models/demos/llama3_70b_galaxy/README.md
+++ b/models/demos/llama3_70b_galaxy/README.md
@@ -154,14 +154,16 @@ You can try and change the `max_length` parameter on the provided prompt files t
 ### vLLM Model Serving
 Ensure first you have a proper TT-Metal installation. (Optional check: `python -c "import tt_lib"`).
 
-vLLM can be installed from the TT fork at https://github.com/tenstorrent/vllm/tree/dev.
-
-Please follow the [README from vLLM](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/README.md) for the latest instructions on how to build vLLM and install the TT plugin.
+Install vLLM through the standalone
+[Tenstorrent vLLM TT plugin](https://github.com/tenstorrent/vllm-tt-plugin)
+and follow its README.
 
 #### Running the vLLM server
 Llama-3.3-70B on Galaxy runs on a single Galaxy device mesh using single-process TT lanes. Serve it with the familiar `--data_parallel_size` / `--max_num_seqs` flags; the TT backend transparently maps them to in-process lanes (it logs at startup that single-process lane-DP is running instead of gathered multi-process DP). Run:
 ```
-MESH_DEVICE=TG TT_LLAMA_TEXT_VER=llama3_70b_galaxy VLLM_RPC_TIMEOUT=900000 python plugins/vllm-tt-plugin/examples/server_example_tt.py --model "meta-llama/Llama-3.3-70B-Instruct" --data_parallel_size 4 --max_num_seqs 8 --async-scheduling --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 220000000}}'
+VLLM_TT_PLUGIN_ROOT=/path/to/vllm-tt-plugin
+cd "$VLLM_TT_PLUGIN_ROOT"
+MESH_DEVICE=TG TT_LLAMA_TEXT_VER=llama3_70b_galaxy VLLM_RPC_TIMEOUT=900000 python examples/server_example_tt.py --model "meta-llama/Llama-3.3-70B-Instruct" --data_parallel_size 4 --max_num_seqs 8 --async-scheduling --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 220000000}}'
 ```
 
 `--data_parallel_size 4 --max_num_seqs 8` runs 4 TT lanes with 8 requests each, for 32-request global concurrency. No config changes are needed versus the historical DP=4 setup.

--- a/models/demos/multimodal/gemma3/README.md
+++ b/models/demos/multimodal/gemma3/README.md
@@ -26,7 +26,8 @@ HF_MODEL=google/gemma-3-27b-it pytest models/demos/multimodal/gemma3/demo/text_d
 ```
 Notes:
 Use --dummy_weights true  to enable dummy_weights loading in demo
-Tested with [vllm:03cb300](https://github.com/tenstorrent/vllm/commit/03cb30064575c7dbda6f62f18d7889758531bcfd)
+Tested with [vllm:03cb300](https://github.com/tenstorrent/vllm/commit/03cb30064575c7dbda6f62f18d7889758531bcfd). **Important**: currently, the TT-specific vLLM
+development is in [vLLM TT Plugin](https://github.com/tenstorrent/vllm-tt-plugin), while the fork is deprecated.
 
 ```
 HF_MODEL=google/gemma-3-27b-it MESH_DEVICE=T3K python plugins/vllm-tt-plugin/examples/offline_inference_tt.py --model "google/gemma-3-27b-it" --multi_modal --max_seqs_in_batch 32 --additional-config '{"tt": {"l1_small_size": 768, "fabric_config": "FABRIC_1D"}}'

--- a/tech_reports/LLMs/llms.md
+++ b/tech_reports/LLMs/llms.md
@@ -1392,7 +1392,7 @@ Implementing continuous batching requires that the serving code track data for e
 
 ### 3.5 vLLM Integration
 
-vLLM is an [open-source LLM serving library](https://github.com/vllm-project/vllm). Tenstorrent maintains a [fork of vLLM](https://github.com/tenstorrent/vllm/tree/dev) for serving models in production on Tenstorrent hardware. For more information about vLLM and the instructions on integrating Tenstorrent models into vLLM, please see the [vLLM Integration Tech Report](./vLLM_integration.md).
+vLLM is an [open-source LLM serving library](https://github.com/vllm-project/vllm). Tenstorrent integrates TT hardware through the standalone [vLLM TT plugin](https://github.com/tenstorrent/vllm-tt-plugin). For model integration instructions, see the [vLLM Integration Tech Report](./vLLM_integration.md).
 
 ## 4. Best Practices and Optimizations
 ### 4.1 Tracing

--- a/tech_reports/LLMs/vLLM_integration.md
+++ b/tech_reports/LLMs/vLLM_integration.md
@@ -3,7 +3,9 @@
 ## Overview
 vLLM is an [open-source LLM serving library](https://github.com/vllm-project/vllm). We use vLLM to serve our models in production because of the features it enables. On the serving side, vLLM supports continuous batching (see [LLMs Tech Report - Continuous Batching](./llms.md#34-continuous-batching) for more info) and [paged attention](https://arxiv.org/pdf/2309.06180). In addition, vLLM provides an OpenAI-compatible server which is useful for deployment.
 
-Tenstorrent maintains a [fork of vLLM](https://github.com/tenstorrent/vllm/tree/dev) for serving models on Tenstorrent hardware. The [vLLM TT plugin README](https://github.com/tenstorrent/vllm/tree/dev/plugins/vllm-tt-plugin/README.md) has instructions for setting up the environment and running the inference example.
+Tenstorrent integrates with upstream vLLM through the
+[vLLM TT plugin](https://github.com/tenstorrent/vllm-tt-plugin). Its README has
+instructions for setting up the environment and running inference.
 
 **Quick Links for vLLM's public docs**:
 - vLLM Docs Homepage: https://docs.vllm.ai/en/latest
@@ -16,53 +18,101 @@ In order to add vLLM support to a new Tenstorrent model, the following requireme
 1. **The model must implement paged attention** using the TT-NN `paged_fill_cache`, `paged_update_cache`, and `paged_scaled_dot_product_attention_decode` ops (see [LLMs Tech Report - Attention](./llms.md#24-attention) and [LLMs Tech Report - Prefill and Decode](./llms.md#32-prefill-and-decode) for more info). An example usage of these ops is in the `forward_prefill` and `forward_decode` functions in [models/tt_transformers/tt/attention.py](https://github.com/tenstorrent/tt-metal/blob/main/models/tt_transformers/tt/attention.py) (part of the [TT-Transformers](https://github.com/tenstorrent/tt-metal/tree/main/models/tt_transformers) library).
 
 2. **The model generation class must conform to a specific interface**. An example generation class is `LlamaForCausalLM` in [models/tt_transformers/tt/generator_vllm.py](https://github.com/tenstorrent/tt-metal/blob/main/models/tt_transformers/tt/generator_vllm.py). The class must have the following functions:
-    - `initialize_vllm_model`: class method which returns an instance of the model. In vLLM, this function is used by `TTModelLoader::load_model` in [plugins/vllm-tt-plugin/src/vllm_tt_plugin/loader.py](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/loader.py). The `max_batch_size` argument represents the total batch size when combining all data parallel groups or single-process lanes, and `tt_data_parallel` represents the total number of TT KV-cache replicas/submeshes used by the model.
+    - `initialize_vllm_model`: class method which returns an instance of the model. In vLLM, this function is used by `TTModelLoader::load_model` in [src/vllm_tt_plugin/loader.py](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/loader.py). The `max_batch_size` argument is the engine-local capacity: per-rank for standard multi-process DP and the merged capacity across in-process lanes for lane-DP. `tt_data_parallel` is the number of TT KV-cache replicas/submeshes owned by that model instance.
       ```python
-      initialize_vllm_model(cls, hf_config : transformers.PretrainedConfig, mesh_device : ttnn.MeshDevice, max_batch_size : int, tt_data_parallel : int, optimizations : str)
+      initialize_vllm_model(cls, hf_config : transformers.PretrainedConfig, mesh_device : ttnn.MeshDevice, max_batch_size : int, max_seq_len : int, tt_data_parallel : int, optimizations : str | None)
       ```
-    - `allocate_kv_cache`: returns the paged kv cache which will be passed to the model during inference. The `kv_cache_shape` argument has shape `(max_num_blocks, num_kv_heads, block_size, head_size)`. This function is used by `TTModelRunner::initialize_kv_cache` in [plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py).
+    - `allocate_kv_cache`: returns the paged kv cache which will be passed to the model during inference. The `kv_cache_shape` argument has shape `(max_num_blocks, num_kv_heads, block_size, head_size)`. This function is used by `TTModelRunner::initialize_kv_cache` in [src/vllm_tt_plugin/model_runner.py](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/model_runner.py).
       ```python
       allocate_kv_cache(kv_cache_shape : tuple, dtype : torch.dtype, num_layers : int)
       ```
-    - `prefill_forward` (**text-only models**): returns the prefill outputs on host. The `tokens` argument has shape `(batch_size, max_prompt_len)` and has been zero-padded along the last dim to the length of the longest prompt in the batch. `page_table` has shape `(batch_size, num_blocks)` and has been zero-padded along the last dim to the max number of blocks in the batch. `prompt_lens` has shape `(batch_size)`. The `sampling_params` argument is a dataclass with sampling attributes such as `temperature`, `top_p`, `top_k` (note: the current default in vLLM is to not pass in this argument and instead sample on host, unless sampling on device is enabled explicitly). For fully-DP or DP-attention models, the `empty_slots` argument is used to indicate request positions in the global DP batch (only to be used for determining the DP group of a request, not for the actual request index in the batch which can change). This function is used by `TTModelRunner::execute_with_model_input` in [plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py) and the preparation of the inputs takes place in `TTModelRunner::_prepare_model_inputs`.
+    - `prefill_forward` (**text-only models**): returns the prefill outputs on host. The `tokens` argument has shape `(batch_size, max_prompt_len)` and has been zero-padded along the last dim to the length of the longest prompt in the batch. `page_table` has shape `(batch_size, num_blocks)` and has been zero-padded along the last dim to the max number of blocks in the batch. `prompt_lens` has shape `(batch_size)`. The `sampling_params` argument is a dataclass with sampling attributes such as `temperature`, `top_p`, `top_k` (note: the current default in vLLM is to not pass in this argument and instead sample on host, unless sampling on device is enabled explicitly). `empty_slots` identifies the exact engine-local physical state slots being initialized: rank-local under standard multi-process DP and merged across in-process lane-DP. This function is used by `TTModelRunner::submit_prefill` in [src/vllm_tt_plugin/model_runner.py](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/model_runner.py).
       ```python
-      prefill_forward(tokens : torch.Tensor, page_table : torch.Tensor, kv_cache : list, prompt_lens : torch.Tensor, sampling_params : TTSamplingParams, empty_slots : list)
+      prefill_forward(tokens : torch.Tensor, page_table : torch.Tensor | None = None, kv_cache : list | None = None, prompt_lens : torch.Tensor | None = None, empty_slots : list[int] | None = None, enable_trace : bool = True, sampling_params : TTSamplingParams | None = None, start_pos : torch.Tensor | list[int] | None = None, **kwargs)
       ```
-    - `decode_forward` (**text-only models**): returns the decode outputs on host if `read_from_device=True` (default True) otherwise on device. The `tokens` argument has shape `(max_batch_size, 1)` and has been zero-padded along the batch dim to the max batch size (along with `start_pos` with shape `(max_batch_size)` and `page_table` with shape `(max_batch_size, max_num_blocks)`). For fully-DP or DP-attention models, each DP group's batch is padded and the batches are concatenated. The decode inputs are intentionally padded to `max_batch_size` and `max_num_blocks` since the default behaviour in vLLM is to use `enable_trace=True` and TT-NN tracing requires constant input shapes. Similar to `prefill_forward`, the `sampling_params` argument is a dataclass with sampling attributes such as `temperature`, `top_p`, `top_k` (note: the current default in vLLM is to not pass in this argument and instead sample on host, unless sampling on device is enabled explicitly). This function is used by `TTModelRunner::execute_with_model_input` in [plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py).
+    - `decode_forward` (**text-only models**): returns the decode outputs on host if `read_from_device=True` (default True) otherwise on device. The `tokens` argument has shape `(max_batch_size, 1)` and has been zero-padded along the batch dim to the max batch size (along with `start_pos` with shape `(max_batch_size)` and `page_table` with shape `(max_batch_size, max_num_blocks)`). For fully-DP or DP-attention models, each DP group's batch is padded and the batches are concatenated. The decode inputs are intentionally padded to `max_batch_size` and `max_num_blocks` since the default behaviour in vLLM is to use `enable_trace=True` and TT-NN tracing requires constant input shapes. Similar to `prefill_forward`, the optional `sampling_params` argument is a dataclass with sampling attributes such as `temperature`, `top_p`, `top_k`. For eligible structured decode, the plugin sets `defer_device_sampling=True` and deliberately omits `sampling_params`; `decode_forward` then returns an opaque one-shot payload containing device logits and authoritative decode state instead of sampling immediately.
       ```python
-      decode_forward(tokens : torch.Tensor, start_pos : torch.Tensor, page_table : torch.Tensor, kv_cache : list, enable_trace : bool, read_from_device : bool, sampling_params : TTSamplingParams)
+      decode_forward(tokens : torch.Tensor, start_pos : torch.Tensor, page_table : torch.Tensor, kv_cache : list, enable_trace : bool = True, read_from_device : bool = True, sampling_params : TTSamplingParams | None = None, reset_batch : bool = False, prompt_tokens : torch.Tensor | None = None, output_tokens : torch.Tensor | None = None, slot_remap = None, defer_device_sampling : bool = False, grammar_bitmask : torch.Tensor | None = None, skip_trace_precompile : bool = False, **kwargs)
       ```
-    - `warmup_model_prefill`: wrapper function that calls the model specific prefill warmup function that compiles the model and captures the traces (for prefill). The `kv_cache`, `enable_trace` and `sampling_params` are passed from vLLM. The `enable_trace` [True/False] argument determines whether tracing in prefill will be used or not. The `sampling_params` [List] argument is a list of all types of samplings that a model can perform. The `sampling_params` list argument contains `TTSamplingParams` objects, and always contains at the end of the list a `None` value which resembles host sampling.
+      The plugin later completes that payload after vLLM produces its packed
+      `int32` grammar mask:
       ```python
-      warmup_model_prefill(kv_cache : list, enable_trace : bool, sampling_params : list)
+      sample_decode_on_device(deferred_decode, *, sampling_params : TTSamplingParams, grammar_bitmask : torch.Tensor)
+      ```
+      The deferred payload owns position, reset, token-history, slot-remap,
+      trace, and reload state. It is consumed exactly once. The grammar mask
+      has shape `(batch_size, ceil(vocab_size / 32))`, with one bit per token
+      and `1` meaning allowed. Rows follow the immutable submitted TT row
+      order, including all-allowed rows for plain requests and padding gaps.
+      Multi-model execution concatenates complete model-local slot blocks.
+      `slot_remap[i] = j` means destination slot `i` inherits sampler state
+      from source slot `j`; each accepted decode applies it exactly once before
+      advancing per-slot sampling state.
+    - `warmup_model_prefill`: compiles or captures the model's prefill variants. The plugin invokes it once without tracing and again with tracing when configured.
+      ```python
+      warmup_model_prefill(kv_cache : list, enable_trace : bool, can_sample_on_device : bool)
+      ```
+    - `warmup_model_decode`: compiles or captures decode and sampling variants. `can_sample_device_grammar=True` adds grammar-on variants, excluding logprob configurations that the plugin keeps on host. Traced grammar requires the plugin's normal two-phase order: compile with `enable_trace=False`, then capture with `enable_trace=True`.
+      ```python
+      warmup_model_decode(kv_cache : list, enable_trace : bool, max_batch_size : int, num_blocks : int, can_sample_on_device : bool, can_sample_device_grammar : bool = False, read_from_device : bool = True, greedy_only : bool = False, skip_trace_precompile : bool = False, sampling_trace_variants_prepared : bool = False)
+      ```
+      `grammar_bitmask` on `decode_forward` is used only by model warmup to
+      capture the grammar-on sampling trace. Runtime grammar arrives later via
+      `sample_decode_on_device`.
+      With `trace_mode=all`, the plugin also calls these hooks around prefill
+      trace capture so both host- and device-sampled decode buffers exist before
+      any trace is live:
+      ```python
+      prepare_device_grammar_decode_trace_warmup(kv_cache : list, max_batch_size : int, num_blocks : int) -> bool
+      capture_prepared_device_grammar_decode_trace() -> None
+      ```
+      Returning `False` from preparation keeps structured outputs on host.
+      Returning `True` requires the capture hook to exist.
+    - `enable_device_grammar`: allocates the persistent grammar-mask state after
+      the plugin has selected device grammar for this runtime and before model
+      warmup captures traces. It returns whether activation succeeded and sets
+      `device_grammar_enabled` accordingly.
+      ```python
+      enable_device_grammar() -> bool
       ```
     - `model_capabilities`: Class dictionary that lets VLLM know which optional
       TT backend features the model supports. We use it in
-      [platform.py](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py)
+      [platform.py](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/platform.py)
       to validate requested features and enable or disable them in VLLM. Missing
-      keys default to `False`. The currently recognized keys are
-      `supports_prefix_caching`, `supports_async_decode`, and
-      `supports_sample_on_device`. `supports_prefix_caching` controls automatic
+      keys default to `False`. The recognized sampling keys include
+      `supports_prefix_caching`, `supports_async_decode`,
+      `supports_sample_on_device`, and `supports_device_grammar`.
+      `supports_prefix_caching` controls automatic
       prefix caching. `supports_async_decode` allows async scheduling for models
       that can submit decode with `read_from_device=False` and later read the
       output asynchronously. `supports_sample_on_device` allows the
-      `sample_on_device_mode` TT config option. Example:
-      `model_capabilities={"supports_prefix_caching": True, "supports_async_decode": True, "supports_sample_on_device": True}`
+      `sample_on_device_mode` TT config option. `supports_device_grammar`
+      additionally certifies late packed-mask application before decode token
+      selection. It requires `supports_sample_on_device`; the initial contract
+      excludes structured prefill, row-sharded sampling, async structured
+      overlap (launch with `--no-async-scheduling`), logprobs, and block-output
+      models. The loaded generator exposes `device_grammar_enabled` after
+      `enable_device_grammar()` runs; a false value makes the plugin retain host
+      sampling.
+      Example:
+      `model_capabilities={"supports_prefix_caching": True, "supports_async_decode": True, "supports_sample_on_device": True, "supports_device_grammar": True}`
 3. **(Multi-modal models only)** Currently, we only support image+text input modalities. An example generation class is `Gemma3ForConditionalGeneration` in [models/tt_transformers/tt/generator_vllm.py](https://github.com/tenstorrent/tt-metal/blob/main/models/tt_transformers/tt/generator_vllm.py). For more info on multi-modal models see also [vLLM Docs - Multi-Modal Support](https://docs.vllm.ai/en/latest/contributing/model/multimodal.html)). These models have the same interface requirements as the text-only models, as well as the following:
    - `prefill_forward` (**image+text models**): same as text-only models with an additional kwarg (`pixel_values`) for the image inputs.
 
 ## Testing the Model in vLLM
-Once the model meets all of the requirements specified in [Implementation Requirements for Model Integration](#implementation-requirements-for-model-integration), it can be tested in vLLM by following the instructions in the [vLLM TT plugin README](https://github.com/tenstorrent/vllm/tree/dev/plugins/vllm-tt-plugin/README.md) and doing the following:
-1. The model needs to be registered using `ModelRegistry.register_model` in the TT plugin's registration path, primarily [plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_registry.py](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_registry.py) and [plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py).
-2. Testing offline inference, continuous batching, and performance (see [Running the Offline Inference Example](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/README.md#running-the-offline-inference-example)).
-3. Testing various sequence lengths of increasing size using the `--test_increasing_seq_lens` option of [plugins/vllm-tt-plugin/examples/offline_inference_tt.py](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/examples/offline_inference_tt.py).
-4. Testing model serving of asynchronous requests with the server example (see [Running the Server Example](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/README.md#running-the-server-example)). For Galaxy text models, prefer the single-process lane path documented in [Single-Process Galaxy Serving](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/README.md#single-process-galaxy-serving).
+Once the model meets all of the requirements specified in [Implementation Requirements for Model Integration](#implementation-requirements-for-model-integration), it can be tested in vLLM by following the instructions in the [vLLM TT plugin README](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/README.md) and doing the following:
+1. The model needs to be registered using `ModelRegistry.register_model` in the TT plugin's registration path, primarily [src/vllm_tt_plugin/model_registry.py](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/model_registry.py) and [src/vllm_tt_plugin/platform.py](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/platform.py).
+2. Test offline inference, continuous batching, and performance using the plugin README.
+3. Test increasing sequence lengths with [examples/offline_inference_tt.py](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/examples/offline_inference_tt.py).
+4. Test asynchronous requests with the server instructions in the plugin README. For Galaxy text models, prefer its documented single-process lane path.
 
-## vLLM Modifications
-Occasionally, additional changes may be needed on the vLLM side to support a new model (e.g. supporting a new type of model, inputs of a different modality, or customizing the KV cache initialization). If this is the case, please make a pull request to the [dev branch](https://github.com/tenstorrent/vllm/tree/dev) (which acts as our main branch, and is not permitted to be committed to directly). The main files for our TT vLLM backend are the following:
-- [`platform.py`](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py): handles platform definition, config validation, and runtime-class selection.
-- [`model_registry.py`](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_registry.py): handles TT model registration.
-- [`loader.py`](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/loader.py): handles model initialization.
-- [`worker.py`](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py): handles device initialization and KV cache management.
-- [`model_runner.py`](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py): handles input preparation and model execution.
-- [`engine.py`](https://github.com/tenstorrent/vllm/blob/dev/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py): handles the TT engine core, batch-queue behavior, and gathered-DP orchestration.
+## vLLM TT Plugin Modifications
+TT-specific behavior belongs in
+[tenstorrent/vllm-tt-plugin](https://github.com/tenstorrent/vllm-tt-plugin),
+not in upstream vLLM or the deprecated `tenstorrent/vllm` fork. The main plugin
+files are:
+- [`platform.py`](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/platform.py): handles platform definition, config validation, and runtime-class selection.
+- [`model_registry.py`](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/model_registry.py): handles TT model registration.
+- [`loader.py`](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/loader.py): handles model initialization.
+- [`worker.py`](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/worker.py): handles device initialization and KV cache management.
+- [`model_runner.py`](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/model_runner.py): handles input preparation and model execution.

--- a/tech_reports/LLMs/vLLM_integration.md
+++ b/tech_reports/LLMs/vLLM_integration.md
@@ -30,72 +30,31 @@ In order to add vLLM support to a new Tenstorrent model, the following requireme
       ```python
       prefill_forward(tokens : torch.Tensor, page_table : torch.Tensor | None = None, kv_cache : list | None = None, prompt_lens : torch.Tensor | None = None, empty_slots : list[int] | None = None, enable_trace : bool = True, sampling_params : TTSamplingParams | None = None, start_pos : torch.Tensor | list[int] | None = None, **kwargs)
       ```
-    - `decode_forward` (**text-only models**): returns the decode outputs on host if `read_from_device=True` (default True) otherwise on device. The `tokens` argument has shape `(max_batch_size, 1)` and has been zero-padded along the batch dim to the max batch size (along with `start_pos` with shape `(max_batch_size)` and `page_table` with shape `(max_batch_size, max_num_blocks)`). For fully-DP or DP-attention models, each DP group's batch is padded and the batches are concatenated. The decode inputs are intentionally padded to `max_batch_size` and `max_num_blocks` since the default behaviour in vLLM is to use `enable_trace=True` and TT-NN tracing requires constant input shapes. Similar to `prefill_forward`, the optional `sampling_params` argument is a dataclass with sampling attributes such as `temperature`, `top_p`, `top_k`. For eligible structured decode, the plugin sets `defer_device_sampling=True` and deliberately omits `sampling_params`; `decode_forward` then returns an opaque one-shot payload containing device logits and authoritative decode state instead of sampling immediately.
+    - `decode_forward` (**text-only models**): returns the decode outputs on host if `read_from_device=True` (default True) otherwise on device. The `tokens` argument has shape `(max_batch_size, 1)` and has been zero-padded along the batch dim to the max batch size (along with `start_pos` with shape `(max_batch_size)` and `page_table` with shape `(max_batch_size, max_num_blocks)`). For fully-DP or DP-attention models, each DP group's batch is padded and the batches are concatenated. The decode inputs are intentionally padded to `max_batch_size` and `max_num_blocks` since the default behaviour in vLLM is to use `enable_trace=True` and TT-NN tracing requires constant input shapes. Similar to `prefill_forward`, the optional `sampling_params` argument is a dataclass with sampling attributes such as `temperature`, `top_p`, `top_k`. The plugin keeps structured-output requests on host sampling, even when device sampling is enabled, and applies the grammar mask on host before token selection.
       ```python
-      decode_forward(tokens : torch.Tensor, start_pos : torch.Tensor, page_table : torch.Tensor, kv_cache : list, enable_trace : bool = True, read_from_device : bool = True, sampling_params : TTSamplingParams | None = None, reset_batch : bool = False, prompt_tokens : torch.Tensor | None = None, output_tokens : torch.Tensor | None = None, slot_remap = None, defer_device_sampling : bool = False, grammar_bitmask : torch.Tensor | None = None, skip_trace_precompile : bool = False, **kwargs)
+      decode_forward(tokens : torch.Tensor, start_pos : torch.Tensor, page_table : torch.Tensor, kv_cache : list, enable_trace : bool = True, read_from_device : bool = True, sampling_params : TTSamplingParams | None = None, reset_batch : bool = False, prompt_tokens : torch.Tensor | None = None, output_tokens : torch.Tensor | None = None, slot_remap = None, **kwargs)
       ```
-      The plugin later completes that payload after vLLM produces its packed
-      `int32` grammar mask:
-      ```python
-      sample_decode_on_device(deferred_decode, *, sampling_params : TTSamplingParams, grammar_bitmask : torch.Tensor)
-      ```
-      The deferred payload owns position, reset, token-history, slot-remap,
-      trace, and reload state. It is consumed exactly once. The grammar mask
-      has shape `(batch_size, ceil(vocab_size / 32))`, with one bit per token
-      and `1` meaning allowed. Rows follow the immutable submitted TT row
-      order, including all-allowed rows for plain requests and padding gaps.
-      Multi-model execution concatenates complete model-local slot blocks.
-      `slot_remap[i] = j` means destination slot `i` inherits sampler state
-      from source slot `j`; each accepted decode applies it exactly once before
-      advancing per-slot sampling state.
     - `warmup_model_prefill`: compiles or captures the model's prefill variants. The plugin invokes it once without tracing and again with tracing when configured.
       ```python
       warmup_model_prefill(kv_cache : list, enable_trace : bool, can_sample_on_device : bool)
       ```
-    - `warmup_model_decode`: compiles or captures decode and sampling variants. `can_sample_device_grammar=True` adds grammar-on variants, excluding logprob configurations that the plugin keeps on host. Traced grammar requires the plugin's normal two-phase order: compile with `enable_trace=False`, then capture with `enable_trace=True`.
+    - `warmup_model_decode`: compiles or captures the model's decode and sampling variants. The plugin first compiles prefill and decode with `enable_trace=False`, then captures each with `enable_trace=True` when its trace mode is enabled.
       ```python
-      warmup_model_decode(kv_cache : list, enable_trace : bool, max_batch_size : int, num_blocks : int, can_sample_on_device : bool, can_sample_device_grammar : bool = False, read_from_device : bool = True, greedy_only : bool = False, skip_trace_precompile : bool = False, sampling_trace_variants_prepared : bool = False)
-      ```
-      `grammar_bitmask` on `decode_forward` is used only by model warmup to
-      capture the grammar-on sampling trace. Runtime grammar arrives later via
-      `sample_decode_on_device`.
-      With `trace_mode=all`, the plugin also calls these hooks around prefill
-      trace capture so both host- and device-sampled decode buffers exist before
-      any trace is live:
-      ```python
-      prepare_device_grammar_decode_trace_warmup(kv_cache : list, max_batch_size : int, num_blocks : int) -> bool
-      capture_prepared_device_grammar_decode_trace() -> None
-      ```
-      Returning `False` from preparation keeps structured outputs on host.
-      Returning `True` requires the capture hook to exist.
-    - `enable_device_grammar`: allocates the persistent grammar-mask state after
-      the plugin has selected device grammar for this runtime and before model
-      warmup captures traces. It returns whether activation succeeded and sets
-      `device_grammar_enabled` accordingly.
-      ```python
-      enable_device_grammar() -> bool
+      warmup_model_decode(kv_cache : list, enable_trace : bool, max_batch_size : int, num_blocks : int, can_sample_on_device : bool)
       ```
     - `model_capabilities`: Class dictionary that lets VLLM know which optional
       TT backend features the model supports. We use it in
       [platform.py](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/platform.py)
       to validate requested features and enable or disable them in VLLM. Missing
-      keys default to `False`. The recognized sampling keys include
+      keys default to `False`. Recognized keys include
       `supports_prefix_caching`, `supports_async_decode`,
-      `supports_sample_on_device`, and `supports_device_grammar`.
+      and `supports_sample_on_device`.
       `supports_prefix_caching` controls automatic
       prefix caching. `supports_async_decode` allows async scheduling for models
       that can submit decode with `read_from_device=False` and later read the
       output asynchronously. `supports_sample_on_device` allows the
-      `sample_on_device_mode` TT config option. `supports_device_grammar`
-      additionally certifies late packed-mask application before decode token
-      selection. It requires `supports_sample_on_device`; the initial contract
-      excludes structured prefill, row-sharded sampling, async structured
-      overlap (launch with `--no-async-scheduling`), logprobs, and block-output
-      models. The loaded generator exposes `device_grammar_enabled` after
-      `enable_device_grammar()` runs; a false value makes the plugin retain host
-      sampling.
-      Example:
-      `model_capabilities={"supports_prefix_caching": True, "supports_async_decode": True, "supports_sample_on_device": True, "supports_device_grammar": True}`
+      `sample_on_device_mode` TT config option. Example:
+      `model_capabilities={"supports_prefix_caching": True, "supports_async_decode": True, "supports_sample_on_device": True}`
 3. **(Multi-modal models only)** Currently, we only support image+text input modalities. An example generation class is `Gemma3ForConditionalGeneration` in [models/tt_transformers/tt/generator_vllm.py](https://github.com/tenstorrent/tt-metal/blob/main/models/tt_transformers/tt/generator_vllm.py). For more info on multi-modal models see also [vLLM Docs - Multi-Modal Support](https://docs.vllm.ai/en/latest/contributing/model/multimodal.html)). These models have the same interface requirements as the text-only models, as well as the following:
    - `prefill_forward` (**image+text models**): same as text-only models with an additional kwarg (`pixel_values`) for the image inputs.
 


### PR DESCRIPTION
### PR Category

Documentation

### Summary

Main README, model docs, and tech reports still refer to the deprecated vLLM TT fork. Mentioning [vLLM TT Plugin](https://github.com/tenstorrent/vllm-tt-plugin) everywhere instead. Deprecation note is in ./README.md.

P.S. If `tt-buddy` / `skills` and other TT tools still reference the fork, agents usually get confused and either work within both environments if the plugin is available locally or only choose the fork by default.

### Notes for Reviewers

Only documentation is changed:
* If it's a mere reference to vLLM (e.g., "we support vLLM this way:..."), then this PR corrects the path to the supported vLLM TT repository (plugin).
* But if a document describes skills or experiments, then remind that the fork is
deprecated and only provide the links to the plugin without changing the accompanying snippets, because these documents might require re-evaluation, which we don't do in this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sanjaradylov/doc.plugin-not-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sanjaradylov/doc.plugin-not-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sanjaradylov/doc.plugin-not-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sanjaradylov/doc.plugin-not-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sanjaradylov/doc.plugin-not-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sanjaradylov/doc.plugin-not-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sanjaradylov/doc.plugin-not-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sanjaradylov/doc.plugin-not-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sanjaradylov/doc.plugin-not-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sanjaradylov/doc.plugin-not-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sanjaradylov/doc.plugin-not-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sanjaradylov/doc.plugin-not-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sanjaradylov/doc.plugin-not-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sanjaradylov/doc.plugin-not-fork)