### PR TITLE
fix: clamp softplus exp tail to prevent SFPU overflow

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -258,6 +258,39 @@ def test_softplus_threshold_boundary(device, beta, threshold):
     run_softplus_boundary_test(device, beta, threshold)
 
 
+def test_softplus_fp32_overflow(device):
+    """Regression test for #55798: softplus in float32 returned inf/NaN for large-negative inputs.
+
+    softplus_exp_negative on Blackhole/Wormhole passes an unclamped z to the Hacker's-Delight
+    round-to-nearest helper (valid only for |z| <= 2^22), so the exponent overflowed and the
+    new_exp > 0 flush-to-zero guard was bypassed. The fix clamps z to -126.5 before rounding.
+
+    softplus(-a) = log(1 + exp(-a)) -> 0 for large a; the result must be finite and close to 0.
+    """
+    extreme_values = [
+        -1e7,
+        -1e8,
+        -1e10,
+        -float(2**119),
+        -float(2**125),
+        -float(2**126),
+    ]
+    torch_input = torch.tensor([extreme_values], dtype=torch.float32)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+    output_tensor = ttnn.softplus(input_tensor, beta=1.0, threshold=20.0)
+    output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor))
+
+    # No inf/NaN — the core regression
+    assert torch.isfinite(output_tensor).all(), f"softplus produced non-finite values: {output_tensor}"
+
+    # Compare with reference (torch handles this correctly)
+    golden = torch.nn.functional.softplus(torch_input, beta=1.0, threshold=20.0)
+    assert_allclose(output_tensor, golden, atol=1e-3, rtol=1e-3)
+
+
 def test_tanhshrink_ulp(device):
     """ULP regression guard for the dedicated tanhshrink SFPU op (issue #45520).
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -64,6 +64,14 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
 
     // Range reduction: x = k*ln(2) + r
     sfpi::vFloat z = x * INV_LN2;
+    // Clamp z: the Hacker's-Delight round-to-nearest helper (magic
+    // constant 0x4B400000, valid only for |z| <= 2^22) mis-rounds large
+    // negative z, producing a positive exponent that bypasses the
+    // new_exp > 0 flush-to-zero guard and returns inf/NaN instead of 0.
+    // exp(-a) underflows to 0 for a > ~126.5, so clamping here is exact.
+    // Mirrors the guard already present in ckernel_sfpu_xielu.h (#54046).
+    constexpr float UNDERFLOW_THRESHOLD = -126.5f;
+    z = sfpi::max(z, UNDERFLOW_THRESHOLD);
     sfpi::vInt k_int;
     sfpi::vFloat k = _sfpu_round_to_nearest_int32_(z, k_int);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -64,6 +64,14 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
 
     // Range reduction: x = k*ln(2) + r
     sfpi::vFloat z = x * INV_LN2;
+    // Clamp z: the Hacker's-Delight round-to-nearest helper (magic
+    // constant 0x4B400000, valid only for |z| <= 2^22) mis-rounds large
+    // negative z, producing a positive exponent that bypasses the
+    // new_exp > 0 flush-to-zero guard and returns inf/NaN instead of 0.
+    // exp(-a) underflows to 0 for a > ~126.5, so clamping here is exact.
+    // Mirrors the guard already present in ckernel_sfpu_xielu.h (#54046).
+    constexpr float UNDERFLOW_THRESHOLD = -126.5f;
+    z = sfpi::max(z, UNDERFLOW_THRESHOLD);
     sfpi::vInt k_int;
     sfpi::vFloat k = _sfpu_round_to_nearest_int32_(z, k_int);
 


### PR DESCRIPTION
Fixes #55798

## Problem
`ttnn.softplus(x, beta, threshold)` in float32 returns `+inf`, `NaN` and large values for large-magnitude negative inputs (e.g. `softplus(-1e7)` is `+inf`).

## Root Cause
`softplus_exp_negative()` passes `z = x * INV_LN2` unclamped to the Hacker's-Delight round-to-nearest helper (`_sfpu_round_to_nearest_int32_`). That helper's magic constant `0x4B400000` is only valid for `|z| <= 2^22`, so for large negative z it mis-rounds and produces a positive exponent, bypassing the `new_exp > 0` flush-to-zero guard.

## Fix
Add `z = sfpi::max(z, -126.5f)` before the rounding call. This is exact because exp(x) underflows to 0 for x < -126.5. The same guard is already used by `ckernel_sfpu_xielu.h` (#54046).

## Files Changed
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h` (blackhole)
- `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h` (wormhole, byte-identical)