### PR TITLE
Fix LLK device print buffer size assertion

### DIFF
--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -447,7 +447,9 @@ struct mailboxes_t {
 };
 
 // DevicePrintMemoryLayout asserts
+#ifdef DEVICE_PRINT_BUFFER_SIZE
 static_assert(sizeof(DevicePrintMemoryLayout) == DEVICE_PRINT_BUFFER_SIZE);
+#endif
 static_assert(sizeof(DevicePrintMemoryLayout) % 4 == 0);
 #if defined(ARCH_WORMHOLE) || defined(ARCH_BLACKHOLE)
 static_assert(decltype(DevicePrintMemoryLayout::buffer)::processor_count == PROCESSOR_COUNT);

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -447,7 +447,7 @@ struct mailboxes_t {
 };
 
 // DevicePrintMemoryLayout asserts
-static_assert(sizeof(DevicePrintMemoryLayout) == DPRINT_BUFFER_SIZE * PROCESSOR_COUNT);
+static_assert(sizeof(DevicePrintMemoryLayout) == DEVICE_PRINT_BUFFER_SIZE);
 static_assert(sizeof(DevicePrintMemoryLayout) % 4 == 0);
 #if defined(ARCH_WORMHOLE) || defined(ARCH_BLACKHOLE)
 static_assert(decltype(DevicePrintMemoryLayout::buffer)::processor_count == PROCESSOR_COUNT);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
- Update the `DevicePrintMemoryLayout` size assertion to compare against `DEVICE_PRINT_BUFFER_SIZE`, matching the total buffer size used by LLK device-print builds.

### Notes for reviewers
- Tested locally `pytest python_tests/test_device_print.py` (13 passed)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_test_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_test_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_test_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix_test_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_test_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_test_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix_test_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix_test_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_test_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_test_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_test_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_test_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_test_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_test_device_print)