### PR TITLE
Improve Gemma4 prefill accuracy with Tanh GELU and FP32 RMSNorm

### DIFF
--- a/models/demos/gemma4/tt/attention/operations.py
+++ b/models/demos/gemma4/tt/attention/operations.py
@@ -146,10 +146,29 @@ def apply_per_head_norm(tensor, weight, eps, with_scale=True, memory_config=None
         num_heads = orig_shape[1]
         seq_or_batch = orig_shape[2]
         flat = ttnn.reshape(tensor, (1, 1, num_heads * seq_or_batch, head_dim))
+    # Match Hugging Face's FP32 per-head Q/K/V RMSNorm computation.
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        tensor.device().arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
     if with_scale and weight is not None:
-        normed = ttnn.rms_norm(flat, weight=weight, epsilon=eps, memory_config=memory_config)
+        normed = ttnn.rms_norm(
+            flat,
+            weight=weight,
+            epsilon=eps,
+            memory_config=memory_config,
+            compute_kernel_config=compute_kernel_config,
+        )
     else:
-        normed = ttnn.rms_norm(flat, epsilon=eps, memory_config=memory_config)
+        normed = ttnn.rms_norm(
+            flat,
+            epsilon=eps,
+            memory_config=memory_config,
+            compute_kernel_config=compute_kernel_config,
+        )
 
     return ttnn.reshape(normed, orig_shape)
 

--- a/models/demos/gemma4/tt/rms_norm.py
+++ b/models/demos/gemma4/tt/rms_norm.py
@@ -29,16 +29,29 @@ class RMSNorm(nn.Module):
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 cache_file_name=get_cache_file_name(tensor_cache_path, "weight"),
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                mesh_mapper=self.mesh_config.shard_mapper(mesh_device, mesh_dims=(None, -2))
-                if self.is_distributed
-                else None,
+                mesh_mapper=(
+                    self.mesh_config.shard_mapper(mesh_device, mesh_dims=(None, -2)) if self.is_distributed else None
+                ),
             )
+            # TILE gamma enables the large-tensor RMSNorm path, which bounds L1 usage
+            # for FP32 intermediate buffers in the 5376-wide prefill norm.
+            # Keep the row-major copy for the width-sharded decode path.
+            flat_weight = ttnn.reshape(self.tt_weight, (1, 1, 1, hf_config.hidden_size))
+            self.tt_weight_tile = ttnn.to_layout(flat_weight, ttnn.TILE_LAYOUT)
         else:
             self.tt_weight = None
+            self.tt_weight_tile = None
 
         self.eps = hf_config.rms_norm_eps
         self.mesh_device = mesh_device
-
+        # Match the reference's FP32 prefill RMSNorm computation.
+        self.prefill_compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
         # Decode width-sharded fast path. The plain (interleaved) rms_norm runs
         # the RMS reduction over the full hidden width on few cores — ~76 us for
         # a single-token [1,1,32,hidden] norm on Gemma4-31B (hidden=5376). Width-
@@ -160,15 +173,20 @@ class RMSNorm(nn.Module):
                 if self._sharded_cfg:
                     return self._forward_sharded(x)
 
+            is_prefill = len(x.shape) == 4 and x.shape[-2] > ttnn.TILE_SIZE
+            compute_kernel_config = self.prefill_compute_kernel_config if is_prefill else None
+            weight = self.tt_weight_tile if is_prefill and self.tt_weight_tile is not None else self.tt_weight
             if self.with_scale:
                 tt_output = ttnn.rms_norm(
                     x,
-                    weight=self.tt_weight,
+                    weight=weight,
                     epsilon=self.eps,
+                    compute_kernel_config=compute_kernel_config,
                 )
             else:
                 tt_output = ttnn.rms_norm(
                     x,
                     epsilon=self.eps,
+                    compute_kernel_config=compute_kernel_config,
                 )
             return tt_output

--- a/models/demos/gemma4/tt/shared_mlp.py
+++ b/models/demos/gemma4/tt/shared_mlp.py
@@ -20,7 +20,6 @@ import torch
 
 import ttnn
 from models.demos.gemma4.tt.ccl import ccl_allreduce
-from models.demos.gemma4.tt.compute_config import gelu_variant
 from models.demos.gemma4.tt.dram_sharded import TILE_SIZE, DramShardedLinear, can_dram_shard
 from models.demos.gemma4.utils.general_utils import get_cache_file_name
 
@@ -216,8 +215,8 @@ class SharedMLP:
         gate = ttnn.slice(gate_up, [0, 0, 0, shard], [1, 1, s, 2 * shard])
         gate_up.deallocate(True)
 
-        # Prefer Accurate over FastLut/Tanh for device PCC (see compute_config).
-        gate = ttnn.gelu(gate, variant=gelu_variant())
+        # Match the checkpoint's gelu_pytorch_tanh activation.
+        gate = ttnn.gelu(gate, variant=ttnn.GeluVariant.Tanh)
         hidden = ttnn.mul(gate, up)
         gate.deallocate(True)
         up.deallocate(True)

