### PR TITLE
[QUASAR] Bug fix: block the RISC in llk_wait_tiles until WAIT_TILES resolves so wait_front() returns with tiles resident

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
@@ -25,6 +25,15 @@ inline void llk_wait_tiles(const std::int32_t dfb_id, const std::uint32_t num_ti
     TT_WAIT_TILES(ckernel::p_stall::STALL_UNPACK, num_tiles, tc_id);
     // TEN-4746: arm this dfb; a real unpack (UNPACR) on it must clear this before the matching pop.
     LLK_TDMA_GUARD_NOTE_WAIT(dfb_id);
+
+    // TT_WAIT_TILES only gates the Tensix instruction stream (the unpacker) and returns to the RISC-V core
+    // immediately. Also block the RISC until that WAIT_TILES has resolved, so wait_front() has the same contract as
+    // on Blackhole: when it returns, a RISC-side L1 read of the waited entries (read_tile_value, get_tile_address)
+    // is safe. WAIT_TILES executes on the SYNC engine (same class as STALLWAIT/SEMWAIT), so poll this thread's SYNC
+    // busy bit in the tensix_busy_status CSR rather than the tile counter: the CSR is a direct view of the engine
+    // state and does not lag like the NEO-local tile-counter mirror. csr_read fences first, which orders the
+    // WAIT_TILES store above ahead of the read. In the common case (tiles already present) this is one CSR read.
+    ckernel::wait_sync_idle();
 }
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
@@ -26,13 +26,10 @@ inline void llk_wait_tiles(const std::int32_t dfb_id, const std::uint32_t num_ti
     // TEN-4746: arm this dfb; a real unpack (UNPACR) on it must clear this before the matching pop.
     LLK_TDMA_GUARD_NOTE_WAIT(dfb_id);
 
-    // TT_WAIT_TILES only gates the Tensix instruction stream (the unpacker) and returns to the RISC-V core
-    // immediately. Also block the RISC until that WAIT_TILES has resolved, so wait_front() has the same contract as
-    // on Blackhole: when it returns, a RISC-side L1 read of the waited entries (read_tile_value, get_tile_address)
-    // is safe. WAIT_TILES executes on the SYNC engine (same class as STALLWAIT/SEMWAIT), so poll this thread's SYNC
-    // busy bit in the tensix_busy_status CSR rather than the tile counter: the CSR is a direct view of the engine
-    // state and does not lag like the NEO-local tile-counter mirror. csr_read fences first, which orders the
-    // WAIT_TILES store above ahead of the read. In the common case (tiles already present) this is one CSR read.
+    // TT_WAIT_TILES only gates the Tensix instruction stream and returns to the RISC-V core immediately. We want to
+    // also block the RISC until that WAIT_TILES has resolved, so wait_front() has the same contract as on Blackhole:
+    // when it returns, a RISC-side L1 read of the waited entries is safe. Poll this thread's SYNC busy bit in the
+    // tensix_busy_status CSR.
     ckernel::wait_sync_idle();
 }
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #55744

On Quasar, `dfb.read_tile_value()` and `dfb.get_tile_address()` returned zeros on all three TRISC threads even though the producer had delivered the tiles and DFB held the correct data.

Root cause: on Quasar UNPACK, `wait_front()` is a single posted TT_WAIT_TILES. It gates the unpacker (Tensix instructions queued behind it stall until the tile counter has enough tiles) but returns to the RISC-V core immediately. The RISC-side L1 load in `read_tile_value` therefore raced the DM producer's NOC write and read the still-zeroed L1. UNPACK then relayed the zeros to MATH and PACK over the mailbox, so the mailbox path was never at fault. Blackhole never hit this because its `llk_wait_tiles` is a RISC spin loop on the CB semaphore, so data is in L1 by the time `wait_front` returns. The tt-2xx port kept the code shape and lost that implicit guarantee.

Fix, in tt-2xx/dataflow_buffer.inl, UNPACK branch of both `get_tile_address` and `read_tile_value`:
1. `ckernel::tensix_sync()` blocks the RISC until this Tensix thread is idle, retiring the pending WAIT_TILES and any in-flight POP_TILES from the previous `pop_front()`.
2. Spin on tile_counters[tc].f.posted until it covers tile_index + 1. In the common case the WAIT_TILES has already resolved after step 1, so this is one load.
3. `read_tile_value` loads through the uncached L1 alias (MEM_L1_UNCACHED_BASE), so a stale RISC data-cache line from an earlier lap of the ring is never returned.

The `tensix_sync()` is required before the poll: POP_TILES retires asynchronously after the unpacker's rd-done and f.posted is live occupancy, so a bare poll for entry N+1 can pass on entry N's not-yet-retired credit. The poll is kept as a backstop and to cover `tile_index > 0` after a `wait_front(n)`.

Only this peek path pays for the RISC-side wait. The normal `wait_front` / `copy_tile` / `pop_front` flow stays hardware-gated with no RISC involvement. `get_tile_address` still returns the plain L1 address, matching `get_read_ptr` on TRISC and the CB twin in cb_api.h.

Also removes the #ifndef ARCH_QUASAR gate on the two declarations and re-enables `UnitMeshFixture.DataflowBufferReadTileValue` on Quasar.

### Notes for reviewers
- Verified on the Quasar emulator with `UnitMeshFixture.DataflowBufferReadTileValue` (unit_tests_api). Blackhole path is untouched.
- Blackhole and Quasar differ in where flow control lives (RISC spin vs. hardware tile counters), which is why this is a Quasar-only change.
- The same latent assumption exists in the CB versions of `read_tile_value` / `get_tile_address` in `cb_api.h`. Left for a follow-up.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skotarac/fix_wait_front_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skotarac/fix_wait_front_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skotarac/fix_wait_front_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skotarac/fix_wait_front_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skotarac/fix_wait_front_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skotarac/fix_wait_front_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skotarac/fix_wait_front_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skotarac/fix_wait_front_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skotarac/fix_wait_front_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skotarac/fix_wait_front_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skotarac/fix_wait_front_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skotarac/fix_wait_front_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skotarac/fix_wait_front_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skotarac/fix_wait_front_qsr)