### PR TITLE
[skip ci] Broaden tt-train CODEOWNERS so any senior owner can approve

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,7 @@ METALIUM_GUIDE.md @davorchap @tenstorrent/metalium-developers-infra
 .github/instructions/nanobind.instructions.md @tenstorrent/metalium-developers-ttnn-core @nsextonTT
 .github/instructions/python.instructions.md @tenstorrent/metalium-developers-infra
 .github/instructions/tt-stl.instructions.md @ayerofieiev-tt @akerteszTT @riverwuTT
-.github/instructions/tt-train.instructions.md @ayerofieiev-tt @philei-tt @jmalone-tt @kevinwuTT @abustamanteTT @mdragulaTT
+.github/instructions/tt-train.instructions.md @tenstorrent/tt-train @kevinwuTT @abustamanteTT
 .github/instructions/ttnn-core.instructions.md @tenstorrent/metalium-developers-ttnn-core @aliaksei-sala
 .github/instructions/ttnn-ops.instructions.md @tenstorrent/metalium-developers-ops-leads
 .github/instructions/ttnn.instructions.md @tenstorrent/metalium-developers-ttnn-core
@@ -648,18 +648,15 @@ docs/source/ttnn/ @tenstorrent/metalium-developers-ttnn-core @razorback3 @dongji
 dockerfile/** @tenstorrent/metalium-developers-infra
 
 # tt-train
-# primary owners
-tt-train/** @ayerofieiev-tt @philei-tt @jmalone-tt
-tt-train/**/CMakeLists.txt @ayerofieiev-tt @philei-tt @jmalone-tt @tenstorrent/metalium-developers-infra
-# kernel development
-tt-train/sources/ttml/metal/** @mdragulaTT @vmelnykovTT @dyurshevichTT @zbaczewskiTT
-# ops
-tt-train/sources/ttml/ops/** @mdragulaTT @vmelnykovTT @dyurshevichTT
-# optimizers
-tt-train/sources/ttml/optimizers/** @tenstorrent/tt-train-optimizers
-# tests
-tt-train/tests/** @mdragulaTT @vmelnykovTT @dyurshevichTT @zbaczewskiTT @abustamanteTT
-tt-train/tests/**/CMakeLists.txt @mdragulaTT @vmelnykovTT @dyurshevichTT @zbaczewskiTT @abustamanteTT @tenstorrent/metalium-developers-infra
+# @tenstorrent/tt-train: owners with a broad view of the whole tree; any member can approve any change under tt-train.
+tt-train/** @tenstorrent/tt-train
+# Kernels, ops and tests: the team plus the people developing there day to day.
+tt-train/sources/ttml/metal/** @tenstorrent/tt-train @lgalasTT
+tt-train/sources/ttml/ops/** @tenstorrent/tt-train @lgalasTT
+tt-train/tests/** @tenstorrent/tt-train @lgalasTT @abustamanteTT
+# Last on purpose: CODEOWNERS is last-match-wins, so this must follow the directory rules
+# above for infra to keep co-ownership of every CMakeLists.txt.
+tt-train/**/CMakeLists.txt @tenstorrent/tt-train @lgalasTT @abustamanteTT @tenstorrent/metalium-developers-infra
 
 # .clang-tidy files - Metalium infra team owns all clang-tidy configuration files
 **/.clang-tidy @tenstorrent/metalium-developers-infra


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Make tt-train approvals easier to get. `main` requires an approving review from a code owner of every matched rule, so today anything outside `metal/`, `ops/`, `optimizers/` or `tests/`, and any `CMakeLists.txt`, needs one of @ayerofieiev-tt, @philei-tt or @jmalone-tt.

**What changes**
- Every tt-train rule is owned by the new `@tenstorrent/tt-train` team: @ayerofieiev-tt @philei-tt @jmalone-tt @vmelnykovTT @dyurshevichTT @mdragulaTT @nmauriceTT @zbaczewskiTT. One approval from any member clears any tt-train PR. Membership changes no longer need a CODEOWNERS PR.
- `metal/**`, `ops/**`, `tests/**` and the `CMakeLists.txt` rules additionally list @lgalasTT and @abustamanteTT, so they are requested on kernel, op and test PRs.
- The `optimizers/**` rule is removed: the kernel owners cover optimizers together, so a separate rule is no longer needed.
- `tt-train.instructions.md` keeps its owners and adds the team.
- Infra keeps co-ownership of every `CMakeLists.txt`.

The team is visible, has write access on tt-metal (internal-requests #1654), and has code review auto-assignment off, so the whole team is requested on each PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/tt-train-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/tt-train-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/tt-train-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/tt-train-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/tt-train-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/tt-train-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/tt-train-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/tt-train-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/tt-train-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/tt-train-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/tt-train-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/tt-train-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/tt-train-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/tt-train-codeowners)