--- a/models/demos/gemma4_d_p/tt/attention/operations.py
+++ b/models/demos/gemma4_d_p/tt/attention/operations.py
@@ -72,10 +72,29 @@ def apply_per_head_norm(tensor, weight, eps, with_scale=True, memory_config=None
         num_heads = orig_shape[1]
         seq_or_batch = orig_shape[2]
         flat = ttnn.reshape(tensor, (1, 1, num_heads * seq_or_batch, head_dim))
+    # Match Hugging Face's FP32 per-head Q/K/V RMSNorm computation.
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        tensor.device().arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
     if with_scale and weight is not None:
-        normed = ttnn.rms_norm(flat, weight=weight, epsilon=eps, memory_config=memory_config)
+        normed = ttnn.rms_norm(
+            flat,
+            weight=weight,
+            epsilon=eps,
+            memory_config=memory_config,
+            compute_kernel_config=compute_kernel_config,
+        )
     else:
-        normed = ttnn.rms_norm(flat, epsilon=eps, memory_config=memory_config)
+        normed = ttnn.rms_norm(
+            flat,
+            epsilon=eps,
+            memory_config=memory_config,
+            compute_kernel_config=compute_kernel_config,
+        )
 
     return ttnn.reshape(normed, orig_shape)
 

--- a/models/demos/gemma4_d_p/tt/mlp.py
+++ b/models/demos/gemma4_d_p/tt/mlp.py
@@ -96,7 +96,7 @@ class MLP:
     def __call__(self, hidden_states):
         """Apply column-parallel gate/up projections and row-parallel down projection."""
         gate = ttnn.linear(hidden_states, self.gate_proj, compute_kernel_config=self.compute_kernel_config)
-        gate = ttnn.gelu(gate, fast_and_approximate_mode=True)
+        gate = ttnn.gelu(gate, variant=ttnn.GeluVariant.Tanh)
         up = ttnn.linear(hidden_states, self.up_proj, compute_kernel_config=self.compute_kernel_config)
         hidden = ttnn.mul(gate, up)
         gate.deallocate(True)

--- a/models/demos/gemma4_d_p/tt/rms_norm.py
+++ b/models/demos/gemma4_d_p/tt/rms_norm.py
@@ -29,11 +29,28 @@ class RMSNorm(nn.Module):
                 cache_file_name=get_cache_file_name(tensor_cache_path, "weight"),
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
+            # TILE gamma enables the large-tensor RMSNorm path, which bounds L1 usage
+            # for the FP32 intermediate buffers in the 5376-wide prefill norm.
+            flat_weight = ttnn.reshape(self.tt_weight, (1, 1, 1, hf_config.hidden_size))
+            self.tt_weight = ttnn.to_layout(flat_weight, ttnn.TILE_LAYOUT)
         else:
             self.tt_weight = None
 
         self.eps = hf_config.rms_norm_eps
         self.mesh_device = mesh_device
+        # Match the reference's FP32 prefill RMSNorm computation.
+        self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
 
     def forward(self, x):
-        return ttnn.rms_norm(x, weight=self.tt_weight, epsilon=self.eps)
+        return ttnn.rms_norm(
+            x,
+            weight=self.tt_weight,
+            epsilon=self.eps,
+            compute_kernel_config=self.compute_kernel_config,
+        )


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Use the Tanh approximation of GELU (`gelu_pytorch_tanh`), matching the HF Gemma 4 implementation, and enable FP32 accumulation for prefill and per-head RMSNorm to improve KV-cache accuracy.
On BH Galaxy with CP=8, TP=4, and 262,144 tokens, all 3,840 measured KV block PCCs improved: 

Metric | Before | After
-- | -- | --
Mean KV PCC | 0.950771 | 0.978182
Minimum KV PCC | 0.766887 | 0.881797

These measurements were obtained on the [svuckovic/gemma4-prefill-freeze-sep-07 branch](https://github.com/tenstorrent/tt-metal/tree/svuckovic/gemma4-prefill-freeze-sep-07), which contains the full Gemma4 prefill implementation. 

Detailed PCC tables can be found here:
[PCC report before fixes.md](https://github.com/user-attachments/files/32009590/PCC.report.before.fixes.md)
[PCC report after fixes.md](https://github.com/user-attachments/files/32009588/PCC.report.after.fixes.md)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amilovanovic/gemma4-pcc-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amilovanovic/gemma4-pcc-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amilovanovic/gemma4-pcc-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amilovanovic/gemma4-pcc-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amilovanovic/gemma4-pcc-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amilovanovic/gemma4-pcc-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amilovanovic/gemma4-pcc-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amilovanovic/gemma4-pcc-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amilovanovic/gemma4-pcc-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amilovanovic/gemma4-pcc-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amilovanovic/gemma4-pcc-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amilovanovic/gemma4-pcc-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amilovanovic/gemma4-pcc-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amilovanovic/gemma4-pcc-improvements)