### PR TITLE
[Test Only]: move a large topk test to L2, run a simpler one instead

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce_large_shapes.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce_large_shapes.py
@@ -18,6 +18,7 @@ from tests.ttnn.unit_tests.operations.reduce.test_cumprod import test_cumprod_ba
 from tests.ttnn.unit_tests.operations.reduce.test_cumprod import test_cumprod_preallocated as _cumprod_preallocated
 from tests.ttnn.unit_tests.operations.reduce.test_fast_reduce_nc import test_fast_reduce_nc as _fast_reduce_nc
 from tests.ttnn.unit_tests.operations.reduce.test_intimg import test_cumsum_channel_last as _cumsum_channel_last
+from tests.ttnn.unit_tests.operations.reduce.test_reduction import test_2d_topk as _2d_topk
 from tests.ttnn.unit_tests.operations.reduce.test_sum import test_sum_subcores as _sum_subcores
 
 
@@ -109,3 +110,19 @@ def test_sum_subcores_large(device, sub_core_grids, dtype, shape):
 @pytest.mark.parametrize("dataformat", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["bfloat16", "bfloat8_b"])
 def test_fast_reduce_nc_large(input_shape, dims, compute_kernel_options, dataformat, device):
     _fast_reduce_nc(input_shape, dims, compute_kernel_options, dataformat, device)
+
+
+# 128256 is the Llama-3 vocab. It is not a power of two and is above
+# multi_core_max_width_exclusive, so it fails both gates in topk_multicore_structurally_eligible
+# and runs the single-core factory -- which splits over tile ROWS, and dim1=1 is one tile row.
+# One core therefore walks all 4008 tiles serially: cheap on hardware, ~23 min under ttsim, which
+# is why it is here rather than in the sanity group. Delegating to test_2d_topk keeps the
+# assertions shared; its bfloat16 branch selects the same thresholds this shape was asserted on.
+@pytest.mark.parametrize("dim1", [1])
+@pytest.mark.parametrize("dim2", [128256])
+@pytest.mark.parametrize("dim", [1])
+@pytest.mark.parametrize("k", [50])
+@pytest.mark.parametrize("largest", [True])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_large_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
+    _2d_topk(device, dim1, dim2, dim, k, largest, dtype)

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce_large_shapes.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce_large_shapes.py
@@ -112,12 +112,7 @@ def test_fast_reduce_nc_large(input_shape, dims, compute_kernel_options, datafor
     _fast_reduce_nc(input_shape, dims, compute_kernel_options, dataformat, device)
 
 
-# 128256 is the Llama-3 vocab. It is not a power of two and is above
-# multi_core_max_width_exclusive, so it fails both gates in topk_multicore_structurally_eligible
-# and runs the single-core factory -- which splits over tile ROWS, and dim1=1 is one tile row.
-# One core therefore walks all 4008 tiles serially: cheap on hardware, ~23 min under ttsim, which
-# is why it is here rather than in the sanity group. Delegating to test_2d_topk keeps the
-# assertions shared; its bfloat16 branch selects the same thresholds this shape was asserted on.
+# 128256 is the Llama-3 vocab.
 @pytest.mark.parametrize("dim1", [1])
 @pytest.mark.parametrize("dim2", [128256])
 @pytest.mark.parametrize("dim", [1])

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -566,8 +566,6 @@ def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
 @pytest.mark.parametrize("k", [50])
 @pytest.mark.parametrize("largest", [True])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-# skip_wide_topk_on_sim subsumes skip_routed_topk_on_sim here: it covers every simulator, not
-# just Blackhole's, so the BH-only SFPCONFIG gap no longer needs its own marker on this test.
 @skip_wide_topk_on_sim
 def test_large_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     torch.manual_seed(2005)
@@ -621,12 +619,6 @@ def test_large_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     )
 
 
-# Keeps the UInt32 index datapath under the simulator now that test_large_2d_topk does not run
-# there. is_uint32_index_required() widens on "padded width > 65535" or "input is fp32"; the fp32
-# arm reaches the same index CB at two tiles instead of 2048.
-#
-# Do NOT rename this with a "test_2d_topk" prefix: ttsim-skip-list.yaml deselects that node id and
-# pytest matches --deselect with a plain nodeid.startswith(), so it would be dropped on ttsim.
 @pytest.mark.parametrize("dim2", [64])
 @pytest.mark.parametrize("k", [32])
 def test_topk_fp32_uint32_indices(device, dim2, k):

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -468,25 +468,12 @@ skip_routed_topk_on_sim = pytest.mark.skipif(
     ),
 )
 
