### PR TITLE
fix: repeat_bw uses logical shape and handles all four dimensions

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1596,7 +1596,7 @@ std::vector<Tensor> repeat_bw(
     auto output_memory_config = output_mem_config.value_or(
         input.memory_config());  // TODO: Remove after ternary forward ops migration is completed
 
-    auto shape_wh = input.padded_shape();
+    auto shape_wh = input.shape();
     TT_FATAL(shape_wh[0] == 1, "Input shape[0] must be 1 but got {}", shape_wh[0]);
     auto* ttnn_device = input.device();
     // input.padded_shape()[0]
@@ -1625,6 +1625,38 @@ std::vector<Tensor> repeat_bw(
         ttsl::SmallVector<int64_t> dim = {1};
         TT_FATAL(shape[0] == 1 && shape[2] == 1 && shape[3] == 1, "repeat[0], [2], [3] should be 1");
         std::array<std::uint32_t, 4> intended_shape_array = {shape_wh[0], 1, shape_wh[2], shape_wh[3]};
+        const auto required = ttnn::Shape(intended_shape_array);
+        Tensor result = ttnn::moreh_sum(
+            grad,
+            dim,
+            true,
+            ttnn::zeros(required, input.dtype(), input.layout(), *ttnn_device, output_memory_config),
+            output_memory_config,
+            std::nullopt);
+        grad_tensor.emplace_back(result);
+        return grad_tensor;
+    }
+    if (shape[2] > 1) {
+        ttsl::SmallVector<int64_t> dim = {2};
+        TT_FATAL(
+            shape[0] == 1 && shape[1] == 1 && shape[3] == 1, "repeat[0], [1], [3] should be 1 for dim-2 repeat_bw");
+        std::array<std::uint32_t, 4> intended_shape_array = {shape_wh[0], shape_wh[1], 1, shape_wh[3]};
+        const auto required = ttnn::Shape(intended_shape_array);
+        Tensor result = ttnn::moreh_sum(
+            grad,
+            dim,
+            true,
+            ttnn::zeros(required, input.dtype(), input.layout(), *ttnn_device, output_memory_config),
+            output_memory_config,
+            std::nullopt);
+        grad_tensor.emplace_back(result);
+        return grad_tensor;
+    }
+    if (shape[3] > 1) {
+        ttsl::SmallVector<int64_t> dim = {3};
+        TT_FATAL(
+            shape[0] == 1 && shape[1] == 1 && shape[2] == 1, "repeat[0], [1], [2] should be 1 for dim-3 repeat_bw");
+        std::array<std::uint32_t, 4> intended_shape_array = {shape_wh[0], shape_wh[1], shape_wh[2], 1};
         const auto required = ttnn::Shape(intended_shape_array);
         Tensor result = ttnn::moreh_sum(
             grad,


### PR DESCRIPTION
Fixes #55799

## Bugs Fixed

### 1. TT_FATAL on non-tile-multiple shapes
`repeat_bw` used `input.padded_shape()` to preallocate the `moreh_sum` output, but `moreh` validates the preallocated shape against the **logical** dims of the reduction. For inputs like `(1, 1, 17, 37)` (padded to `(1, 1, 32, 32)`), the mismatch triggered `TT_FATAL` inside `moreh_sum`.

**Fix**: use `input.shape()` (logical shape) instead of `input.padded_shape()`.

### 2. Empty gradient for dim-2/dim-3 repeat
The function only handled `shape[0] > 1` and `shape[1] > 1`. A repeat along dim 2 or 3 fell through to `return grad_tensor;` with an empty vector — no gradient was returned.

**Fix**: add symmetric cases for `shape[2] > 1` and `shape[3] > 1`, following the exact pattern of the existing dim-0/dim-1 handling.

### 3. Wrong-shaped gradient when dim extent > 1
Using padded shape for the output constructor produced `(1, 1, 32, 32)` instead of `(1, 3, 32, 32)` for a `(1, 3, 32, 32)` input — the whole axis was summed instead of the correct subtile block.

**Fix**: same as #1 — logical shape gives correct output dims.

## Files Changed
- `ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp`
