### PR TITLE
#50840: Route fold TILE DRAM inputs through tile-native scratch-gather factory

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
@@ -187,7 +187,8 @@ def _run_fold(
     assert_with_pcc(ref.float(), got.float(), pcc)
 
 
-# Interleaved routing — RM goes through MultiCoreDRAMFold RM branch; TILE untilizes first.
+# Interleaved routing — RM goes through MultiCoreDRAMFold RM branch; TILE takes the tile-native
+# scratch-gather factory when its output-row scratch fits L1, else falls back to untilize→RM.
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
@@ -390,6 +390,48 @@ def test_fold_f32_dtype(shape, layout, in_mc_factory, device):
     _run_fold(shape, 2, 2, layout, in_mc_factory(shape, device), None, device, dtype=ttnn.float32)
 
 
+# Tile-native scratch-gather bit-exactness — PCC can't see a scatter landing a few slots off or a write
+# past the scratch page; bf16 tile-native must round-trip byte-identically.
+
+
+@pytest.mark.parametrize(
+    "shape, stride",
+    [
+        pytest.param((1, 32, 32, 32), (2, 2), id="tile_native_32x32x32_2x2"),
+        pytest.param((1, 32, 32, 64), (2, 2), id="tile_native_32x32x64_2x2"),
+    ],
+)
+def test_fold_tile_native_bf16_bit_exact(shape, stride, device):
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=DRAM_INTERLEAVED
+    )
+    got = ttnn.to_torch(ttnn.fold(ttnn_in, stride[0], stride[1]).cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert torch.equal(_fold_golden(x, stride[0], stride[1]), got)
+
+
+# Capacity-boundary regression — pins the tile_native_fold_scratch_fits_l1 fallback; one shape fits
+# (tile-native) and one overflows (composite untilize→RM), both must produce bit-exact output.
+
+
+@pytest.mark.parametrize(
+    "shape, stride",
+    [
+        pytest.param((1, 32, 32, 32), (2, 2), id="fits_L1_tile_native"),
+        pytest.param((1, 224, 224, 320), (16, 16), id="overflows_L1_composite"),
+    ],
+)
+def test_fold_tile_capacity_boundary(shape, stride, device):
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=DRAM_INTERLEAVED
+    )
+    got = ttnn.to_torch(ttnn.fold(ttnn_in, stride[0], stride[1]).cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert torch.equal(_fold_golden(x, stride[0], stride[1]), got)
+
+
 # Non-standard strides — asymmetric, non-power-of-two (e.g. 3x5, 2x3).
 
 
@@ -507,10 +549,10 @@ def test_fold_invalid_shard_shape_fatals(device):
             None,
             id="rm_dram_height_sharded",
         ),
-        # TILE interleaved (composite untilize hop).
+        # TILE interleaved (tile-native scratch-gather factory).
         pytest.param(ttnn.TILE_LAYOUT, (1, 16, 16, 8), lambda s, d: L1_INTERLEAVED, None, id="tile_l1_interleaved"),
         pytest.param(ttnn.TILE_LAYOUT, (1, 16, 16, 8), lambda s, d: DRAM_INTERLEAVED, None, id="tile_dram_interleaved"),
-        # TILE W/B-sharded (composite untilize + L1-interleaved staging).
+        # TILE W/B-sharded (composite untilize→RM before prim, sharded staging).
         pytest.param(ttnn.TILE_LAYOUT, (1, 32, 32, 128), _tile_width_shard, None, id="tile_width_sh"),
         pytest.param(ttnn.TILE_LAYOUT, (1, 32, 32, 128), _tile_block_shard, None, id="tile_block_sh"),
     ],

--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -111,12 +111,10 @@ def test_fold_with_permute_for_dram_tensor(device, nhw, channels, stride, paddin
             f"Skipping invalid padding combination: padded_h={padded_h}, padded_w={padded_w}, stride_h={stride_h}, stride_w={stride_w}"
         )
 
-    # FP32 has twice the per-stick byte footprint of bfloat16, so the largest configuration
-    # (channels=320 with a 32x32 stride) makes the fold dataflow buffers grow to ~2.7 MB, past the
-    # ~1.5 MB per-core L1. This is a pre-existing device capacity limit — the DFB/CB sizing is
-    # dtype-driven and identical on main — not a fold correctness issue, so skip it.
+    # fp32 + channels=320 + stride=(32,32): output stick alone is 32*32*320*4=1.25 MB, so both
+    # tile-native and RM-fallback paths overflow per-core L1 (~1.5 MB) — device capacity, not a bug.
     if input_dtype == ttnn.float32 and channels == 320 and stride == (32, 32):
-        pytest.skip("FP32 fold DFBs exceed per-core L1 for channels=320 with 32x32 stride (capacity limit)")
+        pytest.skip("FP32 fold: channels=320 + 32x32 stride overflows per-core L1 (capacity limit)")
 
     torch_input_dtype = torch.float32 if input_dtype == ttnn.float32 else torch.bfloat16
     torch_input_tensor = torch.rand((batch_size, channels, height, width), dtype=torch_input_dtype)

--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -487,3 +487,12 @@ def run_fold_sharded_test(device, act_shape, stride_h, stride_w, padding, core_g
 )
 def test_fold_sharded(device, act_shape, stride_h, stride_w, padding, core_grid):
     run_fold_sharded_test(device, act_shape, stride_h, stride_w, padding, core_grid)
+
+
+def test_fold_tile_partial_tile_width_rejected(device, expect_error):
+    """Logical W=48 padded to 64: 64%32==0 hides the partial-tile W the tile-native writer would OOB into. validate_fold must FATAL on logical_shape now."""
+    shape = (1, 32, 48, 32)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+    with expect_error(RuntimeError, "stride_w|logical W"):
+        ttnn.fold(ttnn_in, 32, 32)

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -18,15 +18,22 @@ bool is_fast_path_input(const Tensor& t) {
            t.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED && t.layout() == Layout::ROW_MAJOR;
 }
 