-# 128256 is neither a power of two nor below multi_core_max_width_exclusive, so it fails both
-# gates in topk_multicore_structurally_eligible and runs the single-core factory. That factory
-# splits work over tile ROWS only, and dim1=1 pads to a single tile row, so one core walks all
-# 4008 tiles serially. Wt is only the trip count of the incremental-insertion loop in
-# kernels/compute/topk.cpp -- there is no width-keyed branch -- so ttsim re-runs one code path
-# 4008 times and observes nothing a narrow cell does not already show. Measured 1391 s on
-# sim_wh_n150, ~20% of the whole reduce group's simulator budget.
-#
-# The rest of this directory's topk coverage is already deselected on ttsim for exactly this
-# reason (ttsim-skip-list.yaml: all of test_topk.py, plus test_2d_topk here, both under #54860);
-# this cell was missed in that pass. Hardware behaviour is unchanged, and HW coverage of this
-# shape is stricter elsewhere: test_topk.py::test_topk_large_2d_shapes runs
-# (1, 1, 32, 128256, dim=3, k=50) across sorted x largest x pass_indices_tensor and adds an
-# exact assert_equal on the values that this test does not make.
+
 skip_wide_topk_on_sim = pytest.mark.skipif(
     bool(os.environ.get("TT_METAL_SIMULATOR")),
     reason=(
         "128256-wide single-core topk costs ~23 min on ttsim and exercises no width-specific "
-        "code path; HW coverage lives in test_topk.py::test_topk_large_2d_shapes (#54791)"
+        "code path"
     ),
 )
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -552,8 +552,6 @@ def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     )
 
 
-# Do not rename with a "test_2d_topk" prefix: ttsim-skip-list.yaml deselects that node id and
-# pytest --deselect matches on nodeid.startswith(), so it would be dropped on ttsim.
 @pytest.mark.parametrize("dim2", [64])
 @pytest.mark.parametrize("k", [32])
 def test_topk_fp32_uint32_indices(device, dim2, k):
@@ -578,8 +576,7 @@ def test_topk_fp32_uint32_indices(device, dim2, k):
     # ttnn.to_torch picks; no uint16 sign fixup is needed here.
     ttnn_torch_columns = ttnn.to_torch(ttnn_topk_indices).to(torch.int64)
 
