### PR TITLE
precompile: defer Metal 2.0 spec-factory compile during the collect pass

### DIFF
--- a/tests/plugins/up_front_collect.py
+++ b/tests/plugins/up_front_collect.py
@@ -522,12 +522,22 @@ def pytest_sessionfinish(session, exitstatus):
             device.enable_program_cache()
         except Exception:
             pass
-        n_prog, n_err, used, wall = ttnn.graph.up_front_compile(device, _WORKERS, True)
+        n_prog, n_err, used, wall, n_already = ttnn.graph.up_front_compile(device, _WORKERS, True)
+        n_built = n_prog - n_already
         print(
-            f"UP_FRONT_COLLECT: compiled {n_prog} programs in {wall:.1f}s "
-            f"(workers={used}, errors={n_err}) -> on-disk JIT cache warm",
+            f"UP_FRONT_COLLECT: {n_prog} collected · {n_built} built · {n_already} already compiled "
+            f"in {wall:.1f}s (workers={used}, errors={n_err}) -> on-disk JIT cache warm",
             flush=True,
         )
+        if n_already:
+            # Every already-compiled program was JIT'd inline and serially during the
+            # collect pass -- the exact cost this pass exists to remove. Not fatal, but
+            # it must not look like a fast, healthy run.
+            print(
+                f"UP_FRONT_COLLECT: WARNING {n_already}/{n_prog} programs arrived already "
+                f"compiled; those were built serially during collect, not in parallel here.",
+                flush=True,
+            )
         if n_err == 0 and n_prog == n_unique:
             result_status = "ok"
             result_reason = "ok"

--- a/tests/ttnn/unit_tests/test_up_front_compile.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile.py
@@ -59,8 +59,11 @@ def test_up_front_compile(device):
     assert n_unique >= 1
 
     # Parallel compile -> warms the on-disk kernel cache. Must report zero errors.
-    num_programs, num_errors, workers, wall = ttnn.graph.up_front_compile(device, 4)
-    print(f"up_front: compiled {num_programs} programs in {wall:.2f}s (workers={workers}, errors={num_errors})")
+    num_programs, num_errors, workers, wall, num_already = ttnn.graph.up_front_compile(device, 4)
+    print(
+        f"up_front: {num_programs} collected | {num_programs - num_already} built | "
+        f"{num_already} already compiled in {wall:.2f}s (workers={workers}, errors={num_errors})"
+    )
     assert num_errors == 0, "parallel compile reported errors"
 
     # The real run is now warm and must still be numerically correct. Use PCC
@@ -107,14 +110,22 @@ def test_up_front_collect_mechanics(device):
 
     # compile() JIT-builds exactly the deduped unique set, error-free, then resets the
     # collector. If compile silently skipped programs this parity check would catch it.
-    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(device, 4)
+    num_programs, num_errors, _, _, num_already = ttnn.graph.up_front_compile(device, 4)
     assert num_errors == 0, "parallel compile reported errors"
     assert num_programs == unique, f"compiled {num_programs} programs, expected the {unique} unique collected"
+    # Every collected program must arrive UNCOMPILED, so this pass is the thing that
+    # builds it -- in parallel. A non-zero count means something compiled it inline
+    # during collect (as Metal 2.0 spec factories did before defer_compile), which
+    # silently degrades the pass to serial compilation behind op dispatch.
+    assert num_already == 0, (
+        f"{num_already}/{num_programs} programs were already compiled on arrival -- "
+        f"they were JIT'd inline during collect, defeating the parallel pass"
+    )
     assert ttnn.graph.up_front_num_collected() == 0, "compile() should clear the collector"
 
     # Compiling an empty collector is a no-op, not an error.
-    n, e, _, _ = ttnn.graph.up_front_compile(device, 4)
-    assert (n, e) == (0, 0), f"empty compile should be a no-op, got ({n}, {e})"
+    n, e, _, _, already = ttnn.graph.up_front_compile(device, 4)
+    assert (n, e, already) == (0, 0, 0), f"empty compile should be a no-op, got ({n}, {e}, {already})"
 
 
 def test_up_front_collect_accumulates(device):
@@ -144,3 +155,57 @@ def test_up_front_collect_accumulates(device):
     assert after_second > after_first, "clear=False should accumulate, not reset, across passes"
     assert ttnn.graph.up_front_num_unique() <= after_second
     ttnn.graph.up_front_clear()
