### PR TITLE
Fix llk-smoke-tests compile failure: guard the legacy DPRINT_BUFFER_SIZE layout assert

### DIFF
--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -447,7 +447,13 @@ struct mailboxes_t {
 };
 
 // DevicePrintMemoryLayout asserts
+// DPRINT_BUFFER_SIZE is the legacy default buffer size, kept only to check that the layout has not
+// changed size. hostdevcommon/dprint_common.h does not declare it under ENV_LLK_INFRA, and the layout
+// is sized by DEVICE_PRINT_BUFFER_SIZE whenever that is overridden, so this check only applies to the
+// default layout.
+#if !defined(DEVICE_PRINT_BUFFER_SIZE) && !defined(ENV_LLK_INFRA)
 static_assert(sizeof(DevicePrintMemoryLayout) == DPRINT_BUFFER_SIZE * PROCESSOR_COUNT);
+#endif
 static_assert(sizeof(DevicePrintMemoryLayout) % 4 == 0);
 #if defined(ARCH_WORMHOLE) || defined(ARCH_BLACKHOLE)
 static_assert(decltype(DevicePrintMemoryLayout::buffer)::processor_count == PROCESSOR_COUNT);

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -447,11 +447,11 @@ struct mailboxes_t {
 };
 
 // DevicePrintMemoryLayout asserts
-// DPRINT_BUFFER_SIZE is the legacy default buffer size, kept only to check that the layout has not
-// changed size. hostdevcommon/dprint_common.h does not declare it under ENV_LLK_INFRA, and the layout
-// is sized by DEVICE_PRINT_BUFFER_SIZE whenever that is overridden, so this check only applies to the
-// default layout.
-#if !defined(DEVICE_PRINT_BUFFER_SIZE) && !defined(ENV_LLK_INFRA)
+// DPRINT_BUFFER_SIZE is the legacy per-thread size, kept only to check that the layout has not changed
+// size: every default layout is 204 bytes per processor. hostdevcommon/dprint_common.h does not declare
+// it under ENV_LLK_INFRA, and DEVICE_PRINT_BUFFER_SIZE / DEVICE_PRINT_BUFFER_SIZE2 resize the buffers
+// when overridden, so this check only describes the default layout.
+#if !defined(DEVICE_PRINT_BUFFER_SIZE) && !defined(DEVICE_PRINT_BUFFER_SIZE2) && !defined(ENV_LLK_INFRA)
 static_assert(sizeof(DevicePrintMemoryLayout) == DPRINT_BUFFER_SIZE * PROCESSOR_COUNT);
 #endif
 static_assert(sizeof(DevicePrintMemoryLayout) % 4 == 0);


### PR DESCRIPTION
### Problem

`llk-smoke-tests / llk_smoke_wormhole` fails for every PR that touches an LLK path, at `test_device_print`:

```
../../hw/inc/hostdev/dev_msgs.h:450:50: error: 'DPRINT_BUFFER_SIZE' was not declared in this scope; did you mean 'DEVICE_PRINT_BUFFER_SIZE'?
  450 | static_assert(sizeof(DevicePrintMemoryLayout) == DPRINT_BUFFER_SIZE * PROCESSOR_COUNT);
```

Example failing run, on an unrelated SFPU PR: https://github.com/tenstorrent/tt-metal/actions/runs/34323695811/job/102376702160

### Cause

`hostdevcommon/dprint_common.h` declares `DPRINT_BUFFER_SIZE` only under `#if !defined(ENV_LLK_INFRA)`, but `dev_msgs.h` references it in an unconditional `static_assert`.

That was latent until #55513 added `internal/debug/assert_common.h` (which includes `hostdev/dev_msgs.h`) and made `internal/hw_thread.h` include it. `api/debug/device_print.h` includes `hw_thread.h`, and the tt-llk test harness compiles `device_print.h` with `-DENV_LLK_INFRA -DDEVICE_PRINT_BUFFER_SIZE=16384`, so the assert is now instantiated in a translation unit where the constant does not exist.

The assert is also numerically meaningless in that configuration: `DevicePrintMemoryLayout` is sized by `DEVICE_PRINT_BUFFER_SIZE` when that macro is defined, so the legacy `204 * PROCESSOR_COUNT` default-size check does not describe the layout.

Main's post-commit does not catch this because the LLK smoke job is path-gated, and main commits that do not touch LLK skip it.

### Fix

Guard the size check on the same condition that governs the constant it uses. The other two `DevicePrintMemoryLayout` asserts are untouched and stay active in every build.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-llk-dprint-buffer-size-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-llk-dprint-buffer-size-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-llk-dprint-buffer-size-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/fix-llk-dprint-buffer-size-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-llk-dprint-buffer-size-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-llk-dprint-buffer-size-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/fix-llk-dprint-buffer-size-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/fix-llk-dprint-buffer-size-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-llk-dprint-buffer-size-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-llk-dprint-buffer-size-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-llk-dprint-buffer-size-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-llk-dprint-buffer-size-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-llk-dprint-buffer-size-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-llk-dprint-buffer-size-assert)