-    # Each returned index must name the column its value came from. Tie-safe: both sides are
-    # read from the same position, so this holds however the op breaks equal values.
+    # Each returned index must name the column its value came from.
     assert torch.equal(torch.gather(input, 1, ttnn_torch_columns), ttnn_torch_values)
 
     assert_numeric_metrics(

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -469,12 +469,6 @@ skip_routed_topk_on_sim = pytest.mark.skipif(
 )
 
 
-skip_wide_topk_on_sim = pytest.mark.skipif(
-    bool(os.environ.get("TT_METAL_SIMULATOR")),
-    reason="128256-wide single-core topk costs ~23 min on ttsim and exercises no width-specific code path",
-)
-
-
 @pytest.mark.parametrize("dim1", [1])
 @pytest.mark.parametrize("dim", [1])
 @pytest.mark.parametrize("largest", [True])
@@ -558,67 +552,8 @@ def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     )
 
 
-@pytest.mark.parametrize("dim1", [1])
-# 128256 (Llama-3 vocab) carries the UInt32 index / 32-bit-dest branch. 151936 (Qwen) takes the
-# same path and is 18% wider, and it is still covered by tests/.../reduce/test_topk.py.
-@pytest.mark.parametrize("dim2", [128256])
-@pytest.mark.parametrize("dim", [1])
-@pytest.mark.parametrize("k", [50])
-@pytest.mark.parametrize("largest", [True])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-@skip_wide_topk_on_sim
-def test_large_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
-    torch.manual_seed(2005)
-    shape = [dim1, dim2]
-    torch_dtype = torch.bfloat16
-
-    input = torch.randn(shape, dtype=torch_dtype) * 0.9
-
-    pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=dim, largest=largest, sorted=True)
-
-    ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
-    ttnn_input = ttnn.fill_implicit_tile_padding(ttnn_input, TEST_PADDING_VALUE)
-    ttnn_topk_values, ttnn_topk_indices = ttnn.topk(ttnn_input, k, dim=dim, largest=largest, sorted=True)
-
-    desired_shape = [dim1, dim2]
-    desired_shape[dim] = k
-
-    assert list(ttnn_topk_values.shape) == desired_shape
-    assert list(ttnn_topk_indices.shape) == desired_shape
-
-    ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
-    ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices)
-
-    # Add 2^16 to negative values
-    ttnn_torch_indices = ttnn_torch_indices.to(dtype=torch.int32)
-    ttnn_torch_indices = torch.where(ttnn_torch_indices < 0, ttnn_torch_indices + 65536, ttnn_torch_indices)
-
-    if dtype == ttnn.bfloat8_b:
-        pcc_values = 0.99
-    else:
-        pcc_values = 1.0
-
-    # Convert to int64 only for torch.gather which requires signed indices
-    ttnn_torch_gather_from_indices = torch.gather(
-        input, dim, ttnn_torch_indices.to(torch.int64)  # Convert to signed only for PyTorch API compatibility
-    )
-
-    cosine = torch.nn.CosineSimilarity(dim=dim)
-    ttnn_torch_cosine = torch.mean(cosine(pyt_topk_values, ttnn_torch_gather_from_indices))
-    assert (
-        ttnn_torch_cosine > 0.99
-    ), f"Cosine similarity between topk values and gather from indices is {ttnn_torch_cosine} which is less than 0.99"
-    # test for equivalence
-    assert_numeric_metrics(
-        pyt_topk_values,
-        ttnn_torch_values,
-        pcc_threshold=0.9999,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-    )
-
-
+# Do not rename with a "test_2d_topk" prefix: ttsim-skip-list.yaml deselects that node id and
+# pytest --deselect matches on nodeid.startswith(), so it would be dropped on ttsim.
 @pytest.mark.parametrize("dim2", [64])
 @pytest.mark.parametrize("k", [32])
 def test_topk_fp32_uint32_indices(device, dim2, k):

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -468,6 +468,28 @@ skip_routed_topk_on_sim = pytest.mark.skipif(
     ),
 )
 
+# 128256 is neither a power of two nor below multi_core_max_width_exclusive, so it fails both
+# gates in topk_multicore_structurally_eligible and runs the single-core factory. That factory
+# splits work over tile ROWS only, and dim1=1 pads to a single tile row, so one core walks all
+# 4008 tiles serially. Wt is only the trip count of the incremental-insertion loop in
+# kernels/compute/topk.cpp -- there is no width-keyed branch -- so ttsim re-runs one code path
+# 4008 times and observes nothing a narrow cell does not already show. Measured 1391 s on
+# sim_wh_n150, ~20% of the whole reduce group's simulator budget.
+#
+# The rest of this directory's topk coverage is already deselected on ttsim for exactly this
+# reason (ttsim-skip-list.yaml: all of test_topk.py, plus test_2d_topk here, both under #54860);
+# this cell was missed in that pass. Hardware behaviour is unchanged, and HW coverage of this
+# shape is stricter elsewhere: test_topk.py::test_topk_large_2d_shapes runs
+# (1, 1, 32, 128256, dim=3, k=50) across sorted x largest x pass_indices_tensor and adds an
+# exact assert_equal on the values that this test does not make.
+skip_wide_topk_on_sim = pytest.mark.skipif(
+    bool(os.environ.get("TT_METAL_SIMULATOR")),
+    reason=(
+        "128256-wide single-core topk costs ~23 min on ttsim and exercises no width-specific "
+        "code path; HW coverage lives in test_topk.py::test_topk_large_2d_shapes (#54791)"
+    ),
+)
+
 
 @pytest.mark.parametrize("dim1", [1])
 @pytest.mark.parametrize("dim", [1])
@@ -560,7 +582,9 @@ def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
 @pytest.mark.parametrize("k", [50])
 @pytest.mark.parametrize("largest", [True])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-@skip_routed_topk_on_sim
