### PR TITLE
[LLK][Quasar] Drain the math pipeline in the Dest-to-source move guards

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
@@ -194,7 +194,9 @@ inline void move_d2a_fixed_face(const std::uint8_t addrmod)
     // MOVD2A src is relative to dest_section_base + dest_counter.
     // Use fixed offsets (0, 8) — the dest counter handles face progression.
     // NOTE: For different tile dimensions we need different amounts of MOV* instructions; see separate issue.
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
+    // MATH drains the preceding math instructions so their source-bank release has landed before
+    // SRCA_VLD tests the bank that MOVD2A will write.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::NOTHING, p_stall::MATH, p_stall::SRCA_VLD);
     TTI_MOVD2A(0, 0, addrmod, p_movd2a::MOV_8_ROWS, 0);
     TTI_MOVD2A(0, 8, addrmod, p_movd2a::MOV_8_ROWS, 8);
 }
@@ -204,7 +206,9 @@ inline void move_d2b_fixed_face(const std::uint8_t addrmod)
     // MOVD2B src is relative to dest_section_base + dest_counter.
     // Use fixed offsets (0, 8) — the dest counter handles face progression.
     // NOTE: For different tile dimensions we need different amounts of MOV* instructions; see separate issue.
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCB_VLD);
+    // MATH drains the preceding math instructions so their source-bank release has landed before
+    // SRCB_VLD tests the bank that MOVD2B will write.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::NOTHING, p_stall::MATH, p_stall::SRCB_VLD);
     TTI_MOVD2B(0, 0, addrmod, p_movd2b::MOV_8_ROWS, 0, 0);
     TTI_MOVD2B(0, 8, addrmod, p_movd2b::MOV_8_ROWS, 0, 8);
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -71,7 +71,9 @@ inline void _reduce_row_transpose_fpu_()
     _configure_mov_ops_explicit_alu_data_format_state_<true>(DataFormat::Int32, DataFormat::Int32);
     _reduce_row_transpose_alu_cfg_enter_();
 
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCB_VLD);
+    // MATH drains the preceding math instructions so their source-bank release has landed before
+    // SRCB_VLD tests the bank that MOVD2B will write.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::NOTHING, p_stall::MATH, p_stall::SRCB_VLD);
 
     // Step 1: Read lo16 from dest into SrcB rows 16-31 and transpose.
     TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, 0);

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_transpose_dest.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_transpose_dest.h
@@ -214,8 +214,9 @@ inline void _llk_math_transpose_dest_(const std::uint32_t tile_idx)
     _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_idx);
 
     // Wait condition SRCB_VLD is required as MOVD2B doesn't automatically wait
-    // for SrcB[MatrixUnit.SrcBBank].AllowedClient == SrcClient::MatrixUnit.
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, p_stall::WAIT_SFPU, p_stall::SRCB_VLD);
+    // for SrcB[MatrixUnit.SrcBBank].AllowedClient == SrcClient::MatrixUnit. MATH drains the
+    // preceding math instructions so their source-bank release has landed before SRCB_VLD tests it.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH, p_stall::WAIT_SFPU, p_stall::SRCB_VLD);
 
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
@@ -243,8 +243,9 @@ inline void _llk_math_eltwise_unary_broadcast_(const std::uint32_t tile_idx)
     _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_idx);
 
     // Wait condition SRCB_VLD is required as MOVD2B doesn't automatically wait
-    // for SrcB[MatrixUnit.SrcBBank].AllowedClient == SrcClient::MatrixUnit.
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, p_stall::WAIT_SFPU, p_stall::SRCB_VLD); // TEN-4367 - SrcB sync workaround
+    // for SrcB[MatrixUnit.SrcBBank].AllowedClient == SrcClient::MatrixUnit. MATH drains the
+    // preceding math instructions so their source-bank release has landed before SRCB_VLD tests it.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH, p_stall::WAIT_SFPU, p_stall::SRCB_VLD); // TEN-4367 - SrcB sync workaround
 
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
 


### PR DESCRIPTION
Closes #55965.

The five `STALLWAIT`s that gate Quasar's Dest-to-source moves name the source-bank acquisition but not the math drain:

```c
TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
TTI_MOVD2A(...);
```

`SRCA_VLD` / `SRCB_VLD` report whether the bank the Matrix Unit *currently points at* has been handed to the Matrix Unit. Both the hand-back and the pointer advance are performed by the **preceding** Matrix Unit instruction — an eltwise op carrying `CLR_AB` / `CLR_SRC?_VLD`, or a standalone `CLEARDVALID` / `SETRWC` with `clear_ab_vld`. Until that instruction has executed, the condition still describes the pre-flip bank, which the Matrix Unit still owns, so it reads as satisfied and the wait is discharged without ever testing the bank the move will write.

