### PR TITLE
[skip ci] MINFRA-1703: switch from CIv2 loudbox iommu sku to CIv1 (due to long VM start up time)

### DIFF
--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -158,9 +158,13 @@ skus:
       - in-service
     weights-cache-mode: lfc
 
-  bh_loudbox_civ2_viommu:
+  bh_loudbox_iommu:
     runs_on:
-      - tt-ubuntu-2204-BH-LoudBox-viommu-stable
+      - in-service
+      - arch-blackhole
+      - BH-LoudBox-iommu
+      - pipeline-functional
+    weights-cache-mode: cloud-mlperf
 
   bh_quietbox_2:
     runs_on:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -206,7 +206,7 @@ scaleout:
     wh_n300_civ2: 15
     wh_llmbox_civ2: 65
     bh_loudbox: 195
-    bh_loudbox_civ2_viommu: 45
+    bh_loudbox_iommu: 45
     bh_p300: 195
     bh_quietbox_2: 195
   stress:

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -378,7 +378,7 @@ jobs:
               "bh_loudbox"
               "bh_p300"
               "bh_p300_viommu"
-              "bh_loudbox_civ2_viommu"
+              "bh_loudbox_iommu"
               "bh_quietbox_2"
               "bh_quietbox_2_iommu"
             )

--- a/.github/workflows/tm-fabric-tests.yaml
+++ b/.github/workflows/tm-fabric-tests.yaml
@@ -64,8 +64,8 @@ on:
         required: false
         default: true
         type: boolean
-      run-bh_loudbox_civ2_viommu:
-        description: "Run on bh_loudbox_civ2_viommu"
+      run-bh_loudbox_iommu:
+        description: "Run on bh_loudbox_iommu"
         required: false
         default: true
         type: boolean
@@ -181,7 +181,7 @@ jobs:
         || (github.event_name == 'workflow_dispatch' && (
               inputs.run-wh_n300_civ2 || inputs.run-wh_llmbox_civ2 || inputs.run-wh_galaxy
               || inputs.run-bh_loudbox || inputs.run-bh_p300 || inputs.run-bh_quietbox_2
-              || inputs.run-bh_loudbox_civ2_viommu))
+              || inputs.run-bh_loudbox_iommu))
         || github.event_name == 'push'
         || github.event_name == 'workflow_call' }}
       # Assemble enabled-skus from the checked per-SKU booleans on workflow_dispatch;
@@ -196,7 +196,7 @@ jobs:
               inputs.run-bh_loudbox               && 'bh_loudbox,'               || '',
               inputs.run-bh_p300                  && 'bh_p300,'                  || '',
               inputs.run-bh_quietbox_2            && 'bh_quietbox_2,'            || '',
-              inputs.run-bh_loudbox_civ2_viommu   && 'bh_loudbox_civ2_viommu,'   || ''
+              inputs.run-bh_loudbox_iommu         && 'bh_loudbox_iommu,'         || ''
             ) || 'ALL_SKUS_IN_TESTS' }}
       test-names: ${{ inputs.hw-test-names || '' }}
 

--- a/tests/pipeline_reorg/fabric_tests.yaml
+++ b/tests/pipeline_reorg/fabric_tests.yaml
@@ -200,7 +200,7 @@
 - name: BH ccl nightly tests
   cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly
   skus:
-    bh_loudbox_civ2_viommu:
+    bh_loudbox_iommu:
       timeout: 30
     bh_p300:
       timeout: 30


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Test only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
https://tenstorrent.atlassian.net/browse/MINFRA-1675
https://tenstorrent.atlassian.net/browse/MINFRA-1703
CIv2 viommu loudbox VM start up time exploded so we're migrating all users who need loudbox+iommu to civ1 so we can investigate.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
TM Fabric tests (loudbox iommu sku only): https://github.com/tenstorrent/tt-metal/actions/runs/34362931808

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=williamly/loudbox-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:williamly/loudbox-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=williamly/loudbox-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:williamly/loudbox-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=williamly/loudbox-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:williamly/loudbox-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=williamly/loudbox-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:williamly/loudbox-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=williamly/loudbox-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:williamly/loudbox-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=williamly/loudbox-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:williamly/loudbox-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=williamly/loudbox-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:williamly/loudbox-iommu-sku)