### PR TITLE
fix: promote integer tensor to float for float scalar in DIV/MUL

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -606,10 +606,17 @@ inline auto invoke_binary_ng_impl(
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
     const auto a_dtype = lhs.dtype();
-    const DataType b_dtype = [&] {
+    const auto b_dtype = [&] {
         if constexpr (requires { rhs.dtype(); }) {
             return rhs.dtype();
         } else {
+            // When rhs is a scalar, determine its effective dtype for
+            // integer division detection and type promotion.
+            if constexpr (std::is_same_v<std::decay_t<decltype(rhs)>, unary::ScalarVariant>) {
+                if (std::holds_alternative<float>(rhs)) {
+                    return DataType::FLOAT32;
+                }
+            }
             return a_dtype;
         }
     }();
@@ -658,6 +665,21 @@ inline auto invoke_binary_ng_impl(
                     a_dtype);
                 rhs_promoted = ttnn::typecast(rhs, target);
             }
+        }
+    }
+    // Scalar path: when rhs is a float scalar and lhs is 32-bit int, promote
+    // lhs to float to match PyTorch type promotion and avoid truncation.
+    if constexpr (!requires { rhs.dtype(); }) {
+        const bool is_float_arith = (binary_op_type == operations::binary::BinaryOpType::DIV) ||
+                                    (binary_op_type == operations::binary::BinaryOpType::MUL);
+        if (is_float_arith && is_32bit_int(a_dtype) && std::holds_alternative<float>(rhs)) {
+            const auto target = float_promote_target(b_dtype);
+            log_debug(
+                tt::LogOp,
+                "Binary: typecasting lhs from integer dtype {} to {} to match float scalar rhs",
+                a_dtype,
+                target);
+            lhs_promoted = ttnn::typecast(lhs, target);
         }
     }
     const Tensor& lhs_eff = lhs_promoted.has_value() ? *lhs_promoted : lhs;


### PR DESCRIPTION
Fixes #55684

## Problem

Every binary eltwise op that takes a scalar silently truncates the scalar when the tensor operand is `int32` or `uint32`. The scalar is encoded using the tensor's dtype, so `2.5` reaches the kernel as `2` and `0.5` as `0`.

Most damagingly, `ttnn.div(int32_tensor, 0.5)` returns `inf` because 0.5 truncates to 0, causing division by zero.

The equivalent **tensor** form is correct — this is purely a scalar-path bug.

## Root Cause

`pack_scalar_runtime_arg` encodes the scalar with the tensor's dtype (`binary_ng_utils.cpp:682`). The dtype promotion logic that fixes this for tensor-tensor pairs (`binary.cpp:638`, guarded by `requires { rhs.dtype(); }`) is **skipped** for scalar operands because scalars don't have `.dtype()`.

## Fix

Two changes in `ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp`:

1. **Update `b_dtype`** for scalars: when `rhs` is a `float`, set `b_dtype = DataType::FLOAT32` instead of `a_dtype`. This makes `is_integer_division` correctly false for `int_tensor / float_scalar`.

2. **Add scalar promotion block**: when `rhs` is a float scalar, `a` is INT32/UINT32, and the op is DIV/MUL, typecast the integer tensor to float (same pattern as the existing tensor-tensor promotion). This ensures the scalar is packed as a float and the kernel performs float arithmetic.

This matches PyTorch type promotion: `div(int32_tensor, 0.5)` → float32 result.

## Files changed

- `ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp` (+23/-1)
