### PR TITLE
[skip ci] [Cleanup] Guide Copilot reviews to relevant DeepWiki context

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,6 +17,32 @@
 | `tools/` | Profiler, debugger, scaleout tooling |
 | `.github/` | CI/CD workflows and infra |
 
+## External Repository Context
+
+When a correctness question depends on behavior outside tt-metal that local code
+and documentation do not resolve, use the DeepWiki MCP tools for the relevant
+repository:
+
+- `tenstorrent/tt-umd`: device discovery, coordinate translation, memory access,
+  and communication contracts.
+- `tenstorrent/tt-kmd`: Linux driver interfaces, including IOCTLs, mmap, DMA
+  buffers, page pinning, device resource lifetime, and reset/recovery. Consult
+  when the question crosses the UMD/kernel-driver boundary.
+- `tenstorrent/tt-isa-documentation`: instruction semantics, NoC ordering,
+  synchronization, alignment, and architecture-specific hardware behavior.
+
+Use `ask_question` for focused questions naming the relevant symbols and hardware
+architecture. Follow the answer's source references and verify their applicability
+before reporting a defect. Check UMD behavior against the submodule revision used
+by the PR, KMD behavior against supported driver versions and UMD compatibility
+requirements (including the Linux kernel version where relevant), and ISA behavior
+against the target hardware architecture. DeepWiki's indexed revision may differ.
+
+Cite supporting source code or documentation in findings. If DeepWiki is
+unavailable or a claim cannot be verified, state any material uncertainty and
+avoid asserting an unverified defect. Use DeepWiki only to resolve concrete review
+questions.
+
 ## Review Language
 
 Respond in **English**. Be terse. Use code blocks for every actionable diff.


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Copilot's review instructions do not explain when to use the configured DeepWiki MCP server for questions about dependencies and hardware. Add targeted guidance for `tenstorrent/tt-umd`, `tenstorrent/tt-kmd`, and `tenstorrent/tt-isa-documentation` when local code and documentation leave a correctness question unresolved.

Require source-backed findings and verification against the applicable UMD revision, supported KMD versions, and hardware architecture. Surface material uncertainty when the external context cannot be verified.

### Notes for reviewers
- The change adds one section near the top of `.github/copilot-instructions.md` and preserves the existing review criteria.
- The repository's DeepWiki MCP configuration and the setting allowing MCP tools during reviews are already enabled.
- Validation: reviewed the single-file diff; checked whitespace, final newline, merge-conflict markers, and the repository's file-size limit. This is a documentation-only change, so no build is needed.
- DeepWiki's MCP endpoint was confirmed to expose documentation for all three repositories. Actual use by Copilot remains to be verified in a relevant review session; this PR does not claim improved review quality.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/copilot-deepwiki-review-context)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/copilot-deepwiki-review-context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/copilot-deepwiki-review-context)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/copilot-deepwiki-review-context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/copilot-deepwiki-review-context)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/copilot-deepwiki-review-context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/copilot-deepwiki-review-context)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/copilot-deepwiki-review-context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/copilot-deepwiki-review-context)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/copilot-deepwiki-review-context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/copilot-deepwiki-review-context)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/copilot-deepwiki-review-context)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/copilot-deepwiki-review-context)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/copilot-deepwiki-review-context)