### PR TITLE
[Bug fix] Align graph_report stringify test with _safe_arg_str fallback

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
@@ -3983,19 +3983,6 @@ class TestRecordPythonOperation:
         assert len(g._python_io_data) == 1
         assert reserved["arguments"]["bias"] == "1"
 
-    def test_unprintable_arg_is_recorded_as_placeholder(self):
-        import ttnn.graph as g
-
-        class Boom:
-            def __str__(self):
-                raise RuntimeError("stringify failed")
-
-        g.record_python_operation("ttnn.add", (Boom(),), {})
-        assert len(g._python_io_data) == 1
-        record = g._python_io_data[0]
-        assert record["name"] == "ttnn.add"
-        assert record["arguments"]["0"] == "<unprintable Boom: RuntimeError: stringify failed>"
-
     def test_populate_failure_keeps_the_reserved_record(self, expect_error, monkeypatch):
         import ttnn.graph as g
 

--- a/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
@@ -3983,17 +3983,33 @@ class TestRecordPythonOperation:
         assert len(g._python_io_data) == 1
         assert reserved["arguments"]["bias"] == "1"
 
-    def test_populate_failure_keeps_the_reserved_record(self, expect_error):
+    def test_unprintable_arg_is_recorded_as_placeholder(self):
         import ttnn.graph as g
 
         class Boom:
             def __str__(self):
                 raise RuntimeError("stringify failed")
 
-        with expect_error(RuntimeError, "stringify failed"):
-            g.record_python_operation("ttnn.add", (Boom(),), {})
+        g.record_python_operation("ttnn.add", (Boom(),), {})
         assert len(g._python_io_data) == 1
-        assert g._python_io_data[0]["name"] == "ttnn.add"
+        record = g._python_io_data[0]
+        assert record["name"] == "ttnn.add"
+        assert record["arguments"]["0"] == "<unprintable Boom: RuntimeError: stringify failed>"
+
+    def test_populate_failure_keeps_the_reserved_record(self, expect_error, monkeypatch):
+        import ttnn.graph as g
+
+        reserved = g.append_python_io_record("ttnn.add")
+
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("stringify failed")
+
+        monkeypatch.setattr(g, "_safe_arg_str", boom)
+        with expect_error(RuntimeError, "stringify failed"):
+            g.record_python_operation("ttnn.add", (1,), {}, record=reserved)
+        assert len(g._python_io_data) == 1
+        assert g._python_io_data[0] is reserved
+        assert reserved["name"] == "ttnn.add"
 
     def test_python_stack_trace_captured_when_enabled(self):
         import ttnn.graph as g


### PR DESCRIPTION
### PR Category

Bug fix - fix main branch failing tests

### Summary

Sanity on `main` has been red since #53041 (`3095a4fe`) with a single failure:

`TestRecordPythonOperation.test_populate_failure_keeps_the_reserved_record`
(`DID NOT RAISE RuntimeError`) in `ttnn-sanity-tests / core ttnn unit test group`
on `sim_wh_n150`, `wh_n300_civ2`, and `sim_bh_p150`.

`_safe_arg_str` (`ttnn/ttnn/graph.py:464-469`) now catches stringify failures
and returns `<unprintable Type: Exc: msg>` so recording cannot take down an
operation. That is the intended #53041 contract (also covered by
`TestSafeArgStr.test_unprintable_str_fallback`). The integration test still
expected the old raise.

This PR only updates
`tests/ttnn/unit_tests/base_functionality/test_graph_report.py`:

- `test_populate_failure_keeps_the_reserved_record` keeps the reserved-slot
  invariant by monkeypatching `_safe_arg_str` to raise, matching the decorator
  path in `ttnn/ttnn/decorators.py:1466-1477`.

Relates to #28836 / #53041.

### Notes for reviewers

No production code. Do not revert the `_safe_arg_str` try/except — that would
re-break diagnostic recording and fight `test_unprintable_str_fallback`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/issue/28836_fix_graph_report_stringify_test)