### PR TITLE
[Test Only] Add Quasar FDS interrupt tests

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_common.h
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_common.h
@@ -54,6 +54,12 @@ inline void finish(status_ptr status, uint32_t l1_address, uint32_t num_slots, u
 
 inline status_ptr begin_dispatch(uint32_t l1_address, uint32_t num_slots) {
     status_ptr status = begin(l1_address, num_slots);
+    // Interrupts are disabled defensively, for a sharper version of the reason below: a kernel that
+    // died while armed would leave a level standing on this node, and the level is derived rather
+    // than latched, so no later program could quiet it by acknowledging anything. Out of reset
+    // every threshold and every count is zero, which is a firing condition, so this also covers a
+    // node whose enable register was set before its groups were configured.
+    overlay::FdsDispatch::fds_config_interrupt_en(0);
     // Auto dispatch is disabled defensively: a kernel that died between enabling it and its
     // teardown would leave the output multiplexer on the queue path, turning every later direct
     // write on this engine into silence far from the fault. The outbox parks on the output bus,
@@ -70,6 +76,9 @@ inline status_ptr begin_dispatch(uint32_t l1_address, uint32_t num_slots) {
 
 inline status_ptr begin_worker(uint32_t l1_address, uint32_t num_slots) {
     status_ptr status = begin(l1_address, num_slots);
+    // Same defensive interrupt disable as begin_dispatch, for the same reason: this register map
+    // has its own enable register and its own all-zero reset state.
+    overlay::FdsNeo::fds_config_interrupt_en(0);
     // Same defensive disable as begin_dispatch, and the same limit on what it can reset. The
     // outbox park matters more on this map: zero is input register 0, and a stale zero outbox
     // under a mistimed enable would divert a status-clearing write into the queue and emit it as

--- a/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_common.h
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_common.h
@@ -204,3 +204,26 @@ constexpr uint32_t kTokenDelivered = 11;
 constexpr uint32_t kMismatchedGo = 2;
 constexpr uint32_t kMatchedGo = 3;
 }  // namespace fds_outbox
+
+// Status slots and failure codes shared by the interrupt kernels, whose protocol lives in
+// quasar_fds_interrupt.h. Slot 0 is the result word as everywhere else. The interrupt count in
+// slot 1 doubles as the handler's flag: the handler bumps it last, so a kernel that sees it move
+// knows the handler ran to the end, and the kernels wait on it rather than on a separate word.
+namespace fds_interrupt_status {
+constexpr uint32_t kSlotInterruptCount = 1;
+// The PLIC source the handler claimed. Kernels that make no claim check put something else in
+// slot 2 and name it themselves.
+constexpr uint32_t kSlotClaimedSource = 2;
+
+// The armed interrupt never arrived.
+constexpr uint32_t kTimeoutInterrupt = 0x5A5A0070;
+// One arrived inside a window that had to stay quiet.
+constexpr uint32_t kUnexpectedInterrupt = 0x5A5A0071;
+// The claim named a source other than 16 + the group under test.
+constexpr uint32_t kWrongSource = 0x5A5A0072;
+// mcause was not a machine external interrupt.
+constexpr uint32_t kWrongCause = 0x5A5A0073;
+// mhartid landed outside the PLIC's context range, so no context offset could be computed and
+// nothing was armed at all.
+constexpr uint32_t kBadHartContext = 0x5A5A0074;
+}  // namespace fds_interrupt_status

--- a/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt.h
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt.h
@@ -1,0 +1,306 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// The interrupt-delivery protocol every FDS interrupt kernel of this suite shares, in the role
+// quasar_fds_epoch.h plays for the polling kernels.
+//
+// An FDS group raises a level, not a pulse: irq[g] is (count[g] == threshold[g]) && interrupt_en[g],
+// re-evaluated continuously and never latched. The level reaches the hart as a machine external
+// interrupt, mcause 11, through a tile-local PLIC in which FDS group g is source 16 + g. Three
+// consequences shape everything below.
+//
+// Equality, not meets-or-exceeds. A count that has overshot its threshold is not a firing
+// condition, and a count that has never moved is one whenever the threshold is zero too — which
+// every register is out of reset. So a group is given its threshold before its interrupt enable
+// bit, or arming fires with no traffic at all.
+//
+// Sticky at the PLIC, live at the FDS. The PLIC latches the level into a pending bit that survives
+// until a context claims it, and a claim completed while the level still stands is re-delivered at
+// once. Quieting a source therefore means changing what the FDS is comparing — clearing the input
+// registers feeding the count, or clearing the interrupt enable bit — and doing it before the
+// completion. Handlers here clear, read an FDS register back so the clear has demonstrably landed,
+// and only then complete.
+//
+// Nothing else in tt-metal arms this path. mstatus.MIE and mie.MEIE are clear on every hart in this
+// suite, and the firmware's vectored table at INTERRUPT_TABLE_BASE registers slots 0 and 13 only,
+// leaving slot 11 free. That table is shared by all harts of a node and persists across launches,
+// so arming saves the word it overwrites and the teardown puts it back. mie bit 13 is never
+// touched: it belongs to the dataflow buffer ISR.
+
+#include <cstdint>
+
+#include "quasar_fds_common.h"
+
+namespace fds_interrupt {
+
+// The PLIC is tile-local and takes 32-bit accesses only. Priority of source s sits at +4*s; the
+// per-context blocks are the enable words at +0x2000 + 0x80*c, the threshold at +0x200000 +
+// 0x1000*c, and the claim/complete register one word past that threshold.
+constexpr uint32_t kPlicBase = 0x08000000;
+constexpr uint32_t kPlicPriorityBase = kPlicBase;
+constexpr uint32_t kPlicEnableBase = kPlicBase + 0x2000;
+constexpr uint32_t kPlicEnableStride = 0x80;
+constexpr uint32_t kPlicThresholdBase = kPlicBase + 0x200000;
+constexpr uint32_t kPlicClaimBase = kPlicBase + 0x200004;
+constexpr uint32_t kPlicContextStride = 0x1000;
+
+// FDS group g arrives at the PLIC as source 16 + g.
+constexpr uint32_t kFdsPlicSourceBase = 16;
+
+// A source is delivered only while its priority strictly exceeds the context threshold, and both
+// are three-bit fields. One is the smallest value that beats the zero written below.
+constexpr uint32_t kFdsInterruptPriority = 1;
+
+// A PLIC context is a hart here, so mhartid indexes the per-context blocks directly. That the
+// harts of a node are numbered 0..7 is assumed rather than confirmed, so arming refuses anything
+// outside the range instead of computing an offset from a number it cannot place.
+constexpr uint32_t kNumPlicContexts = 8;
+
+constexpr uint32_t kMieMachineExternal = uint32_t{1} << MACHINE_EXTERNAL_INTERRUPT_OFFSET;
+constexpr uint32_t kMstatusMie = uint32_t{1} << 3;
+
+// The low word of mcause for a machine external interrupt. Only the low word is recorded: arriving
+// through table slot 11 at all already establishes the interrupt bit, since vectored mode sends
+// synchronous exceptions to slot 0.
+constexpr uint32_t kMachineExternalCauseLow = MACHINE_EXTERNAL_INTERRUPT_OFFSET;
+
+// How long a handler waits for the level it just cleared to fall before it completes the claim.
+// Bounded like every wait in this suite, and generous: the level crosses a few register stages on
+// its way out of the FDS block.
+constexpr uint32_t kHandlerSettleIterations = 1000;
+
+// Stale pendings a drain will shed. A handful can be latched from earlier programs; far fewer than
+// this, but a source whose level still stands re-pends the instant it is completed, so the loop
+// needs a bound to fail rather than spin.
+constexpr uint32_t kMaxStalePendings = 64;
+
+// A handler that completes a claim while its level still stands is re-entered immediately, so a
+// level nothing here can lower becomes an unbounded storm and the kernel never runs again to report
+// it. Past this many entries the handler drops the source from its context, which stops delivery
+// whatever the level is doing, and the kernel then fails on the interrupt count instead of the run
+// hanging. Well above the two entries the most demanding of these tests expects.
+constexpr uint32_t kMaxHandlerEntries = 8;
+
+inline uint32_t plic_read32(uint32_t address) { return *reinterpret_cast<volatile uint32_t*>(address); }
+
+inline void plic_write32(uint32_t address, uint32_t value) { *reinterpret_cast<volatile uint32_t*>(address) = value; }
+
+inline uint32_t read_mhartid() {
+    uint64_t value = 0;
+    asm volatile("csrr %0, mhartid" : "=r"(value));
+    return static_cast<uint32_t>(value);
+}
+
+inline uint64_t read_mcause() {
+    uint64_t value = 0;
+    asm volatile("csrr %0, mcause" : "=r"(value));
+    return value;
+}
+
+constexpr uint32_t fds_plic_source(uint32_t group_id) { return kFdsPlicSourceBase + group_id; }
+
+inline uint32_t plic_claim(uint32_t context) { return plic_read32(kPlicClaimBase + context * kPlicContextStride); }
+
+inline void plic_complete(uint32_t context, uint32_t source) {
+    plic_write32(kPlicClaimBase + context * kPlicContextStride, source);
+}
+
+inline void plic_enable_source(uint32_t context, uint32_t source, bool enable) {
+    const uint32_t address =
+        kPlicEnableBase + context * kPlicEnableStride + (source / 32) * static_cast<uint32_t>(sizeof(uint32_t));
+    const uint32_t bit = uint32_t{1} << (source % 32);
+    const uint32_t word = plic_read32(address);
+    plic_write32(address, enable ? (word | bit) : (word & ~bit));
+}
+
+// register_handler_for_interrupt writes this slot; reading it first is what lets the teardown put
+// back whatever the firmware left there.
+inline volatile uint32_t* interrupt_table_slot(uint32_t index) {
+    return reinterpret_cast<volatile uint32_t*>(INTERRUPT_TABLE_BASE) + index;
+}
+
+// A pending latched before this kernel armed would be delivered the moment the hart enables the
+// source and would be indistinguishable from the interrupt under test. Claim and complete until
+// nothing is pending sheds them; the PLIC hands out nothing a context has not enabled, so this is
+// only meaningful once the enable bits are set.
+inline void drain_stale_pendings(uint32_t context) {
+    for (uint32_t i = 0; i < kMaxStalePendings; i++) {
+        const uint32_t claimed = plic_claim(context);
+        if (claimed == 0) {
+            return;
+        }
+        plic_complete(context, claimed);
+    }
+}
+
+// The ROCC instructions behind the FDS accessors carry no memory clobber, so nothing otherwise
+// stops the compiler from sinking a handler's FDS clears past the L1 store that tells the kernel
+// the handler ran.
+inline void order_fds_before_status() { asm volatile("" ::: "memory"); }
+
+// What arming changed, and everything the teardown needs to put it back. Returned to the kernel
+// rather than kept in a static: the handler learns its context from mhartid and its source from
+// the claim, so nothing else needs this, and a static would outlive the launch that set it.
+struct arming_state {
+    uint32_t context = 0;
+    // The groups whose PLIC sources were routed to this hart, one bit per group id. More than one
+    // is routed when a test has to show which of several configured groups the claim names.
+    uint32_t group_mask = 0;
+    uint32_t saved_table_word = 0;
+};
+
+// Routes every group in group_mask to this hart and points interrupt table slot 11 at handler.
+// False means mhartid is outside the PLIC's context range, which would make every context offset a
+// guess. The FDS interrupt enable register is deliberately untouched: which groups are armed on the
+// FDS side, and when, is what these tests vary.
+inline bool arm_external_interrupt(uint32_t group_mask, void (*handler)(), arming_state& state) {
+    const uint32_t context = read_mhartid();
+    if (context >= kNumPlicContexts) {
+        return false;
+    }
+
+    state.context = context;
+    state.group_mask = group_mask;
+    state.saved_table_word = *interrupt_table_slot(MACHINE_EXTERNAL_INTERRUPT_OFFSET);
+
+    register_handler_for_interrupt(MACHINE_EXTERNAL_INTERRUPT_OFFSET, handler);
+    // The table is instruction memory: the jump just written is not fetchable until the icache
+    // drops what it holds for that address.
+    invalidate_l1_icache();
+
+    plic_write32(kPlicThresholdBase + context * kPlicContextStride, 0);
+    for (uint32_t mask = group_mask, group = 0; mask != 0; mask >>= 1, group++) {
+        if (mask & 1u) {
+            const uint32_t source = fds_plic_source(group);
+            plic_write32(kPlicPriorityBase + source * static_cast<uint32_t>(sizeof(uint32_t)), kFdsInterruptPriority);
+            plic_enable_source(context, source, true);
+        }
+    }
+
+    drain_stale_pendings(context);
+
+    asm volatile("csrrs zero, mie, %0" ::"r"(kMieMachineExternal));
+    asm volatile("csrrs zero, mstatus, %0" ::"r"(kMstatusMie));
+    return true;
+}
+
+// Everything after the FDS interrupt enable register has been cleared. Split out because that
+// first step is the only part of the teardown that differs between the two register maps.
+inline void finish_disarm(const arming_state& state) {
+    // Drained while the sources are still enabled in this context: the PLIC drops a completion
+    // from a context that does not have the source enabled, and a claim left in flight would block
+    // that source for every later program on this node.
+    drain_stale_pendings(state.context);
+    for (uint32_t mask = state.group_mask, group = 0; mask != 0; mask >>= 1, group++) {
+        if (mask & 1u) {
+            plic_enable_source(state.context, fds_plic_source(group), false);
+        }
+    }
+
+    asm volatile("csrrc zero, mie, %0" ::"r"(kMieMachineExternal));
+    asm volatile("csrrc zero, mstatus, %0" ::"r"(kMstatusMie));
+
+    *interrupt_table_slot(MACHINE_EXTERNAL_INTERRUPT_OFFSET) = state.saved_table_word;
+    invalidate_l1_icache();
+}
+
+// Called from a handler, before it completes its claim. Nothing happens until the entry count says
+// the level is one this kernel cannot lower.
+inline void stop_interrupt_storm(uint32_t context, uint32_t source, uint32_t entry) {
+    if (entry >= kMaxHandlerEntries) {
+        plic_enable_source(context, source, false);
+    }
+}
+
+// Zero every slot the handler owns, before anything can be delivered into them. The host clears
+// the whole block before launch, but these are the only kernels in this suite that read their own
+// status block back, and a store from this core is what makes the value definite in the cache this
+// core will read it through — whatever an earlier program left cached for the same address. Call
+// this before arming. The range is half open: every kernel here owns its slots from the interrupt
+// count to the end of its status block, so end_slot is that block's slot count.
+inline void clear_handler_slots(fds_kernel::status_ptr status, uint32_t first_slot, uint32_t end_slot) {
+    for (uint32_t slot = first_slot; slot < end_slot; slot++) {
+        status[slot] = 0;
+    }
+}
+
+// The interrupt count slot doubles as the handler's flag: the handler bumps it last, so a kernel
+// that sees a new value knows the handler ran to the end.
+inline bool wait_for_interrupt_count(fds_kernel::status_ptr status, uint32_t expected, uint32_t poll_iterations) {
+    for (uint32_t i = 0; i < poll_iterations; i++) {
+        if (status[fds_interrupt_status::kSlotInterruptCount] >= expected) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// True when the count held at expected for the whole window.
+inline bool interrupt_count_steady(fds_kernel::status_ptr status, uint32_t expected, uint32_t silence_iterations) {
+    for (uint32_t i = 0; i < silence_iterations; i++) {
+        if (status[fds_interrupt_status::kSlotInterruptCount] != expected) {
+            return false;
+        }
+    }
+    return true;
+}
+
+namespace dispatch {
+
+// Clear the input registers currently carrying group_id, which is what lowers the count and with it
+// the level. Group status is the live per-lane map and is not gated by the enable register, so it
+// names exactly the lanes contributing to the count. A clear sticks under a held sender, so this
+// does not have to race the workers.
+inline void clear_group_inputs(uint32_t group_id, uint32_t worker_mask) {
+    const uint32_t done_lanes = overlay::FdsDispatch::fds_read_group_status(group_id) & worker_mask;
+    for (uint32_t mask = done_lanes, neo = 0; mask != 0; mask >>= 1, neo++) {
+        if (mask & 1u) {
+            overlay::FdsDispatch::fds_clear_neo_status(neo);
+        }
+    }
+}
+
+// Read the count back until it shows the clear has landed. The read back is the point as much as
+// the wait is: a completion issued before the level has fallen is re-delivered immediately.
+inline void wait_count_cleared(uint32_t group_id) {
+    for (uint32_t i = 0; i < kHandlerSettleIterations; i++) {
+        if (overlay::FdsDispatch::fds_read_group_count(group_id) == 0) {
+            return;
+        }
+    }
+}
+
+inline void disarm_external_interrupt(const arming_state& state) {
+    overlay::FdsDispatch::fds_config_interrupt_en(0);
+    // Read back so the disable has landed before the drain: a drain that races it would complete
+    // claims under a level still standing and shed nothing.
+    overlay::FdsDispatch::fds_read_group_count(0);
+    finish_disarm(state);
+}
+
+}  // namespace dispatch
+
+namespace neo {
+
+// Same read back as the dispatch-side wait, against the register this map exposes.
+inline void wait_status_cleared(uint32_t group_id) {
+    for (uint32_t i = 0; i < kHandlerSettleIterations; i++) {
+        if (overlay::FdsNeo::fds_read_group_status(group_id) == 0) {
+            return;
+        }
+    }
+}
+
+inline void disarm_external_interrupt(const arming_state& state) {
+    overlay::FdsNeo::fds_config_interrupt_en(0);
+    // Same read back as the dispatch-side teardown, for the same reason.
+    overlay::FdsNeo::fds_read_group_status(0);
+    finish_disarm(state);
+}
+
+}  // namespace neo
+
+}  // namespace fds_interrupt

--- a/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_dispatch.cpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Interrupt delivery on the done threshold: the same handshake the polling tests drive, collected
+// by a handler instead of a spin on the count. What this pins beyond delivery itself is the
+// identity of what was delivered — the claim must name this group's source and no other, and the
+// cause must be a machine external interrupt — and that the level does not come back once the
+// handler has cleared the inputs feeding it.
+//
+// The group is armed before the ready wait, which is only safe because the trigger is an equality:
+// the count is zero and the threshold is not, so nothing fires until the dones actually arrive.
+
+#include <cstdint>
+#include "api/compile_time_args.h"
+
+#include "quasar_fds_common.h"
+#include "quasar_fds_interrupt.h"
+
+using fds_interrupt_status::kSlotClaimedSource;
+using fds_interrupt_status::kSlotInterruptCount;
+
+// Mirrored by test_quasar_fds.cpp.
+constexpr uint32_t kSlotMcauseLow = 3;
+constexpr uint32_t kSlotHartId = 4;
+constexpr uint32_t kNumSlots = 5;
+
+// The handler cannot be handed arguments, so it reads the same compile-time values kernel_main
+// does. Nothing it needs lives in static storage: its counter and its flag are status slots.
+constexpr uint32_t kL1Address = get_named_compile_time_arg_val("l1_address");
+constexpr uint32_t kGroupId = get_named_compile_time_arg_val("group_id");
+constexpr uint32_t kWorkerMask = get_named_compile_time_arg_val("worker_mask");
+// The count the interrupt is meant to mark. Every worker in the epoch belongs to this group, so
+// the host sets it to the worker count; the two are named separately because the ready wait counts
+// workers whatever their group, exactly as in quasar_dispatch_engine_signal.cpp.
+constexpr uint32_t kDoneThreshold = get_named_compile_time_arg_val("done_threshold");
+constexpr uint32_t kNumReadyWorkers = get_named_compile_time_arg_val("num_workers");
+constexpr uint32_t kPollIterations = get_named_compile_time_arg_val("poll_iterations");
+constexpr uint32_t kSilenceIterations = get_named_compile_time_arg_val("silence_iterations");
+
+static_assert(kGroupId < kReadyTokenA, "payload group ids must stay below the ready tokens");
+static_assert(kDoneThreshold > 0, "a zero threshold would fire the moment the group was armed");
+
+__attribute__((interrupt)) void fds_done_interrupt_handler() {
+    fds_kernel::status_ptr status = reinterpret_cast<fds_kernel::status_ptr>(kL1Address);
+    const uint32_t context = fds_interrupt::read_mhartid();
+    const uint32_t mcause_low = static_cast<uint32_t>(fds_interrupt::read_mcause());
+    const uint32_t claimed = fds_interrupt::plic_claim(context);
+    const uint32_t entry = status[kSlotInterruptCount];
+
+    status[kSlotHartId] = context;
+    status[kSlotMcauseLow] = mcause_low;
+    status[kSlotClaimedSource] = claimed;
+
+    // The level has to come down before the claim is completed, and only the inputs feeding the
+    // count can bring it down.
+    fds_interrupt::dispatch::clear_group_inputs(kGroupId, kWorkerMask);
+    fds_interrupt::dispatch::wait_count_cleared(kGroupId);
+    fds_interrupt::order_fds_before_status();
+
+    fds_interrupt::stop_interrupt_storm(context, claimed, entry);
+    fds_interrupt::plic_complete(context, claimed);
+    status[kSlotInterruptCount] = entry + 1;
+}
+
+void kernel_main() {
+    fds_kernel::status_ptr status = fds_kernel::begin_dispatch(kL1Address, kNumSlots);
+    fds_interrupt::clear_handler_slots(status, kSlotInterruptCount, kNumSlots);
+    // A captured done survives its sender and its program, so shed the previous epoch before an
+    // enable bit can turn that stale count into this epoch's interrupt.
+    fds_epoch::clear_dispatch_inputs(kWorkerMask);
+    overlay::FdsDispatch::fds_read_group_count(kGroupId);
+    overlay::FdsDispatch::fds_config_groupid(kGroupId, kWorkerMask, kDoneThreshold);
+
+    fds_interrupt::arming_state arming;
+    if (!fds_interrupt::arm_external_interrupt(uint32_t{1} << kGroupId, fds_done_interrupt_handler, arming)) {
+        fds_kernel::finish(status, kL1Address, kNumSlots, fds_interrupt_status::kBadHartContext);
+        return;
+    }
+    overlay::FdsDispatch::fds_config_interrupt_en(uint32_t{1} << kGroupId);
+
+    if (!fds_kernel::workers_are_ready(status, kL1Address, kNumSlots, kWorkerMask, kNumReadyWorkers, kPollIterations)) {
+        fds_interrupt::dispatch::disarm_external_interrupt(arming);
+        return;
+    }
+
+    overlay::FdsDispatch::fds_clear_go();
+    overlay::FdsDispatch::fds_go(/*ad_enable=*/false, kGroupId);
+
+    uint32_t result = kComplete;
+    if (!fds_interrupt::wait_for_interrupt_count(status, 1, kPollIterations)) {
+        result = fds_interrupt_status::kTimeoutInterrupt;
+    }
+
+    if (result == kComplete && status[kSlotClaimedSource] != fds_interrupt::fds_plic_source(kGroupId)) {
+        result = fds_interrupt_status::kWrongSource;
+    }
+
+    if (result == kComplete && status[kSlotMcauseLow] != fds_interrupt::kMachineExternalCauseLow) {
+        result = fds_interrupt_status::kWrongCause;
+    }
+
+    // The handler cleared the input registers under senders that are still holding their dones. A
+    // clear sticks under a held sender, so the count must stay at zero and the level must stay
+    // down; a second entry here is the level re-arming itself.
+    if (result == kComplete && !fds_interrupt::interrupt_count_steady(status, 1, kSilenceIterations)) {
+        result = fds_interrupt_status::kUnexpectedInterrupt;
+    }
+
+    fds_interrupt::dispatch::disarm_external_interrupt(arming);
+    overlay::FdsDispatch::fds_clear_go();
+
+    fds_kernel::finish(status, kL1Address, kNumSlots, result);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_equality_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_equality_dispatch.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// The trigger is an equality, not a meets-or-exceeds. The threshold is set one below the number of
+// workers, so the count overshoots it and stops there, and the interrupt enable is withheld until
+// it has: arming against a count of N with a threshold of N-1 must stay silent. A model that fires
+// on count >= threshold fires here.
+//
+// The count is then brought down onto the threshold by clearing one done lane — the count is
+// derived from the input registers, so dropping one lane subtracts one from it — and the same
+// arming that was silent a moment ago must now deliver. The two halves are what make this an
+// assertion about the comparison rather than about arming order: nothing between them changes but
+// the count, and it changes downwards.
+
+#include <cstdint>
+#include "api/compile_time_args.h"
+
+#include "quasar_fds_common.h"
+#include "quasar_fds_interrupt.h"
+
+using fds_interrupt_status::kSlotInterruptCount;
+
+// Mirrored by test_quasar_fds.cpp. The lane map the group was holding when the enable bit went on,
+// so a failure names the count the comparison was made against.
+constexpr uint32_t kSlotStatusAtArm = 2;
+constexpr uint32_t kNumSlots = 3;
+
+// The dones never all showed on the wire, so the overshoot under test never existed.
+constexpr uint32_t kTimeoutStatus = 0x5A5A0075;
+// Fired while the count sat above the threshold: a meets-or-exceeds trigger.
+constexpr uint32_t kFiredAtOvershoot = fds_interrupt_status::kUnexpectedInterrupt;
+// The count was brought down onto the threshold and nothing fired.
+constexpr uint32_t kTimeoutAtEquality = fds_interrupt_status::kTimeoutInterrupt;
+
+constexpr uint32_t kL1Address = get_named_compile_time_arg_val("l1_address");
+constexpr uint32_t kGroupId = get_named_compile_time_arg_val("group_id");
+constexpr uint32_t kWorkerMask = get_named_compile_time_arg_val("worker_mask");
+constexpr uint32_t kNumReadyWorkers = get_named_compile_time_arg_val("num_workers");
+constexpr uint32_t kPollIterations = get_named_compile_time_arg_val("poll_iterations");
+constexpr uint32_t kSilenceIterations = get_named_compile_time_arg_val("silence_iterations");
+
+// One below the number of workers, so the count can reach the threshold only by coming back down.
+constexpr uint32_t kDoneThreshold = kNumReadyWorkers - 1;
+
+static_assert(kGroupId < kReadyTokenA, "payload group ids must stay below the ready tokens");
+static_assert(kNumReadyWorkers >= 2, "the overshoot needs a threshold of at least one below N");
+
+__attribute__((interrupt)) void fds_equality_interrupt_handler() {
+    fds_kernel::status_ptr status = reinterpret_cast<fds_kernel::status_ptr>(kL1Address);
+    const uint32_t context = fds_interrupt::read_mhartid();
+    const uint32_t claimed = fds_interrupt::plic_claim(context);
+    const uint32_t entry = status[kSlotInterruptCount];
+
+    fds_interrupt::dispatch::clear_group_inputs(kGroupId, kWorkerMask);
+    fds_interrupt::dispatch::wait_count_cleared(kGroupId);
+    fds_interrupt::order_fds_before_status();
+
+    fds_interrupt::stop_interrupt_storm(context, claimed, entry);
+    fds_interrupt::plic_complete(context, claimed);
+    status[kSlotInterruptCount] = entry + 1;
+}
+
+void kernel_main() {
+    fds_kernel::status_ptr status = fds_kernel::begin_dispatch(kL1Address, kNumSlots);
+    fds_interrupt::clear_handler_slots(status, kSlotInterruptCount, kNumSlots);
+    overlay::FdsDispatch::fds_config_groupid(kGroupId, kWorkerMask, kDoneThreshold);
+
+    // The PLIC side is armed up front; the FDS interrupt enable is what this test withholds.
+    fds_interrupt::arming_state arming;
+    if (!fds_interrupt::arm_external_interrupt(uint32_t{1} << kGroupId, fds_equality_interrupt_handler, arming)) {
+        fds_kernel::finish(status, kL1Address, kNumSlots, fds_interrupt_status::kBadHartContext);
+        return;
+    }
+
+    if (!fds_kernel::workers_are_ready(status, kL1Address, kNumSlots, kWorkerMask, kNumReadyWorkers, kPollIterations)) {
+        fds_interrupt::dispatch::disarm_external_interrupt(arming);
+        return;
+    }
+
+    overlay::FdsDispatch::fds_clear_go();
+    overlay::FdsDispatch::fds_go(/*ad_enable=*/false, kGroupId);
+
+    // Waited out on status rather than on the count, because status is ungated by the enable mask
+    // and so reports the lanes whether or not the group was ever configured to count them. Every
+    // lane present is the overshoot the arming below has to be silent against.
+    uint32_t result = kComplete;
+    uint32_t status_at_arm = 0;
+    bool all_dones_visible = false;
+    for (uint32_t i = 0; i < kPollIterations && !all_dones_visible; i++) {
+        status_at_arm = overlay::FdsDispatch::fds_read_group_status(kGroupId) & kWorkerMask;
+        all_dones_visible = static_cast<uint32_t>(__builtin_popcount(status_at_arm)) >= kNumReadyWorkers;
+    }
+    status[kSlotStatusAtArm] = status_at_arm;
+    if (!all_dones_visible) {
+        result = kTimeoutStatus;
+    }
+
+    if (result == kComplete) {
+        overlay::FdsDispatch::fds_config_interrupt_en(uint32_t{1} << kGroupId);
+        if (!fds_interrupt::interrupt_count_steady(status, 0, kSilenceIterations)) {
+            result = kFiredAtOvershoot;
+        }
+    }
+
+    if (result == kComplete) {
+        // One lane out of the count, and the arming that was silent must now deliver.
+        const uint32_t cleared_lane = static_cast<uint32_t>(__builtin_ctz(status_at_arm));
+        overlay::FdsDispatch::fds_clear_neo_status(cleared_lane);
+        if (!fds_interrupt::wait_for_interrupt_count(status, 1, kPollIterations)) {
+            result = kTimeoutAtEquality;
+        }
+    }
+
+    fds_interrupt::dispatch::disarm_external_interrupt(arming);
+    overlay::FdsDispatch::fds_clear_go();
+
+    fds_kernel::finish(status, kL1Address, kNumSlots, result);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_group_mask_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_group_mask_dispatch.cpp
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// The interrupt enable register is per group, and the source the PLIC reports is the group that
+// fired. Two groups are configured identically — full lane mask, threshold equal to the number of
+// workers — and only one of them is ever signalled. The quiet group is armed and the signalled one
+// is not, so during the silence window the signalled group sits exactly at its threshold with no
+// enable bit while the armed group sits at a count of zero against a threshold of N. Neither may
+// deliver, and a per-group enable is the only reason.
+//
+// The signalled group is then armed too, and the claim must name its source rather than the quiet
+// group's. Both sources are routed to this hart at the PLIC, so naming the wrong one is a result
+// this test can actually observe.
+//
+// Distinct from quasar_fds_interrupt_equality_dispatch.cpp: that one varies the count against a
+// fixed arming, this one varies the arming against a fixed count.
+
+#include <cstdint>
+#include "api/compile_time_args.h"
+
+#include "quasar_fds_common.h"
+#include "quasar_fds_interrupt.h"
+
+using fds_interrupt_status::kSlotClaimedSource;
+using fds_interrupt_status::kSlotInterruptCount;
+
+// Mirrored by test_quasar_fds.cpp.
+constexpr uint32_t kNumSlots = 3;
+
+// The dones never all showed on the wire, so the signalled group never reached its threshold.
+constexpr uint32_t kTimeoutStatus = 0x5A5A0079;
+// A delivery while the only armed group was nowhere near its threshold.
+constexpr uint32_t kFiredUnarmed = fds_interrupt_status::kUnexpectedInterrupt;
+
+constexpr uint32_t kL1Address = get_named_compile_time_arg_val("l1_address");
+constexpr uint32_t kGroupId = get_named_compile_time_arg_val("group_id");
+constexpr uint32_t kQuietGroupId = get_named_compile_time_arg_val("quiet_group_id");
+constexpr uint32_t kWorkerMask = get_named_compile_time_arg_val("worker_mask");
+constexpr uint32_t kNumReadyWorkers = get_named_compile_time_arg_val("num_workers");
+constexpr uint32_t kPollIterations = get_named_compile_time_arg_val("poll_iterations");
+constexpr uint32_t kSilenceIterations = get_named_compile_time_arg_val("silence_iterations");
+
+static_assert(kGroupId < kReadyTokenA, "payload group ids must stay below the ready tokens");
+static_assert(kQuietGroupId < kReadyTokenA, "payload group ids must stay below the ready tokens");
+static_assert(kGroupId != kQuietGroupId, "the two groups must be distinguishable in the claim");
+static_assert(kNumReadyWorkers > 0, "a zero threshold would fire both groups before any done arrived");
+
+__attribute__((interrupt)) void fds_group_mask_interrupt_handler() {
+    fds_kernel::status_ptr status = reinterpret_cast<fds_kernel::status_ptr>(kL1Address);
+    const uint32_t context = fds_interrupt::read_mhartid();
+    const uint32_t claimed = fds_interrupt::plic_claim(context);
+    const uint32_t entry = status[kSlotInterruptCount];
+
+    status[kSlotClaimedSource] = claimed;
+
+    // Only the signalled group has lanes to clear; the quiet group shares the lanes but no worker
+    // ever drove its id onto one, so its count is zero throughout and clearing does nothing to it.
+    fds_interrupt::dispatch::clear_group_inputs(kGroupId, kWorkerMask);
+    fds_interrupt::dispatch::wait_count_cleared(kGroupId);
+    fds_interrupt::order_fds_before_status();
+
+    fds_interrupt::stop_interrupt_storm(context, claimed, entry);
+    fds_interrupt::plic_complete(context, claimed);
+    status[kSlotInterruptCount] = entry + 1;
+}
+
+void kernel_main() {
+    fds_kernel::status_ptr status = fds_kernel::begin_dispatch(kL1Address, kNumSlots);
+    fds_interrupt::clear_handler_slots(status, kSlotInterruptCount, kNumSlots);
+    // Both groups participate in a silence assertion, so neither may begin with a captured value
+    // from a previous launch.
+    fds_epoch::clear_dispatch_inputs(kWorkerMask);
+    overlay::FdsDispatch::fds_read_group_count(kGroupId);
+    overlay::FdsDispatch::fds_config_groupid(kGroupId, kWorkerMask, kNumReadyWorkers);
+    overlay::FdsDispatch::fds_config_groupid(kQuietGroupId, kWorkerMask, kNumReadyWorkers);
+
+    // Both sources routed to this hart, so the claim can name either one.
+    fds_interrupt::arming_state arming;
+    const uint32_t routed_groups = (uint32_t{1} << kGroupId) | (uint32_t{1} << kQuietGroupId);
+    if (!fds_interrupt::arm_external_interrupt(routed_groups, fds_group_mask_interrupt_handler, arming)) {
+        fds_kernel::finish(status, kL1Address, kNumSlots, fds_interrupt_status::kBadHartContext);
+        return;
+    }
+    // On the FDS side, only the group nobody will signal.
+    overlay::FdsDispatch::fds_config_interrupt_en(uint32_t{1} << kQuietGroupId);
+
+    if (!fds_kernel::workers_are_ready(status, kL1Address, kNumSlots, kWorkerMask, kNumReadyWorkers, kPollIterations)) {
+        fds_interrupt::dispatch::disarm_external_interrupt(arming);
+        return;
+    }
+
+    overlay::FdsDispatch::fds_clear_go();
+    overlay::FdsDispatch::fds_go(/*ad_enable=*/false, kGroupId);
+
+    // Status rather than count, so the wait does not depend on the enable register this test is
+    // manipulating.
+    uint32_t result = kComplete;
+    bool all_dones_visible = false;
+    for (uint32_t i = 0; i < kPollIterations && !all_dones_visible; i++) {
+        const uint32_t done_lanes = overlay::FdsDispatch::fds_read_group_status(kGroupId) & kWorkerMask;
+        all_dones_visible = static_cast<uint32_t>(__builtin_popcount(done_lanes)) >= kNumReadyWorkers;
+    }
+    if (!all_dones_visible) {
+        result = kTimeoutStatus;
+    }
+
+    if (result == kComplete && !fds_interrupt::interrupt_count_steady(status, 0, kSilenceIterations)) {
+        result = kFiredUnarmed;
+    }
+
+    if (result == kComplete) {
+        overlay::FdsDispatch::fds_config_interrupt_en(routed_groups);
+        if (!fds_interrupt::wait_for_interrupt_count(status, 1, kPollIterations)) {
+            result = fds_interrupt_status::kTimeoutInterrupt;
+        }
+    }
+
+    if (result == kComplete && status[kSlotClaimedSource] != fds_interrupt::fds_plic_source(kGroupId)) {
+        result = fds_interrupt_status::kWrongSource;
+    }
+
+    fds_interrupt::dispatch::disarm_external_interrupt(arming);
+    overlay::FdsDispatch::fds_clear_go();
+
+    fds_kernel::finish(status, kL1Address, kNumSlots, result);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_repend_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_repend_dispatch.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Completing a claim while the level still stands re-delivers it. The handler's first entry
+// deliberately skips the clear every other handler in this suite performs and completes with the
+// done still on the wire, so the FDS comparison is still true; a second entry must follow. The
+// second entry clears, reads back, and completes as usual, and a silence window asserts there is
+// no third.
+//
+// This is the positive counterpart of the silence window in quasar_fds_interrupt_dispatch.cpp:
+// that one shows a cleared level staying down, this one shows an uncleared level coming back. Only
+// together do they establish that the clear is what quiets the source, rather than the completion.
+
+#include <cstdint>
+#include "api/compile_time_args.h"
+
+#include "quasar_fds_common.h"
+#include "quasar_fds_interrupt.h"
+
+using fds_interrupt_status::kSlotInterruptCount;
+
+// Mirrored by test_quasar_fds.cpp.
+constexpr uint32_t kNumSlots = 2;
+
+// The first delivery never arrived.
+constexpr uint32_t kTimeoutFirst = fds_interrupt_status::kTimeoutInterrupt;
+// The claim was completed under a standing level and nothing came back.
+constexpr uint32_t kTimeoutRedelivery = 0x5A5A0076;
+// A third delivery after the second entry cleared the inputs.
+constexpr uint32_t kThirdDelivery = fds_interrupt_status::kUnexpectedInterrupt;
+
+constexpr uint32_t kL1Address = get_named_compile_time_arg_val("l1_address");
+constexpr uint32_t kGroupId = get_named_compile_time_arg_val("group_id");
+constexpr uint32_t kWorkerMask = get_named_compile_time_arg_val("worker_mask");
+constexpr uint32_t kPollIterations = get_named_compile_time_arg_val("poll_iterations");
+constexpr uint32_t kSilenceIterations = get_named_compile_time_arg_val("silence_iterations");
+
+// One worker, so one done is the whole count.
+constexpr uint32_t kDoneThreshold = 1;
+
+static_assert(kGroupId < kReadyTokenA, "payload group ids must stay below the ready tokens");
+
+__attribute__((interrupt)) void fds_repend_interrupt_handler() {
+    fds_kernel::status_ptr status = reinterpret_cast<fds_kernel::status_ptr>(kL1Address);
+    const uint32_t context = fds_interrupt::read_mhartid();
+    const uint32_t claimed = fds_interrupt::plic_claim(context);
+    const uint32_t entry = status[kSlotInterruptCount];
+
+    // The first entry leaves the input register alone on purpose, so the count is still at the
+    // threshold when the claim is completed below and the source has to re-pend.
+    if (entry != 0) {
+        fds_interrupt::dispatch::clear_group_inputs(kGroupId, kWorkerMask);
+        fds_interrupt::dispatch::wait_count_cleared(kGroupId);
+    }
+    fds_interrupt::order_fds_before_status();
+
+    fds_interrupt::stop_interrupt_storm(context, claimed, entry);
+    fds_interrupt::plic_complete(context, claimed);
+    status[kSlotInterruptCount] = entry + 1;
+}
+
+void kernel_main() {
+    fds_kernel::status_ptr status = fds_kernel::begin_dispatch(kL1Address, kNumSlots);
+    fds_interrupt::clear_handler_slots(status, kSlotInterruptCount, kNumSlots);
+    // The first entry deliberately leaves its input standing, so it must be caused by this epoch's
+    // done rather than a capture inherited from an earlier launch.
+    fds_epoch::clear_dispatch_inputs(kWorkerMask);
+    overlay::FdsDispatch::fds_read_group_count(kGroupId);
+    overlay::FdsDispatch::fds_config_groupid(kGroupId, kWorkerMask, kDoneThreshold);
+
+    fds_interrupt::arming_state arming;
+    if (!fds_interrupt::arm_external_interrupt(uint32_t{1} << kGroupId, fds_repend_interrupt_handler, arming)) {
+        fds_kernel::finish(status, kL1Address, kNumSlots, fds_interrupt_status::kBadHartContext);
+        return;
+    }
+    overlay::FdsDispatch::fds_config_interrupt_en(uint32_t{1} << kGroupId);
+
+    if (!fds_kernel::workers_are_ready(status, kL1Address, kNumSlots, kWorkerMask, kNumWorkers, kPollIterations)) {
+        fds_interrupt::dispatch::disarm_external_interrupt(arming);
+        return;
+    }
+
+    overlay::FdsDispatch::fds_clear_go();
+    overlay::FdsDispatch::fds_go(/*ad_enable=*/false, kGroupId);
+
+    uint32_t result = kComplete;
+    if (!fds_interrupt::wait_for_interrupt_count(status, 1, kPollIterations)) {
+        result = kTimeoutFirst;
+    }
+
+    // Both entries can land before this kernel runs again, so the wait is for the count reaching
+    // two rather than for a transition through one.
+    if (result == kComplete && !fds_interrupt::wait_for_interrupt_count(status, 2, kPollIterations)) {
+        result = kTimeoutRedelivery;
+    }
+
+    if (result == kComplete && !fds_interrupt::interrupt_count_steady(status, 2, kSilenceIterations)) {
+        result = kThirdDelivery;
+    }
+
+    fds_interrupt::dispatch::disarm_external_interrupt(arming);
+    overlay::FdsDispatch::fds_clear_go();
+
+    fds_kernel::finish(status, kL1Address, kNumSlots, result);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_storm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_storm_dispatch.cpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// The reset state is a firing state. Out of reset every threshold and every count is zero, so a
+// group left at its reset threshold has count 0 equal to threshold 0, and arming it raises the
+// level with no traffic on any wire — no workers run in this epoch at all. That is the hazard for
+// anything that arms before it configures.
+//
+// The count reached that way has to be built rather than assumed: input registers keep their
+// captures across launches, and the workers of every other test drive this same group id and never
+// clear it at exit. So this kernel sheds the inherited captures first, exactly as the kernels with
+// a ready wait do, and only then is the count zero because nothing has signalled.
+//
+// The second half is what makes it more than a curiosity: the reflex that quiets every other
+// group, clearing the input registers, cannot quiet this one. The count is already zero, so
+// lowering it is not available, and the handler's first entry proves it by clearing everything,
+// reading the count back, and being re-entered anyway. Only dropping the interrupt enable bit
+// takes this level down, which the second entry does.
+
+#include <cstdint>
+#include "api/compile_time_args.h"
+
+#include "quasar_fds_common.h"
+#include "quasar_fds_interrupt.h"
+
+using fds_interrupt_status::kSlotInterruptCount;
+
+// Mirrored by test_quasar_fds.cpp.
+constexpr uint32_t kNumSlots = 2;
+
+// Arming a group whose count and threshold are both zero delivered nothing.
+constexpr uint32_t kTimeoutInterrupt = fds_interrupt_status::kTimeoutInterrupt;
+// Clearing the input registers took the level down, which it cannot do to a count already at zero.
+constexpr uint32_t kQuietedByClear = 0x5A5A0077;
+// The enable bit was dropped and deliveries kept coming.
+constexpr uint32_t kDisarmDidNotQuiet = 0x5A5A0078;
+
+constexpr uint32_t kL1Address = get_named_compile_time_arg_val("l1_address");
+constexpr uint32_t kGroupId = get_named_compile_time_arg_val("group_id");
+constexpr uint32_t kWorkerMask = get_named_compile_time_arg_val("worker_mask");
+constexpr uint32_t kPollIterations = get_named_compile_time_arg_val("poll_iterations");
+constexpr uint32_t kSilenceIterations = get_named_compile_time_arg_val("silence_iterations");
+
+// The reset value, written out rather than inherited so the firing condition is stated where the
+// test rests on it.
+constexpr uint32_t kResetThreshold = 0;
+
+static_assert(kGroupId < kReadyTokenA, "payload group ids must stay below the ready tokens");
+
+__attribute__((interrupt)) void fds_storm_interrupt_handler() {
+    fds_kernel::status_ptr status = reinterpret_cast<fds_kernel::status_ptr>(kL1Address);
+    const uint32_t context = fds_interrupt::read_mhartid();
+    const uint32_t claimed = fds_interrupt::plic_claim(context);
+    const uint32_t entry = status[kSlotInterruptCount];
+
+    if (entry == 0) {
+        // Every input register, not just the lanes carrying this group: none of them carries it,
+        // which is the point. The count read back is what makes the failure below a measurement
+        // rather than an assumption.
+        fds_epoch::clear_dispatch_inputs(kWorkerMask);
+        overlay::FdsDispatch::fds_read_group_count(kGroupId);
+    } else {
+        // The one write that does take this level down, followed by the same read back the other
+        // handlers make after their clears: the completion below must not outrun it, or the source
+        // re-pends and the disarm looks like it failed.
+        overlay::FdsDispatch::fds_config_interrupt_en(0);
+        overlay::FdsDispatch::fds_read_group_count(kGroupId);
+    }
+    fds_interrupt::order_fds_before_status();
+
+    fds_interrupt::stop_interrupt_storm(context, claimed, entry);
+    fds_interrupt::plic_complete(context, claimed);
+    status[kSlotInterruptCount] = entry + 1;
+}
+
+void kernel_main() {
+    fds_kernel::status_ptr status = fds_kernel::begin_dispatch(kL1Address, kNumSlots);
+    fds_interrupt::clear_handler_slots(status, kSlotInterruptCount, kNumSlots);
+    // A done captured from an earlier launch carries this group id and would hold the count above
+    // the threshold, so arming would deliver nothing and the reset state would look quiet.
+    fds_epoch::clear_dispatch_inputs(kWorkerMask);
+    overlay::FdsDispatch::fds_read_group_count(kGroupId);
+    // A full enable mask and a threshold of zero: every lane is watched and none of them has to do
+    // anything for the comparison to hold.
+    overlay::FdsDispatch::fds_config_groupid(kGroupId, kWorkerMask, kResetThreshold);
+
+    fds_interrupt::arming_state arming;
+    if (!fds_interrupt::arm_external_interrupt(uint32_t{1} << kGroupId, fds_storm_interrupt_handler, arming)) {
+        fds_kernel::finish(status, kL1Address, kNumSlots, fds_interrupt_status::kBadHartContext);
+        return;
+    }
+
+    // No ready handshake and no go: there are no workers in this epoch. The enable bit alone is
+    // the whole stimulus.
+    overlay::FdsDispatch::fds_config_interrupt_en(uint32_t{1} << kGroupId);
+
+    uint32_t result = kComplete;
+    if (!fds_interrupt::wait_for_interrupt_count(status, 1, kPollIterations)) {
+        result = kTimeoutInterrupt;
+    }
+
+    if (result == kComplete && !fds_interrupt::wait_for_interrupt_count(status, 2, kPollIterations)) {
+        result = kQuietedByClear;
+    }
+
+    if (result == kComplete && !fds_interrupt::interrupt_count_steady(status, 2, kSilenceIterations)) {
+        result = kDisarmDidNotQuiet;
+    }
+
+    fds_interrupt::dispatch::disarm_external_interrupt(arming);
+
+    fds_kernel::finish(status, kL1Address, kNumSlots, result);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_worker.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/fds/quasar_fds_interrupt_worker.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// The worker side of interrupt delivery, and the only test in this suite on the NEO register map's
+// interrupt path. A worker that polls for its go can miss one, so the specification has workers run
+// with interrupts armed; here the go is collected by a handler and the lane is never polled.
+//
+// Arming happens before the first ready pulse. The initial handshake is the one moment the engine
+// can raise a go, so a worker that armed after pulsing would have been a poller for exactly the
+// window in which the go can arrive. The epoch protocol already orders it that way — clear inputs,
+// then pulse — and this kernel arms inside that order rather than alongside it.
+//
+// fds_epoch::wait_for_go cannot serve as the wait: it polls the lane, which is the mechanism under
+// test. The loop below keeps the protocol's ready pulsing and takes its completion condition from
+// the handler's count instead.
+
+#include <cstdint>
+#include "api/compile_time_args.h"
+
+#include "quasar_fds_common.h"
+#include "quasar_fds_interrupt.h"
+
+using fds_interrupt_status::kSlotClaimedSource;
+using fds_interrupt_status::kSlotInterruptCount;
+
+// Mirrored by test_quasar_fds.cpp. Which dispatch instance drove this NEO, as the handler found it.
+constexpr uint32_t kSlotGoLane = 3;
+constexpr uint32_t kNumSlots = 4;
+
+constexpr uint32_t kL1Address = get_named_compile_time_arg_val("l1_address");
+constexpr uint32_t kGroupId = get_named_compile_time_arg_val("group_id");
+constexpr uint32_t kDispatchMask = get_named_compile_time_arg_val("dispatch_mask");
+constexpr uint32_t kPollIterations = get_named_compile_time_arg_val("poll_iterations");
+
+// One engine drives this worker, so one go on any lane is the whole count.
+constexpr uint32_t kGoThreshold = 1;
+
+static_assert(kGroupId < kReadyTokenA, "payload group ids must stay below the ready tokens");
+
+__attribute__((interrupt)) void fds_go_interrupt_handler() {
+    fds_kernel::status_ptr status = reinterpret_cast<fds_kernel::status_ptr>(kL1Address);
+    const uint32_t context = fds_interrupt::read_mhartid();
+    const uint32_t claimed = fds_interrupt::plic_claim(context);
+    const uint32_t entry = status[kSlotInterruptCount];
+
+    status[kSlotClaimedSource] = claimed;
+
+    // The engine holds its go, so the level stays up until the input register carrying it is
+    // cleared. Which dispatch instance drives this NEO is not established, so every lane the host
+    // named is scanned rather than a chosen one.
+    for (uint32_t mask = kDispatchMask, inst = 0; mask != 0; mask >>= 1, inst++) {
+        if ((mask & 1u) != 0 && overlay::FdsNeo::fds_read_de_status(inst) == kGroupId) {
+            status[kSlotGoLane] = inst;
+            overlay::FdsNeo::fds_clear_de_status(inst);
+        }
+    }
+    fds_interrupt::neo::wait_status_cleared(kGroupId);
+    fds_interrupt::order_fds_before_status();
+
+    fds_interrupt::stop_interrupt_storm(context, claimed, entry);
+    fds_interrupt::plic_complete(context, claimed);
+    status[kSlotInterruptCount] = entry + 1;
+}
+
+void kernel_main() {
+    fds_kernel::status_ptr status = fds_kernel::begin_worker(kL1Address, kNumSlots);
+    fds_interrupt::clear_handler_slots(status, kSlotInterruptCount, kNumSlots);
+    overlay::FdsNeo::fds_config_groupid(kGroupId, kDispatchMask, kGoThreshold);
+
+    fds_interrupt::arming_state arming;
+    if (!fds_interrupt::arm_external_interrupt(uint32_t{1} << kGroupId, fds_go_interrupt_handler, arming)) {
+        fds_kernel::finish(status, kL1Address, kNumSlots, fds_interrupt_status::kBadHartContext);
+        return;
+    }
+
+    // Inputs are shed before the enable bit goes on: a go inherited from a previous epoch would
+    // otherwise stand at the threshold the moment this group is armed, and the interrupt would
+    // report the last epoch's signal.
+    fds_epoch::clear_worker_inputs(kDispatchMask);
+    overlay::FdsNeo::fds_config_interrupt_en(uint32_t{1} << kGroupId);
+
+    uint32_t ready_token = kReadyTokenA;
+    bool go_received = false;
+    for (uint32_t i = 0; i < kPollIterations && !go_received; i++) {
+        fds_epoch::pulse_ready(ready_token, i);
+        go_received = status[kSlotInterruptCount] != 0;
+    }
+
+    uint32_t result = go_received ? kComplete : fds_interrupt_status::kTimeoutInterrupt;
+    if (result == kComplete && status[kSlotClaimedSource] != fds_interrupt::fds_plic_source(kGroupId)) {
+        result = fds_interrupt_status::kWrongSource;
+    }
+
+    fds_interrupt::neo::disarm_external_interrupt(arming);
+
+    // As in the polling worker, the store before the done is a local one no reader consumes on
+    // seeing the done, so it needs no ordering of its own.
+    fds_kernel::finish(status, kL1Address, kNumSlots, result);
+
+    // The last ready token is still on the done wire, so this is a change the engine will capture.
+    if (result == kComplete) {
+        overlay::FdsNeo::fds_done(/*ad_enable=*/false, kGroupId);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_quasar_fds.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_fds.cpp
@@ -68,15 +68,13 @@ constexpr uint32_t kWorkerMask = all_lanes_mask(kNumNeoWires);
 constexpr uint32_t kDispatchMask = all_lanes_mask(kNumDispatchInstances);
 
 constexpr uint32_t kGroupId = 1;
-// Each side gives up rather than spinning forever, so a missing signal fails the test with a
-// readable status word instead of hanging it. Kept modest because this runs under a cycle
-// simulator, where a million iterations costs minutes of wall clock. Both signals are held rather
-// than pulsed, so a shorter wait cannot miss one.
-constexpr uint32_t kPollIterations = 100000;
-// Length of the windows in which a kernel asserts that nothing appears. Long enough that the event
-// under test lands early in the window with orders of magnitude to spare, short enough not to
-// dominate simulator wall clock.
-constexpr uint32_t kSilenceIterations = 20000;
+// A timeout, not a wait: every loop exits as soon as its signal lands, so this is spent only on a
+// failure, where it buys a readable status word instead of a hang.
+constexpr uint32_t kPollIterations = 70000;
+// Length of the windows in which a kernel asserts that nothing appears. These have no early exit,
+// so they run to the end and set how long the suite takes. A window that closes too early does
+// not fail, it passes without testing.
+constexpr uint32_t kSilenceIterations = 8000;
 
 std::vector<CoreCoord> all_dispatch_engine_cores(IDevice* dev) {
     return detail::get_quasar_soc_dispatch_engine_logical_cores(

--- a/tests/tt_metal/tt_metal/test_quasar_fds.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_fds.cpp
@@ -850,3 +850,276 @@ TEST_F(QuasarFdsFixture, DispatchEngineAutoDispatchOutboxMismatch) {
             << "value observed on the wire: " << worker_status[kSlotObservedValue];
     }
 }
+
+// An FDS done-threshold level reaches every dispatch engine as one machine external interrupt,
+// names the configured group at the PLIC, and stays quiet after the handler clears its inputs.
+TEST_F(QuasarFdsFixture, DispatchEngineInterruptOnDoneThreshold) {
+    // Slots of quasar_fds_interrupt_dispatch.cpp.
+    constexpr uint32_t kSlotInterruptCount = 1;
+    constexpr uint32_t kSlotClaimedSource = 2;
+    constexpr uint32_t kSlotMcauseLow = 3;
+    constexpr uint32_t kSlotHartId = 4;
+    constexpr uint32_t kNumDispatchSlots = 5;
+
+    const CoreRangeSet workers = full_worker_grid();
+
+    uint32_t group_id = kGroupId;
+    for (const CoreCoord& dispatch_core : all_dispatch_engine_cores(device_)) {
+        SCOPED_TRACE("dispatch engine " + dispatch_core.str() + " group " + std::to_string(group_id));
+        const FdsProgramResult result = run_fds_program(
+            device_,
+            FdsProgram{
+                .dispatch_cores = {dispatch_core},
+                .dispatch_kernel = fds_kernel_path("quasar_fds_interrupt_dispatch.cpp"),
+                .dispatch_args =
+                    {{"group_id", group_id},
+                     {"worker_mask", kWorkerMask},
+                     {"done_threshold", workers.num_cores()},
+                     {"num_workers", workers.num_cores()},
+                     {"silence_iterations", kSilenceIterations},
+                     {"poll_iterations", kPollIterations}},
+                .num_dispatch_slots = kNumDispatchSlots,
+                .worker_kernel = fds_kernel_path("quasar_fds_worker_signal.cpp"),
+                .worker_groups = {WorkerGroup{
+                    .cores = workers,
+                    .args =
+                        {{"group_id", group_id},
+                         {"dispatch_mask", kDispatchMask},
+                         {"poll_iterations", kPollIterations}}}},
+                .num_worker_slots = kNumHandshakeWorkerSlots});
+        log_fds_program(result);
+
+        const std::vector<uint32_t>& dispatch_status = result.dispatch[0].status;
+        EXPECT_EQ(dispatch_status[kSlotResult], kComplete)
+            << "interrupt count=" << dispatch_status[kSlotInterruptCount]
+            << " claimed source=" << dispatch_status[kSlotClaimedSource]
+            << " mcause low=" << dispatch_status[kSlotMcauseLow] << " hart=" << dispatch_status[kSlotHartId];
+        EXPECT_EQ(dispatch_status[kSlotInterruptCount], 1u) << "claimed source=" << dispatch_status[kSlotClaimedSource];
+        EXPECT_EQ(dispatch_status[kSlotClaimedSource], 16u + group_id)
+            << "interrupt count=" << dispatch_status[kSlotInterruptCount];
+        for (const CoreStatus& worker : result.workers) {
+            EXPECT_EQ(worker.status[kSlotResult], kComplete)
+                << "worker on core " << worker.core.str() << " result=" << worker.status[kSlotResult];
+        }
+        group_id++;
+    }
+}
+
+// Arming below an already-overshot count must stay silent until one lane is cleared back to exact
+// equality, separating the FDS equality comparator from a meets-or-exceeds implementation.
+TEST_F(QuasarFdsFixture, DispatchEngineInterruptIsEquality) {
+    // Slots of quasar_fds_interrupt_equality_dispatch.cpp.
+    constexpr uint32_t kSlotInterruptCount = 1;
+    constexpr uint32_t kSlotStatusObservedAtArm = 2;
+    constexpr uint32_t kNumDispatchSlots = 3;
+
+    const CoreRangeSet workers = full_worker_grid();
+    const uint32_t num_workers = workers.num_cores();
+    if (num_workers < 2) {
+        GTEST_SKIP() << "Test requires at least two worker nodes";
+    }
+
+    for (const CoreCoord& dispatch_core : all_dispatch_engine_cores(device_)) {
+        SCOPED_TRACE("dispatch engine " + dispatch_core.str());
+        const FdsProgramResult result = run_fds_program(
+            device_,
+            FdsProgram{
+                .dispatch_cores = {dispatch_core},
+                .dispatch_kernel = fds_kernel_path("quasar_fds_interrupt_equality_dispatch.cpp"),
+                .dispatch_args =
+                    {{"group_id", kGroupId},
+                     {"worker_mask", kWorkerMask},
+                     {"num_workers", num_workers},
+                     {"silence_iterations", kSilenceIterations},
+                     {"poll_iterations", kPollIterations}},
+                .num_dispatch_slots = kNumDispatchSlots,
+                .worker_kernel = fds_kernel_path("quasar_fds_worker_signal.cpp"),
+                .worker_groups = {WorkerGroup{
+                    .cores = workers,
+                    .args =
+                        {{"group_id", kGroupId},
+                         {"dispatch_mask", kDispatchMask},
+                         {"poll_iterations", kPollIterations}}}},
+                .num_worker_slots = kNumHandshakeWorkerSlots});
+        log_fds_program(result);
+
+        const std::vector<uint32_t>& dispatch_status = result.dispatch[0].status;
+        EXPECT_EQ(dispatch_status[kSlotResult], kComplete)
+            << "interrupt count=" << dispatch_status[kSlotInterruptCount] << " status observed at arm=0x" << std::hex
+            << dispatch_status[kSlotStatusObservedAtArm];
+        EXPECT_EQ(dispatch_status[kSlotInterruptCount], 1u)
+            << "status observed at arm=0x" << std::hex << dispatch_status[kSlotStatusObservedAtArm];
+        EXPECT_EQ(
+            static_cast<uint32_t>(__builtin_popcount(dispatch_status[kSlotStatusObservedAtArm] & kWorkerMask)),
+            num_workers)
+            << "status observed at arm=0x" << std::hex << dispatch_status[kSlotStatusObservedAtArm];
+        for (const CoreStatus& worker : result.workers) {
+            EXPECT_EQ(worker.status[kSlotResult], kComplete)
+                << "worker on core " << worker.core.str() << " result=" << worker.status[kSlotResult];
+        }
+    }
+}
+
+// Completing a PLIC claim while the FDS level still stands must deliver the source again; clearing
+// the input before the second completion must then leave it quiet.
+TEST_F(QuasarFdsFixture, DispatchEngineInterruptCompleteWithoutClearRePends) {
+    // Slots of quasar_fds_interrupt_repend_dispatch.cpp.
+    constexpr uint32_t kSlotInterruptCount = 1;
+    constexpr uint32_t kNumDispatchSlots = 2;
+
+    for (const CoreCoord& dispatch_core : all_dispatch_engine_cores(device_)) {
+        SCOPED_TRACE("dispatch engine " + dispatch_core.str());
+        const FdsProgramResult result = run_fds_program(
+            device_,
+            FdsProgram{
+                .dispatch_cores = {dispatch_core},
+                .dispatch_kernel = fds_kernel_path("quasar_fds_interrupt_repend_dispatch.cpp"),
+                .dispatch_args =
+                    {{"group_id", kGroupId},
+                     {"worker_mask", kWorkerMask},
+                     {"silence_iterations", kSilenceIterations},
+                     {"poll_iterations", kPollIterations}},
+                .num_dispatch_slots = kNumDispatchSlots,
+                .worker_kernel = fds_kernel_path("quasar_fds_worker_signal.cpp"),
+                .worker_groups = {WorkerGroup{
+                    .cores = kSingleWorkerCore,
+                    .args =
+                        {{"group_id", kGroupId},
+                         {"dispatch_mask", kDispatchMask},
+                         {"poll_iterations", kPollIterations}}}},
+                .num_worker_slots = kNumHandshakeWorkerSlots});
+        log_fds_program(result);
+
+        const std::vector<uint32_t>& dispatch_status = result.dispatch[0].status;
+        EXPECT_EQ(dispatch_status[kSlotResult], kComplete)
+            << "interrupt count=" << dispatch_status[kSlotInterruptCount];
+        EXPECT_EQ(dispatch_status[kSlotInterruptCount], 2u) << "result=" << std::hex << dispatch_status[kSlotResult];
+        EXPECT_EQ(result.workers[0].status[kSlotResult], kComplete)
+            << "worker result=" << result.workers[0].status[kSlotResult];
+    }
+}
+
+// Arming a reset-zero threshold produces an interrupt without traffic, clearing zero-valued inputs
+// cannot quiet that level, and disarming the group can.
+TEST_F(QuasarFdsFixture, DispatchEngineInterruptResetStateStorm) {
+    // Slots of quasar_fds_interrupt_storm_dispatch.cpp.
+    constexpr uint32_t kSlotInterruptCount = 1;
+    constexpr uint32_t kNumDispatchSlots = 2;
+
+    for (const CoreCoord& dispatch_core : all_dispatch_engine_cores(device_)) {
+        SCOPED_TRACE("dispatch engine " + dispatch_core.str());
+        const FdsProgramResult result = run_fds_program(
+            device_,
+            FdsProgram{
+                .dispatch_cores = {dispatch_core},
+                .dispatch_kernel = fds_kernel_path("quasar_fds_interrupt_storm_dispatch.cpp"),
+                .dispatch_args =
+                    {{"group_id", kGroupId},
+                     {"worker_mask", kWorkerMask},
+                     {"silence_iterations", kSilenceIterations},
+                     {"poll_iterations", kPollIterations}},
+                .num_dispatch_slots = kNumDispatchSlots,
+                .worker_kernel = "",
+                .worker_groups = {}});
+        log_fds_program(result);
+
+        const std::vector<uint32_t>& dispatch_status = result.dispatch[0].status;
+        EXPECT_EQ(dispatch_status[kSlotResult], kComplete)
+            << "interrupt count=" << dispatch_status[kSlotInterruptCount];
+        EXPECT_EQ(dispatch_status[kSlotInterruptCount], 2u) << "result=" << std::hex << dispatch_status[kSlotResult];
+    }
+}
+
+// A worker arms before advertising readiness and receives the dispatch engine's go through the
+// worker-side FDS register map as one machine external interrupt.
+TEST_F(QuasarFdsFixture, WorkerInterruptOnGo) {
+    // Slots of quasar_fds_interrupt_worker.cpp.
+    constexpr uint32_t kSlotInterruptCount = 1;
+    constexpr uint32_t kSlotClaimedSource = 2;
+    constexpr uint32_t kSlotGoLane = 3;
+    constexpr uint32_t kNumWorkerSlots = 4;
+
+    for (const CoreCoord& dispatch_core : all_dispatch_engine_cores(device_)) {
+        SCOPED_TRACE("dispatch engine " + dispatch_core.str());
+        const FdsProgramResult result = run_fds_program(
+            device_,
+            FdsProgram{
+                .dispatch_cores = {dispatch_core},
+                .dispatch_kernel = fds_kernel_path("quasar_dispatch_engine_signal.cpp"),
+                .dispatch_args =
+                    {{"group_id", kGroupId},
+                     {"worker_mask", kWorkerMask},
+                     {"done_threshold", 1},
+                     {"num_workers", 1},
+                     {"quiet_group_mask", 0},
+                     {"poll_iterations", kPollIterations}},
+                .num_dispatch_slots = kNumHandshakeDispatchSlots,
+                .worker_kernel = fds_kernel_path("quasar_fds_interrupt_worker.cpp"),
+                .worker_groups = {WorkerGroup{
+                    .cores = kSingleWorkerCore,
+                    .args =
+                        {{"group_id", kGroupId},
+                         {"dispatch_mask", kDispatchMask},
+                         {"poll_iterations", kPollIterations}}}},
+                .num_worker_slots = kNumWorkerSlots});
+        log_fds_program(result);
+
+        EXPECT_EQ(result.dispatch[0].status[kSlotResult], kComplete)
+            << "dispatch result=" << result.dispatch[0].status[kSlotResult];
+        const std::vector<uint32_t>& worker_status = result.workers[0].status;
+        EXPECT_EQ(worker_status[kSlotResult], kComplete)
+            << "interrupt count=" << worker_status[kSlotInterruptCount]
+            << " claimed source=" << worker_status[kSlotClaimedSource] << " go lane=" << worker_status[kSlotGoLane];
+        EXPECT_EQ(worker_status[kSlotInterruptCount], 1u) << "claimed source=" << worker_status[kSlotClaimedSource];
+        EXPECT_EQ(worker_status[kSlotClaimedSource], 16u + kGroupId) << "go lane=" << worker_status[kSlotGoLane];
+    }
+}
+
+// With two equally configured groups held at different counts, arming only the group away from
+// threshold stays silent; arming the group already at threshold must claim that group's source.
+TEST_F(QuasarFdsFixture, DispatchEngineInterruptEnableIsPerGroup) {
+    // Slots of quasar_fds_interrupt_group_mask_dispatch.cpp.
+    constexpr uint32_t kQuietGroupId = 2;
+    constexpr uint32_t kSlotInterruptCount = 1;
+    constexpr uint32_t kSlotClaimedSource = 2;
+    constexpr uint32_t kNumDispatchSlots = 3;
+
+    const CoreRangeSet workers = full_worker_grid();
+
+    for (const CoreCoord& dispatch_core : all_dispatch_engine_cores(device_)) {
+        SCOPED_TRACE("dispatch engine " + dispatch_core.str());
+        const FdsProgramResult result = run_fds_program(
+            device_,
+            FdsProgram{
+                .dispatch_cores = {dispatch_core},
+                .dispatch_kernel = fds_kernel_path("quasar_fds_interrupt_group_mask_dispatch.cpp"),
+                .dispatch_args =
+                    {{"group_id", kGroupId},
+                     {"quiet_group_id", kQuietGroupId},
+                     {"worker_mask", kWorkerMask},
+                     {"num_workers", workers.num_cores()},
+                     {"silence_iterations", kSilenceIterations},
+                     {"poll_iterations", kPollIterations}},
+                .num_dispatch_slots = kNumDispatchSlots,
+                .worker_kernel = fds_kernel_path("quasar_fds_worker_signal.cpp"),
+                .worker_groups = {WorkerGroup{
+                    .cores = workers,
+                    .args =
+                        {{"group_id", kGroupId},
+                         {"dispatch_mask", kDispatchMask},
+                         {"poll_iterations", kPollIterations}}}},
+                .num_worker_slots = kNumHandshakeWorkerSlots});
+        log_fds_program(result);
+
+        const std::vector<uint32_t>& dispatch_status = result.dispatch[0].status;
+        EXPECT_EQ(dispatch_status[kSlotResult], kComplete) << "interrupt count=" << dispatch_status[kSlotInterruptCount]
+                                                           << " claimed source=" << dispatch_status[kSlotClaimedSource];
+        EXPECT_EQ(dispatch_status[kSlotInterruptCount], 1u) << "claimed source=" << dispatch_status[kSlotClaimedSource];
+        EXPECT_EQ(dispatch_status[kSlotClaimedSource], 16u + kGroupId)
+            << "quiet group source would be " << 16u + kQuietGroupId;
+        for (const CoreStatus& worker : result.workers) {
+            EXPECT_EQ(worker.status[kSlotResult], kComplete)
+                << "worker on core " << worker.core.str() << " result=" << worker.status[kSlotResult];
+        }
+    }
+}


### PR DESCRIPTION
### PR Category
Test Only

### Summary
This PR adds directed tests for the Quasar FDS interrupt path, next to the existing polling-based FDS tests.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fds_interrupt_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_fds_interrupt_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fds_interrupt_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_fds_interrupt_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_fds_interrupt_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_fds_interrupt_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_fds_interrupt_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_fds_interrupt_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_fds_interrupt_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_fds_interrupt_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_fds_interrupt_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_fds_interrupt_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_fds_interrupt_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_fds_interrupt_tests)