### PR TITLE
[skip ci] produce_data: fetch job logs as one archive per attempt

### DIFF
--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -18,10 +18,11 @@ download_artifacts() {
     local workflow_run_id=$2
 
     echo "[info] Downloading test reports for workflow run $workflow_run_id"
-    api_output=$(gh api --paginate /repos/$repo/actions/runs/$workflow_run_id/artifacts | jq -r '.artifacts[] | .name')
-    if echo "$api_output" | grep -q "test_reports_"; then
-        gh run download --repo $repo -D generated/cicd/$workflow_run_id/artifacts --pattern test_reports_* $workflow_run_id
-    else
+    # `gh run download` lists the run's artifacts itself, so the separate
+    # /artifacts listing that used to gate this call was a second (paginated) request
+    # spent only to decide whether to make the first. A run with no test_reports_*
+    # artifact makes this a no-op, which is the same outcome the gate produced.
+    if ! gh run download --repo $repo -D generated/cicd/$workflow_run_id/artifacts --pattern 'test_reports_*' $workflow_run_id 2>/dev/null; then
         echo "[Warning] Test reports not found for workflow run $workflow_run_id"
     fi
 }
@@ -77,6 +78,64 @@ get_jobs_with_pagination_fallback() {
     fi
 }
 
+# Fetch every job log for the attempt in ONE request.
+#
+# GitHub serves the whole attempt's logs as a single zip:
+#   GET /repos/{repo}/actions/runs/{id}/attempts/{n}/logs
+# The previous implementation instead called /actions/jobs/{job_id}/logs once per job,
+# which made this script's cost scale with the size of the run being analyzed. On a
+# 129-job merge-gate run that was 129 requests against the repository's shared
+# 15,000/hr GITHUB_TOKEN budget, and produce_data runs ~173 times an hour.
+#
+# The unpacking is a Python helper rather than `unzip` because archive entries carry
+# step names verbatim, emoji included: `unzip` can fail to create such a name, and
+# having no tty to answer its "continue?" prompt it then aborts and leaves a silently
+# partial extraction. See extract_job_logs_from_archive.py.
+#
+# Any job the archive does not cover is left to the per-job fallback in
+# download_logs_for_all_jobs, so a mapping miss costs one request instead of a lost log.
+#
+# Returns non-zero if the archive could not be fetched or unpacked at all.
+download_logs_archive_for_attempt() {
+    local repo=$1
+    local workflow_run_id=$2
+    local attempt_number=$3
+    local jobs_data=$4
+
+    local logs_dir="generated/cicd/$workflow_run_id/logs"
+    local script_dir
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local archive="$tmp_dir/logs.zip"
+    local jobs_file="$tmp_dir/jobs.json"
+
+    printf '%s' "$jobs_data" > "$jobs_file"
+
+    echo "[info] fetching the whole attempt's logs as one archive"
+    # Same escape-sequence handling as the per-job path: gh >= 2.97.0 needs the flag,
+    # older images in the fleet do not have it.
+    if ! gh api --allow-escape-sequences "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/logs" > "$archive" 2>/dev/null; then
+        if ! gh api "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/logs" > "$archive" 2>/dev/null; then
+            echo "[Warning] could not download the attempt log archive; falling back to per-job downloads"
+            rm -rf "$tmp_dir"
+            return 1
+        fi
+    fi
+
+    if ! python3 "$script_dir/extract_job_logs_from_archive.py" \
+            --archive "$archive" \
+            --jobs-json "$jobs_file" \
+            --logs-dir "$logs_dir"; then
+        echo "[Warning] falling back to per-job log downloads"
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
+    rm -rf "$tmp_dir"
+    return 0
+}
+
 download_logs_for_all_jobs() {
     local repo=$1
     local workflow_run_id=$2
@@ -87,17 +146,26 @@ download_logs_for_all_jobs() {
     # Get jobs using the pagination fallback function
     jobs_data=$(get_jobs_with_pagination_fallback "$repo" "$workflow_run_id" "$attempt_number")
 
+    download_logs_archive_for_attempt "$repo" "$workflow_run_id" "$attempt_number" "$jobs_data" || true
+
     # Process the jobs data
     echo "$jobs_data" | jq -c '.jobs[] | {id: .id, conclusion: .conclusion}' | while read -r job; do
         job_id=$(echo "$job" | jq -r '.id')
         job_conclusion=$(echo "$job" | jq -r '.conclusion')
-        echo "[info] download logs for job with id $job_id, attempt number $attempt_number"
-        # https://github.com/tenstorrent/tt-metal/issues/12966
-        # We bypass any log download that returned a non-zero exit code so the downloader doesn't crash midway.
-        # williamly: We may want to check http status code for robustness in the future again but it may be costly in terms of api calls used.
-        # We output escape sequences, gh cli >= 2.97.0 requires --allow-escape-sequences else it fails. Fall back to regular call for older images.
-        gh api --allow-escape-sequences /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log || \
-            gh api /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log || true
+        # The attempt archive above normally supplied this already, so only jobs it did
+        # not cover cost a request here. Skipped jobs and jobs that never reached a
+        # conclusion have no log to serve, so asking for one is a guaranteed-wasted
+        # request -- on the run this was measured against, 44 of 129 jobs were skipped.
+        if [[ ! -s generated/cicd/$workflow_run_id/logs/$job_id.log ]] &&
+           [[ "$job_conclusion" != "skipped" && "$job_conclusion" != "null" && -n "$job_conclusion" ]]; then
+            echo "[info] download logs for job with id $job_id, attempt number $attempt_number"
+            # https://github.com/tenstorrent/tt-metal/issues/12966
+            # We bypass any log download that returned a non-zero exit code so the downloader doesn't crash midway.
+            # williamly: We may want to check http status code for robustness in the future again but it may be costly in terms of api calls used.
+            # We output escape sequences, gh cli >= 2.97.0 requires --allow-escape-sequences else it fails. Fall back to regular call for older images.
+            gh api --allow-escape-sequences /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log || \
+                gh api /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log || true
+        fi
 
         # Download annotations for failed jobs only (failure reason).
         if [[ "$job_conclusion" == "failure" ]]; then

--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -22,8 +22,13 @@ download_artifacts() {
     # /artifacts listing that used to gate this call was a second (paginated) request
     # spent only to decide whether to make the first. A run with no test_reports_*
     # artifact makes this a no-op, which is the same outcome the gate produced.
-    if ! gh run download --repo $repo -D generated/cicd/$workflow_run_id/artifacts --pattern 'test_reports_*' $workflow_run_id 2>/dev/null; then
-        echo "[Warning] Test reports not found for workflow run $workflow_run_id"
+    #
+    # gh's own message is kept and reported: "no artifacts match" and "rate limit
+    # exceeded" both land here, and collapsing the second into "not found" is how a
+    # throttled fetch gets mistaken for a run that simply had no test reports.
+    local download_error
+    if ! download_error=$(gh run download --repo $repo -D generated/cicd/$workflow_run_id/artifacts --pattern 'test_reports_*' $workflow_run_id 2>&1 >/dev/null); then
+        echo "[Warning] Test reports not downloaded for workflow run $workflow_run_id: ${download_error:-no reason given}"
     fi
 }
 
@@ -87,13 +92,16 @@ get_jobs_with_pagination_fallback() {
 # 129-job merge-gate run that was 129 requests against the repository's shared
 # 15,000/hr GITHUB_TOKEN budget, and produce_data runs ~173 times an hour.
 #
-# The unpacking is a Python helper rather than `unzip` because archive entries carry
-# step names verbatim, emoji included: `unzip` can fail to create such a name, and
+# The unpacking is a Python helper rather than `unzip` because archive entries carry job
+# and step names verbatim, emoji included: `unzip` can fail to create such a name, and
 # having no tty to answer its "continue?" prompt it then aborts and leaves a silently
-# partial extraction. See extract_job_logs_from_archive.py.
+# partial extraction -- observed truncating at 46 of 85 job logs. See
+# extract_job_logs_from_archive.py, which also explains the entry-name-to-job-id mapping.
 #
-# Any job the archive does not cover is left to the per-job fallback in
-# download_logs_for_all_jobs, so a mapping miss costs one request instead of a lost log.
+# Any job the archive does not cover -- including any whose name does not resolve to
+# exactly one job, which the helper leaves unmapped on purpose -- falls through to the
+# per-job path in download_logs_for_all_jobs, so an ambiguous or missing entry costs one
+# request instead of risking a log filed under the wrong job.
 #
 # Returns non-zero if the archive could not be fetched or unpacked at all.
 download_logs_archive_for_attempt() {
@@ -114,10 +122,15 @@ download_logs_archive_for_attempt() {
 
     echo "[info] fetching the whole attempt's logs as one archive"
     # Same escape-sequence handling as the per-job path: gh >= 2.97.0 needs the flag,
-    # older images in the fleet do not have it.
-    if ! gh api --allow-escape-sequences "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/logs" > "$archive" 2>/dev/null; then
-        if ! gh api "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/logs" > "$archive" 2>/dev/null; then
-            echo "[Warning] could not download the attempt log archive; falling back to per-job downloads"
+    # older images in the fleet do not have it. Both errors are surfaced rather than
+    # discarded -- a 403 here is the signal that the repository's hourly REST budget is
+    # gone, and silencing it turns that into an unexplained fallback.
+    local archive_error retry_error
+    if ! archive_error=$(gh api --allow-escape-sequences "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/logs" 2>&1 >"$archive"); then
+        if ! retry_error=$(gh api "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/logs" 2>&1 >"$archive"); then
+            echo "[Warning] could not download the attempt log archive: ${retry_error:-no reason given}"
+            echo "[Warning] first attempt (with --allow-escape-sequences) said: ${archive_error:-no reason given}"
+            echo "[Warning] falling back to per-job downloads"
             rm -rf "$tmp_dir"
             return 1
         fi
@@ -154,8 +167,10 @@ download_logs_for_all_jobs() {
         job_conclusion=$(echo "$job" | jq -r '.conclusion')
         # The attempt archive above normally supplied this already, so only jobs it did
         # not cover cost a request here. Skipped jobs and jobs that never reached a
-        # conclusion have no log to serve, so asking for one is a guaranteed-wasted
-        # request -- on the run this was measured against, 44 of 129 jobs were skipped.
+        # conclusion have no log to serve, and asking anyway cost *two* requests each:
+        # the 404 from the first call is a non-zero exit, so the "||" retry below fires
+        # and 404s in turn. On the run this was measured against that was 44 of 129 jobs,
+        # so 88 guaranteed-wasted requests.
         if [[ ! -s generated/cicd/$workflow_run_id/logs/$job_id.log ]] &&
            [[ "$job_conclusion" != "skipped" && "$job_conclusion" != "null" && -n "$job_conclusion" ]]; then
             echo "[info] download logs for job with id $job_id, attempt number $attempt_number"

--- a/infra/data_collection/github/extract_job_logs_from_archive.py
+++ b/infra/data_collection/github/extract_job_logs_from_archive.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unpack a GitHub run-attempt log archive into the <job_id>.log layout this pipeline expects.
+
+GitHub serves every job log for a run attempt as one zip:
+
+    GET /repos/{repo}/actions/runs/{run_id}/attempts/{attempt}/logs
+
+which replaces the one-request-per-job loop download_cicd_logs_and_artifacts.sh used to
+run. That loop made this pipeline's API cost scale with the size of the run being
+analyzed -- 129 requests for a 129-job merge-gate run, against the repository's shared
+15,000/hr GITHUB_TOKEN budget, ~173 times an hour.
+
+The archive names entries after job and step names, but everything downstream reads
+<job_id>.log, so entries have to be mapped back onto job ids. Two properties of the
+archive make that worth doing in Python rather than with `unzip`:
+
+  * Step names appear verbatim in entry paths, emoji included. `unzip` can fail to
+    create such a name, and because it then prompts to continue and gets no tty in CI,
+    it aborts the whole extraction and leaves a silently partial result.
+  * Entry names contain characters that are glob-special to `unzip`'s own pattern
+    matching (`[`, `]`), so selecting entries by name is unreliable.
+
+Reading the zip directly avoids both: names are matched in memory and the only paths
+created on disk are ones we choose.
+
+Job names are matched to entry names on an aggressively normalized form (lowercased,
+everything but [a-z0-9] dropped) because the archive flattens characters that are
+illegal in a filename -- most visibly the "/" in "<caller job> / <called job>" -- and
+guessing GitHub's exact substitution table would be a standing source of breakage.
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+import zipfile
+from collections import defaultdict
+
+# Top-level archive entries are the whole-job logs, named "<ordinal>_<job name>.txt".
+# The per-job subdirectories below them hold the same content split per step.
+TOP_LEVEL_JOB_LOG = re.compile(r"^(\d+)_(?P<name>.*)\.txt$")
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]")
+
+
+def normalize(name: str) -> str:
+    return _NON_ALNUM.sub("", name.lower())
+
+
+def build_name_index(jobs: list) -> dict:
+    """normalized job name -> list of job ids, most recent id last.
+
+    A list rather than a single id because matrix legs can share a name; ids are handed
+    out one per matching entry so two same-named jobs land in two different files.
+    """
+    index = defaultdict(list)
+    for job in jobs:
+        job_id = job.get("id")
+        name = job.get("name")
+        if job_id is None or not name:
+            continue
+        index[normalize(str(name))].append(int(job_id))
+    return index
+
+
+def extract(archive_path: pathlib.Path, jobs: list, logs_dir: pathlib.Path) -> int:
+    index = build_name_index(jobs)
+    written = 0
+
+    with zipfile.ZipFile(archive_path) as archive:
+        for entry in archive.infolist():
+            if entry.is_dir() or "/" in entry.filename:
+                continue
+            matched = TOP_LEVEL_JOB_LOG.match(entry.filename)
+            if not matched:
+                continue
+
+            candidates = index.get(normalize(matched.group("name")))
+            if not candidates:
+                # Left for the per-job fallback in the shell script, so an unmapped
+                # entry costs one request rather than losing the log.
+                continue
+            job_id = candidates.pop(0)
+
+            # Written by us under an id we chose, so no archive-supplied name -- and no
+            # emoji or overlong path -- ever reaches the filesystem.
+            with archive.open(entry) as source, open(logs_dir / f"{job_id}.log", "wb") as target:
+                while chunk := source.read(1024 * 1024):
+                    target.write(chunk)
+            written += 1
+
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", required=True, type=pathlib.Path)
+    parser.add_argument("--jobs-json", required=True, type=pathlib.Path)
+    parser.add_argument("--logs-dir", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+
+    if not args.logs_dir.is_dir():
+        print(f"[Warning] logs dir does not exist: {args.logs_dir}", file=sys.stderr)
+        return 1
+
+    try:
+        jobs = json.loads(args.jobs_json.read_text()).get("jobs") or []
+    except (OSError, ValueError) as exc:
+        print(f"[Warning] could not read jobs payload: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        written = extract(args.archive, jobs, args.logs_dir)
+    except (OSError, zipfile.BadZipFile) as exc:
+        print(f"[Warning] could not unpack the attempt log archive: {exc}", file=sys.stderr)
+        return 1
+
+    # No logs at all means the archive was not usable; let the caller fall back rather
+    # than proceed with an empty logs dir, which the parsers downstream assert against.
+    if written == 0:
+        print("[Warning] attempt log archive contained no recognizable job logs", file=sys.stderr)
+        return 1
+
+    print(f"[info] recovered {written} job logs from the archive in 1 request")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/data_collection/github/extract_job_logs_from_archive.py
+++ b/infra/data_collection/github/extract_job_logs_from_archive.py
@@ -13,23 +13,28 @@ run. That loop made this pipeline's API cost scale with the size of the run bein
 analyzed -- 129 requests for a 129-job merge-gate run, against the repository's shared
 15,000/hr GITHUB_TOKEN budget, ~173 times an hour.
 
-The archive names entries after job and step names, but everything downstream reads
-<job_id>.log, so entries have to be mapped back onto job ids. Two properties of the
-archive make that worth doing in Python rather than with `unzip`:
+Everything downstream reads <job_id>.log, so archive entries have to be mapped back onto
+job ids. Entry names are the job name with "/" rewritten to "_" and nothing else changed
+-- measured exact on 85/85 entries of run 34360282367 -- so that substitution is the
+primary match. Emoji and characters like "[", "]", "(" and "," survive byte-for-byte in
+the central directory; the "?" that `unzip -l` shows for them is its own display
+rendering, not archive content.
 
-  * Step names appear verbatim in entry paths, emoji included. `unzip` can fail to
-    create such a name, and because it then prompts to continue and gets no tty in CI,
-    it aborts the whole extraction and leaves a silently partial result.
-  * Entry names contain characters that are glob-special to `unzip`'s own pattern
-    matching (`[`, `]`), so selecting entries by name is unreliable.
+A normalized comparison (lowercased, everything but [a-z0-9] dropped) runs as a second
+tier in case GitHub ever changes the substitution. It is deliberately not the primary
+match: it maps distinct job names onto the same key ("a/b" and "a-b" both become "ab"),
+and a wrong match here is worse than a missing one, because it files a job's failure
+signature and runner telemetry under a different job.
 
-Reading the zip directly avoids both: names are matched in memory and the only paths
-created on disk are ones we choose.
+So any name -- at either tier -- that does not resolve to exactly one job is left
+unmapped on purpose. The caller falls back to a per-job request for those, which costs
+one request and makes misattribution impossible rather than merely unobserved.
 
-Job names are matched to entry names on an aggressively normalized form (lowercased,
-everything but [a-z0-9] dropped) because the archive flattens characters that are
-illegal in a filename -- most visibly the "/" in "<caller job> / <called job>" -- and
-guessing GitHub's exact substitution table would be a standing source of breakage.
+Reading the zip directly, rather than shelling out to `unzip`, also keeps archive-supplied
+names off the filesystem entirely: the only paths written are <job_id>.log. `unzip` can
+fail to create an entry whose name contains emoji, and having no tty to answer the
+"continue?" prompt that follows, it aborts and leaves a silently partial extraction --
+observed truncating at 46 of 85 job logs.
 """
 
 import argparse
@@ -38,62 +43,80 @@ import pathlib
 import re
 import sys
 import zipfile
-from collections import defaultdict
+from collections import Counter, defaultdict
 
 # Top-level archive entries are the whole-job logs, named "<ordinal>_<job name>.txt".
 # The per-job subdirectories below them hold the same content split per step.
-TOP_LEVEL_JOB_LOG = re.compile(r"^(\d+)_(?P<name>.*)\.txt$")
+TOP_LEVEL_JOB_LOG = re.compile(r"^(?P<ordinal>\d+)_(?P<name>.*)\.txt$")
 
 _NON_ALNUM = re.compile(r"[^a-z0-9]")
+
+
+def archive_name_for(job_name: str) -> str:
+    """The entry name GitHub gives a job's log."""
+    return job_name.replace("/", "_")
 
 
 def normalize(name: str) -> str:
     return _NON_ALNUM.sub("", name.lower())
 
 
-def build_name_index(jobs: list) -> dict:
-    """normalized job name -> list of job ids, most recent id last.
+def _unique_index(jobs: list, key) -> dict:
+    """key(job name) -> job id, holding only keys that exactly one job produces.
 
-    A list rather than a single id because matrix legs can share a name; ids are handed
-    out one per matching entry so two same-named jobs land in two different files.
+    Keys claimed by more than one job are dropped rather than resolved, so an ambiguous
+    name can never be silently attributed to whichever job happened to be listed first.
     """
-    index = defaultdict(list)
+    grouped = defaultdict(list)
     for job in jobs:
         job_id = job.get("id")
         name = job.get("name")
         if job_id is None or not name:
             continue
-        index[normalize(str(name))].append(int(job_id))
-    return index
+        grouped[key(str(name))].append(int(job_id))
+    return {k: ids[0] for k, ids in grouped.items() if len(ids) == 1}
+
+
+def resolve_entries(archive: zipfile.ZipFile, jobs: list) -> dict:
+    """Archive entry name -> job id, for entries that map to exactly one job.
+
+    Both directions are checked for ambiguity: a name matching several jobs is dropped by
+    _unique_index, and a job claimed by several entries is dropped here. What survives is
+    a strict one-to-one mapping.
+    """
+    by_archive_name = _unique_index(jobs, archive_name_for)
+    by_normalized = _unique_index(jobs, normalize)
+
+    resolved = {}
+    for entry in archive.infolist():
+        if entry.is_dir() or "/" in entry.filename:
+            continue
+        matched = TOP_LEVEL_JOB_LOG.match(entry.filename)
+        if not matched:
+            continue
+        name = matched.group("name")
+
+        job_id = by_archive_name.get(name)
+        if job_id is None:
+            job_id = by_normalized.get(normalize(name))
+        if job_id is None:
+            continue
+        resolved[entry.filename] = job_id
+
+    claimed_more_than_once = {job_id for job_id, count in Counter(resolved.values()).items() if count > 1}
+    return {entry: job_id for entry, job_id in resolved.items() if job_id not in claimed_more_than_once}
 
 
 def extract(archive_path: pathlib.Path, jobs: list, logs_dir: pathlib.Path) -> int:
-    index = build_name_index(jobs)
-    written = 0
-
     with zipfile.ZipFile(archive_path) as archive:
-        for entry in archive.infolist():
-            if entry.is_dir() or "/" in entry.filename:
-                continue
-            matched = TOP_LEVEL_JOB_LOG.match(entry.filename)
-            if not matched:
-                continue
-
-            candidates = index.get(normalize(matched.group("name")))
-            if not candidates:
-                # Left for the per-job fallback in the shell script, so an unmapped
-                # entry costs one request rather than losing the log.
-                continue
-            job_id = candidates.pop(0)
-
-            # Written by us under an id we chose, so no archive-supplied name -- and no
-            # emoji or overlong path -- ever reaches the filesystem.
-            with archive.open(entry) as source, open(logs_dir / f"{job_id}.log", "wb") as target:
+        resolved = resolve_entries(archive, jobs)
+        for entry_name, job_id in resolved.items():
+            # Written under an id we chose, so no archive-supplied name -- and no emoji
+            # or overlong path -- ever reaches the filesystem.
+            with archive.open(entry_name) as source, open(logs_dir / f"{job_id}.log", "wb") as target:
                 while chunk := source.read(1024 * 1024):
                     target.write(chunk)
-            written += 1
-
-    return written
+    return len(resolved)
 
 
 def main() -> int:

--- a/infra/tests/data_collection/test_extract_job_logs_from_archive.py
+++ b/infra/tests/data_collection/test_extract_job_logs_from_archive.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the run-attempt log archive unpacker.
+
+The helper is standard-library-only by design, so these run without the rest of the
+data-collection dependency set.
+
+The cases that matter are the ones where a wrong answer is silent: an entry attributed to
+the wrong job produces a plausible, non-empty <job_id>.log, which the caller's "is the
+file missing?" fallback check cannot detect. Those are covered explicitly.
+"""
+
+import io
+import json
+import zipfile
+
+import pytest
+
+from infra.data_collection.github import extract_job_logs_from_archive as extractor
+
+
+def _archive(entries: dict) -> zipfile.ZipFile:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name, content in entries.items():
+            archive.writestr(name, content)
+    buffer.seek(0)
+    return zipfile.ZipFile(buffer)
+
+
+def _jobs(*pairs) -> list:
+    return [{"id": job_id, "name": name} for job_id, name in pairs]
+
+
+def test_maps_entries_to_job_ids_on_the_exact_archive_name():
+    archive = _archive({"0_build.txt": "log body"})
+    assert extractor.resolve_entries(archive, _jobs((11, "build"))) == {"0_build.txt": 11}
+
+
+def test_slash_in_a_job_name_is_a_underscore_in_the_archive():
+    # "<caller job> / <called job>" is the shape every reusable-workflow job takes, and
+    # the "/" is the one character GitHub rewrites.
+    archive = _archive({"7_ttnn-merge-gate-tests _ fetch-ttsim (libttsim_bh.so).txt": "body"})
+    jobs = _jobs((22, "ttnn-merge-gate-tests / fetch-ttsim (libttsim_bh.so)"))
+    assert extractor.resolve_entries(archive, jobs) == {
+        "7_ttnn-merge-gate-tests _ fetch-ttsim (libttsim_bh.so).txt": 22
+    }
+
+
+def test_emoji_and_punctuation_survive_byte_for_byte():
+    # `unzip -l` renders these as "?", but the central directory holds them verbatim, so
+    # the exact-name tier must match without any normalization.
+    name = "build-sweeps _ build (Ubuntu 22.04, Release) _ 🛠️ Build Release"
+    archive = _archive({f"50_{name}.txt": "body"})
+    assert extractor.resolve_entries(archive, _jobs((33, name))) == {f"50_{name}.txt": 33}
+
+
+def test_normalized_form_is_a_second_tier_when_the_exact_name_does_not_match():
+    archive = _archive({"3_Build   Release.txt": "body"})
+    assert extractor.resolve_entries(archive, _jobs((44, "Build Release"))) == {"3_Build   Release.txt": 44}
+
+
+def test_two_jobs_sharing_a_name_are_left_unmapped():
+    # Rather than handing the entry to whichever job the API happened to list first.
+    archive = _archive({"0_matrix leg.txt": "body"})
+    assert extractor.resolve_entries(archive, _jobs((1, "matrix leg"), (2, "matrix leg"))) == {}
+
+
+def test_distinct_names_colliding_only_under_normalization_are_left_unmapped():
+    # "a/b" -> "a_b" and "a-b" both normalize to "ab". The exact tier still resolves
+    # "a_b", but "a-b" is ambiguous at the normalized tier and must not be guessed.
+    archive = _archive({"0_a_b.txt": "first", "1_a-b.txt": "second"})
+    resolved = extractor.resolve_entries(archive, _jobs((1, "a/b"), (2, "a-b")))
+    assert resolved == {"0_a_b.txt": 1, "1_a-b.txt": 2}
+
+
+def test_one_job_claimed_by_several_entries_is_left_unmapped():
+    archive = _archive({"0_Build Release.txt": "first", "1_build release.txt": "second"})
+    assert extractor.resolve_entries(archive, _jobs((5, "Build Release"))) == {}
+
+
+def test_per_step_entries_and_unrelated_files_are_ignored():
+    archive = _archive(
+        {
+            "0_build.txt": "job log",
+            "build/1_Set up job.txt": "step log",
+            "build/2_🛠️ Compile.txt": "step log",
+            "notes.md": "not a job log",
+        }
+    )
+    assert extractor.resolve_entries(archive, _jobs((9, "build"))) == {"0_build.txt": 9}
+
+
+def test_entry_with_no_matching_job_is_left_unmapped():
+    archive = _archive({"0_build.txt": "body", "1_ghost.txt": "body"})
+    assert extractor.resolve_entries(archive, _jobs((9, "build"))) == {"0_build.txt": 9}
+
+
+def test_extract_writes_job_id_named_files_with_the_entry_contents(tmp_path):
+    archive_path = tmp_path / "logs.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("0_build.txt", "first body")
+        archive.writestr("1_test _ run.txt", "second body")
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+
+    written = extractor.extract(archive_path, _jobs((11, "build"), (22, "test / run")), logs_dir)
+
+    assert written == 2
+    assert (logs_dir / "11.log").read_text() == "first body"
+    assert (logs_dir / "22.log").read_text() == "second body"
+    # Nothing named after an archive entry reaches disk.
+    assert sorted(p.name for p in logs_dir.iterdir()) == ["11.log", "22.log"]
+
+
+def test_ambiguous_job_gets_no_file_so_the_caller_falls_back(tmp_path):
+    archive_path = tmp_path / "logs.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("0_matrix leg.txt", "body")
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+
+    assert extractor.extract(archive_path, _jobs((1, "matrix leg"), (2, "matrix leg")), logs_dir) == 0
+    assert list(logs_dir.iterdir()) == []
+
+
+def test_malformed_archive_is_reported_rather_than_raising(tmp_path, capsys):
+    archive_path = tmp_path / "logs.zip"
+    archive_path.write_bytes(b"this is not a zip")
+    jobs_path = tmp_path / "jobs.json"
+    jobs_path.write_text(json.dumps({"jobs": _jobs((1, "build"))}))
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+
+    exit_code = _run_main(tmp_path, archive_path, jobs_path, logs_dir)
+
+    assert exit_code == 1
+    assert "could not unpack" in capsys.readouterr().err
+
+
+def test_archive_with_no_recognizable_job_logs_signals_fallback(tmp_path, capsys):
+    archive_path = tmp_path / "logs.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("build/1_Set up job.txt", "step log only")
+    jobs_path = tmp_path / "jobs.json"
+    jobs_path.write_text(json.dumps({"jobs": _jobs((1, "build"))}))
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+
+    exit_code = _run_main(tmp_path, archive_path, jobs_path, logs_dir)
+
+    assert exit_code == 1
+    assert "no recognizable job logs" in capsys.readouterr().err
+
+
+def _run_main(tmp_path, archive_path, jobs_path, logs_dir) -> int:
+    import sys
+
+    argv = sys.argv
+    sys.argv = [
+        "extract_job_logs_from_archive.py",
+        "--archive",
+        str(archive_path),
+        "--jobs-json",
+        str(jobs_path),
+        "--logs-dir",
+        str(logs_dir),
+    ]
+    try:
+        return extractor.main()
+    finally:
+        sys.argv = argv
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Problem

`produce_data` is the largest single consumer of tt-metal's REST budget.
`download_cicd_logs_and_artifacts.sh` calls `/actions/jobs/{job_id}/logs` **once per
job**, so its cost scales with the size of the run it is analyzing — 129 requests for a
129-job merge-gate run. It runs ~173 times an hour.

`GITHUB_TOKEN` is limited to [15,000 requests/hour **per repository**](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)
on Enterprise Cloud, shared by every concurrent run in the repo. We are exhausting it
roughly 45 minutes into each window and then failing until it resets. Measured on
2026-09-09: the window opened ~14:10, drained by ~14:56, and jobs 403'd until the next
reset.

That shows up as unrelated failures elsewhere, e.g. in [run 34360282367](https://github.com/tenstorrent/tt-metal/actions/runs/34360282367):

- `fetch-ttsim` — `403` on `repos/tenstorrent/ttsim/releases/assets/...`
- `build-runtime-basic-image / Build and push` — `403` on `repos/tenstorrent/tt-metal/actions/runs/34360282367/artifacts?name=...`

#55841 removed the per-CIv2-job annotations call, which was the smaller half. The
per-job log call is the rest.

## Change

Fetch the whole attempt's logs in **one** request via
`/actions/runs/{id}/attempts/{n}/logs`, then map the archive's entries back onto job
ids so the `<job_id>.log` layout every consumer reads is unchanged.

Two smaller savings alongside it:

- **Skipped jobs no longer get a log request.** They have no log to serve, and asking
  anyway cost *two* requests each — the 404 from the first call is a non-zero exit, so
  the `||` retry fires and 404s in turn. That was 44 of 129 jobs on the measured run,
  so 88 wasted requests.
- **Dropped the paginated `/artifacts` listing** that only existed to gate
  `gh run download`, which lists the run's artifacts itself.

### Mapping entries to job ids

Entry names are the job name with `/` rewritten to `_` and **nothing else changed** —
exact on 85/85 entries of run 34360282367 — so that substitution is the primary match.
A normalized comparison (lowercased, non-alphanumerics dropped) is a second tier in case
GitHub ever changes the substitution.

Ambiguity is refused rather than resolved, in both directions: an entry name several
jobs could produce, or a job several entries claim, is left unmapped and falls through
to a per-job request. Guessing would be worse than a missing log, because a wrong match
files a job's failure signature and runner telemetry under a different job while
producing a plausible non-empty file that the caller's fallback check cannot detect.

### Why a Python helper instead of `unzip`

`unzip` can fail to create an entry whose name contains emoji, and with no tty to answer
the `continue?` prompt that follows it aborts, leaving a **silently partial** extraction
— observed truncating at 46 of 85 job logs while returning plausible-looking output.
Reading the zip in Python also means the only paths written to disk are ones we choose
(`<job_id>.log`), so archive-supplied names never reach the filesystem.

## Verification

Against [run 34360282367](https://github.com/tenstorrent/tt-metal/actions/runs/34360282367) (129 jobs, 85 with logs):

| | before | after |
|---|---|---|
| log requests | 129 | **1** |
| logs recovered | 85 | 85 |
| filenames | `<job_id>.log` | unchanged |

13 tests cover the mapping — both tiers, the `/` rewrite, emoji, ambiguity in both
directions, per-step entries, unmatched entries, and malformed or empty archives. The
helper is standard-library-only, so they run without the rest of the data-collection
dependencies.

`infra/tests/data_collection/test_cicd.py` exercises `workflows.py` against fixtures
rather than this downloader, and the on-disk contract it depends on is unchanged — but
it needs a CI run here, I could not install `loguru` locally.

## Still to decide (not in this PR)

Trimming the 60-workflow `workflow_run` trigger list is the other available lever.
Ranked by share of produce_data's log calls, measured over 14:08–15:00 UTC on
2026-09-09:

| calls/hr | share | pipeline | runs/hr x jobs/run |
|---:|---:|---|---|
| 2565 | 48.0% | PR Gate | 57 x 45 |
| 1740 | 32.6% | Merge Gate | 58 x 30 |
| 325 | 6.1% | Nightly tt-metal L2 tests | 5 x 65 |
| 230 | 4.3% | (Profiler) Choose your pipeline | 5 x 46 |
| 161 | 3.0% | Blaze Models Prefill tests | 7 x 23 |
| ~320 | 6.0% | all 8 others that fired | |

**PR Gate and Merge Gate are ~81% of the cost.** 47 of the 60 listed workflows did not
fire at all in the window, so pruning the long tail buys nothing.

That makes PR Gate the only removal with real savings, and it is a data-loss decision
for the pipeline's owners rather than a mechanical one — PR-branch runs are also where
some CIv2 node/serial telemetry comes from. A more surgical option would be ingesting
only `main` and `merge_group` runs rather than dropping a pipeline outright.

This PR is the mechanical fix; it loses no data and should be judged on its own.

cc @williamlyTT