`p_stall::MATH` holds the wait until the thread's math pipeline has retired, so the acquisition is sampled on the post-flip bank. That is the same drain merged #55107 added at 33 Wormhole/Blackhole sites and #52256 added to the two generic Blackhole paths before it; #55106 deferred Quasar pending an operand-encoding and bank-handshake check, which #55965 records.

### The change

One wait-resource slot per site. Quasar's `STALLWAIT` carries three enumerated slots rather than a bitmask, and every site left at least one at `p_stall::NOTHING`, so **the instruction count is unchanged** and any existing `WAIT_SFPU` is preserved. `STALLWAIT` holds until all selected conditions are simultaneously met, so one combined operand set is correct; a second `STALLWAIT` would not compose, since there is one wait latch per thread.

| file | function | move |
|---|---|---|
| `tt_llk_quasar/common/inc/cmath_common.h` | `move_d2a_fixed_face` | `MOVD2A` |
| `tt_llk_quasar/common/inc/cmath_common.h` | `move_d2b_fixed_face` | `MOVD2B` |
| `tt_llk_quasar/llk_lib/llk_math_reduce.h` | `_reduce_row_transpose_fpu_` | `MOVD2B` ×4 |
| `tt_llk_quasar/llk_lib/llk_math_transpose_dest.h` | `_llk_math_transpose_dest_` | `MOVD2B` (MOP) |
| `tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h` | `_llk_math_eltwise_unary_broadcast_` | `MOVD2B` (MOP) |

Quasar only. Wormhole and Blackhole already carry `p_stall::MATH` at every counterpart.

### Why the precondition is structural, not occasional

`_llk_math_eltwise_binary_` with `reuse_dest != NONE` calls `eltwise_binary_reuse_dest_as_src()` at the top of a per-face loop, immediately followed by `run_bank0_sw_cntl`. That MOP's `set_last_outer_loop_instr` carries `p_setrwc::CLR_AB`, so its last instruction releases and flips **both** source banks. Every face iteration ≥ 1 therefore runs the `STALLWAIT` with a both-bank flip in flight. `_llk_math_transpose_dest_` and `_llk_math_eltwise_unary_broadcast_` have the same shape: each MOP variant installs one `CLEARDVALID` as its end op, and the callers loop over tiles.

The window is not a fixed pipeline delay either — the clearing instruction is itself an eltwise op waiting on its own operands, so it can sit unexecuted for as long as the unpacker takes.

### Verification

**This is a hardening change, not a live-failure repair, and it wants a Quasar simulator run before merge** — there is no Quasar silicon or simulator on my machine. Every verdict is static plus a design check, so there is no fail-without/pass-with test.

Compilation, per site rather than per file:

| site | instantiated by | variants compiled |
|---|---|---|
| `cmath_common.h` `move_d2a_fixed_face` | `test_eltwise_binary_reuse_dest_quasar` (`DEST_TO_SRCA`) | 640 |
| `cmath_common.h` `move_d2b_fixed_face` | `test_eltwise_binary_reuse_dest_quasar` (`DEST_TO_SRCB`) | 640 |
| `llk_math_transpose_dest.h` | `test_transpose_dest_quasar` | 1116 |
| `llk_math_unary_broadcast.h` | `test_unary_broadcast_quasar` | 72 |
| `llk_math_reduce.h` `_reduce_row_transpose_fpu_` | **nothing** | 0 |

Stating the last row plainly: the reduce site is behind `is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_ROW`, and `tests/sources/reduce_test.cpp:67` hardcodes `is_int_fpu_en = false`. The `is_int_fpu_en = true` test sources are all datacopy/pack paths — a different function's template parameter. So the Quasar int32 FPU reduce-row path is not instantiated by any test; `test_reduce_quasar` compiles 15678 variants and none reaches it. That line is type-checked only.

### Not in this change

`tt_llk_quasar/llk_lib/experimental/llk_math_reduce_runtime_custom.h` `reduce_block_max_row_transpose_face_row` emits `MOVD2B` with no `STALLWAIT` at all. It is left alone deliberately: the Wormhole and Blackhole copies of that file have no guard there either, so it is a separate three-architecture question rather than a Quasar parity gap. Recorded in #55965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/quasar-dest-to-src-math-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/quasar-dest-to-src-math-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/quasar-dest-to-src-math-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/quasar-dest-to-src-math-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/quasar-dest-to-src-math-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/quasar-dest-to-src-math-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/quasar-dest-to-src-math-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/quasar-dest-to-src-math-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/quasar-dest-to-src-math-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/quasar-dest-to-src-math-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/quasar-dest-to-src-math-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/quasar-dest-to-src-math-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/quasar-dest-to-src-math-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/quasar-dest-to-src-math-drain)