+# skip_wide_topk_on_sim subsumes skip_routed_topk_on_sim here: it covers every simulator, not
+# just Blackhole's, so the BH-only SFPCONFIG gap no longer needs its own marker on this test.
+@skip_wide_topk_on_sim
 def test_large_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     torch.manual_seed(2005)
     shape = [dim1, dim2]

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -471,10 +471,7 @@ skip_routed_topk_on_sim = pytest.mark.skipif(
 
 skip_wide_topk_on_sim = pytest.mark.skipif(
     bool(os.environ.get("TT_METAL_SIMULATOR")),
-    reason=(
-        "128256-wide single-core topk costs ~23 min on ttsim and exercises no width-specific "
-        "code path"
-    ),
+    reason="128256-wide single-core topk costs ~23 min on ttsim and exercises no width-specific code path",
 )
 
 
@@ -614,6 +611,50 @@ def test_large_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
         ttnn_torch_cosine > 0.99
     ), f"Cosine similarity between topk values and gather from indices is {ttnn_torch_cosine} which is less than 0.99"
     # test for equivalence
+    assert_numeric_metrics(
+        pyt_topk_values,
+        ttnn_torch_values,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
+
+
+# Keeps the UInt32 index datapath under the simulator now that test_large_2d_topk does not run
+# there. is_uint32_index_required() widens on "padded width > 65535" or "input is fp32"; the fp32
+# arm reaches the same index CB at two tiles instead of 2048.
+#
+# Do NOT rename this with a "test_2d_topk" prefix: ttsim-skip-list.yaml deselects that node id and
+# pytest matches --deselect with a plain nodeid.startswith(), so it would be dropped on ttsim.
+@pytest.mark.parametrize("dim2", [64])
+@pytest.mark.parametrize("k", [32])
+def test_topk_fp32_uint32_indices(device, dim2, k):
+    torch.manual_seed(2005)
+    shape = [1, dim2]
+
+    # fp32 rather than bfloat16: it is what forces the 32-bit index datapath at this width.
+    input = torch.randn(shape, dtype=torch.float32) * 0.9
+    pyt_topk_values, _ = torch.topk(input, k, dim=1, largest=True, sorted=True)
+
+    ttnn_input = ttnn.from_torch(input, ttnn.float32, layout=ttnn.Layout.TILE, device=device)
+    ttnn_input = ttnn.fill_implicit_tile_padding(ttnn_input, TEST_PADDING_VALUE)
+    ttnn_topk_values, ttnn_topk_indices = ttnn.topk(ttnn_input, k, dim=1, largest=True, sorted=True)
+
+    assert list(ttnn_topk_values.shape) == [1, k]
+    assert list(ttnn_topk_indices.shape) == [1, k]
+    # The point of the test: 64 fits 16 bits, so only the fp32 arm can widen the index dtype.
+    assert ttnn_topk_indices.dtype == ttnn.uint32
+
+    ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
+    # Indices are columns in [0, 64), so they are non-negative under any 32-bit torch dtype
+    # ttnn.to_torch picks; no uint16 sign fixup is needed here.
+    ttnn_torch_columns = ttnn.to_torch(ttnn_topk_indices).to(torch.int64)
+
+    # Each returned index must name the column its value came from. Tie-safe: both sides are
+    # read from the same position, so this holds however the op breaks equal values.
+    assert torch.equal(torch.gather(input, 1, ttnn_torch_columns), ttnn_torch_values)
+
     assert_numeric_metrics(
         pyt_topk_values,
         ttnn_torch_values,


### PR DESCRIPTION
### PR Category

Test Only

### Summary

Relates to #54791, #54790, #54861.

`tests/ttnn/unit_tests/operations/reduce/test_reduction.py::test_large_2d_topk` costs
1391 s on `sim_wh_n150` — about 20% of the entire `ttnn reduce group` simulator budget —
and exercises no code path that a narrow cell does not already cover.

This change moves the long running test to L2 nightly and adds a simpler one, which still exercises the UInt32 index datapath under the simulator.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/skip-wide-topk-on-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/skip-wide-topk-on-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/skip-wide-topk-on-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/skip-wide-topk-on-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/skip-wide-topk-on-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/skip-wide-topk-on-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/skip-wide-topk-on-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/skip-wide-topk-on-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/skip-wide-topk-on-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/skip-wide-topk-on-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/skip-wide-topk-on-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/skip-wide-topk-on-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/skip-wide-topk-on-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/skip-wide-topk-on-ttsim)

