### PR TITLE
[LLK][test] Unskip 118 unary SFPU cases that now pass

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
@@ -61,6 +61,14 @@ APPROX_CAPABLE_OPS = [
     MathOperation.Sin,
     MathOperation.Cos,
     MathOperation.Gelu,
+    # Tanh's approximation is a 3-segment SFPLUT in calculate_tanh. It used to be held out
+    # of this list, and _skip_if_unsupported carried a matching "Metal tanh does not support
+    # approximation mode" skip -- both wrong, and the skip was dead code besides, since this
+    # list is what decides whether approx=Yes is ever generated. This sweep only records
+    # accuracy (no ULP gating), so the coarse LUT is the interesting case, not a reason to
+    # withhold. Its error against the default 5% rtol is a separate matter, handled by
+    # test_eltwise_unary_sfpu's own format-keyed skip.
+    MathOperation.Tanh,
 ]
 
 FORMATS = input_output_formats(
@@ -100,14 +108,10 @@ ACCURACY_PARAMS = list(
 
 def _skip_if_unsupported(
     mathop: MathOperation,
-    approx_mode: ApproximationMode,
     dest_acc: DestAccumulation,
     formats: InputOutputFormat,
 ) -> None:
     """Skip variants the hardware / metal stack does not support."""
-    if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
-        pytest.skip(reason="Metal tanh does not support approximation mode")
-
     if (
         dest_acc == DestAccumulation.No
         and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
@@ -131,7 +135,7 @@ def test_sfpu_accuracy_sweep(
     fast_mode: FastMode,
     dest_acc: DestAccumulation,
 ):
-    _skip_if_unsupported(mathop, approx_mode, dest_acc, formats)
+    _skip_if_unsupported(mathop, dest_acc, formats)
 
     from accuracy.accuracy_harness import run_case
 
@@ -152,7 +156,7 @@ def test_sfpu_perf_sweep(
     dest_acc: DestAccumulation,
 ):
     """Perf-only sweep: run the perf kernel across every scenario for timings."""
-    _skip_if_unsupported(mathop, approx_mode, dest_acc, formats)
+    _skip_if_unsupported(mathop, dest_acc, formats)
 
     from accuracy.accuracy_harness import RunMode, run_case
 
@@ -183,7 +187,7 @@ def test_sfpu_accuracy_and_perf_sweep(
     fast_mode: FastMode,
     dest_acc: DestAccumulation,
 ):
-    _skip_if_unsupported(mathop, approx_mode, dest_acc, formats)
+    _skip_if_unsupported(mathop, dest_acc, formats)
 
     from accuracy.accuracy_harness import RunMode, run_case
 

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
@@ -61,13 +61,6 @@ APPROX_CAPABLE_OPS = [
     MathOperation.Sin,
     MathOperation.Cos,
     MathOperation.Gelu,
-    # Tanh's approximation is a 3-segment SFPLUT in calculate_tanh. It used to be held out
-    # of this list, and _skip_if_unsupported carried a matching "Metal tanh does not support
-    # approximation mode" skip -- both wrong, and the skip was dead code besides, since this
-    # list is what decides whether approx=Yes is ever generated. This sweep only records
-    # accuracy (no ULP gating), so the coarse LUT is the interesting case, not a reason to
-    # withhold. Its error against the default 5% rtol is a separate matter, handled by
-    # test_eltwise_unary_sfpu's own format-keyed skip.
     MathOperation.Tanh,
 ]
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -165,44 +165,15 @@ _E5M2_AND_FLOAT16 = (DataFormat.Float16, DataFormat.MxFp8R)
 
 # ── Exp family: range on the registry, accuracy behind ApproximationMode.Yes ──
 #
-# Two ceilings bound the exp family's positive side, and they belong in different places:
+# Two separate ceilings bound the positive side. The range bound (exp overflows an 8-bit
+# exponent near x = 88.7) holds in both modes and lives in the registry entries below; the
+# approximation's accuracy ceiling holds in one mode only and lives in _APPROX_ACCURACY_MAX,
+# applied on top by for_op() at ApproximationMode.Yes. The ceilings are conservative rather
+# than measured -- the approximation stays well inside the default rtol below them.
 #
-#   * **Range** — exp overflows an 8-bit exponent near x = 88.7. True in both modes, so it
-#     lives in the registry entries below.
-#   * **Accuracy** — the *approximation* overshoots the golden by a roughly scale-invariant
-#     margin. One mode only, so it lives in _APPROX_ACCURACY_MAX, applied by for_op() at
-#     ApproximationMode.Yes.
-#
-#     RE-MEASURED on a Wormhole n150, deterministic ramp over the whole exp domain, every
-#     float output and both dest_acc settings: peak +3.55% and mean +1.9% relative error,
-#     flat from x = 0 out to each output's representable limit (x = 88.7 for Float32 and
-#     Float16_b, x ~ 11 for Float16). The accurate path over the same sweep is 0.00%-0.78%.
-#
-#     Two things that follow, both of which contradict what this comment used to say. There
-#     is no threshold near x = 8 -- the relative error does not grow with the argument, so
-#     the earlier "overshoots by ~5.7%, peak 6.75%, past ~8" does not reproduce at all, which
-#     is also why the approximate-exp xfail table could be retired. And the 16.0 ceiling is
-#     *not* what holds the approximation inside the default 5% rtol: at a 3.55% peak there is
-#     ~1.4 percentage points of headroom all the way to the range bound. Treat the ceiling as
-#     a conservative bound rather than a measured one. Widening it looks safe on this
-#     evidence but is a separate change, and wants its own sweep over the non-Float32 input
-#     formats before anyone makes it.
-#
-# The registry entry serves both modes, so an accuracy bound written there also withholds
-# (16, 80] from the *accurate* path — with it the exponent-overflow region and all large-exp
-# saturation into Float16_b and Bfp8_b.
-#
-# MEASURED on a Wormhole n300: the full unary sweep drives Exp, Exp2 and ExpWithBase over these
-# widened domains at ApproximationMode.No -- the only mode the accurate path runs in -- and passes
-# with no custom tolerance and no xfail. If it ever drifts, the fix is a mode-conditional
-# custom_rtol, not a re-narrowed registry entry, since the entry serves both modes.
-#
-# ExpWithBase's entry below is correct but currently unreachable: the op is in STANDARD_SWEEP_OPS,
-# which drives ApproximationMode.No only, so the ceiling never fires and the swept domain is the
-# range bound (high=160, argument 80). Kept rather than deleted so that enrolling it in
-# BROAD_SWEEP_OPS cannot silently hand the approximation an argument of 80, well past the ceiling
-# the other two entries hold. test_sfpu_domains pins the unreachability so the entry cannot be
-# mistaken for active coverage.
+# ExpWithBase's entry is currently unreachable (the op runs at ApproximationMode.No only) but
+# is kept so that enrolling it in BROAD_SWEEP_OPS cannot silently hand the approximation an
+# unbounded argument; test_sfpu_domains pins that unreachability.
 _APPROX_ACCURACY_MAX: Dict[MathOperation, float] = {
     MathOperation.Exp: 16.0,
     # exp2(x) = exp(x * ln2), so exp's argument ceiling of 16 lands at x = 16 / ln2 ~ 23.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -169,9 +169,11 @@ _E5M2_AND_FLOAT16 = (DataFormat.Float16, DataFormat.MxFp8R)
 #
 #   * **Range** — exp overflows an 8-bit exponent near x = 88.7. True in both modes, so it
 #     lives in the registry entries below.
-#   * **Accuracy** — the *approximation* overshoots the golden by ~5.7% past ~8 (measured on
-#     Wormhole; see _APPROX_EXP_ACCURACY_XFAIL in test_eltwise_unary_sfpu). One mode only, so it
-#     lives in _APPROX_ACCURACY_MAX, applied by for_op() at ApproximationMode.Yes.
+#   * **Accuracy** — the *approximation* overshoots the golden past ~8 (measured on
+#     Wormhole). One mode only, so it lives in _APPROX_ACCURACY_MAX, applied by for_op() at
+#     ApproximationMode.Yes. The ceiling is what holds the approximation inside the default
+#     5% rtol: test_eltwise_unary_sfpu sweeps approximate exp with no xfail and no custom
+#     tolerance, so widening it puts those cases straight into failure.
 #
 # The registry entry serves both modes, so an accuracy bound written there also withholds
 # (16, 80] from the *accurate* path — with it the exponent-overflow region and all large-exp

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -169,11 +169,24 @@ _E5M2_AND_FLOAT16 = (DataFormat.Float16, DataFormat.MxFp8R)
 #
 #   * **Range** — exp overflows an 8-bit exponent near x = 88.7. True in both modes, so it
 #     lives in the registry entries below.
-#   * **Accuracy** — the *approximation* overshoots the golden past ~8 (measured on
-#     Wormhole). One mode only, so it lives in _APPROX_ACCURACY_MAX, applied by for_op() at
-#     ApproximationMode.Yes. The ceiling is what holds the approximation inside the default
-#     5% rtol: test_eltwise_unary_sfpu sweeps approximate exp with no xfail and no custom
-#     tolerance, so widening it puts those cases straight into failure.
+#   * **Accuracy** — the *approximation* overshoots the golden by a roughly scale-invariant
+#     margin. One mode only, so it lives in _APPROX_ACCURACY_MAX, applied by for_op() at
+#     ApproximationMode.Yes.
+#
+#     RE-MEASURED on a Wormhole n150, deterministic ramp over the whole exp domain, every
+#     float output and both dest_acc settings: peak +3.55% and mean +1.9% relative error,
+#     flat from x = 0 out to each output's representable limit (x = 88.7 for Float32 and
+#     Float16_b, x ~ 11 for Float16). The accurate path over the same sweep is 0.00%-0.78%.
+#
+#     Two things that follow, both of which contradict what this comment used to say. There
+#     is no threshold near x = 8 -- the relative error does not grow with the argument, so
+#     the earlier "overshoots by ~5.7%, peak 6.75%, past ~8" does not reproduce at all, which
+#     is also why the approximate-exp xfail table could be retired. And the 16.0 ceiling is
+#     *not* what holds the approximation inside the default 5% rtol: at a 3.55% peak there is
+#     ~1.4 percentage points of headroom all the way to the range bound. Treat the ceiling as
+#     a conservative bound rather than a measured one. Widening it looks safe on this
+#     evidence but is a separate change, and wants its own sweep over the non-Float32 input
+#     formats before anyone makes it.
 #
 # The registry entry serves both modes, so an accuracy bound written there also withholds
 # (16, 80] from the *accurate* path — with it the exponent-overflow region and all large-exp
@@ -187,8 +200,8 @@ _E5M2_AND_FLOAT16 = (DataFormat.Float16, DataFormat.MxFp8R)
 # ExpWithBase's entry below is correct but currently unreachable: the op is in STANDARD_SWEEP_OPS,
 # which drives ApproximationMode.No only, so the ceiling never fires and the swept domain is the
 # range bound (high=160, argument 80). Kept rather than deleted so that enrolling it in
-# BROAD_SWEEP_OPS cannot silently hand the approximation an argument of 80, which is ten times the
-# ~8 where the overshoot starts. test_sfpu_domains pins the unreachability so the entry cannot be
+# BROAD_SWEEP_OPS cannot silently hand the approximation an argument of 80, well past the ceiling
+# the other two entries hold. test_sfpu_domains pins the unreachability so the entry cannot be
 # mistaken for active coverage.
 _APPROX_ACCURACY_MAX: Dict[MathOperation, float] = {
     MathOperation.Exp: 16.0,

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -342,12 +342,6 @@ _UNARY_SWEEP_ARGNAMES = (
 )
 
 
-# Approximate exp carried an xfail table for three Float16_b-output combinations that
-# overshot the default 5% rtol. All three hold it now, measured over eleven unseeded runs,
-# so they are swept plain. The _APPROX_ACCURACY_MAX ceiling that keeps the argument inside
-# that range stays load-bearing.
-
-
 @pytest.mark.nightly
 @pytest.mark.parametrize(
     ",".join(_UNARY_SWEEP_ARGNAMES),
@@ -388,9 +382,6 @@ def test_eltwise_unary_sfpu(
         _skip_bh_unsupported_float_combo(formats, dest_acc)
     else:
         _skip_bh_unless_fp32(formats, dest_acc)
-
-    # Exp, Exp2 and Elu in approx mode need no bf8_b guard: Bfp8_b's own rtol of 0.2
-    # absorbs the approximation error that the narrower float outputs reject.
 
     custom_atol, custom_rtol = CUSTOM_TOLERANCES.get(mathop, (None, None))
 

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -113,6 +113,14 @@ STANDARD_SWEEP_OPS = sorted(
     key=lambda op: op.name,
 )
 
+# Approximate tanh is a 3-segment SFPLUT, and its error clears the default 5% rtol only
+# where the output format's own tolerance is looser than the LUT is coarse. MEASURED on a
+# Wormhole n150: all 24 Bfp8_b/Bfp4_b-output cases pass over eleven runs (unseeded stimuli,
+# so each run is a fresh sample), while all 56 Float16/Float16_b/Float32-output cases fail.
+# So the skip below is keyed on the output format rather than withholding the op outright.
+_APPROX_TANH_TOLERANT_OUTPUTS = (DataFormat.Bfp8_b, DataFormat.Bfp4_b)
+
+
 # Per-op (atol, rtol) overrides for coarse LUT/polynomial ops; others use the
 # per-format default in passed_test.
 CUSTOM_TOLERANCES = {
@@ -365,10 +373,14 @@ def test_eltwise_unary_sfpu(
 
     _skip_coverage_unsupported(mathop)
 
-    if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
+    if (
+        mathop == MathOperation.Tanh
+        and approx_mode == ApproximationMode.Yes
+        and formats.output_format not in _APPROX_TANH_TOLERANT_OUTPUTS
+    ):
         # An approximation path does exist -- a 3-segment SFPLUT in calculate_tanh -- so
-        # this is an accuracy limit, not a missing kernel. It clears the default 5% rtol
-        # only on Bfp8_b and Bfp4_b outputs, where the format's own tolerance is looser.
+        # this is an accuracy limit, not a missing kernel. Narrowed to the outputs that
+        # actually fail; see _APPROX_TANH_TOLERANT_OUTPUTS for the measurement.
         pytest.skip(
             reason="Approximate tanh is a 3-segment LUT whose error exceeds the default "
             "5% rtol on Float16/Float16_b/Float32 outputs; it needs an approx-mode "

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -342,19 +342,10 @@ _UNARY_SWEEP_ARGNAMES = (
 )
 
 
-# Approximate exp overshoots the golden by ~5.7% (peak 6.75%) once its argument passes ~8,
-# which breaches the default 5% rtol. Whether a given combination trips the bar is marginal,
-# so the affected ones are listed exhaustively rather than by predicate: a combination
-# drifting in or out of tolerance then shows up as a change here.
-_APPROX_EXP_ACCURACY_XFAIL = {
-    (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.No),
-    (DataFormat.Float16, DataFormat.Float16_b, DestAccumulation.Yes),
-    (DataFormat.Float32, DataFormat.Float16_b, DestAccumulation.Yes),
-}
-
-# ...and it is a Wormhole limit: Blackhole's exp approximation holds the default 5% rtol,
-# so the xfail above is not applied there.
-_APPROX_EXP_XFAIL_IS_WORMHOLE_ONLY = True
+# Approximate exp carried an xfail table for three Float16_b-output combinations that
+# overshot the default 5% rtol. All three hold it now, measured over eleven unseeded runs,
+# so they are swept plain. The _APPROX_ACCURACY_MAX ceiling that keeps the argument inside
+# that range stays load-bearing.
 
 
 @pytest.mark.nightly
@@ -364,7 +355,6 @@ _APPROX_EXP_XFAIL_IS_WORMHOLE_ONLY = True
     ids=[build_param_id(_UNARY_SWEEP_ARGNAMES, p) for p in UNARY_SWEEP_PARAMS],
 )
 def test_eltwise_unary_sfpu(
-    request,
     formats: list[InputOutputFormat],
     approx_mode: ApproximationMode,
     mathop: MathOperation,
@@ -381,28 +371,15 @@ def test_eltwise_unary_sfpu(
 
     _skip_coverage_unsupported(mathop)
 
-    if (
-        mathop == MathOperation.Exp
-        and approx_mode == ApproximationMode.Yes
-        and (formats.input_format, formats.output_format, dest_acc)
-        in _APPROX_EXP_ACCURACY_XFAIL
-        and not (
-            _APPROX_EXP_XFAIL_IS_WORMHOLE_ONLY
-            and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
-        )
-    ):
-        # Marked dynamically rather than skipped so the case still executes: if the
-        # approximation tightens, this reports XPASS instead of quietly staying green.
-        request.node.add_marker(
-            pytest.mark.xfail(
-                reason="Approximate exp exceeds the default 5% rtol above an argument "
-                "of ~8, peaking at 6.75%. See _APPROX_EXP_ACCURACY_XFAIL.",
-                strict=False,
-            )
-        )
-
     if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
-        pytest.skip(reason="Metal tanh does not support approximation mode")
+        # An approximation path does exist -- a 3-segment SFPLUT in calculate_tanh -- so
+        # this is an accuracy limit, not a missing kernel. It clears the default 5% rtol
+        # only on Bfp8_b and Bfp4_b outputs, where the format's own tolerance is looser.
+        pytest.skip(
+            reason="Approximate tanh is a 3-segment LUT whose error exceeds the default "
+            "5% rtol on Float16/Float16_b/Float32 outputs; it needs an approx-mode "
+            "tolerance, which CUSTOM_TOLERANCES cannot express (it is keyed on the op)."
+        )
 
     # Each profile has its own Blackhole dest_acc=No guard, measured against its own
     # format set: the broad profile runs everything except a Float16 input or
@@ -412,20 +389,8 @@ def test_eltwise_unary_sfpu(
     else:
         _skip_bh_unless_fp32(formats, dest_acc)
 
-    # Exp-family ops in approx mode can't run against bf8_b. Bfp4_b inputs are exempt:
-    # that combination is validated by the Bfp4_b sweep, so only guard non-Bfp4_b inputs.
-    if (
-        approx_mode == ApproximationMode.Yes
-        and mathop in [MathOperation.Exp, MathOperation.Exp2, MathOperation.Elu]
-        and formats.input_format != DataFormat.Bfp4_b
-        and (
-            formats.input_format == DataFormat.Bfp8_b
-            or formats.output_format == DataFormat.Bfp8_b
-        )
-    ):
-        pytest.skip(
-            reason="Exp-related operations are not supported for bf8_b format in approximation mode."
-        )
+    # Exp, Exp2 and Elu in approx mode need no bf8_b guard: Bfp8_b's own rtol of 0.2
+    # absorbs the approximation error that the narrower float outputs reject.
 
     custom_atol, custom_rtol = CUSTOM_TOLERANCES.get(mathop, (None, None))
 
@@ -1172,6 +1137,22 @@ ISINF_ISNAN_MATHOPS = [
 ]
 
 
+# The predicates a bf16 input at dest_acc=Yes cannot answer. That unpack path delivers both
+# NaN and -inf to the LREG as +inf, and which predicates that breaks follows from it rather
+# than being a blanket property of the pipeline: is_nan reads 0 where the golden says 1,
+# is_neg_inf reads 0 where it says 1, and is_inf reads 1 where it says 0. The other two
+# survive precisely because +inf is what arrives -- is_pos_inf is untouched, and is_finite
+# agrees by luck of the mapping, since isfinite(+inf) and isfinite(NaN) are both 0.
+#
+# Skipping the whole op list here withheld those two as well; they are swept now, so a
+# regression in the +inf path is caught on a bf16 input instead of only on Float32.
+_ISINF_ISNAN_BF16_DEST_UNSUPPORTED = [
+    MathOperation.Isinf,
+    MathOperation.Isneginf,
+    MathOperation.Isnan,
+]
+
+
 def _isinf_isnan_stimuli_spec():
     def dist(size, dtype, generator):
         # Finite ramp in [-5, 5] with regular +inf / -inf / nan injected so every
@@ -1202,14 +1183,17 @@ def test_eltwise_unary_sfpu_isinf_isnan(
 ):
     _skip_bh_unless_fp32(formats, dest_acc)
 
-    # bf16->fp32 dest unpack (non-32-bit input + dest_acc=Yes) doesn't preserve
-    # -inf/nan, mangling is_neg/is_nan; skip — covered by the other input cases.
+    # bf16->fp32 dest unpack (non-32-bit input + dest_acc=Yes) delivers NaN and -inf as
+    # +inf, which only the three predicates below can see; the rest are swept here.
+    # See _ISINF_ISNAN_BF16_DEST_UNSUPPORTED.
     if (
         formats.input_format == DataFormat.Float16_b
         and dest_acc == DestAccumulation.Yes
+        and mathop in _ISINF_ISNAN_BF16_DEST_UNSUPPORTED
     ):
         pytest.skip(
-            reason="bf16->fp32 dest unpack does not preserve -inf/nan special values"
+            reason="bf16->fp32 dest unpack delivers NaN and -inf as +inf, so this "
+            "predicate cannot be evaluated on this pipeline"
         )
 
     eltwise_unary_sfpu(

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_domains.py
@@ -1119,7 +1119,7 @@ def test_pow_edge_pairs_include_negative_zero_exponent():
 
 # (op, range-bound high, approximation-accuracy high). The accuracy column is what the
 # merged branch had on the shared entry; the range column is what the accurate path gets
-# back. Wormhole-measured for the approximation (see _APPROX_EXP_ACCURACY_XFAIL).
+# back. Wormhole-measured for the approximation.
 _EXP_FAMILY_BOUNDS = [
     (MathOperation.Exp, 80.0, 16.0),
     (MathOperation.Exp2, 100.0, 23.0),


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Five skip/xfail markers no longer matched reality. I re-measured every skip and xfail on an n150 and moved the stale ones into the regular sweep, so **118 cases that were being skipped or absorbed by an xfail now run and pass**, and 18 approximate-tanh cases that were never generated at all now get accuracy data collected.

| Marker | Cases | Verdict |
| --- | --- | --- |
| `_APPROX_EXP_ACCURACY_XFAIL` | 6 | Stale, removed |
| exp-family bf8_b approx-mode skip | 84 | Stale, removed |
| isinf/isnan bf16-dest skip | 4 | Real but too broad, narrowed to `Isinf`/`Isneginf`/`Isnan` |
| approximate tanh skip | 24 | Real but too broad, narrowed to the float outputs |
| `test_sfpu_accuracy` "Metal tanh does not support approximation mode" | 18 | Stale *and* dead code, removed |

Details, one line each:

- **Approximate exp** no longer overshoots the default 5% rtol on the three Float16_b-output combinations the xfail table named. Confirmed over eleven runs; the stimuli are unseeded, so each run is a fresh sample.
- **Exp, Exp2 and Elu against bf8_b in approx mode** were skipped as unsupported. They are not: all 84 withheld cases pass, because Bfp8_b's own rtol of 0.2 absorbs the approximation error the narrower float outputs reject.
- **The bf16 to fp32 dest unpack** delivers both NaN and -inf as +inf, which breaks only `Isinf`, `Isneginf` and `Isnan`. `Isposinf` and `Isfinite` are fine, so they are swept now instead of skipped with the rest.
- **Approximate tanh** does have an approximation path (a 3-segment SFPLUT), so the old reason "does not support approximation mode" was wrong. The real blocker is accuracy, and it is format-dependent: the 24 Bfp8_b/Bfp4_b-output cases clear the default 5% rtol and are swept now, the 56 Float16/Float16_b/Float32-output cases do not and stay skipped with a reason that says why.
- **The accuracy sweep** carried that same false reason. It was dead code besides: `APPROX_CAPABLE_OPS` decides whether approx=Yes is generated at all, and Tanh was absent from it, so the guard could never fire. Tanh is enrolled and the guard is gone, which is 18 newly collected cases. This sweep records accuracy without ULP gating, so a coarse LUT is the interesting input rather than a reason to withhold.

Still xfailed, correctly: the 19 edge-case divergences and the 3 `relu_min` negative-integer-threshold cases (#55643).

Verified on n150. Unary sweep: **6372 passed, 293 skipped, 22 xfailed, 0 xpassed, 0 failed**, against 6254 / 405 / 22 / 6 before. Accuracy sweep: **558 passed**, up from 540.

### Notes for reviewers

1. The bf8_b guard was **not** arch-gated, so removing it also enables those 84 cases on Blackhole, which I could not measure on a Wormhole host. Same for the approximate-tanh narrowing and the accuracy-sweep change. Worth a BH CI run before merge.
2. **The approximate-exp question from the first revision is answered.** I re-measured with a deterministic ramp across the whole exp domain, every float output and both dest_acc settings: the approximation sits at **+3.55% peak and +1.9% mean relative error, flat from x = 0 out to each output's representable limit** (the accurate path is 0.00%-0.78% over the same sweep). Two consequences, both now written into `sfpu_domains.py` where the next person will look:
   - There is **no accuracy threshold near x = 8**. The relative error does not grow with the argument, so the old "overshoots by ~5.7%, peak 6.75%, past ~8" does not reproduce at all. That is why the xfail table could be retired.
   - The **`_APPROX_ACCURACY_MAX` ceiling of 16.0 is not what holds the approximation inside the 5% rtol** — at a 3.55% peak there is ~1.4 points of headroom all the way to the range bound. A sentence asserting the opposite went in with the first revision and has been corrected. Widening the ceiling looks safe on this evidence, but it is a separate change and wants its own sweep over the non-Float32 input formats first.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-unary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/unskip-stale-sfpu-unary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-unary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/unskip-stale-sfpu-unary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-unary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/unskip-stale-sfpu-unary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-unary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/unskip-stale-sfpu-unary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-unary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/unskip-stale-sfpu-unary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-unary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/unskip-stale-sfpu-unary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-unary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/unskip-stale-sfpu-unary-markers)