+
+
+def test_up_front_collect_defers_spec_factory_compile(device):
+    """Metal 2.0 ProgramSpec factories must NOT compile at construction while a
+    collect pass is active.
+
+    MakeMeshWorkloadFromSpecs compiles eagerly by default (it is the last statement
+    in the factory). Under collect that is exactly wrong: the workload is stashed and
+    discarded, so the compile happens inline, one kernel at a time, behind op
+    dispatch — and the later parallel pass finds every program already compiled and
+    does nothing. The pass then reports a very fast, very healthy-looking no-op.
+
+    ttnn.rms_norm routes to ttnn::prim::layer_norm, whose factory is ProgramSpec-based,
+    so it exercises that path. The invariant: everything the pass is handed is built BY
+    the pass. Drop the defer_compile argument at
+    mesh_device_operation_adapter.hpp's MakeMeshWorkloadFromSpecs call and this fails
+    with num_already == num_programs.
+    """
+    torch.manual_seed(0)
+    ttnn.graph.up_front_clear()
+
+    shapes = [(1, 1, 32, 64), (1, 1, 64, 128), (1, 1, 128, 256)]
+    for shape in shapes:
+        ttnn.graph.up_front_begin_collect(clear=False)
+        try:
+            x = ttnn.from_torch(
+                torch.randn(*shape, dtype=torch.bfloat16),
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                dtype=ttnn.bfloat16,
+            )
+            ttnn.rms_norm(x)
+        finally:
+            ttnn.graph.up_front_end_collect()
+
+    unique = ttnn.graph.up_front_num_unique()
+    assert unique >= 1, "rms_norm didn't reach the collector — did the spec-factory path change?"
+
+    num_programs, num_errors, _, _, num_already = ttnn.graph.up_front_compile(device, 4)
+    assert num_errors == 0, "parallel compile reported errors"
+    assert num_programs == unique
+    assert num_already == 0, (
+        f"{num_already}/{num_programs} spec-factory programs arrived already compiled — "
+        f"they were JIT'd inline and serially during collect, defeating the parallel pass"
+    )
+
+    # The normal (non-deferred) path must be unaffected: a deferred workload is
+    # discarded, and the real run builds and compiles its own.
+    t = torch.randn(1, 1, 128, 256)
+    x = ttnn.from_torch(t, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+    got = ttnn.to_torch(ttnn.rms_norm(x)).float().flatten()
+    expected = (t / torch.sqrt(t.pow(2).mean(-1, keepdim=True) + 1e-12)).flatten()
+    pcc = torch.corrcoef(torch.stack([got, expected]))[0, 1].item()
+    assert pcc > 0.999, f"warm rms_norm incorrect: PCC {pcc}"

--- a/tests/ttnn/unit_tests/test_up_front_compile_ccl.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile_ccl.py
@@ -87,7 +87,8 @@ def test_all_gather_up_front_compile(mesh_device):
     # Parallel compile warms the cache, error-free. A CCL op's MeshWorkload holds multiple
     # programs (sender/receiver), so compile builds >= the unique workload count — unlike a
     # homogeneous op where one program covers the whole mesh.
-    num_programs, num_errors, _, wall = ttnn.graph.up_front_compile(mesh_device, 4)
+    num_programs, num_errors, _, wall, num_already = ttnn.graph.up_front_compile(mesh_device, 4)
+    assert num_already == 0, f"{num_already}/{num_programs} arrived already compiled (compiled inline during collect)"
     print(
         f"CCL parallel compile: {num_programs} programs in {wall:.2f}s (errors={num_errors}, unique workloads={n_unique})"
     )

--- a/tests/ttnn/unit_tests/test_up_front_compile_mesh.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile_mesh.py
@@ -40,7 +40,8 @@ def _collect_and_compile(mesh_device, run_body):
         ttnn.graph.up_front_end_collect()
     n_unique = ttnn.graph.up_front_num_unique()
     assert ttnn.graph.up_front_num_collected() >= 1, "collect captured nothing on the mesh"
-    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(mesh_device, 4)
+    num_programs, num_errors, _, _, num_already = ttnn.graph.up_front_compile(mesh_device, 4)
+    assert num_already == 0, f"{num_already}/{num_programs} arrived already compiled (compiled inline during collect)"
     assert num_errors == 0, "parallel compile reported errors"
     assert num_programs == n_unique, f"compiled {num_programs} programs, expected the {n_unique} unique collected"
 

--- a/tests/ttnn/unit_tests/test_up_front_compile_mlp.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile_mlp.py
@@ -61,7 +61,8 @@ def test_mlp_up_front_compile(device):
     assert n_unique >= 1
 
     # Parallel compile warms the kernel cache and must build exactly the unique set, error-free.
-    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(device, 4)
+    num_programs, num_errors, _, _, num_already = ttnn.graph.up_front_compile(device, 4)
+    assert num_already == 0, f"{num_already}/{num_programs} arrived already compiled (compiled inline during collect)"
     assert num_errors == 0, "parallel compile reported errors"
     assert num_programs == n_unique, f"compiled {num_programs} programs, expected the {n_unique} unique collected"
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -34,8 +34,14 @@ namespace tt::tt_metal::experimental {
 //
 // Runtime arguments for Programs created from a ProgramSpec must be configured
 // through SetProgramRunArgs or UpdateProgramRunArgs, not the legacy host APIs.
+//
+// defer_compile: build the Program but SKIP the trailing compile + allocation step,
+// returning an uncompiled Program. See the note on MakeMeshWorkloadFromSpecs below.
 Program MakeProgramFromSpec(
-    distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation = false);
+    distributed::MeshDevice& mesh_device,
+    const ProgramSpec& spec,
+    bool skip_validation = false,
+    bool defer_compile = false);
 
 // Create a MeshWorkload object from a set of region-mapped ProgramSpecs
 // (This will become a constructor for the MeshWorkload class)
@@ -45,10 +51,21 @@ Program MakeProgramFromSpec(
 // PRE-CONDITION: If skip_validation is true, the caller guarantees that
 // the ProgramSpecs satisfy all semantic validation requirements.
 //
+// defer_compile: build the programs but SKIP the trailing
+// MeshWorkloadImpl::compile step, returning an UNCOMPILED, UNFINALIZED
+// MeshWorkload. This exists for callers that only want the Programs
+// materialized so their kernels can be JIT-compiled later, in bulk and in
+// parallel (see ttnn::up_front_compile). Setting run args on the result is
+// still legal — SetProgramRunArgs is order-agnostic with respect to allocation.
+//
+// PRE-CONDITION: a deferred MeshWorkload MUST NOT be enqueued or otherwise
+// treated as dispatch-ready until it has been compiled. The intended consumers
+// are compile-only paths that discard the workload afterwards.
 distributed::MeshWorkload MakeMeshWorkloadFromSpecs(
     distributed::MeshDevice& mesh_device,
     const std::unordered_map<distributed::MeshCoordinateRange, ProgramSpec>& program_specs,
-    bool skip_validation = false);
+    bool skip_validation = false,
+    bool defer_compile = false);
 
 // Create a MeshWorkload object from single ProgramSpec,
 // to be applied mesh-wide (SPMD)
@@ -59,8 +76,12 @@ distributed::MeshWorkload MakeMeshWorkloadFromSpecs(
 // PRE-CONDITION: If skip_validation is true, the caller guarantees that
 // the ProgramSpec satisfies all semantic validation requirements.
 //
+// defer_compile: see MakeMeshWorkloadFromSpecs above.
 distributed::MeshWorkload MakeMeshWorkloadFromSpec(
-    distributed::MeshDevice& mesh_device, const ProgramSpec& program_spec, bool skip_validation = false);
+    distributed::MeshDevice& mesh_device,
+    const ProgramSpec& program_spec,
+    bool skip_validation = false,
+    bool defer_compile = false);
 
 // Configure the arguments (mutable parameters) of an existing Program
 // (This will become a member function for the Program class)

--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -55,6 +55,12 @@ public:
     // Used in ops.
     std::vector<std::shared_ptr<CircularBuffer>> circular_buffers() const;
 
+    // True once this Program's kernels have been JIT-compiled for at least one build
+    // key. Exposed because ProgramImpl is not visible outside tt_metal, and callers
+    // that compile programs in bulk (e.g. ttnn's up-front precompile) need to tell
+    // "I compiled this" from "it arrived already compiled".
+    bool is_compiled() const;
+
     // debug/test/internal usage.
     detail::ProgramImpl& impl() { return *internal_; }
     const detail::ProgramImpl& impl() const { return *internal_; }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -3367,16 +3367,22 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
 // Public Entry Points
 // ============================================================================
 
-Program MakeProgramFromSpec(distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation) {
+Program MakeProgramFromSpec(
+    distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation, bool defer_compile) {
     Program program = BuildProgramFromSpec(mesh_device, spec, skip_validation);
-    program.impl().compile_and_allocate(&mesh_device, false);
+    // defer_compile: hand back a built-but-uncompiled Program. The caller takes
+    // responsibility for compiling it before any dispatch.
+    if (!defer_compile) {
+        program.impl().compile_and_allocate(&mesh_device, false);
+    }
     return program;
 }
 
 distributed::MeshWorkload MakeMeshWorkloadFromSpecs(
     distributed::MeshDevice& mesh_device,
     const std::unordered_map<distributed::MeshCoordinateRange, ProgramSpec>& program_specs,
-    bool skip_validation) {
+    bool skip_validation,
+    bool defer_compile) {
     const distributed::MeshCoordinateRange mesh_extent(mesh_device.shape());
     distributed::MeshWorkload workload;
     TT_FATAL(!program_specs.empty(), "At least one ProgramSpec is required to create a MeshWorkload.");
@@ -3388,17 +3394,23 @@ distributed::MeshWorkload MakeMeshWorkloadFromSpecs(
             mesh_device.shape());
         workload.impl().add_program(device_range, BuildProgramFromSpec(mesh_device, program_spec, skip_validation));
     }
-    workload.impl().compile(&mesh_device);
+    // defer_compile: skip compile + CB/DFB allocation + finalize, handing back an
+    // uncompiled, unfinalized MeshWorkload. Not dispatch-ready; see the header.
+    if (!defer_compile) {
+        workload.impl().compile(&mesh_device);
+    }
     return workload;
 }
 
 distributed::MeshWorkload MakeMeshWorkloadFromSpec(
-    distributed::MeshDevice& mesh_device, const ProgramSpec& program_spec, bool skip_validation) {
+    distributed::MeshDevice& mesh_device, const ProgramSpec& program_spec, bool skip_validation, bool defer_compile) {
     distributed::MeshWorkload workload;
     workload.impl().add_program(
         distributed::MeshCoordinateRange(mesh_device.shape()),
         BuildProgramFromSpec(mesh_device, program_spec, skip_validation));
-    workload.impl().compile(&mesh_device);
+    if (!defer_compile) {
+        workload.impl().compile(&mesh_device);
+    }
     return workload;
 }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2940,6 +2940,8 @@ void detail::ProgramImpl::compile_and_allocate(IDevice* device, bool force_slow_
     this->compile_and_allocate_device_ = device;
 }
 
+bool Program::is_compiled() const { return internal_->is_compiled(); }
+
 void detail::ProgramImpl::set_runtime_id(ProgramId id) { this->runtime_id = id; }
 
 void Program::set_runtime_id(ProgramId id) { internal_->set_runtime_id(id); }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -30,6 +30,7 @@
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/config.hpp"
 #include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/up_front_compile.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "ttnn/operation_concepts.hpp"
 #include "ttnn/operation.hpp"
@@ -921,7 +922,15 @@ public:
             for (const auto& range : tensor_coords.ranges()) {
                 program_specs.emplace(range, artifacts.spec);
             }
-            auto mesh_workload = tt::tt_metal::experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
+            // Up-front parallel precompile: while the collect pass is active the
+            // workload is stashed and discarded (device_operation.hpp), never
+            // dispatched — so ask the spec factory NOT to compile it here. Leaving
+            // the compile eager would JIT every kernel inline and serially, and the
+            // later parallel_compile would find nothing to do. See
+            // ttnn/up_front_compile.hpp.
+            const bool defer_compile = ttnn::up_front_compile::should_defer_compile();
+            auto mesh_workload = tt::tt_metal::experimental::MakeMeshWorkloadFromSpecs(
+                *mesh_device, program_specs, /*skip_validation=*/false, defer_compile);
 
             // Apply the factory's initial ProgramRunArgs to each MeshWorkload program.
             for (auto& [range, program] : mesh_workload.get_programs()) {

--- a/ttnn/api/ttnn/up_front_compile.hpp
+++ b/ttnn/api/ttnn/up_front_compile.hpp
@@ -23,8 +23,13 @@ namespace ttnn::up_front_compile {
 
 // Result of a parallel_compile pass.
 struct CompileStats {
-    std::size_t num_programs = 0;  // distinct programs JIT-compiled
+    std::size_t num_programs = 0;  // distinct programs handed to the pass
     std::size_t num_errors = 0;    // programs whose compile threw
+    // Programs that were ALREADY compiled on arrival, so this pass did no work for
+    // them. A non-zero value means something compiled them inline during collect —
+    // i.e. the pass ran serially behind op dispatch instead of in parallel here.
+    // Healthy is 0. See the note on eager spec-factory compilation below.
+    std::size_t num_already_compiled = 0;
     int max_workers = 0;
     double wall_seconds = 0.0;
 };
@@ -91,6 +96,21 @@ private:
     std::size_t total_collected_ = 0;
     std::uint64_t synthetic_key_ = 0;  // for hash==0 (cache-disabled) fallback
 };
+
+// Should the caller building a Metal 2.0 workload from a ProgramSpec SKIP the
+// compile step and hand back an uncompiled workload?
+//
+// True exactly while a collect pass is active on this thread. During collect the
+// workload is stashed and discarded, never dispatched, and its kernels are
+// JIT-compiled later in bulk by parallel_compile. Compiling at construction
+// instead (the Metal 2.0 spec-factory default) makes that later pass a no-op and
+// degenerates the warm pass into serial, one-kernel-at-a-time compilation behind
+// op dispatch.
+//
+// Deferral is not separately configurable: it is exactly the collect pass's own
+// state. A workload built during collect is never dispatched, and one built
+// outside it always is.
+bool should_defer_compile();
 
 // Begin a collect pass: enables NO_DISPATCH graph capture (buffers mocked,
 // nothing dispatched) and marks the collector active on this thread.

--- a/ttnn/core/graph/graph_nanobind.cpp
+++ b/ttnn/core/graph/graph_nanobind.cpp
@@ -434,18 +434,22 @@ void py_graph_module(nb::module_& m) {
         "up_front_compile",
         [](tt::tt_metal::distributed::MeshDevice* device, int max_workers, bool clear) {
             auto s = ttnn::up_front_compile::parallel_compile(device, max_workers, clear);
-            return std::make_tuple(s.num_programs, s.num_errors, s.max_workers, s.wall_seconds);
+            return std::make_tuple(s.num_programs, s.num_errors, s.max_workers, s.wall_seconds, s.num_already_compiled);
         },
         nb::arg("device"),
         nb::arg("max_workers") = 0,
         nb::arg("clear") = true,
         nb::call_guard<nb::gil_scoped_release>(),
-        R"doc(up_front_compile(device, max_workers=0, clear=True) -> (num_programs, num_errors, max_workers, wall_seconds)
+        R"doc(up_front_compile(device, max_workers=0, clear=True) -> (num_programs, num_errors, max_workers, wall_seconds, num_already_compiled)
 
         JIT-compile every distinct collected program in parallel, warming the on-disk
         kernel cache (TT_METAL_CACHE). The subsequent real run / trace capture runs warm.
         max_workers<=0 uses hardware concurrency (note: the build executor saturates
         ~4 workers, so higher buys little). The GIL is released for the duration.
+
+        num_already_compiled counts programs that arrived already compiled, i.e. that
+        this pass did NO work for. Healthy is 0; a large value means they were JIT'd
+        inline and serially during the collect pass.
         )doc");
 }
 

--- a/ttnn/core/up_front_compile.cpp
+++ b/ttnn/core/up_front_compile.cpp
@@ -76,6 +76,8 @@ std::vector<tt::tt_metal::Program*> ProgramCollector::program_pointers() {
     return out;
 }
 
+bool should_defer_compile() { return ProgramCollector::active() != nullptr; }
+
 void begin_collect(bool clear, bool real_alloc) {
     if (clear) {
         ProgramCollector::instance().clear();
@@ -124,6 +126,11 @@ CompileStats parallel_compile(tt::tt_metal::distributed::MeshDevice* device, int
     CompileStats stats;
     stats.num_programs = progs.size();
     stats.max_workers = max_workers;
+    // Snapshot before compiling: anything already compiled was JIT'd inline during
+    // the collect pass, which is exactly what this pass exists to avoid. Reported so
+    // the degenerate case is visible instead of looking like a very fast run.
+    stats.num_already_compiled = static_cast<std::size_t>(
+        std::count_if(progs.begin(), progs.end(), [](tt::tt_metal::Program* p) { return p->is_compiled(); }));
 
     auto t0 = clock::now();
     if (!progs.empty()) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
@@ -21,6 +21,7 @@
 #include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_metal2_common.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/up_front_compile.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::rotary_embedding_indexed {
 
@@ -613,7 +614,11 @@ RotaryEmbeddingIndexedDeviceOperation::MeshWorkloadFactory::create_at(
         run_args.tensor_args.emplace(METADATA_PARAM, TensorArgument{tensor_args.metadata->mesh_tensor()});
     }
 
-    auto program = MakeProgramFromSpec(*mesh_device, spec);
+    // Defer the compile while the up-front precompile collect pass is active: the
+    // workload is stashed and discarded, never dispatched, and its kernels are
+    // JIT-compiled in bulk later. See ttnn/up_front_compile.hpp.
+    const bool defer_compile = ttnn::up_front_compile::should_defer_compile();
+    auto program = MakeProgramFromSpec(*mesh_device, spec, /*skip_validation=*/false, defer_compile);
     SetProgramRunArgs(program, run_args);
     return {std::move(program), SharedVariables{}};
 }


### PR DESCRIPTION
## Issue

`MakeMeshWorkloadFromSpecs`, `MakeMeshWorkloadFromSpec` and `MakeProgramFromSpec` compile the workload as their last statement (since #49437). The up-front precompile collector in `device_operation.hpp` assumes the opposite — that it receives a built but not-yet-compiled workload. For every `ProgramSpec`-factory op that assumption is now false: the collect pass JIT-compiles each kernel inline and serially, and the session-end `parallel_compile` finds every program already compiled and returns immediately. It reports this as success.

Measured on production `ttnn.rms_norm` (→ `ttnn::prim::layer_norm`, a spec factory), full golden suite, 40,828 cases, JIT server:

- warm pass: **6,924 s**
- reported: `UP_FRONT_COLLECT: compiled 3420 programs in 1.7s (workers=32, errors=0)` — 3,420 cache hits
- JIT-server ELF mtimes: ~1 kernel in flight at a time, never 32

The `ProgramDescriptor` path is unaffected; it only calls `add_program` and never compiles.

## Fix

- `defer_compile` parameter (default `false`) on the three factories in `metal2_host_api/program.hpp`. When set, the trailing `compile()` / `compile_and_allocate()` is skipped and the workload is returned uncompiled. Safe for this caller: collect runs under `NO_DISPATCH` and discards the workload; `SetProgramRunArgs` is order-agnostic with respect to allocation.
- `ttnn::up_front_compile::should_defer_compile()` — true exactly while a collect pass is active. Passed at the two call sites: `mesh_device_operation_adapter.hpp` (the only adapter call, covers every `create_program_artifacts` spec factory) and `rotary_embedding_indexed` (the only op that hand-rolls `MakeProgramFromSpec`).
- Make the degenerate case visible: `Program::is_compiled()`, `CompileStats::num_already_compiled`, and `ttnn.graph.up_front_compile` now returns a 5-tuple `(num_programs, num_errors, max_workers, wall_seconds, num_already_compiled)`. The plugin prints `N collected · N built · N already compiled` and warns when the last is non-zero. The `test_up_front_compile*` tests assert it is zero; a new test drives `ttnn.rms_norm` through the collector to cover the spec-factory path.

The 5-tuple is a change for any external caller of `ttnn.graph.up_front_compile`; all in-tree callers are updated here.

## Testing

- Builds (Release + Tracy) in the `llk_helper_library`-based worktree the measurements came from.
- With the fix, the same rms_norm collect pass no longer compiles anything inline: 166 s with `UP_FRONT_COLLECT_NO_COMPILE=1`, against the 6,924 s above.
- `scripts/run_safe_pytest.sh --run-all tests/ttnn/unit_tests/test_up_front_compile.py` — 4 passed on a Blackhole p150b, including the new `test_up_front_collect_defers_spec_factory_compile`. The `_mlp` / `_mesh` / `_ccl` variants were not run (the latter two need a mesh).
- A before/after full graded rms_norm run with the JIT server is the next step and will be posted here.

Related: #55768 (same base) removes the pytest `-rA` reporting cost that sat underneath this.
