### PR TITLE
[LLK][test] Unskip 4 ttnn_where cases that now pass

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_ternary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_ternary.py
@@ -278,11 +278,6 @@ def test_ttnn_where(
 ):
 
     if (
-        formats.input == DataFormat.Float32 and formats.output == DataFormat.Float32
-    ) and dest_acc == DestAccumulation.No:
-        pytest.skip("DataFormat.Float32 not supported with DestAccumulation.No")
-
-    if (
         formats.input == DataFormat.Float16_b and formats.output == DataFormat.Float16_b
     ) and dest_acc == DestAccumulation.Yes:
         pytest.skip("DataFormat.Float16_b not supported with DestAccumulation.Yes")
@@ -394,11 +389,6 @@ def test_ttnn_where_mcw(
     # Multi-tile tensor dimensions (2x2 tiles of 32x32).
     height = 64
     width = 64
-
-    if (
-        formats.input == DataFormat.Float32 and formats.output == DataFormat.Float32
-    ) and dest_acc == DestAccumulation.No:
-        pytest.skip("DataFormat.Float32 not supported with DestAccumulation.No")
 
     if (
         formats.input == DataFormat.Float16_b and formats.output == DataFormat.Float16_b


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Re-measured every skip in `test_sfpu_ternary.py` on an n150. **One of the six is stale**, so its 4 cases join the regular sweep: 43 passed / 21 skipped, against 39 / 25 before.

The find is that two **identically worded** skips disagree:

| Guard | Cases | Unskipped |
| --- | --- | --- |
| `Float32`+`dest_acc=No` in `test_ttnn_where` / `test_ttnn_where_mcw` | 4 | **all pass** → removed |
| `Float32`+`dest_acc=No` in `test_sfpu_ternary` / `test_sfpu_ternary_edges` | 7 | all fail → kept |

Same condition, same message, opposite verdict. The `where` kernels do not need the 32-bit dest that `_run_sfpu_ternary` does, and one shared wording was hiding that the two disagree. The four `where` cases were confirmed over ten runs, which is worth doing here because the `where` stimuli set no seed, so every run samples fresh values.

Everything else in the file was measured too, and stays:

| Guard | Cases | Result |
| --- | --- | --- |
| Bfp8_b for anything but addcmul | 6 | all fail unskipped, real |
| `Float32`+`dest_acc=No` in the two sweeps | 7 | all fail unskipped, real |
| `Float16_b`+`dest_acc=Yes` in the `where` tests | 4 | all fail unskipped, real |
| addcmul has no operand-C edge | 3 | an empty stimulus set, not a marker |

That last one is not a limitation: addcmul multiplies by `c`, so there is no pole or knee for an edge probe to reach.

The file carries **no xfails at all**, so there was no xpass to retire here.

### Notes for reviewers
The two `where` tests look copy-pasted from each other and from the ternary sweeps, which is how one guard came to cover four call sites with different hardware needs. The remaining `Float16_b`+`dest_acc=Yes` guard is still duplicated across both `where` tests — real in both, but worth folding into a helper if you would rather it lived in one place.

I probed each guard in a separate file rather than removing several at once. That matters: in the binary-SFPU equivalent of this change, removing two guards together made 14 row-broadcast failures look like Bfp8_b failures.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-ternary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/unskip-stale-sfpu-ternary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-ternary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/unskip-stale-sfpu-ternary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-ternary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/unskip-stale-sfpu-ternary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-ternary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/unskip-stale-sfpu-ternary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-ternary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/unskip-stale-sfpu-ternary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-ternary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/unskip-stale-sfpu-ternary-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/unskip-stale-sfpu-ternary-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/unskip-stale-sfpu-ternary-markers)