-bool is_tile_native_fold_supported(const Tensor& input_tensor) {
-    if (input_tensor.layout() != Layout::TILE) {
+bool tile_native_fold_scratch_fits_l1(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w) {
+    if (input_tensor.layout() != tt::tt_metal::Layout::TILE) {
         return false;
     }
-    const bool is_dram = input_tensor.memory_config().buffer_type() == tt::tt_metal::BufferType::DRAM;
-    const uint32_t noc_align =
-        is_dram ? tt::tt_metal::hal::get_dram_alignment() : tt::tt_metal::hal::get_l1_alignment();
-    const uint32_t c_bytes = input_tensor.logical_shape()[-1] * input_tensor.element_size();
-    return c_bytes % noc_align == 0;
+    // Output dtype mirrors compute_output_specs: BFLOAT8_B/BFLOAT16 collapse to BFLOAT16 on RM output.
+    const auto in_dt = input_tensor.dtype();
+    const auto out_dt = (in_dt == tt::tt_metal::DataType::FLOAT32 || in_dt == tt::tt_metal::DataType::UINT16)
+                            ? in_dt
+                            : tt::tt_metal::DataType::BFLOAT16;
+    const uint32_t out_elem = tt::datum_size(datatype_to_dataformat_converter(out_dt));
+    const uint32_t input_width = input_tensor.logical_shape()[2];
+    const uint32_t C = input_tensor.logical_shape()[-1];
+    const uint64_t scratch_bytes = static_cast<uint64_t>(input_width / stride_w) * stride_h * stride_w * C * out_elem;
+    // ~200 KB reserve for the src0/src1 tile CBs and kernel code/stack (pattern from conv3d factory).
+    constexpr uint64_t kOverhead = 200 * 1024;
+    return scratch_bytes + kOverhead < tt::tt_metal::hal::get_max_worker_l1_unreserved_size();
 }
 
 tt::tt_metal::ShardSpec synthesize_fold_output_shard_spec(

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/synthesize_output_shard_spec.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/hal.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
@@ -15,6 +16,17 @@ namespace ttnn::operations::data_movement {
 bool is_fast_path_input(const Tensor& t) {
     return t.memory_config().is_l1() && t.is_sharded() && t.shard_spec().has_value() &&
            t.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED && t.layout() == Layout::ROW_MAJOR;
+}
+
+bool is_tile_native_fold_supported(const Tensor& input_tensor) {
+    if (input_tensor.layout() != Layout::TILE) {
+        return false;
+    }
+    const bool is_dram = input_tensor.memory_config().buffer_type() == tt::tt_metal::BufferType::DRAM;
+    const uint32_t noc_align =
+        is_dram ? tt::tt_metal::hal::get_dram_alignment() : tt::tt_metal::hal::get_l1_alignment();
+    const uint32_t c_bytes = input_tensor.logical_shape()[-1] * input_tensor.element_size();
+    return c_bytes % noc_align == 0;
 }
 
 tt::tt_metal::ShardSpec synthesize_fold_output_shard_spec(

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -18,22 +18,32 @@ bool is_fast_path_input(const Tensor& t) {
            t.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED && t.layout() == Layout::ROW_MAJOR;
 }
 
+tt::tt_metal::DataType fold_output_dtype(tt::tt_metal::DataType input_dtype) {
+    return (input_dtype == tt::tt_metal::DataType::FLOAT32 || input_dtype == tt::tt_metal::DataType::UINT16)
+               ? input_dtype
+               : tt::tt_metal::DataType::BFLOAT16;
+}
+
+uint64_t tile_native_fold_scratch_bytes(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w) {
+    const uint32_t out_elem = tt::datum_size(datatype_to_dataformat_converter(fold_output_dtype(input_tensor.dtype())));
+    const auto& shape = input_tensor.logical_shape();
+    const uint32_t input_width = shape[2];
+    const uint32_t C = shape[-1];
+    return static_cast<uint64_t>(input_width / stride_w) * stride_h * stride_w * C * out_elem;
+}
+
 bool tile_native_fold_scratch_fits_l1(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w) {
     if (input_tensor.layout() != tt::tt_metal::Layout::TILE) {
         return false;
     }
-    // Output dtype mirrors compute_output_specs: BFLOAT8_B/BFLOAT16 collapse to BFLOAT16 on RM output.
-    const auto in_dt = input_tensor.dtype();
-    const auto out_dt = (in_dt == tt::tt_metal::DataType::FLOAT32 || in_dt == tt::tt_metal::DataType::UINT16)
-                            ? in_dt
-                            : tt::tt_metal::DataType::BFLOAT16;
-    const uint32_t out_elem = tt::datum_size(datatype_to_dataformat_converter(out_dt));
-    const uint32_t input_width = input_tensor.logical_shape()[2];
-    const uint32_t C = input_tensor.logical_shape()[-1];
-    const uint64_t scratch_bytes = static_cast<uint64_t>(input_width / stride_w) * stride_h * stride_w * C * out_elem;
-    // ~200 KB reserve for the src0/src1 tile CBs and kernel code/stack (pattern from conv3d factory).
-    constexpr uint64_t kOverhead = 200 * 1024;
-    return scratch_bytes + kOverhead < tt::tt_metal::hal::get_max_worker_l1_unreserved_size();
+    const uint64_t scratch = tile_native_fold_scratch_bytes(input_tensor, stride_h, stride_w);
+    // src0/src1 tile CBs scale with C_tiles (the factory sizes both to C_tiles entries).
+    const auto in_df = datatype_to_dataformat_converter(input_tensor.dtype());
+    const auto out_df = datatype_to_dataformat_converter(fold_output_dtype(input_tensor.dtype()));
+    const uint32_t c_tiles = tt::div_up(input_tensor.padded_shape()[-1], tt::constants::TILE_WIDTH);
+    const uint64_t cb_bytes = static_cast<uint64_t>(tt::tile_size(in_df) + tt::tile_size(out_df)) * c_tiles;
+    constexpr uint64_t kCodeStackReserve = 32 * 1024;
+    return scratch + cb_bytes + kCodeStackReserve < tt::tt_metal::hal::get_max_worker_l1_unreserved_size();
 }
 
 tt::tt_metal::ShardSpec synthesize_fold_output_shard_spec(
@@ -60,29 +70,37 @@ Fold::program_factory_t Fold::select_program_factory(
 
 void validate_fold(const std::vector<Tensor>& input_tensors, uint32_t stride_h, uint32_t stride_w) {
     const Tensor& input_tensor = input_tensors.at(0);
-    const auto& input_shape = input_tensor.padded_shape();
+    const auto& logical_shape = input_tensor.logical_shape();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Fold: Expect input tensor to be stored on device.");
     TT_FATAL(input_tensor.buffer() != nullptr, "Fold: Expect input tensor to be allocated on a device buffer.");
 
     // Reject zero strides before any modulo/div; guards both fast + composite paths and compute_output_specs.
     TT_FATAL(stride_h > 0 && stride_w > 0, "Fold: stride_h ({}) and stride_w ({}) must be > 0.", stride_h, stride_w);
-    // H/W divisibility applies to both paths (fast-path's shard-shape check does not imply width divisibility).
+    // Divisibility on logical (padded hides partial-tile W remainders that the tile-native writer would OOB into).
     TT_FATAL(
-        input_shape[1] % stride_h == 0,
-        "Fold: Input height ({}) must be divisible by stride_h ({}).",
-        input_shape[1],
+        logical_shape[1] % stride_h == 0,
+        "Fold: logical H ({}) must be divisible by stride_h ({}).",
+        logical_shape[1],
         stride_h);
     TT_FATAL(
-        input_shape[2] % stride_w == 0,
-        "Fold: Input width ({}) must be divisible by stride_w ({}).",
-        input_shape[2],
+        logical_shape[2] % stride_w == 0,
+        "Fold: logical W ({}) must be divisible by stride_w ({}).",
+        logical_shape[2],
         stride_w);
+
+    // TILE input routes through the tile-native factory (in prim::fold); refuse configs whose row scratch won't fit L1.
+    // Composite falls back to untilize→RM before prim, so this only fires on direct prim::fold(TILE) callers.
+    TT_FATAL(
+        input_tensor.layout() != tt::tt_metal::Layout::TILE ||
+            tile_native_fold_scratch_fits_l1(input_tensor, stride_h, stride_w),
+        "Fold (TILE): tile-native scratch {} B + tile CBs exceed per-core L1; untilize input to RM first.",
+        tile_native_fold_scratch_bytes(input_tensor, stride_h, stride_w));
 
     if (is_fast_path_input(input_tensor)) {
         auto shard_shape = input_tensor.shard_spec().value().shape;
         TT_FATAL(
-            shard_shape[0] % (input_shape[2] * stride_h) == 0,
+            shard_shape[0] % (logical_shape[2] * stride_h) == 0,
             "Fold (fast path): shard height must be divisible by input width times stride_h.");
     } else if (input_tensor.is_sharded() && input_tensor.shard_spec().has_value()) {
         // Per-shard sticks must be patch_size-divisible; else fold silently truncates. Specless → compute_output_specs
@@ -109,12 +127,7 @@ Fold::spec_return_value_t Fold::compute_output_specs(
     const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
     const auto& input_tensor = tensors.input_tensor;
     const ttnn::Shape& input_shape = input_tensor.logical_shape();
-    auto input_dtype = input_tensor.dtype();
-
-    tt::tt_metal::DataType output_dtype =
-        (input_dtype == tt::tt_metal::DataType::FLOAT32 || input_dtype == tt::tt_metal::DataType::UINT16)
-            ? input_dtype
-            : tt::tt_metal::DataType::BFLOAT16;
+    const tt::tt_metal::DataType output_dtype = fold_output_dtype(input_tensor.dtype());
 
     // NHWC pixel_unshuffle; folded_4d vs collapsed picked upfront — shard bytes identical.
     const uint32_t out_N = input_shape[0];

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -16,9 +16,9 @@ namespace ttnn::operations::data_movement {
 // Fast path: L1 + HS + RM + concrete shard_spec. Shared by composite and device_op.
 bool is_fast_path_input(const Tensor& t);
 
-// TILE-native tiled factory needs (logical C * elem_size) aligned to the output buffer's NoC align
-// (writer scatters `c_bytes` at `patch_idx * c_bytes` intra-page); else fall back to composite untilize.
-bool is_tile_native_fold_supported(const Tensor& input_tensor);
+// Tile-native tiled factory holds one full output row in L1 scratch (`out_W * sh * sw * C * out_elem`);
+// if that overflows the per-core budget, composite untilize→RM does the same work with 1-stick scratch.
+bool tile_native_fold_scratch_fits_l1(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w);
 
 // Fresh shard-spec for specless sharded outputs, sized to the populated shard count (not the
 // full compute grid): H/W → num_cores_to_corerangeset over used cores; B → rectangular CoreRange.

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -16,6 +16,10 @@ namespace ttnn::operations::data_movement {
 // Fast path: L1 + HS + RM + concrete shard_spec. Shared by composite and device_op.
 bool is_fast_path_input(const Tensor& t);
 
+// TILE-native tiled factory needs (logical C * elem_size) aligned to the output buffer's NoC align
+// (writer scatters `c_bytes` at `patch_idx * c_bytes` intra-page); else fall back to composite untilize.
+bool is_tile_native_fold_supported(const Tensor& input_tensor);
+
 // Fresh shard-spec for specless sharded outputs, sized to the populated shard count (not the
 // full compute grid): H/W → num_cores_to_corerangeset over used cores; B → rectangular CoreRange.
 // Shared by compute_output_specs and derive_effective_override_memory_config.

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -16,8 +16,14 @@ namespace ttnn::operations::data_movement {
 // Fast path: L1 + HS + RM + concrete shard_spec. Shared by composite and device_op.
 bool is_fast_path_input(const Tensor& t);
 
-// Tile-native tiled factory holds one full output row in L1 scratch (`out_W * sh * sw * C * out_elem`);
-// if that overflows the per-core budget, composite untilize→RM does the same work with 1-stick scratch.
+// Output-dtype rule: FLOAT32/UINT16 pass through; every other input dtype collapses to BFLOAT16 on RM output.
+tt::tt_metal::DataType fold_output_dtype(tt::tt_metal::DataType input_dtype);
+
+// Bytes the tile-native writer's per-super-block RM scratch needs (one output row of contiguous sticks).
+uint64_t tile_native_fold_scratch_bytes(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w);
+
+// Tile-native tiled factory needs `scratch + src0 + src1 CBs` to fit per-core L1 (src0/src1 scale with C_tiles);
+// if not, composite untilize→RM handles the same case with 1-stick scratch.
 bool tile_native_fold_scratch_fits_l1(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w);
 
 // Fresh shard-spec for specless sharded outputs, sized to the populated shard count (not the

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -166,23 +166,19 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
         .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
     };
 
-    // Compute kernel (untilize). Match legacy untilize op's fp32 setup — `UnpackToDest` + `DST_ACCUM_MODE=1`
-    // — else fp32 dest truncates mantissa and `torch.equal` fails vs the untilize→RM composite path.
+    // Compute kernel (untilize). fp32 needs `UnpackToDest` — packer truncates mantissa otherwise and
+    // `torch.equal` fails vs the untilize→RM composite path.
     const bool fp32_dest_acc_en = dfb_data_format == tt::DataFormat::Float32;
     auto make_compute_spec = [&](const KernelSpecName& id, uint32_t nblocks) {
         ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
         if (fp32_dest_acc_en) {
             compute_cfg.unpack_modes.insert({SRC0, UnpackMode::UnpackToDest});
         }
-        KernelSpec::CompilerOptions::Defines compute_defines;
-        if (fp32_dest_acc_en) {
-            compute_defines.insert({"DST_ACCUM_MODE", "1"});
-        }
         return KernelSpec{
             .unique_id = id,
             .source = std::filesystem::path{COMPUTE_UNTILIZE},
             // KernelSpec defaults to O2; compute kernels use O3 (legacy KernelDescriptor default).
-            .compiler_options = {.defines = std::move(compute_defines), .opt_level = KernelBuildOptLevel::O3},
+            .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
             .dfb_bindings =
                 {DFBBinding{.dfb_spec_name = SRC0, .accessor_name = "src", .endpoint_type = DFBEndpointType::CONSUMER},
                  DFBBinding{.dfb_spec_name = SRC1, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER}},

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -41,8 +41,8 @@ DataflowBufferSpec make_dfb(
     };
 }
 
-// TILE-native factory (unreachable): tile-index math only correct for (N,32,32,C≤32); composite untilizes before
-// dispatch. Rewrite would remove the untilize hop.
+// TILE-native factory: reader batches (W_tiles * C_tiles) tiles per input-H row, untilize produces RM sticks in L1,
+// writer scatters each pixel's `c_bytes` into its patch slot (`patch_idx * c_bytes`) inside the output stick.
 ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     const Tensor& input_tensor, const Tensor& output, const uint32_t stride_h, const uint32_t stride_w) {
     auto* device = input_tensor.device();
@@ -87,16 +87,15 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     log_debug(tt::LogOp, "input_tensor_shape: {}", input_padded_shape);
     log_debug(tt::LogOp, "output_tensor_shape: {}", output_padded_shape);
 
-    // Memory layout parameters
-    auto stick_nbytes = output_padded_shape[3] * tt::datum_size(datatype_to_dataformat_converter(output.dtype()));
+    // Fold on logical C (matches compute_output_specs); untilize row stride uses padded C.
+    const uint32_t c_bytes = input_tensor.logical_shape()[-1] * tt::datum_size(out_dfb_data_format);
     uint32_t ntiles = input_tensor.physical_volume() / TILE_HW;
     uint32_t tiles_per_channel_dim = tt::div_up(input_padded_shape[-1], TILE_WIDTH);
     uint32_t tiles_per_width_dim = tt::div_up(input_padded_shape[-2], TILE_HEIGHT);
     uint32_t tiles_per_complete_row = tiles_per_width_dim * tiles_per_channel_dim;
-    // Total number of blocks for batch * height
     uint32_t num_blocks = std::ceil(static_cast<float>(ntiles) / (tiles_per_complete_row));
 
-    uint32_t aligned_stick_nbytes = tt::align(stick_nbytes, TILE_WIDTH * tt::datum_size(out_dfb_data_format));
+    const uint32_t c_padded_bytes = tiles_per_channel_dim * TILE_WIDTH * tt::datum_size(out_dfb_data_format);
     log_debug(
         tt::LogOp, "tiles_per_channel_dim: {}, ntiles: {}, num_blocks: {}", tiles_per_channel_dim, ntiles, num_blocks);
 
@@ -145,32 +144,32 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
             {{"input_width", input_width},
              {"stride_height", stride_h},
              {"stride_width", stride_w},
-             {"stick_nbytes", stick_nbytes},
-             {"aligned_stick_nbytes", aligned_stick_nbytes},
+             {"c_bytes", c_bytes},
+             {"c_padded_bytes", c_padded_bytes},
              {"tiles_per_channel_dim", tiles_per_channel_dim},
-             {"tiles_per_width_dim", tiles_per_width_dim},
-             {"element_size", datum_size(out_dfb_data_format)}},
+             {"tiles_per_width_dim", tiles_per_width_dim}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_block_id", "num_blocks", "patch_height_offset", "output_offset"}},
         .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
     };
 
-    // Compute kernel (untilize). One KernelSpec per legacy compute KernelDescriptor (main + cliff),
-    // preserving the per-group block-count multiplicity. ComputeConfig set directly (Style B):
-    // only fp32_dest_acc_en was set by the legacy op -> enable_32_bit_dest.
+    // Compute kernel (untilize). Match legacy untilize op's fp32 setup — `UnpackToDest` + `DST_ACCUM_MODE=1`
+    // — else fp32 dest truncates mantissa and `torch.equal` fails vs the untilize→RM composite path.
     const bool fp32_dest_acc_en = dfb_data_format == tt::DataFormat::Float32;
     auto make_compute_spec = [&](const KernelSpecName& id, uint32_t nblocks) {
         ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
-        // The compute kernel consumes SRC0. When SRC0 is Float32 and enable_32_bit_dest is set,
-        // the validator requires an explicit unpack mode. Legacy set none (default) -> UnpackToSrc.
         if (fp32_dest_acc_en) {
-            compute_cfg.unpack_modes.insert({SRC0, UnpackMode::UnpackToSrc});
+            compute_cfg.unpack_modes.insert({SRC0, UnpackMode::UnpackToDest});
+        }
+        KernelSpec::CompilerOptions::Defines compute_defines;
+        if (fp32_dest_acc_en) {
+            compute_defines.insert({"DST_ACCUM_MODE", "1"});
         }
         return KernelSpec{
             .unique_id = id,
             .source = std::filesystem::path{COMPUTE_UNTILIZE},
             // KernelSpec defaults to O2; compute kernels use O3 (legacy KernelDescriptor default).
-            .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
+            .compiler_options = {.defines = std::move(compute_defines), .opt_level = KernelBuildOptLevel::O3},
             .dfb_bindings =
                 {DFBBinding{.dfb_spec_name = SRC0, .accessor_name = "src", .endpoint_type = DFBEndpointType::CONSUMER},
                  DFBBinding{.dfb_spec_name = SRC1, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER}},
@@ -202,15 +201,13 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     auto ncores_y = std::ceil(static_cast<float>(ncores) / ncores_x);
     auto cores = grid_to_cores(ncores_x * ncores_y, ncores_x, ncores_y, true);
 
-    const uint32_t patch_size = stride_h * stride_w;       // Size of each patch
-    const uint32_t output_width = input_width / stride_w;  // Output width
+    const uint32_t output_width = input_width / stride_w;
     for (auto core : cores) {
         uint32_t curr_input_height_idx = block_start_id;
         uint32_t curr_output_height_idx = curr_input_height_idx / stride_h;
         uint32_t patch_height_offset = curr_input_height_idx % stride_h;
-        // Total output height * width
-        uint32_t output_offset =
-            (patch_size * curr_output_height_idx * output_width) + (patch_height_offset * stride_w);
+        // `output_offset` is the output page id of (n, h/sh, 0); writer emits `patch_idx * c_bytes` intra-page.
+        uint32_t output_offset = curr_output_height_idx * output_width;
         if (!full_cores.contains(core)) {
             continue;
         }
@@ -232,8 +229,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
         uint32_t curr_input_height_idx = block_start_id;
         uint32_t curr_output_height_idx = curr_input_height_idx / stride_h;
         uint32_t patch_height_offset = curr_input_height_idx % stride_h;
-        uint32_t output_offset =
-            (patch_size * curr_output_height_idx * output_width) + (patch_height_offset * stride_w);
+        uint32_t output_offset = curr_output_height_idx * output_width;
         CoreCoord core = CoreCoord{ncores_full % ncores_x, ncores_full / ncores_x};
         AddRuntimeArgsForNode(
             reader_run.runtime_arg_values,

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -41,8 +41,9 @@ DataflowBufferSpec make_dfb(
     };
 }
 
-// TILE-native factory: reader batches (W_tiles * C_tiles) tiles per input-H row, untilize produces RM sticks in L1,
-// writer scatters each pixel's `c_bytes` into its patch slot (`patch_idx * c_bytes`) inside the output stick.
+// TILE-native factory: work-split is at super-block (= stride_h input H-rows) granularity so the writer
+// can gather stride_h*W pixels into an L1 scratch (cb_asm) and emit one aligned output stick per patch,
+// avoiding the sub-page scatter that dominated the previous byte-level design.
 ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     const Tensor& input_tensor, const Tensor& output, const uint32_t stride_h, const uint32_t stride_w) {
     auto* device = input_tensor.device();
@@ -52,6 +53,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     // without collision.
     const DFBSpecName SRC0{"src0"};
     const DFBSpecName SRC1{"src1"};
+    const DFBSpecName SRC2{"src2"};
     const TensorParamName INPUT{"input"};
     const TensorParamName OUTPUT{"output"};
     const KernelSpecName READER{"reader"};
@@ -89,20 +91,27 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
 
     // Fold on logical C (matches compute_output_specs); untilize row stride uses padded C.
     const uint32_t c_bytes = input_tensor.logical_shape()[-1] * tt::datum_size(out_dfb_data_format);
-    uint32_t ntiles = input_tensor.physical_volume() / TILE_HW;
     uint32_t tiles_per_channel_dim = tt::div_up(input_padded_shape[-1], TILE_WIDTH);
     uint32_t tiles_per_width_dim = tt::div_up(input_padded_shape[-2], TILE_HEIGHT);
-    uint32_t tiles_per_complete_row = tiles_per_width_dim * tiles_per_channel_dim;
-    uint32_t num_blocks = std::ceil(static_cast<float>(ntiles) / (tiles_per_complete_row));
 
     const uint32_t c_padded_bytes = tiles_per_channel_dim * TILE_WIDTH * tt::datum_size(out_dfb_data_format);
-    log_debug(
-        tt::LogOp, "tiles_per_channel_dim: {}, ntiles: {}, num_blocks: {}", tiles_per_channel_dim, ntiles, num_blocks);
+    const uint32_t output_width = input_width / stride_w;
+    const uint32_t patch_size = stride_h * stride_w;
+    const uint32_t output_stick_bytes = patch_size * c_bytes;
+    // One super-block = stride_h consecutive input H-rows → one output H-row. compute_output_specs already
+    // requires stride_h | H, so N*(H/sh) is exact.
+    const uint32_t num_super_blocks = input_tensor.logical_shape()[0] * (input_tensor.logical_shape()[1] / stride_h);
 
-    // Split work across cores for parallel processing
+    log_debug(
+        tt::LogOp,
+        "tiles_per_channel_dim: {}, tiles_per_width_dim: {}, num_super_blocks: {}",
+        tiles_per_channel_dim,
+        tiles_per_width_dim,
+        num_super_blocks);
+
     auto grid_size = device->compute_with_storage_grid_size();
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
-        ttnn::split_blocks_for_tilize(grid_size, num_blocks);
+        ttnn::split_blocks_for_tilize(grid_size, num_super_blocks);
 
     log_debug(
         tt::LogOp,
@@ -113,14 +122,15 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
 
     const uint32_t num_input_tiles = tiles_per_channel_dim;
 
-    // Source DFB and untilized-output DFB for the tiled DRAM fold path.
+    // src0/src1: tile-format input + untilized output; src2: RM scratch sized to one full output row.
     DataflowBufferSpec src0_dfb = make_dfb(SRC0, single_tile_size, num_input_tiles, dfb_data_format);
     DataflowBufferSpec src1_dfb = make_dfb(SRC1, out_single_tile_size, num_input_tiles, out_dfb_data_format);
+    DataflowBufferSpec src2_dfb = make_dfb(SRC2, output_stick_bytes * output_width, 1, out_dfb_data_format);
 
     TensorParameter input_param{.unique_id = INPUT, .spec = input_tensor.tensor_spec()};
     TensorParameter output_param{.unique_id = OUTPUT, .spec = output.tensor_spec()};
 
-    // Reader kernel: DRAM -> DFB. Input tensor is bound; SRC0 is the reader's producer DFB binding.
+    // Reader: DRAM -> src0 (tile CB). Batches stride_h * W_tiles untilize groups per super-block.
     KernelSpec reader_spec{
         .unique_id = READER,
         .source = std::filesystem::path{READER_TILED},
@@ -128,17 +138,21 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
             .dfb_spec_name = SRC0, .accessor_name = "in0", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
         .compile_time_args =
-            {{"tiles_per_channel_dim", tiles_per_channel_dim}, {"tiles_per_width_dim", tiles_per_width_dim}},
+            {{"tiles_per_channel_dim", tiles_per_channel_dim},
+             {"tiles_per_width_dim", tiles_per_width_dim},
+             {"stride_height", stride_h}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_block_id", "num_blocks"}},
         .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
     };
 
-    // Writer kernel: DFB -> DRAM.
+    // Writer: src1 (untilized CB) -> src2 (RM scratch, one output row) -> DRAM (one aligned write per stick).
     KernelSpec writer_spec{
         .unique_id = WRITER,
         .source = std::filesystem::path{WRITER_TILED},
-        .dfb_bindings = {DFBBinding{
-            .dfb_spec_name = SRC1, .accessor_name = "in1", .endpoint_type = DFBEndpointType::CONSUMER}},
+        .dfb_bindings =
+            {DFBBinding{.dfb_spec_name = SRC1, .accessor_name = "in1", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = SRC2, .accessor_name = "in2", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = SRC2, .accessor_name = "in2", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .compile_time_args =
             {{"input_width", input_width},
@@ -148,8 +162,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
              {"c_padded_bytes", c_padded_bytes},
              {"tiles_per_channel_dim", tiles_per_channel_dim},
              {"tiles_per_width_dim", tiles_per_width_dim}},
-        .runtime_arg_schema =
-            {.runtime_arg_names = {"start_block_id", "num_blocks", "patch_height_offset", "output_offset"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"start_block_id", "num_blocks"}},
         .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
     };
 
@@ -174,7 +187,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
                 {DFBBinding{.dfb_spec_name = SRC0, .accessor_name = "src", .endpoint_type = DFBEndpointType::CONSUMER},
                  DFBBinding{.dfb_spec_name = SRC1, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER}},
             .compile_time_args =
-                {{"per_core_block_cnt", nblocks * tiles_per_width_dim},
+                {{"per_core_block_cnt", nblocks * stride_h * tiles_per_width_dim},
                  {"per_core_block_tile_cnt", tiles_per_channel_dim}},
             .hw_config = std::move(compute_cfg),
         };
@@ -201,13 +214,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     auto ncores_y = std::ceil(static_cast<float>(ncores) / ncores_x);
     auto cores = grid_to_cores(ncores_x * ncores_y, ncores_x, ncores_y, true);
 
-    const uint32_t output_width = input_width / stride_w;
     for (auto core : cores) {
-        uint32_t curr_input_height_idx = block_start_id;
-        uint32_t curr_output_height_idx = curr_input_height_idx / stride_h;
-        uint32_t patch_height_offset = curr_input_height_idx % stride_h;
-        // `output_offset` is the output page id of (n, h/sh, 0); writer emits `patch_idx * c_bytes` intra-page.
-        uint32_t output_offset = curr_output_height_idx * output_width;
         if (!full_cores.contains(core)) {
             continue;
         }
@@ -218,18 +225,11 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
         AddRuntimeArgsForNode(
             writer_run.runtime_arg_values,
             core,
-            {{"start_block_id", block_start_id},
-             {"num_blocks", nblocks_per_core},
-             {"patch_height_offset", patch_height_offset},
-             {"output_offset", output_offset}});
+            {{"start_block_id", block_start_id}, {"num_blocks", nblocks_per_core}});
         block_start_id += nblocks_per_core;
     }
 
     if (ncores_full < ncores) {
-        uint32_t curr_input_height_idx = block_start_id;
-        uint32_t curr_output_height_idx = curr_input_height_idx / stride_h;
-        uint32_t patch_height_offset = curr_input_height_idx % stride_h;
-        uint32_t output_offset = curr_output_height_idx * output_width;
         CoreCoord core = CoreCoord{ncores_full % ncores_x, ncores_full / ncores_x};
         AddRuntimeArgsForNode(
             reader_run.runtime_arg_values,
@@ -238,16 +238,13 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
         AddRuntimeArgsForNode(
             writer_run.runtime_arg_values,
             core,
-            {{"start_block_id", block_start_id},
-             {"num_blocks", nblocks_per_core_cliff},
-             {"patch_height_offset", patch_height_offset},
-             {"output_offset", output_offset}});
+            {{"start_block_id", block_start_id}, {"num_blocks", nblocks_per_core_cliff}});
     }
 
     ProgramSpec spec{
         .name = "fold_multi_core_tiled_interleaved",
         .kernels = {reader_spec, writer_spec, compute_spec},
-        .dataflow_buffers = {src0_dfb, src1_dfb},
+        .dataflow_buffers = {src0_dfb, src1_dfb, src2_dfb},
         .tensor_parameters = {input_param, output_param},
         .work_units = {WorkUnitSpec{
             .name = "main",

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -95,9 +95,6 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     uint32_t tiles_per_width_dim = tt::div_up(input_padded_shape[-2], TILE_HEIGHT);
 
     const uint32_t c_padded_bytes = tiles_per_channel_dim * TILE_WIDTH * tt::datum_size(out_dfb_data_format);
-    const uint32_t output_width = input_width / stride_w;
-    const uint32_t patch_size = stride_h * stride_w;
-    const uint32_t output_stick_bytes = patch_size * c_bytes;
     // One super-block = stride_h consecutive input H-rows → one output H-row. compute_output_specs already
     // requires stride_h | H, so N*(H/sh) is exact.
     const uint32_t num_super_blocks = input_tensor.logical_shape()[0] * (input_tensor.logical_shape()[1] / stride_h);
@@ -125,7 +122,8 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     // src0/src1: tile-format input + untilized output; src2: RM scratch sized to one full output row.
     DataflowBufferSpec src0_dfb = make_dfb(SRC0, single_tile_size, num_input_tiles, dfb_data_format);
     DataflowBufferSpec src1_dfb = make_dfb(SRC1, out_single_tile_size, num_input_tiles, out_dfb_data_format);
-    DataflowBufferSpec src2_dfb = make_dfb(SRC2, output_stick_bytes * output_width, 1, out_dfb_data_format);
+    const uint32_t src2_bytes = static_cast<uint32_t>(tile_native_fold_scratch_bytes(input_tensor, stride_h, stride_w));
+    DataflowBufferSpec src2_dfb = make_dfb(SRC2, src2_bytes, 1, out_dfb_data_format);
 
     TensorParameter input_param{.unique_id = INPUT, .spec = input_tensor.tensor_spec()};
     TensorParameter output_param{.unique_id = OUTPUT, .spec = output.tensor_spec()};

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2dfb_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2dfb_tiled.cpp
@@ -13,39 +13,35 @@
 void kernel_main() {
     constexpr uint32_t tiles_per_channel_dim = get_arg(args::tiles_per_channel_dim);
     constexpr uint32_t tiles_per_width_dim = get_arg(args::tiles_per_width_dim);
+    constexpr uint32_t stride_height = get_arg(args::stride_height);
 
-    uint32_t start_block_id = get_arg(args::start_block_id);
-    uint32_t num_blocks = get_arg(args::num_blocks);
+    const uint32_t start_super_block_id = get_arg(args::start_block_id);
+    const uint32_t num_super_blocks = get_arg(args::num_blocks);
 
-    // Initialize interleaved address generator for DRAM access
     const auto s = TensorAccessor(tensor::src);
-
     Noc noc;
     DataflowBuffer dfb_in0(dfb::in0);
-
     const uint32_t tile_bytes = dfb_in0.get_tile_size();
 
-    // Process each block of data
-    uint32_t end_block_id = start_block_id + num_blocks;
-    for (uint32_t i = start_block_id; i < end_block_id; ++i) {
-        // Reserve space in the circular buffer for a row of tiles
-        for (uint32_t j = 0; j < tiles_per_width_dim; ++j) {
-            dfb_in0.reserve_back(tiles_per_channel_dim);
-            uint32_t l1_offset = 0;
-
-            // Read each tile in the current row
-            for (uint32_t k = 0; k < tiles_per_channel_dim; ++k) {
-                // Calculate tile index and read from DRAM to L1
-                uint32_t tile_index = tiles_per_width_dim * tiles_per_channel_dim * i + tiles_per_channel_dim * j + k;
-                noc.async_read(s, dfb_in0, tile_bytes, {.page_id = tile_index}, {.offset_bytes = l1_offset});
-                l1_offset += tile_bytes;
+    // Each super-block = `stride_height` consecutive input rows; the writer gathers them into cb_asm before
+    // emitting one aligned output row, so work must split at super-block granularity across cores.
+    const uint32_t end_super_block_id = start_super_block_id + num_super_blocks;
+    for (uint32_t sb = start_super_block_id; sb < end_super_block_id; ++sb) {
+        const uint32_t input_h_base = sb * stride_height;
+        for (uint32_t local_h = 0; local_h < stride_height; ++local_h) {
+            const uint32_t input_h = input_h_base + local_h;
+            for (uint32_t w_tile = 0; w_tile < tiles_per_width_dim; ++w_tile) {
+                dfb_in0.reserve_back(tiles_per_channel_dim);
+                uint32_t l1_offset = 0;
+                for (uint32_t c_tile = 0; c_tile < tiles_per_channel_dim; ++c_tile) {
+                    const uint32_t tile_index =
+                        input_h * tiles_per_width_dim * tiles_per_channel_dim + w_tile * tiles_per_channel_dim + c_tile;
+                    noc.async_read(s, dfb_in0, tile_bytes, {.page_id = tile_index}, {.offset_bytes = l1_offset});
+                    l1_offset += tile_bytes;
+                }
+                noc.async_read_barrier();
+                dfb_in0.push_back(tiles_per_channel_dim);
             }
-
-            noc.async_read_barrier();
-
-            // Ensure all async reads are complete before proceeding
-            // Push the completed row of tiles to the circular buffer
-            dfb_in0.push_back(tiles_per_channel_dim);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_dfb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_dfb2dram_for_tiled_input.cpp
@@ -10,94 +10,64 @@
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
+using namespace tt::data_movement::common;
+
 void kernel_main() {
-    constexpr uint32_t input_width = get_arg(args::input_width);                      // Width of input tensor
-    constexpr uint32_t stride_height = get_arg(args::stride_height);                  // Vertical stride for fold
-    constexpr uint32_t stride_width = get_arg(args::stride_width);                    // Horizontal stride for fold
-    constexpr uint32_t stick_nbytes = get_arg(args::stick_nbytes);                    // Size of each stick in bytes
-    constexpr uint32_t aligned_stick_nbytes = get_arg(args::aligned_stick_nbytes);    // Aligned size of each stick
-    constexpr uint32_t tiles_per_channel_dim = get_arg(args::tiles_per_channel_dim);  // Tiles per channel dimension
-    constexpr uint32_t tiles_per_width_dim = get_arg(args::tiles_per_width_dim);      // Tiles per width dimension
-    constexpr uint32_t element_size = get_arg(args::element_size);                    // Size of each element in bytes
+    constexpr uint32_t input_width = get_arg(args::input_width);
+    constexpr uint32_t stride_height = get_arg(args::stride_height);
+    constexpr uint32_t stride_width = get_arg(args::stride_width);
+    // `c_bytes` = logical C * elem_size; `c_padded_bytes` = untilize row stride (C_tiles * TILE_WIDTH * elem_size).
+    constexpr uint32_t c_bytes = get_arg(args::c_bytes);
+    constexpr uint32_t c_padded_bytes = get_arg(args::c_padded_bytes);
+    constexpr uint32_t tiles_per_channel_dim = get_arg(args::tiles_per_channel_dim);
+    constexpr uint32_t tiles_per_width_dim = get_arg(args::tiles_per_width_dim);
 
-    // Runtime arguments - Processing parameters
-    const uint32_t start_block_id = get_arg(args::start_block_id);      // Starting block ID for processing
-    const uint32_t num_blocks = get_arg(args::num_blocks);              // Number of blocks to process
-    uint32_t patch_height_offset = get_arg(args::patch_height_offset);  // Current height offset within patch
-    uint32_t output_offset = get_arg(args::output_offset);              // Current output offset
+    const uint32_t start_block_id = get_arg(args::start_block_id);
+    const uint32_t num_blocks = get_arg(args::num_blocks);
+    uint32_t patch_height_offset = get_arg(args::patch_height_offset);
+    uint32_t curr_out_page = get_arg(args::output_offset);
 
-    // Calculated constants
-    constexpr uint32_t output_width = input_width / stride_width;  // Output tensor width
-    constexpr uint32_t patch_size = stride_height * stride_width;  // Total elements per patch
-    // Initialize DRAM address generator for interleaved memory access
+    constexpr uint32_t output_width = input_width / stride_width;
+
     const auto dst = TensorAccessor(tensor::dst);
-
     Noc noc;
     DataflowBuffer dfb_in1(dfb::in1);
 
-    // Processing loop bounds and state variables
     const uint32_t end_block_id = start_block_id + num_blocks;
-    uint32_t curr_offset = output_offset;  // Current working offset
-    uint32_t orig_patch_height_offset = patch_height_offset;
-
-    // Main processing loop - iterate through each block
     for (uint32_t block_id = start_block_id; block_id < end_block_id; block_id++) {
-        uint32_t stick_offset = 0;                // Current stick offset within patch
-        uint32_t stride_width_idx = 0;            // Current position within stride width
-        uint32_t output_stick_idx = curr_offset;  // Current destination stick index
-        uint32_t remaining_width = input_width;   // Remaining width to process
+        uint32_t remaining_width = input_width;
+        uint32_t out_page = curr_out_page;
+        uint32_t stride_w_idx = 0;
+        // Per-input-row patch base within the output stick: `(h % sh) * sw` slots.
+        const uint32_t row_patch_base = patch_height_offset * stride_width;
 
-        // Process each tile in the width dimension
         for (uint32_t tile_idx = 0; tile_idx < tiles_per_width_dim; tile_idx++) {
             dfb_in1.wait_front(tiles_per_channel_dim);
-            // Source the write pointer of the input DFB (matches the legacy WRITE_PTR selector).
-            const uint32_t src_base = dfb_in1.get_write_ptr();
-            uint32_t src_offset = 0;
+            const uint32_t src_base = dfb_in1.get_read_ptr();
 
             const uint32_t width_limit =
                 (remaining_width < tt::constants::TILE_HEIGHT) ? remaining_width : tt::constants::TILE_HEIGHT;
 
-            for (uint32_t stick_idx = 0; stick_idx < width_limit; stick_idx++) {
-                noc.async_write(
-                    CoreLocalMem<uint32_t>(src_base),
-                    dst,
-                    stick_nbytes,
-                    {.offset_bytes = src_offset},
-                    {.page_id = output_stick_idx});
-
-                // Update pointers and indices
-                src_offset += aligned_stick_nbytes;
-                output_stick_idx++;
-                stride_width_idx++;
-
-                // Check if we've completed a stride width - move to next patch row
-                if (stride_width_idx == stride_width) {
-                    stick_offset++;
-                    output_stick_idx = curr_offset + (stick_offset * patch_size);
-                    stride_width_idx = 0;
+            for (uint32_t local_w = 0; local_w < width_limit; local_w++) {
+                const uint32_t patch_idx = row_patch_base + stride_w_idx;
+                // Scatter each input pixel's C real bytes into its patch slot in the output stick.
+                noc_async_write_sharded(
+                    noc, src_base + local_w * c_padded_bytes, dst, out_page, patch_idx * c_bytes, c_bytes);
+                if (++stride_w_idx == stride_width) {
+                    stride_w_idx = 0;
+                    out_page++;
                 }
             }
 
             remaining_width -= tt::constants::TILE_HEIGHT;
-
-            // Ensure all writes complete before moving to next set of tiles_per_channel_dim tiles
             noc.async_write_barrier();
             dfb_in1.pop_front(tiles_per_channel_dim);
         }
 
-        // Update patch offset for next block
-        patch_height_offset++;
-
-        // Check if we've completed a full patch height - move to next patch
-        if (patch_height_offset == stride_height) {
-            // Calculate new output offset for next patch
-            curr_offset = output_offset + (patch_size * output_width) - (orig_patch_height_offset * stride_width);
-            output_offset = curr_offset;
+        // Advance to the next output-h row only after `sh` input rows have been scattered.
+        if (++patch_height_offset == stride_height) {
+            curr_out_page += output_width;
             patch_height_offset = 0;
-            orig_patch_height_offset = 0;
-        } else {
-            // Move to next row within the same patch
-            curr_offset += stride_width;
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_dfb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_dfb2dram_for_tiled_input.cpp
@@ -22,52 +22,60 @@ void kernel_main() {
     constexpr uint32_t tiles_per_channel_dim = get_arg(args::tiles_per_channel_dim);
     constexpr uint32_t tiles_per_width_dim = get_arg(args::tiles_per_width_dim);
 
-    const uint32_t start_block_id = get_arg(args::start_block_id);
-    const uint32_t num_blocks = get_arg(args::num_blocks);
-    uint32_t patch_height_offset = get_arg(args::patch_height_offset);
-    uint32_t curr_out_page = get_arg(args::output_offset);
+    const uint32_t start_super_block_id = get_arg(args::start_block_id);
+    const uint32_t num_super_blocks = get_arg(args::num_blocks);
 
     constexpr uint32_t output_width = input_width / stride_width;
+    constexpr uint32_t patch_size = stride_height * stride_width;
+    constexpr uint32_t output_stick_bytes = patch_size * c_bytes;
 
     const auto dst = TensorAccessor(tensor::dst);
     Noc noc;
-    DataflowBuffer dfb_in1(dfb::in1);
+    DataflowBuffer dfb_untilized(dfb::in1);
+    DataflowBuffer dfb_scratch(dfb::in2);
 
-    const uint32_t end_block_id = start_block_id + num_blocks;
-    for (uint32_t block_id = start_block_id; block_id < end_block_id; block_id++) {
-        uint32_t remaining_width = input_width;
-        uint32_t out_page = curr_out_page;
-        uint32_t stride_w_idx = 0;
-        // Per-input-row patch base within the output stick: `(h % sh) * sw` slots.
-        const uint32_t row_patch_base = patch_height_offset * stride_width;
+    // cb_asm holds one full output row; touched only by this kernel, so raw pointer + local ordering.
+    const uint32_t scratch_base = dfb_scratch.get_write_ptr();
 
-        for (uint32_t tile_idx = 0; tile_idx < tiles_per_width_dim; tile_idx++) {
-            dfb_in1.wait_front(tiles_per_channel_dim);
-            const uint32_t src_base = dfb_in1.get_read_ptr();
+    const uint32_t end_super_block_id = start_super_block_id + num_super_blocks;
+    for (uint32_t sb = start_super_block_id; sb < end_super_block_id; ++sb) {
+        // Gather `stride_height` input rows worth of C-byte sticks into cb_asm; each pixel lands at
+        // `out_w * output_stick_bytes + patch_idx * c_bytes` so every output stick becomes contiguous.
+        for (uint32_t local_h = 0; local_h < stride_height; ++local_h) {
+            uint32_t remaining_width = input_width;
+            const uint32_t row_patch_base = local_h * stride_width;
+            for (uint32_t w_tile = 0; w_tile < tiles_per_width_dim; ++w_tile) {
+                dfb_untilized.wait_front(tiles_per_channel_dim);
+                const uint32_t src_base = dfb_untilized.get_read_ptr();
 
-            const uint32_t width_limit =
-                (remaining_width < tt::constants::TILE_HEIGHT) ? remaining_width : tt::constants::TILE_HEIGHT;
-
-            for (uint32_t local_w = 0; local_w < width_limit; local_w++) {
-                const uint32_t patch_idx = row_patch_base + stride_w_idx;
-                // Scatter each input pixel's C real bytes into its patch slot in the output stick.
-                noc_async_write_sharded(
-                    noc, src_base + local_w * c_padded_bytes, dst, out_page, patch_idx * c_bytes, c_bytes);
-                if (++stride_w_idx == stride_width) {
-                    stride_w_idx = 0;
-                    out_page++;
+                const uint32_t width_limit =
+                    (remaining_width < tt::constants::TILE_HEIGHT) ? remaining_width : tt::constants::TILE_HEIGHT;
+                const uint32_t w_base = w_tile * tt::constants::TILE_HEIGHT;
+                for (uint32_t local_w = 0; local_w < width_limit; ++local_w) {
+                    const uint32_t w_in = w_base + local_w;
+                    const uint32_t out_w = w_in / stride_width;
+                    const uint32_t patch_idx = row_patch_base + (w_in % stride_width);
+                    tt_memmove<false, false, false, c_bytes>(
+                        noc,
+                        scratch_base + out_w * output_stick_bytes + patch_idx * c_bytes,
+                        src_base + local_w * c_padded_bytes,
+                        c_bytes);
                 }
+                remaining_width -= tt::constants::TILE_HEIGHT;
+                dfb_untilized.pop_front(tiles_per_channel_dim);
             }
-
-            remaining_width -= tt::constants::TILE_HEIGHT;
-            noc.async_write_barrier();
-            dfb_in1.pop_front(tiles_per_channel_dim);
         }
-
-        // Advance to the next output-h row only after `sh` input rows have been scattered.
-        if (++patch_height_offset == stride_height) {
-            curr_out_page += output_width;
-            patch_height_offset = 0;
+        // Emit one aligned page-sized write per output stick; super-blocks are laid out sequentially.
+        const uint32_t output_page_base = sb * output_width;
+        for (uint32_t out_w = 0; out_w < output_width; ++out_w) {
+            noc_async_write_sharded(
+                noc,
+                scratch_base + out_w * output_stick_bytes,
+                dst,
+                output_page_base + out_w,
+                /*offset=*/0,
+                output_stick_bytes);
         }
+        noc.async_write_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_dfb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_dfb2dram_for_tiled_input.cpp
@@ -55,7 +55,8 @@ void kernel_main() {
                     const uint32_t w_in = w_base + local_w;
                     const uint32_t out_w = w_in / stride_width;
                     const uint32_t patch_idx = row_patch_base + (w_in % stride_width);
-                    tt_memmove<false, false, false, c_bytes>(
+                    // copy_async=true skips the per-pixel L1D drain; single tail-drain below.
+                    tt_memmove<false, true, false, c_bytes>(
                         noc,
                         scratch_base + out_w * output_stick_bytes + patch_idx * c_bytes,
                         src_base + local_w * c_padded_bytes,
@@ -65,6 +66,11 @@ void kernel_main() {
                 dfb_untilized.pop_front(tiles_per_channel_dim);
             }
         }
+        // One drain per super-block instead of per-pixel: async_write_barrier flushes the NoC self-copy
+        // path; the volatile L1 read serialises any CPU-memmove fallback stores (L1 write-requests are FIFO).
+        noc.async_write_barrier();
+        volatile tt_l1_ptr uint32_t* drain_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(scratch_base);
+        [[maybe_unused]] volatile uint32_t drain_read = *drain_ptr;
         // Emit one aligned page-sized write per output stick; super-blocks are laid out sequentially.
         const uint32_t output_page_base = sb * output_width;
         for (uint32_t out_w = 0; out_w < output_width; ++out_w) {

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -539,8 +539,9 @@ Tensor fold(
             processed_tensor = ttnn::pad(processed_tensor, padding_spec, 0.0f, true, std::nullopt);
         }
 
-        if (processed_tensor.layout() == Layout::TILE) {
-            // TILE-native factory is broken (see fold_multi_core_tiled_interleaved) → untilize→RM.
+        // TILE-native factory handles aligned (C * elem_size); fall back to untilize→RM only when it can't.
+        if (processed_tensor.layout() == Layout::TILE &&
+            !operations::data_movement::is_tile_native_fold_supported(processed_tensor)) {
             processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -539,9 +539,10 @@ Tensor fold(
             processed_tensor = ttnn::pad(processed_tensor, padding_spec, 0.0f, true, std::nullopt);
         }
 
-        // TILE-native factory handles aligned (C * elem_size); fall back to untilize→RM only when it can't.
+        // Tile-native factory holds one full output row in L1 scratch; if it wouldn't fit, fall back
+        // to untilize→RM so prim::fold takes the RM path (1-stick scratch).
         if (processed_tensor.layout() == Layout::TILE &&
-            !operations::data_movement::is_tile_native_fold_supported(processed_tensor)) {
+            !operations::data_movement::tile_native_fold_scratch_fits_l1(processed_tensor, stride_h, stride_w)) {
             processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -539,12 +539,17 @@ Tensor fold(
             processed_tensor = ttnn::pad(processed_tensor, padding_spec, 0.0f, true, std::nullopt);
         }
 
-        // Tile-native factory only supports interleaved TILE; W/B-sharded TILE inputs and shapes whose
-        // row-scratch overflows L1 go through untilize→RM so prim::fold takes the 1-stick RM path.
-        if (processed_tensor.layout() == Layout::TILE &&
-            (processed_tensor.is_sharded() ||
-             !operations::data_movement::tile_native_fold_scratch_fits_l1(processed_tensor, stride_h, stride_w))) {
-            processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
+        // Tile-native factory's writer hits the NoC self-copy path only when c_bytes is 16B-aligned; sub-16B
+        // c_bytes fall to per-pixel CPU memmove which loses ~2x to untilize→RM for small C. W/B-sharded TILE
+        // and scratch-overflow shapes route the same way (RM path is 1-stick and fits any capacity).
+        if (processed_tensor.layout() == Layout::TILE) {
+            const uint32_t out_elem_bytes = tt::datum_size(datatype_to_dataformat_converter(
+                operations::data_movement::fold_output_dtype(processed_tensor.dtype())));
+            const uint32_t c_bytes = processed_tensor.logical_shape()[-1] * out_elem_bytes;
+            if (processed_tensor.is_sharded() || c_bytes % 16 != 0 ||
+                !operations::data_movement::tile_native_fold_scratch_fits_l1(processed_tensor, stride_h, stride_w)) {
+                processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
+            }
         }
 
         result = ttnn::prim::fold(processed_tensor, stride_h, stride_w, collapse_output);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -539,10 +539,11 @@ Tensor fold(
             processed_tensor = ttnn::pad(processed_tensor, padding_spec, 0.0f, true, std::nullopt);
         }
 
-        // Tile-native factory holds one full output row in L1 scratch; if it wouldn't fit, fall back
-        // to untilize→RM so prim::fold takes the RM path (1-stick scratch).
+        // Tile-native factory only supports interleaved TILE; W/B-sharded TILE inputs and shapes whose
+        // row-scratch overflows L1 go through untilize→RM so prim::fold takes the 1-stick RM path.
         if (processed_tensor.layout() == Layout::TILE &&
-            !operations::data_movement::tile_native_fold_scratch_fits_l1(processed_tensor, stride_h, stride_w)) {
+            (processed_tensor.is_sharded() ||
+             !operations::data_movement::tile_native_fold_scratch_fits_l1(processed_tensor, stride_h, stride_w))) {
             processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_device_op.cpp
@@ -5,8 +5,27 @@
 #include "fold_device_op.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/hal.hpp>
 
 namespace ttnn::operations::experimental::quasar {
+
+bool tile_native_fold_scratch_fits_l1(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w) {
+    if (input_tensor.layout() != tt::tt_metal::Layout::TILE) {
+        return false;
+    }
+    // Output dtype mirrors compute_output_specs: BFLOAT8_B/BFLOAT16 collapse to BFLOAT16 on RM output.
+    const auto in_dt = input_tensor.dtype();
+    const auto out_dt = (in_dt == tt::tt_metal::DataType::FLOAT32 || in_dt == tt::tt_metal::DataType::UINT16)
+                            ? in_dt
+                            : tt::tt_metal::DataType::BFLOAT16;
+    const uint32_t out_elem = tt::datum_size(datatype_to_dataformat_converter(out_dt));
+    const uint32_t input_width = input_tensor.logical_shape()[2];
+    const uint32_t C = input_tensor.logical_shape()[-1];
+    const uint64_t scratch_bytes = static_cast<uint64_t>(input_width / stride_w) * stride_h * stride_w * C * out_elem;
+    // ~200 KB reserve for src0/src1 tile CBs and kernel code/stack (pattern from conv3d factory).
+    constexpr uint64_t kOverhead = 200 * 1024;
+    return scratch_bytes + kOverhead < tt::tt_metal::hal::get_max_worker_l1_unreserved_size();
+}
 
 Fold::program_factory_t Fold::select_program_factory(
     const operation_attributes_t& op_attr, const tensor_args_t& /*tensors*/) {
@@ -77,18 +96,15 @@ Fold::spec_return_value_t Fold::compute_output_specs(
             tt::tt_metal::TensorLayout(
                 output_dtype, tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR), mem_config))};
     }
-    // Interleaved tensors (DRAM or L1)
+    // Interleaved tensors (DRAM or L1): DRAM keeps the folded 4D shape (both TILE and RM go through
+    // fold_multi_core_tiled_interleaved / fold_multi_core_row_major_interleaved and land RM).
     ttnn::Shape output_logical_shape = output_shape;
     if (input_tensor.memory_config().is_dram()) {
-        // DRAM path preserves 4D shape; for tiled inputs the caller reshapes afterward
-        output_logical_shape = ttnn::Shape({input_shape[0], input_shape[1], input_shape[2], input_shape[3]});
-        if (input_tensor.layout() == Layout::ROW_MAJOR) {
-            output_logical_shape = ttnn::Shape(
-                {input_shape[0],
-                 input_shape[1] / op_attr.stride_h,
-                 input_shape[2] / op_attr.stride_w,
-                 input_shape[3] * op_attr.stride_h * op_attr.stride_w});
-        }
+        output_logical_shape = ttnn::Shape(
+            {input_shape[0],
+             input_shape[1] / op_attr.stride_h,
+             input_shape[2] / op_attr.stride_w,
+             input_shape[3] * op_attr.stride_h * op_attr.stride_w});
     }
     return {tt::tt_metal::TensorSpec(
         output_logical_shape,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_device_op.cpp
@@ -5,26 +5,37 @@
 #include "fold_device_op.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/math.hpp>
 
 namespace ttnn::operations::experimental::quasar {
+
+tt::tt_metal::DataType fold_output_dtype(tt::tt_metal::DataType input_dtype) {
+    return (input_dtype == tt::tt_metal::DataType::FLOAT32 || input_dtype == tt::tt_metal::DataType::UINT16)
+               ? input_dtype
+               : tt::tt_metal::DataType::BFLOAT16;
+}
+
+uint64_t tile_native_fold_scratch_bytes(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w) {
+    const uint32_t out_elem = tt::datum_size(datatype_to_dataformat_converter(fold_output_dtype(input_tensor.dtype())));
+    const auto& shape = input_tensor.logical_shape();
+    const uint32_t input_width = shape[2];
+    const uint32_t C = shape[-1];
+    return static_cast<uint64_t>(input_width / stride_w) * stride_h * stride_w * C * out_elem;
+}
 
 bool tile_native_fold_scratch_fits_l1(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w) {
     if (input_tensor.layout() != tt::tt_metal::Layout::TILE) {
         return false;
     }
-    // Output dtype mirrors compute_output_specs: BFLOAT8_B/BFLOAT16 collapse to BFLOAT16 on RM output.
-    const auto in_dt = input_tensor.dtype();
-    const auto out_dt = (in_dt == tt::tt_metal::DataType::FLOAT32 || in_dt == tt::tt_metal::DataType::UINT16)
-                            ? in_dt
-                            : tt::tt_metal::DataType::BFLOAT16;
-    const uint32_t out_elem = tt::datum_size(datatype_to_dataformat_converter(out_dt));
-    const uint32_t input_width = input_tensor.logical_shape()[2];
-    const uint32_t C = input_tensor.logical_shape()[-1];
-    const uint64_t scratch_bytes = static_cast<uint64_t>(input_width / stride_w) * stride_h * stride_w * C * out_elem;
-    // ~200 KB reserve for src0/src1 tile CBs and kernel code/stack (pattern from conv3d factory).
-    constexpr uint64_t kOverhead = 200 * 1024;
-    return scratch_bytes + kOverhead < tt::tt_metal::hal::get_max_worker_l1_unreserved_size();
+    const uint64_t scratch = tile_native_fold_scratch_bytes(input_tensor, stride_h, stride_w);
+    const auto in_df = datatype_to_dataformat_converter(input_tensor.dtype());
+    const auto out_df = datatype_to_dataformat_converter(fold_output_dtype(input_tensor.dtype()));
+    const uint32_t c_tiles = tt::div_up(input_tensor.padded_shape()[-1], tt::constants::TILE_WIDTH);
+    const uint64_t cb_bytes = static_cast<uint64_t>(tt::tile_size(in_df) + tt::tile_size(out_df)) * c_tiles;
+    constexpr uint64_t kCodeStackReserve = 32 * 1024;
+    return scratch + cb_bytes + kCodeStackReserve < tt::tt_metal::hal::get_max_worker_l1_unreserved_size();
 }
 
 Fold::program_factory_t Fold::select_program_factory(
@@ -37,8 +48,7 @@ Fold::program_factory_t Fold::select_program_factory(
 
 void validate_fold(const std::vector<Tensor>& input_tensors, bool is_sharded, uint32_t stride_h, uint32_t stride_w) {
     const Tensor& input_tensor = input_tensors.at(0);
-
-    const auto& input_shape = input_tensor.padded_shape();
+    const auto& logical_shape = input_tensor.logical_shape();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Fold: Expect input tensor to be stored on device.");
     TT_FATAL(input_tensor.buffer() != nullptr, "Fold: Expect input tensor to be allocated on a device buffer.");
@@ -46,15 +56,21 @@ void validate_fold(const std::vector<Tensor>& input_tensors, bool is_sharded, ui
         TT_FATAL(
             input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
             "Fold: Only height-sharded input tensors are supported.");
-
         auto shard_shape = input_tensor.shard_spec().value().shape;
         TT_FATAL(
-            shard_shape[0] % (input_shape[2] * stride_h) == 0,
+            shard_shape[0] % (logical_shape[2] * stride_h) == 0,
             "Fold: Shard height must be divisible by input width times stride_h for proper folding operation.");
         TT_FATAL(input_tensor.layout() == Layout::ROW_MAJOR, "Fold: Expect sharded input tensor in row-major layout.");
     } else {
-        TT_FATAL(input_shape[1] % stride_h == 0, "Fold: Input height must be divisible by stride_h.");
-        TT_FATAL(input_shape[2] % stride_w == 0, "Fold: Input width must be divisible by stride_w.");
+        // Divisibility on logical (padded hides partial-tile W that the tile-native writer would OOB into).
+        TT_FATAL(logical_shape[1] % stride_h == 0, "Fold: logical H must be divisible by stride_h.");
+        TT_FATAL(logical_shape[2] % stride_w == 0, "Fold: logical W must be divisible by stride_w.");
+        // TILE input routes through the tile-native factory; refuse configs whose row scratch won't fit L1.
+        TT_FATAL(
+            input_tensor.layout() != tt::tt_metal::Layout::TILE ||
+                tile_native_fold_scratch_fits_l1(input_tensor, stride_h, stride_w),
+            "Fold (TILE): tile-native scratch {} B + tile CBs exceed per-core L1; untilize input to RM first.",
+            tile_native_fold_scratch_bytes(input_tensor, stride_h, stride_w));
     }
 }
 
@@ -70,12 +86,7 @@ Fold::spec_return_value_t Fold::compute_output_specs(
     const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
     auto input_tensor = tensors.input_tensor;
     const ttnn::Shape& input_shape = input_tensor.logical_shape();
-    auto input_dtype = input_tensor.dtype();
-
-    tt::tt_metal::DataType output_dtype =
-        (input_dtype == tt::tt_metal::DataType::FLOAT32 || input_dtype == tt::tt_metal::DataType::UINT16)
-            ? input_dtype
-            : tt::tt_metal::DataType::BFLOAT16;
+    const tt::tt_metal::DataType output_dtype = fold_output_dtype(input_tensor.dtype());
 
     // we concatenate (stride_h sticks in H-dim) * (stride_w in W-dim) into 1 stick along C-dim
     ttnn::Shape output_shape(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_device_op.hpp
@@ -14,6 +14,10 @@
 
 namespace ttnn::operations::experimental::quasar {
 
+// Tile-native tiled factory holds one full output row in L1 scratch (`out_W * sh * sw * C * out_elem`);
+// if that overflows the per-core budget, composite untilize→RM does the same work with 1-stick scratch.
+bool tile_native_fold_scratch_fits_l1(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w);
+
 struct Fold {
     struct operation_attributes_t {
         uint32_t stride_h{};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_device_op.hpp
@@ -14,8 +14,14 @@
 
 namespace ttnn::operations::experimental::quasar {
 
-// Tile-native tiled factory holds one full output row in L1 scratch (`out_W * sh * sw * C * out_elem`);
-// if that overflows the per-core budget, composite untilize→RM does the same work with 1-stick scratch.
+// Output-dtype rule: FLOAT32/UINT16 pass through; every other input dtype collapses to BFLOAT16 on RM output.
+tt::tt_metal::DataType fold_output_dtype(tt::tt_metal::DataType input_dtype);
+
+// Bytes the tile-native writer's per-super-block RM scratch needs (one output row of contiguous sticks).
+uint64_t tile_native_fold_scratch_bytes(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w);
+
+// Tile-native tiled factory needs `scratch + src0 + src1 CBs` to fit per-core L1 (src0/src1 scale with C_tiles);
+// if not, composite untilize→RM handles the same case with 1-stick scratch.
 bool tile_native_fold_scratch_fits_l1(const Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w);
 
 struct Fold {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -32,6 +32,9 @@ using namespace tt::tt_metal::experimental;
 
 namespace {
 
+// TILE-native factory: work-split is at super-block (= stride_h input H-rows) granularity so the writer
+// can gather stride_h*W pixels into an L1 scratch (src2) and emit one aligned output stick per patch,
+// avoiding the sub-page scatter that dominated the previous byte-level design.
 ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     const Tensor& input_tensor, const Tensor& output, const uint32_t stride_h, const uint32_t stride_w) {
     auto* device = input_tensor.device();
@@ -52,23 +55,28 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     log_debug(tt::LogOp, "input_tensor_shape: {}", input_padded_shape);
     log_debug(tt::LogOp, "output_tensor_shape: {}", output_padded_shape);
 
-    // Memory layout parameters
-    auto stick_nbytes = output_padded_shape[3] * tt::datum_size(datatype_to_dataformat_converter(output.dtype()));
-    uint32_t ntiles = input_tensor.physical_volume() / TILE_HW;
+    // Fold on logical C (matches compute_output_specs); untilize row stride uses padded C.
+    const uint32_t c_bytes = input_tensor.logical_shape()[-1] * tt::datum_size(out_cb_data_format);
     uint32_t tiles_per_channel_dim = tt::div_up(input_padded_shape[-1], TILE_WIDTH);
     uint32_t tiles_per_width_dim = tt::div_up(input_padded_shape[-2], TILE_HEIGHT);
-    uint32_t tiles_per_complete_row = tiles_per_width_dim * tiles_per_channel_dim;
-    // Total number of blocks for batch * height
-    uint32_t num_blocks = std::ceil(static_cast<float>(ntiles) / (tiles_per_complete_row));
 
-    uint32_t aligned_stick_nbytes = tt::align(stick_nbytes, TILE_WIDTH * tt::datum_size(out_cb_data_format));
+    const uint32_t c_padded_bytes = tiles_per_channel_dim * TILE_WIDTH * tt::datum_size(out_cb_data_format);
+    const uint32_t output_width = input_width / stride_w;
+    const uint32_t patch_size = stride_h * stride_w;
+    const uint32_t output_stick_bytes = patch_size * c_bytes;
+    // One super-block = stride_h consecutive input H-rows → one output H-row.
+    const uint32_t num_super_blocks = input_tensor.logical_shape()[0] * (input_tensor.logical_shape()[1] / stride_h);
+
     log_debug(
-        tt::LogOp, "tiles_per_channel_dim: {}, ntiles: {}, num_blocks: {}", tiles_per_channel_dim, ntiles, num_blocks);
+        tt::LogOp,
+        "tiles_per_channel_dim: {}, tiles_per_width_dim: {}, num_super_blocks: {}",
+        tiles_per_channel_dim,
+        tiles_per_width_dim,
+        num_super_blocks);
 
-    // Split work across cores for parallel processing
     auto grid_size = device->compute_with_storage_grid_size();
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
-        ttnn::split_blocks_for_tilize(grid_size, num_blocks);
+        ttnn::split_blocks_for_tilize(grid_size, num_super_blocks);
 
     log_debug(
         tt::LogOp,
@@ -84,6 +92,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     const TensorParamName OUTPUT{"output"};
     const DFBSpecName SRC0{"src0"};
     const DFBSpecName SRC1{"src1"};
+    const DFBSpecName SRC2{"src2"};
     const KernelSpecName READER{"reader"};
     const KernelSpecName WRITER{"writer"};
     const KernelSpecName COMPUTE_MAIN{"compute_main"};
@@ -108,6 +117,13 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
         .num_entries = num_input_tiles,
         .data_format_metadata = out_cb_data_format,
     };
+    // src2: RM scratch sized to one full output row; touched only by the writer (self-loop DFB).
+    DataflowBufferSpec src2_dfb{
+        .unique_id = SRC2,
+        .entry_size = output_stick_bytes * output_width,
+        .num_entries = 1,
+        .data_format_metadata = out_cb_data_format,
+    };
 
     // ---- Reader kernel (DRAM -> SRC0) ----
     KernelSpec reader{
@@ -117,31 +133,33 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
             .dfb_spec_name = SRC0, .accessor_name = "src0", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
         .compile_time_args =
-            {{"tiles_per_channel_dim", tiles_per_channel_dim}, {"tiles_per_width_dim", tiles_per_width_dim}},
+            {{"tiles_per_channel_dim", tiles_per_channel_dim},
+             {"tiles_per_width_dim", tiles_per_width_dim},
+             {"stride_height", stride_h}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_block_id", "num_blocks"}},
         .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
     };
 
-    // ---- Writer kernel (SRC1 -> DRAM) ----
+    // ---- Writer kernel (SRC1 -> SRC2 scratch -> DRAM) ----
     KernelSpec writer{
         .unique_id = WRITER,
         .source =
             "ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/kernels/dataflow/"
             "writer_cb2dram_for_tiled_input.cpp",
-        .dfb_bindings = {DFBBinding{
-            .dfb_spec_name = SRC1, .accessor_name = "src1", .endpoint_type = DFBEndpointType::CONSUMER}},
+        .dfb_bindings =
+            {DFBBinding{.dfb_spec_name = SRC1, .accessor_name = "src1", .endpoint_type = DFBEndpointType::CONSUMER},
+             DFBBinding{.dfb_spec_name = SRC2, .accessor_name = "src2", .endpoint_type = DFBEndpointType::PRODUCER},
+             DFBBinding{.dfb_spec_name = SRC2, .accessor_name = "src2", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .compile_time_args =
             {{"input_width", input_width},
              {"stride_height", stride_h},
              {"stride_width", stride_w},
-             {"stick_nbytes", stick_nbytes},
-             {"aligned_stick_nbytes", aligned_stick_nbytes},
+             {"c_bytes", c_bytes},
+             {"c_padded_bytes", c_padded_bytes},
              {"tiles_per_channel_dim", tiles_per_channel_dim},
-             {"tiles_per_width_dim", tiles_per_width_dim},
-             {"element_size", datum_size(out_cb_data_format)}},
-        .runtime_arg_schema =
-            {.runtime_arg_names = {"start_block_id", "num_blocks", "patch_height_offset", "output_offset"}},
+             {"tiles_per_width_dim", tiles_per_width_dim}},
+        .runtime_arg_schema = {.runtime_arg_names = {"start_block_id", "num_blocks"}},
         .hw_config =
             ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
     };
@@ -166,7 +184,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
                     .fp32_dest_acc_en = fp32_dest_acc_en}),
         };
     };
-    KernelSpec compute_main = make_compute(COMPUTE_MAIN, nblocks_per_core * tiles_per_width_dim);
+    KernelSpec compute_main = make_compute(COMPUTE_MAIN, nblocks_per_core * stride_h * tiles_per_width_dim);
 
     const bool has_cliff = !core_range_cliff.ranges().empty();
 
@@ -184,19 +202,10 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     auto ncores_y = std::ceil(static_cast<float>(ncores) / ncores_x);
     auto cores = grid_to_cores(ncores_x * ncores_y, ncores_x, ncores_y, true);
 
-    const uint32_t patch_size = stride_h * stride_w;       // Size of each patch
-    const uint32_t output_width = input_width / stride_w;  // Output width
-
     KernelRunArgs::RuntimeArgValues reader_rta;
     KernelRunArgs::RuntimeArgValues writer_rta;
 
     for (auto core : cores) {
-        uint32_t curr_input_height_idx = block_start_id;
-        uint32_t curr_output_height_idx = curr_input_height_idx / stride_h;
-        uint32_t patch_height_offset = curr_input_height_idx % stride_h;
-        // Total output height * width
-        uint32_t output_offset =
-            (patch_size * curr_output_height_idx * output_width) + (patch_height_offset * stride_w);
         if (!full_cores.contains(core)) {
             continue;
         }
@@ -213,18 +222,11 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
             {
                 {"start_block_id", block_start_id},
                 {"num_blocks", nblocks_per_core},
-                {"patch_height_offset", patch_height_offset},
-                {"output_offset", output_offset},
             });
         block_start_id += nblocks_per_core;
     }
 
     if (ncores_full < ncores) {
-        uint32_t curr_input_height_idx = block_start_id;
-        uint32_t curr_output_height_idx = curr_input_height_idx / stride_h;
-        uint32_t patch_height_offset = curr_input_height_idx % stride_h;
-        uint32_t output_offset =
-            (patch_size * curr_output_height_idx * output_width) + (patch_height_offset * stride_w);
         CoreCoord core = CoreCoord{ncores_full % ncores_x, ncores_full / ncores_x};
         AddRuntimeArgsForNode(
             reader_rta,
@@ -239,15 +241,13 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
             {
                 {"start_block_id", block_start_id},
                 {"num_blocks", nblocks_per_core_cliff},
-                {"patch_height_offset", patch_height_offset},
-                {"output_offset", output_offset},
             });
     }
 
     // ---- Assemble the spec ----
     ProgramSpec spec;
     spec.name = "fold_multi_core_tiled_interleaved";
-    spec.dataflow_buffers = {std::move(src0_dfb), std::move(src1_dfb)};
+    spec.dataflow_buffers = {std::move(src0_dfb), std::move(src1_dfb), std::move(src2_dfb)};
     spec.tensor_parameters = {std::move(input_param), std::move(output_param)};
     spec.kernels = {std::move(reader), std::move(writer), std::move(compute_main)};
     // Reader/writer cover all_cores; the compute work splits into a main core group
@@ -255,7 +255,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     spec.work_units = {
         WorkUnitSpec{.name = "wu_main", .kernels = {READER, WRITER, COMPUTE_MAIN}, .target_nodes = core_range}};
     if (has_cliff) {
-        spec.kernels.push_back(make_compute(COMPUTE_CLIFF, nblocks_per_core_cliff * tiles_per_width_dim));
+        spec.kernels.push_back(make_compute(COMPUTE_CLIFF, nblocks_per_core_cliff * stride_h * tiles_per_width_dim));
         spec.work_units.push_back(WorkUnitSpec{
             .name = "wu_cliff", .kernels = {READER, WRITER, COMPUTE_CLIFF}, .target_nodes = core_range_cliff});
     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -61,9 +61,6 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     uint32_t tiles_per_width_dim = tt::div_up(input_padded_shape[-2], TILE_HEIGHT);
 
     const uint32_t c_padded_bytes = tiles_per_channel_dim * TILE_WIDTH * tt::datum_size(out_cb_data_format);
-    const uint32_t output_width = input_width / stride_w;
-    const uint32_t patch_size = stride_h * stride_w;
-    const uint32_t output_stick_bytes = patch_size * c_bytes;
     // One super-block = stride_h consecutive input H-rows → one output H-row.
     const uint32_t num_super_blocks = input_tensor.logical_shape()[0] * (input_tensor.logical_shape()[1] / stride_h);
 
@@ -118,9 +115,10 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
         .data_format_metadata = out_cb_data_format,
     };
     // src2: RM scratch sized to one full output row; touched only by the writer (self-loop DFB).
+    const uint32_t src2_bytes = static_cast<uint32_t>(tile_native_fold_scratch_bytes(input_tensor, stride_h, stride_w));
     DataflowBufferSpec src2_dfb{
         .unique_id = SRC2,
-        .entry_size = output_stick_bytes * output_width,
+        .entry_size = src2_bytes,
         .num_entries = 1,
         .data_format_metadata = out_cb_data_format,
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
@@ -12,39 +12,36 @@
 void kernel_main() {
     constexpr uint32_t tiles_per_channel_dim = get_arg(args::tiles_per_channel_dim);
     constexpr uint32_t tiles_per_width_dim = get_arg(args::tiles_per_width_dim);
+    constexpr uint32_t stride_height = get_arg(args::stride_height);
 
-    auto start_block_id = get_arg(args::start_block_id);
-    auto num_blocks = get_arg(args::num_blocks);
+    const uint32_t start_super_block_id = get_arg(args::start_block_id);
+    const uint32_t num_super_blocks = get_arg(args::num_blocks);
 
     DataflowBuffer cb_in0(dfb::src0);
     const uint32_t tile_bytes = cb_in0.get_entry_size();
 
-    // Interleaved DRAM access via the bound input tensor.
     const auto s = TensorAccessor(tensor::src);
-
     Noc noc;
 
-    // Process each block of data
-    uint32_t end_block_id = start_block_id + num_blocks;
-    for (uint32_t i = start_block_id; i < end_block_id; ++i) {
-        // Reserve space in the circular buffer for a row of tiles
-        for (uint32_t j = 0; j < tiles_per_width_dim; ++j) {
-            cb_in0.reserve_back(tiles_per_channel_dim);
-            uint32_t l1_offset = 0;
-
-            // Read each tile in the current row
-            for (uint32_t k = 0; k < tiles_per_channel_dim; ++k) {
-                // Calculate tile index and read from DRAM to L1
-                uint32_t tile_index = tiles_per_width_dim * tiles_per_channel_dim * i + tiles_per_channel_dim * j + k;
-                noc.async_read(s, cb_in0, tile_bytes, {.page_id = tile_index}, {.offset_bytes = l1_offset});
-                l1_offset += tile_bytes;
+    // Each super-block = `stride_height` consecutive input rows; the writer gathers them into scratch before
+    // emitting one aligned output row, so work must split at super-block granularity across cores.
+    const uint32_t end_super_block_id = start_super_block_id + num_super_blocks;
+    for (uint32_t sb = start_super_block_id; sb < end_super_block_id; ++sb) {
+        const uint32_t input_h_base = sb * stride_height;
+        for (uint32_t local_h = 0; local_h < stride_height; ++local_h) {
+            const uint32_t input_h = input_h_base + local_h;
+            for (uint32_t w_tile = 0; w_tile < tiles_per_width_dim; ++w_tile) {
+                cb_in0.reserve_back(tiles_per_channel_dim);
+                uint32_t l1_offset = 0;
+                for (uint32_t c_tile = 0; c_tile < tiles_per_channel_dim; ++c_tile) {
+                    const uint32_t tile_index =
+                        input_h * tiles_per_width_dim * tiles_per_channel_dim + w_tile * tiles_per_channel_dim + c_tile;
+                    noc.async_read(s, cb_in0, tile_bytes, {.page_id = tile_index}, {.offset_bytes = l1_offset});
+                    l1_offset += tile_bytes;
+                }
+                noc.async_read_barrier();
+                cb_in0.push_back(tiles_per_channel_dim);
             }
-
-            noc.async_read_barrier();
-
-            // Ensure all async reads are complete before proceeding
-            // Push the completed row of tiles to the circular buffer
-            cb_in0.push_back(tiles_per_channel_dim);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
@@ -9,93 +9,71 @@
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include "experimental/kernel_args.h"
 
+using namespace tt::data_movement::common;
+
 void kernel_main() {
-    constexpr uint32_t input_width = get_arg(args::input_width);                      // Width of input tensor
-    constexpr uint32_t stride_height = get_arg(args::stride_height);                  // Vertical stride for fold
-    constexpr uint32_t stride_width = get_arg(args::stride_width);                    // Horizontal stride for fold
-    constexpr uint32_t stick_nbytes = get_arg(args::stick_nbytes);                    // Size of each stick in bytes
-    constexpr uint32_t aligned_stick_nbytes = get_arg(args::aligned_stick_nbytes);    // Aligned size of each stick
-    constexpr uint32_t tiles_per_channel_dim = get_arg(args::tiles_per_channel_dim);  // Tiles per channel dimension
-    constexpr uint32_t tiles_per_width_dim = get_arg(args::tiles_per_width_dim);      // Tiles per width dimension
-    constexpr uint32_t element_size = get_arg(args::element_size);                    // Size of each element in bytes
-    // input_cb is the untilized data buffer produced by the compute kernel (dfb::src1).
+    constexpr uint32_t input_width = get_arg(args::input_width);
+    constexpr uint32_t stride_height = get_arg(args::stride_height);
+    constexpr uint32_t stride_width = get_arg(args::stride_width);
+    // `c_bytes` = logical C * elem_size; `c_padded_bytes` = untilize row stride (C_tiles * TILE_WIDTH * elem_size).
+    constexpr uint32_t c_bytes = get_arg(args::c_bytes);
+    constexpr uint32_t c_padded_bytes = get_arg(args::c_padded_bytes);
+    constexpr uint32_t tiles_per_channel_dim = get_arg(args::tiles_per_channel_dim);
+    constexpr uint32_t tiles_per_width_dim = get_arg(args::tiles_per_width_dim);
 
-    // Runtime arguments - Processing parameters
-    const uint32_t start_block_id = get_arg(args::start_block_id);      // Starting block ID for processing
-    const uint32_t num_blocks = get_arg(args::num_blocks);              // Number of blocks to process
-    uint32_t patch_height_offset = get_arg(args::patch_height_offset);  // Current height offset within patch
-    uint32_t output_offset = get_arg(args::output_offset);              // Current output offset
+    const uint32_t start_super_block_id = get_arg(args::start_block_id);
+    const uint32_t num_super_blocks = get_arg(args::num_blocks);
 
-    // Calculated constants
-    constexpr uint32_t output_width = input_width / stride_width;  // Output tensor width
-    constexpr uint32_t patch_size = stride_height * stride_width;  // Total elements per patch
-    // Initialize DRAM address generator for interleaved memory access
+    constexpr uint32_t output_width = input_width / stride_width;
+    constexpr uint32_t patch_size = stride_height * stride_width;
+    constexpr uint32_t output_stick_bytes = patch_size * c_bytes;
+
     const auto dst = TensorAccessor(tensor::dst);
-
     Noc noc;
     DataflowBuffer input_cb(dfb::src1);
+    DataflowBuffer scratch_cb(dfb::src2);
 
-    // Processing loop bounds and state variables
-    const uint32_t end_block_id = start_block_id + num_blocks;
-    uint32_t curr_offset = output_offset;  // Current working offset
-    uint32_t orig_patch_height_offset = patch_height_offset;
+    // scratch_cb holds one full output row; touched only by this kernel, so raw pointer + local ordering.
+    const uint32_t scratch_base = scratch_cb.get_write_ptr();
 
-    // Main processing loop - iterate through each block
-    for (uint32_t block_id = start_block_id; block_id < end_block_id; block_id++) {
-        uint32_t stick_offset = 0;                // Current stick offset within patch
-        uint32_t stride_width_idx = 0;            // Current position within stride width
-        uint32_t output_stick_idx = curr_offset;  // Current destination stick index
-        uint32_t remaining_width = input_width;   // Remaining width to process
+    const uint32_t end_super_block_id = start_super_block_id + num_super_blocks;
+    for (uint32_t sb = start_super_block_id; sb < end_super_block_id; ++sb) {
+        // Gather `stride_height` input rows worth of C-byte sticks into scratch; each pixel lands at
+        // `out_w * output_stick_bytes + patch_idx * c_bytes` so every output stick becomes contiguous.
+        for (uint32_t local_h = 0; local_h < stride_height; ++local_h) {
+            uint32_t remaining_width = input_width;
+            const uint32_t row_patch_base = local_h * stride_width;
+            for (uint32_t w_tile = 0; w_tile < tiles_per_width_dim; ++w_tile) {
+                input_cb.wait_front(tiles_per_channel_dim);
+                const uint32_t src_base = input_cb.get_read_ptr();
 
-        // Process each tile in the width dimension
-        for (uint32_t tile_idx = 0; tile_idx < tiles_per_width_dim; tile_idx++) {
-            input_cb.wait_front(tiles_per_channel_dim);
-            // Source the NoC write from the buffer's WRITE pointer (the legacy behavior:
-            // `use<CB::AddrSelector::WRITE_PTR>(input_cb)`). A bare DataflowBuffer source
-            // resolves to its READ pointer, so use a CoreLocalMem view of the write pointer
-            // to preserve the original semantics exactly.
-            const CoreLocalMem<uint32_t> src(input_cb.get_write_ptr());
-            uint32_t src_offset = 0;
-
-            const uint32_t width_limit =
-                (remaining_width < tt::constants::TILE_HEIGHT) ? remaining_width : tt::constants::TILE_HEIGHT;
-
-            for (uint32_t stick_idx = 0; stick_idx < width_limit; stick_idx++) {
-                noc.async_write(src, dst, stick_nbytes, {.offset_bytes = src_offset}, {.page_id = output_stick_idx});
-
-                // Update pointers and indices
-                src_offset += aligned_stick_nbytes;
-                output_stick_idx++;
-                stride_width_idx++;
-
-                // Check if we've completed a stride width - move to next patch row
-                if (stride_width_idx == stride_width) {
-                    stick_offset++;
-                    output_stick_idx = curr_offset + (stick_offset * patch_size);
-                    stride_width_idx = 0;
+                const uint32_t width_limit =
+                    (remaining_width < tt::constants::TILE_HEIGHT) ? remaining_width : tt::constants::TILE_HEIGHT;
+                const uint32_t w_base = w_tile * tt::constants::TILE_HEIGHT;
+                for (uint32_t local_w = 0; local_w < width_limit; ++local_w) {
+                    const uint32_t w_in = w_base + local_w;
+                    const uint32_t out_w = w_in / stride_width;
+                    const uint32_t patch_idx = row_patch_base + (w_in % stride_width);
+                    tt_memmove<false, false, false, c_bytes>(
+                        noc,
+                        scratch_base + out_w * output_stick_bytes + patch_idx * c_bytes,
+                        src_base + local_w * c_padded_bytes,
+                        c_bytes);
                 }
+                remaining_width -= tt::constants::TILE_HEIGHT;
+                input_cb.pop_front(tiles_per_channel_dim);
             }
-
-            remaining_width -= tt::constants::TILE_HEIGHT;
-
-            // Ensure all writes complete before moving to next set of tiles_per_channel_dim tiles
-            noc.async_write_barrier();
-            input_cb.pop_front(tiles_per_channel_dim);
         }
-
-        // Update patch offset for next block
-        patch_height_offset++;
-
-        // Check if we've completed a full patch height - move to next patch
-        if (patch_height_offset == stride_height) {
-            // Calculate new output offset for next patch
-            curr_offset = output_offset + (patch_size * output_width) - (orig_patch_height_offset * stride_width);
-            output_offset = curr_offset;
-            patch_height_offset = 0;
-            orig_patch_height_offset = 0;
-        } else {
-            // Move to next row within the same patch
-            curr_offset += stride_width;
+        // Emit one aligned page-sized write per output stick; super-blocks are laid out sequentially.
+        const uint32_t output_page_base = sb * output_width;
+        for (uint32_t out_w = 0; out_w < output_width; ++out_w) {
+            noc.async_write(
+                CoreLocalMem<uint32_t>(scratch_base + out_w * output_stick_bytes),
+                dst,
+                output_stick_bytes,
+                {},
+                {.page_id = output_page_base + out_w});
         }
+        noc.async_write_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
@@ -54,7 +54,8 @@ void kernel_main() {
                     const uint32_t w_in = w_base + local_w;
                     const uint32_t out_w = w_in / stride_width;
                     const uint32_t patch_idx = row_patch_base + (w_in % stride_width);
-                    tt_memmove<false, false, false, c_bytes>(
+                    // copy_async=true skips the per-pixel L1D drain; single tail-drain below.
+                    tt_memmove<false, true, false, c_bytes>(
                         noc,
                         scratch_base + out_w * output_stick_bytes + patch_idx * c_bytes,
                         src_base + local_w * c_padded_bytes,
@@ -64,6 +65,11 @@ void kernel_main() {
                 input_cb.pop_front(tiles_per_channel_dim);
             }
         }
+        // One drain per super-block instead of per-pixel: async_write_barrier flushes the NoC self-copy
+        // path; the volatile L1 read serialises any CPU-memmove fallback stores (L1 write-requests are FIFO).
+        noc.async_write_barrier();
+        volatile tt_l1_ptr uint32_t* drain_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(scratch_base);
+        [[maybe_unused]] volatile uint32_t drain_read = *drain_ptr;
         // Emit one aligned page-sized write per output stick; super-blocks are laid out sequentially.
         const uint32_t output_page_base = sb * output_width;
         for (uint32_t out_w = 0; out_w < output_width; ++out_w) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/fold.cpp
@@ -633,8 +633,10 @@ Tensor fold(
     const auto in_channels = shape[3];
     const bool was_tiled = processed_tensor.layout() == Layout::TILE;
 
-    // The interleaved fold kernels operate on row-major data, so untilize first.
-    if (was_tiled) {
+    // Tile-native factory holds one full output row in L1 scratch; if it wouldn't fit, fall back
+    // to untilize→RM so prim::qsr::fold takes the RM path (1-stick scratch).
+    if (was_tiled && !ttnn::operations::experimental::quasar::tile_native_fold_scratch_fits_l1(
+                         processed_tensor, stride_h, stride_w)) {
         processed_tensor = ttnn::operations::experimental::quasar::to_layout(processed_tensor, Layout::ROW_MAJOR);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/fold.cpp
@@ -633,11 +633,17 @@ Tensor fold(
     const auto in_channels = shape[3];
     const bool was_tiled = processed_tensor.layout() == Layout::TILE;
 
-    // Tile-native factory holds one full output row in L1 scratch; if it wouldn't fit, fall back
-    // to untilize→RM so prim::qsr::fold takes the RM path (1-stick scratch).
-    if (was_tiled && !ttnn::operations::experimental::quasar::tile_native_fold_scratch_fits_l1(
-                         processed_tensor, stride_h, stride_w)) {
-        processed_tensor = ttnn::operations::experimental::quasar::to_layout(processed_tensor, Layout::ROW_MAJOR);
+    // Tile-native writer hits the NoC self-copy path only when c_bytes is 16B-aligned; sub-16B c_bytes
+    // fall to per-pixel CPU memmove and lose ~2x to untilize→RM for small C. Scratch-overflow shapes
+    // route the same way (RM path is 1-stick).
+    if (was_tiled) {
+        const uint32_t out_elem_bytes = tt::datum_size(datatype_to_dataformat_converter(
+            ttnn::operations::experimental::quasar::fold_output_dtype(processed_tensor.dtype())));
+        const uint32_t c_bytes = processed_tensor.logical_shape()[-1] * out_elem_bytes;
+        if (c_bytes % 16 != 0 || !ttnn::operations::experimental::quasar::tile_native_fold_scratch_fits_l1(
+                                     processed_tensor, stride_h, stride_w)) {
+            processed_tensor = ttnn::operations::experimental::quasar::to_layout(processed_tensor, Layout::ROW_MAJOR);
+        }
     }
 
     auto output_tensor = ttnn::prim::qsr::fold(processed_tensor, stride_h, stride_w);


### PR DESCRIPTION
### Ticket
Link to Github Issue #50840

### Problem
`ttnn.fold` unconditionally untilized every TILE input to RM in the composite before `prim::fold`, wasting a full-tensor pass on inputs the tile-native factory could consume directly.

### Fix
`MultiCoreDRAMFold` gained a scratch-gather writer (`writer_dfb2dram_for_tiled_input.cpp`); one predicate `is_tile_native_fold_supported` (interleaved + 16B-aligned `c_bytes` + bank-0 free L1) gates both the composite fallback and `validate_fold`'s FATAL, so anything it rejects (sub-16B C, scratch overflow, W/B-sharded TILE) still hops through untilize→RM and dispatch stays keyed on `Layout::TILE` in `create_program_artifacts`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/fold_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/fold_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/fold_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/fold_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/fold_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/fold_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/fold_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/fold_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/fold_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/fold_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/fold_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/fold_follow_up)
