### PR TITLE
[llk_helper_library] 6/8 eltwise helpers: migrate Moreh reduction kernels

### DIFF
--- a/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
@@ -22,8 +22,33 @@
 #include "api/compute/reduce.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
 
 namespace ckernel {
+
+namespace ckl = ::compute_kernel_lib;
+
+#if defined(FP32_DEST_ACC_EN)
+inline constexpr auto moreh_data_format_reconfig = ckl::DataFormatReconfig::Enabled;
+#else
+inline constexpr auto moreh_data_format_reconfig = ckl::DataFormatReconfig::Disabled;
+#endif
+
+template <uint32_t Dfb>
+inline constexpr auto moreh_input = ckl::input(
+    Dfb,
+    ckl::WaitPolicy::None,
+    ckl::PopPolicy::None,
+    ckl::InputTileMapping::Scalar,
+    moreh_data_format_reconfig,
+    ckl::TileAddressing::Offset);
+
+template <uint32_t Dfb>
+inline constexpr auto moreh_output =
+    ckl::output(Dfb, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, moreh_data_format_reconfig);
 
 ALWI void pack_tile_with_dt(uint32_t ifrom_dst, DataflowBuffer icb) {
 #if defined FP32_DEST_ACC_EN
@@ -135,6 +160,436 @@ public:
         return get_arg_val<T>(arg_idx++);
     }
 };
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void mul_tiles_to_dfb(uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    DataflowBuffer(Dfb0).wait_front(itile0 + 1);
+    DataflowBuffer(Dfb1).wait_front(itile1 + 1);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::BinaryFpu<ckl::BinaryFpuOp::Mul, moreh_input<Dfb0>, moreh_input<Dfb1>>{itile0, itile1},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+
+    if (pop0) {
+        DataflowBuffer(Dfb0).pop_front(pop0);
+    }
+    if (pop1) {
+        DataflowBuffer(Dfb1).pop_front(pop1);
+    }
+}
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void mul_tiles_and_negative_to_dfb(
+    uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    DataflowBuffer(Dfb0).wait_front(itile0 + 1);
+    DataflowBuffer(Dfb1).wait_front(itile1 + 1);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::BinaryFpu<ckl::BinaryFpuOp::Mul, moreh_input<Dfb0>, moreh_input<Dfb1>>{itile0, itile1},
+        ckl::Negative<>{},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+
+    if (pop0) {
+        DataflowBuffer(Dfb0).pop_front(pop0);
+    }
+    if (pop1) {
+        DataflowBuffer(Dfb1).pop_front(pop1);
+    }
+}
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbMask, uint32_t DfbOut>
+ALWI void mul_tiles_and_mask_tile_to_dfb(
+    uint32_t itile0 = 0,
+    uint32_t itile1 = 0,
+    uint32_t mtile = 0,
+    uint32_t pop0 = 1,
+    uint32_t pop1 = 1,
+    uint32_t popm = 1) {
+    DataflowBuffer(Dfb0).wait_front(itile0 + 1);
+    DataflowBuffer(Dfb1).wait_front(itile1 + 1);
+    DataflowBuffer(DfbMask).wait_front(mtile + 1);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::BinaryFpu<ckl::BinaryFpuOp::Mul, moreh_input<Dfb0>, moreh_input<Dfb1>>{itile0, itile1},
+        ckl::CopyTile<moreh_input<DfbMask>, ckl::Dst::D1>{mtile},
+        ckl::Mask<>{},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+
+    if (pop0) {
+        DataflowBuffer(Dfb0).pop_front(pop0);
+    }
+    if (pop1) {
+        DataflowBuffer(Dfb1).pop_front(pop1);
+    }
+    if (popm) {
+        DataflowBuffer(DfbMask).pop_front(popm);
+    }
+}
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void mul_tiles_log_to_dfb(uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    DataflowBuffer(Dfb0).wait_front(itile0 + 1);
+    DataflowBuffer(Dfb1).wait_front(itile1 + 1);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::BinaryFpu<ckl::BinaryFpuOp::Mul, moreh_input<Dfb0>, moreh_input<Dfb1>>{itile0, itile1},
+        ckl::Log<>{},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+
+    if (pop0) {
+        DataflowBuffer(Dfb0).pop_front(pop0);
+    }
+    if (pop1) {
+        DataflowBuffer(Dfb1).pop_front(pop1);
+    }
+}
+
+template <ckl::BroadcastDim Bcast, uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut, bool ApplyLog = false>
+ALWI void mul_tiles_bcast_to_dfb(uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    DataflowBuffer(Dfb0).wait_front(itile0 + 1);
+    DataflowBuffer(Dfb1).wait_front(itile1 + 1);
+
+    if constexpr (ApplyLog) {
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::BinaryFpu<ckl::BinaryFpuOp::Mul, moreh_input<Dfb0>, ckl::input(moreh_input<Dfb1>, Bcast)>{
+                itile0, itile1},
+            ckl::Log<>{},
+            ckl::PackTile<moreh_output<DfbOut>>{});
+    } else {
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::BinaryFpu<ckl::BinaryFpuOp::Mul, moreh_input<Dfb0>, ckl::input(moreh_input<Dfb1>, Bcast)>{
+                itile0, itile1},
+            ckl::PackTile<moreh_output<DfbOut>>{});
+    }
+
+    if (pop0) {
+        DataflowBuffer(Dfb0).pop_front(pop0);
+    }
+    if (pop1) {
+        DataflowBuffer(Dfb1).pop_front(pop1);
+    }
+}
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void mul_tiles_bcast_rows_to_dfb(uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    mul_tiles_bcast_to_dfb<ckl::BroadcastDim::Row, Dfb0, Dfb1, DfbOut>(itile0, itile1, pop0, pop1);
+}
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void mul_tiles_bcast_rows_log_to_dfb(
+    uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    mul_tiles_bcast_to_dfb<ckl::BroadcastDim::Row, Dfb0, Dfb1, DfbOut, true>(itile0, itile1, pop0, pop1);
+}
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void mul_tiles_bcast_cols_to_dfb(uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    mul_tiles_bcast_to_dfb<ckl::BroadcastDim::Col, Dfb0, Dfb1, DfbOut>(itile0, itile1, pop0, pop1);
+}
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void mul_tiles_bcast_cols_log_to_dfb(
+    uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    mul_tiles_bcast_to_dfb<ckl::BroadcastDim::Col, Dfb0, Dfb1, DfbOut, true>(itile0, itile1, pop0, pop1);
+}
+
+template <uint32_t DfbIn, uint32_t DfbOut>
+ALWI void copy_tile_to_dfb(uint32_t itile = 0, uint32_t pop = 1) {
+    DataflowBuffer(DfbIn).wait_front(itile + 1);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::CopyTile<moreh_input<DfbIn>>{itile},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+
+    if (pop) {
+        DataflowBuffer(DfbIn).pop_front(pop);
+    }
+}
+
+template <uint32_t DfbIn, uint32_t DfbOut>
+ALWI void sign_tile_to_dfb(uint32_t itile = 0, uint32_t pop = 1) {
+    DataflowBuffer(DfbIn).wait_front(itile + 1);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::CopyTile<moreh_input<DfbIn>>{itile},
+        ckl::Sign<>{},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+
+    if (pop) {
+        DataflowBuffer(DfbIn).pop_front(pop);
+    }
+}
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void add_tiles_to_dfb(uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    DataflowBuffer(Dfb0).wait_front(itile0 + 1);
+    DataflowBuffer(Dfb1).wait_front(itile1 + 1);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::BinaryFpu<ckl::BinaryFpuOp::Add, moreh_input<Dfb0>, moreh_input<Dfb1>>{itile0, itile1},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+
+    if (pop0) {
+        DataflowBuffer(Dfb0).pop_front(pop0);
+    }
+    if (pop1) {
+        DataflowBuffer(Dfb1).pop_front(pop1);
+    }
+}
+
+template <uint32_t DfbIn, uint32_t DfbMask, uint32_t DfbOut>
+ALWI void mask_tile_to_dfb(uint32_t itile = 0, uint32_t mtile = 0, uint32_t pop = 1, uint32_t popm = 1) {
+    DataflowBuffer(DfbIn).wait_front(itile + 1);
+    DataflowBuffer(DfbMask).wait_front(mtile + 1);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::CopyTile<moreh_input<DfbIn>>{itile},
+        ckl::CopyTile<moreh_input<DfbMask>, ckl::Dst::D1>{mtile},
+        ckl::Mask<>{},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+
+    if (pop) {
+        DataflowBuffer(DfbIn).pop_front(pop);
+    }
+    if (popm) {
+        DataflowBuffer(DfbMask).pop_front(popm);
+    }
+}
+
+template <ckl::BroadcastDim Bcast, uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void sub_tiles_bcast_to_dfb(uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    DataflowBuffer(Dfb0).wait_front(itile0 + 1);
+    DataflowBuffer(Dfb1).wait_front(itile1 + 1);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::BinaryFpu<ckl::BinaryFpuOp::Sub, moreh_input<Dfb0>, ckl::input(moreh_input<Dfb1>, Bcast)>{itile0, itile1},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+
+    if (pop0) {
+        DataflowBuffer(Dfb0).pop_front(pop0);
+    }
+    if (pop1) {
+        DataflowBuffer(Dfb1).pop_front(pop1);
+    }
+}
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void sub_tiles_bcast_cols_to_dfb(uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    sub_tiles_bcast_to_dfb<ckl::BroadcastDim::Col, Dfb0, Dfb1, DfbOut>(itile0, itile1, pop0, pop1);
+}
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void sub_tiles_bcast_rows_to_dfb(uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    sub_tiles_bcast_to_dfb<ckl::BroadcastDim::Row, Dfb0, Dfb1, DfbOut>(itile0, itile1, pop0, pop1);
+}
+
+template <uint32_t Dfb0, uint32_t Dfb1, uint32_t DfbOut>
+ALWI void sub_tiles_to_dfb(uint32_t itile0 = 0, uint32_t itile1 = 0, uint32_t pop0 = 1, uint32_t pop1 = 1) {
+    sub_tiles_bcast_to_dfb<ckl::BroadcastDim::None, Dfb0, Dfb1, DfbOut>(itile0, itile1, pop0, pop1);
+}
+
+template <bool Negative, uint32_t DfbIn, uint32_t DfbOut>
+ALWI void exp_tile_to_dfb_impl(uint32_t itile = 0, uint32_t pop = 1) {
+    DataflowBuffer(DfbIn).wait_front(itile + 1);
+
+    if constexpr (Negative) {
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::CopyTile<moreh_input<DfbIn>>{itile},
+            ckl::Negative<>{},
+            ckl::Exp<>{},
+            ckl::PackTile<moreh_output<DfbOut>>{});
+    } else {
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::CopyTile<moreh_input<DfbIn>>{itile},
+            ckl::Exp<>{},
+            ckl::PackTile<moreh_output<DfbOut>>{});
+    }
+
+    if (pop) {
+        DataflowBuffer(DfbIn).pop_front(pop);
+    }
+}
+
+template <uint32_t DfbIn, uint32_t DfbOut>
+ALWI void exp_tile_to_dfb(uint32_t itile = 0, uint32_t pop = 1) {
+    exp_tile_to_dfb_impl<false, DfbIn, DfbOut>(itile, pop);
+}
+
+template <uint32_t DfbIn, uint32_t DfbOut>
+ALWI void rexp_tile_to_dfb(uint32_t itile = 0, uint32_t pop = 1) {
+    exp_tile_to_dfb_impl<true, DfbIn, DfbOut>(itile, pop);
+}
+
+template <bool Negative, uint32_t DfbIn, uint32_t DfbMask, uint32_t DfbOut>
+ALWI void exp_tile_and_mask_tile_to_dfb_impl(
+    uint32_t itile = 0, uint32_t mtile = 0, uint32_t pop = 1, uint32_t popm = 1) {
+    DataflowBuffer(DfbIn).wait_front(itile + 1);
+    DataflowBuffer(DfbMask).wait_front(mtile + 1);
+
+    if constexpr (Negative) {
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::CopyTile<moreh_input<DfbIn>>{itile},
+            ckl::Negative<>{},
+            ckl::Exp<>{},
+            ckl::CopyTile<moreh_input<DfbMask>, ckl::Dst::D1>{mtile},
+            ckl::Mask<>{},
+            ckl::PackTile<moreh_output<DfbOut>>{});
+    } else {
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::CopyTile<moreh_input<DfbIn>>{itile},
+            ckl::Exp<>{},
+            ckl::CopyTile<moreh_input<DfbMask>, ckl::Dst::D1>{mtile},
+            ckl::Mask<>{},
+            ckl::PackTile<moreh_output<DfbOut>>{});
+    }
+
+    if (pop) {
+        DataflowBuffer(DfbIn).pop_front(pop);
+    }
+    if (popm) {
+        DataflowBuffer(DfbMask).pop_front(popm);
+    }
+}
+
+template <uint32_t DfbIn, uint32_t DfbMask, uint32_t DfbOut>
+ALWI void exp_tile_and_mask_tile_to_dfb(uint32_t itile = 0, uint32_t mtile = 0, uint32_t pop = 1, uint32_t popm = 1) {
+    exp_tile_and_mask_tile_to_dfb_impl<false, DfbIn, DfbMask, DfbOut>(itile, mtile, pop, popm);
+}
+
+template <uint32_t DfbIn, uint32_t DfbMask, uint32_t DfbOut>
+ALWI void rexp_tile_and_mask_tile_to_dfb(uint32_t itile = 0, uint32_t mtile = 0, uint32_t pop = 1, uint32_t popm = 1) {
+    exp_tile_and_mask_tile_to_dfb_impl<true, DfbIn, DfbMask, DfbOut>(itile, mtile, pop, popm);
+}
+
+template <uint32_t DfbIn, uint32_t DfbOut>
+ALWI void recip_tile_to_dfb(uint32_t itile = 0, uint32_t pop = 1) {
+    DataflowBuffer(DfbIn).wait_front(itile + 1);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::CopyTile<moreh_input<DfbIn>>{itile},
+        ckl::Recip<>{},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+
+    if (pop) {
+        DataflowBuffer(DfbIn).pop_front(pop);
+    }
+}
+
+template <uint32_t DfbIn, uint32_t DfbOut>
+ALWI void log_tile_to_dfb(uint32_t itile = 0, uint32_t pop = 1) {
+    DataflowBuffer(DfbIn).wait_front(itile + 1);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::CopyTile<moreh_input<DfbIn>>{itile},
+        ckl::Log<>{},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+
+    if (pop) {
+        DataflowBuffer(DfbIn).pop_front(pop);
+    }
+}
+
+template <
+    bool AbsX,
+    bool RecipFinal,
+    uint32_t DfbX,
+    uint32_t DfbXpow,
+    uint32_t DfbLogX,
+    uint32_t DfbDecimal,
+    uint32_t DfbExpLogXMulDecimal,
+    uint32_t DfbOut>
+ALWI void power_tile_to_dfb_impl(uint32_t p, bool p_is_negative) {
+    // x^p
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::CopyTile<ckl::input(DfbX, ckl::WaitPolicy::PerTile, ckl::PopPolicy::None, moreh_data_format_reconfig)>{},
+        ckl::Optional<AbsX, ckl::Abs<>>{},
+        ckl::PowerIterative<>{p},
+        ckl::runtime_if(p_is_negative, ckl::Recip<>{}),
+        ckl::PackTile<moreh_output<DfbXpow>>{});
+
+    // log(x)
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::CopyTile<ckl::input(
+            DfbX, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, moreh_data_format_reconfig)>{},
+        ckl::Optional<AbsX, ckl::Abs<>>{},
+        ckl::Log<>{},
+        ckl::PackTile<moreh_output<DfbLogX>>{});
+
+    // exp(log(x) * decimal)
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::BinaryFpu<
+            ckl::BinaryFpuOp::Mul,
+            ckl::input(DfbLogX, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, moreh_data_format_reconfig),
+            ckl::input(DfbDecimal, ckl::WaitPolicy::None, ckl::PopPolicy::None, moreh_data_format_reconfig)>{},
+        ckl::Exp<>{},
+        ckl::PackTile<moreh_output<DfbExpLogXMulDecimal>>{});
+
+    // x^p * exp(log(x) * decimal), optionally followed by reciprocal.
+    ckl::eltwise_chain(
+        ckl::IterationShape::one_tile(),
+        ckl::BinaryFpu<
+            ckl::BinaryFpuOp::Mul,
+            ckl::input(DfbXpow, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, moreh_data_format_reconfig),
+            ckl::input(
+                DfbExpLogXMulDecimal, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, moreh_data_format_reconfig)>{},
+        ckl::Optional<RecipFinal, ckl::Recip<>>{},
+        ckl::PackTile<moreh_output<DfbOut>>{});
+}
+
+template <
+    uint32_t DfbX,
+    uint32_t DfbXpow,
+    uint32_t DfbLogX,
+    uint32_t DfbDecimal,
+    uint32_t DfbExpLogXMulDecimal,
+    uint32_t DfbCorrectXpow>
+ALWI void power_tile_to_dfb(uint32_t p, bool p_is_negative) {
+    power_tile_to_dfb_impl<false, false, DfbX, DfbXpow, DfbLogX, DfbDecimal, DfbExpLogXMulDecimal, DfbCorrectXpow>(
+        p, p_is_negative);
+}
+
+template <
+    uint32_t DfbX,
+    uint32_t DfbXpow,
+    uint32_t DfbLogX,
+    uint32_t DfbDecimal,
+    uint32_t DfbExpLogXMulDecimal,
+    uint32_t DfbCorrectXpow>
+ALWI void power_tile_with_abs_x_to_dfb(uint32_t p, bool p_is_negative) {
+    power_tile_to_dfb_impl<true, false, DfbX, DfbXpow, DfbLogX, DfbDecimal, DfbExpLogXMulDecimal, DfbCorrectXpow>(
+        p, p_is_negative);
+}
+
+template <
+    uint32_t DfbX,
+    uint32_t DfbXpow,
+    uint32_t DfbLogX,
+    uint32_t DfbDecimal,
+    uint32_t DfbExpLogXMulDecimal,
+    uint32_t DfbRecipXpow>
+ALWI void power_and_recip_tile_to_dfb(uint32_t p, bool p_is_negative) {
+    power_tile_to_dfb_impl<false, true, DfbX, DfbXpow, DfbLogX, DfbDecimal, DfbExpLogXMulDecimal, DfbRecipXpow>(
+        p, p_is_negative);
+}
 
 ALWI void mul_tiles_to_cb(
     DataflowBuffer icb0,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/moreh_abs_pow_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/moreh_abs_pow_kernel.cpp
@@ -6,6 +6,14 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
+#if defined(FP32_DEST_ACC_EN)
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Enabled;
+#else
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Disabled;
+#endif
+
 void kernel_main() {
     const auto num_rows_per_core = get_arg(args::num_rows_per_core);
     const auto Wt = get_arg(args::Wt);
@@ -14,21 +22,13 @@ void kernel_main() {
     const bool p_is_negative = get_arg(args::p_is_negative) == 1;
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t dst1 = 1;
 
     // Input/output roles map to the c_in0 / c_out0 DFBs (input == x, output == y).
     compute_kernel_hw_startup(dfb::x, dfb::x, dfb::y);
 
-    DataflowBuffer dfb_x_obj(dfb::x);                // input
-    DataflowBuffer dfb_one_obj(dfb::one);            // one
-    DataflowBuffer dfb_decimal_obj(dfb::decimal);    // decimal
-    DataflowBuffer dfb_mask_w_obj(dfb::mask_w);      // mask_w
-    DataflowBuffer dfb_y_obj(dfb::y);                // output
-    DataflowBuffer dfb_xabs_obj(dfb::xabs);          // |x|
-    DataflowBuffer dfb_xpow_obj(dfb::xpow);          // |x|^p
-    DataflowBuffer dfb_logx_obj(dfb::logx);          // log(|x|)
-    DataflowBuffer dfb_exp_lxmd_obj(dfb::exp_lxmd);  // exp(log(|x|) * decimal)
+    DataflowBuffer dfb_one_obj(dfb::one);
+    DataflowBuffer dfb_decimal_obj(dfb::decimal);
+    DataflowBuffer dfb_mask_w_obj(dfb::mask_w);
 
     dfb_one_obj.wait_front(onetile);
     dfb_decimal_obj.wait_front(onetile);
@@ -42,41 +42,28 @@ void kernel_main() {
     }
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; ++row_idx) {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
-            tile_regs_acquire();
-            dfb_x_obj.wait_front(onetile);
-            dfb_xabs_obj.reserve_back(onetile);
+            ckl::eltwise_chain(
+                ckl::IterationShape::one_tile(),
+                ckl::CopyTile<ckl::input(
+                    dfb::x, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig)>{},
+                ckl::runtime_if(
+                    do_mask_w && (col_idx == Wt - 1),
+                    ckl::CopyTile<
+                        ckl::input(
+                            dfb::mask_w,
+                            ckl::WaitPolicy::None,
+                            ckl::PopPolicy::None,
+                            ckl::InputTileMapping::Scalar,
+                            kDataFormatReconfig,
+                            ckl::TileAddressing::Offset),
+                        ckl::Dst::D1>{},
+                    ckl::Mask<>{}),
+                ckl::Abs<>{},
+                ckl::PackTile<ckl::output(
+                    dfb::xabs, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>{});
 
-            copy_tile_init_with_dt(dfb_x_obj);
-            copy_tile(dfb::x, 0, dst0);
-
-            if (do_mask_w && (col_idx == Wt - 1)) {
-                copy_tile_init_with_dt(dfb_mask_w_obj);
-                copy_tile(dfb::mask_w, 0, dst1);
-
-                mask_tile_init();
-                mask_tile(dst0, dst1);
-            }
-
-            abs_tile_init();
-            abs_tile(dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_xabs_obj);
-            tile_regs_release();
-
-            dfb_x_obj.pop_front(onetile);
-            dfb_xabs_obj.push_back(onetile);
-
-            power_tile_to_cb(
-                dfb_xabs_obj,
-                dfb_xpow_obj,
-                dfb_logx_obj,
-                dfb_decimal_obj,
-                dfb_exp_lxmd_obj,
-                dfb_y_obj,
-                p,
-                p_is_negative);
+            // |x| -> |x|^p via log(|x|) and exp(log(|x|) * decimal).
+            power_tile_to_dfb<dfb::xabs, dfb::xpow, dfb::logx, dfb::decimal, dfb::exp_lxmd, dfb::y>(p, p_is_negative);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
@@ -4,71 +4,57 @@
 
 #include <cstdint>
 
-#include "api/compute/eltwise_binary.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
 void kernel_main() {
     constexpr int onetile = 1;
-    auto per_core_block_cnt = get_arg(args::per_core_block_cnt);
+    const auto per_core_block_cnt = get_arg(args::per_core_block_cnt);
+    DataflowBuffer dfb_scaler(dfb::scaler);
     compute_kernel_hw_startup(dfb::in0, dfb::in1, dfb::out);
-
-    DataflowBuffer dfb_c0(dfb::in0);
-    DataflowBuffer dfb_c1(dfb::in1);
-    DataflowBuffer dfb_c2(dfb::scaler);
-    DataflowBuffer dfb_c24(dfb::im0);
 
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
         bool last_out = block == (per_core_block_cnt - 1);
 
-        dfb_c0.wait_front(onetile);
-        dfb_c1.wait_front(onetile);
-
-        tile_regs_acquire();
-        mul_init(dfb::in0, dfb::in1);
-        mul_tiles(dfb::in0, dfb::in1, 0, 0, 0);
-        tile_regs_commit();
-
-        dfb_c0.pop_front(onetile);
-        dfb_c1.pop_front(onetile);
-
-        dfb_c24.reserve_back(onetile);
-
-        tile_regs_wait();
-        pack_tile(0, dfb::im0);
-        tile_regs_release();
-
-        dfb_c24.push_back(onetile);
+        ckl::mul<
+            ckl::input(dfb::in0),
+            ckl::input(dfb::in1),
+            ckl::output(
+                dfb::im0, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, ckl::DataFormatReconfig::Disabled)>(
+            ckl::IterationShape::tiles(onetile));
 
         // reduce-w
         if (last_out) {
-            compute_kernel_lib::reduce<
+            ckl::reduce<
                 REDUCE_OP,
                 REDUCE_DIM,
                 dfb::im0,
                 dfb::scaler,
                 dfb::out,
-                compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-                compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
-                compute_kernel_lib::ReduceInputBlockShape::single(),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::Accumulate::at(dfb::im1, block));
+                ckl::ReduceInputPolicy::WaitAndPopPerTile,
+                ckl::ReduceDataFormatReconfigMode::NONE>(
+                ckl::ReduceInputBlockShape::single(),
+                ckl::ReduceInputMemoryLayout::contiguous(),
+                ckl::Accumulate::at(dfb::im1, block));
         } else {
-            compute_kernel_lib::reduce<
+            ckl::reduce<
                 REDUCE_OP,
                 REDUCE_DIM,
                 dfb::im0,
                 dfb::scaler,
                 dfb::im1,
-                compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-                compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
-                compute_kernel_lib::ReduceInputBlockShape::single(),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::Accumulate::at(dfb::im1, block));
+                ckl::ReduceInputPolicy::WaitAndPopPerTile,
+                ckl::ReduceDataFormatReconfigMode::NONE>(
+                ckl::ReduceInputBlockShape::single(),
+                ckl::ReduceInputMemoryLayout::contiguous(),
+                ckl::Accumulate::at(dfb::im1, block));
         }
     }
-    // The reduce helper waits on the scaler DFB (scaler) each block but never pops it; the single
-    // scaler tile is reused across all blocks. Pop it once at the end to balance the DFB.
-    dfb_c2.pop_front(onetile);
+    // The reduce helper reuses the scaler tile for every block.
+    dfb_scaler.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
@@ -2,56 +2,56 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "api/compute/bcast.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
 void kernel_main() {
     constexpr int onetile = 1;
-    uint32_t has_input_grad = get_arg(args::has_input_grad);
-    uint32_t has_other_grad = get_arg(args::has_other_grad);
-    uint32_t per_core_block_cnt = get_arg(args::per_core_block_cnt);
+    const auto has_input_grad = get_arg(args::has_input_grad);
+    const auto has_other_grad = get_arg(args::has_other_grad);
+    const auto per_core_block_cnt = get_arg(args::per_core_block_cnt);
 
-    DataflowBuffer dfb_in0(dfb::in0);
-    DataflowBuffer dfb_in1(dfb::in1);
-    DataflowBuffer dfb_in2(dfb::in2);
-    DataflowBuffer dfb_out0(dfb::out0);
-    DataflowBuffer dfb_out1(dfb::out1);
+    DataflowBuffer dfb_c0(dfb::in0);
 
     compute_kernel_hw_startup(dfb::in2, dfb::in0, dfb::out0);
-    bcast_init<EltwiseBinaryType::ELWMUL, BroadcastType::SCALAR>(dfb::in2, dfb::in0);
-    dfb_in0.wait_front(onetile);
+    dfb_c0.wait_front(onetile);
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
         if (has_input_grad) {
-            dfb_in2.wait_front(onetile);
-
-            tile_regs_acquire();
-            mul_tiles_bcast<BroadcastType::SCALAR>(dfb::in2, dfb::in0, 0, 0, 0);
-            tile_regs_commit();
-
-            dfb_in2.pop_front(onetile);
-
-            tile_regs_wait();
-            pack_tile(0, dfb::out0);
-            tile_regs_release();
-
-            dfb_out0.push_back(onetile);
+            ckl::mul<
+                ckl::input(
+                    dfb::in2, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+                ckl::input(
+                    dfb::in0,
+                    ckl::BroadcastDim::Scalar,
+                    ckl::WaitPolicy::None,
+                    ckl::PopPolicy::None,
+                    ckl::DataFormatReconfig::Disabled),
+                ckl::output(
+                    dfb::out0,
+                    ckl::ReservePolicy::PerTile,
+                    ckl::PushPolicy::PerTile,
+                    ckl::DataFormatReconfig::Disabled)>(ckl::IterationShape::tiles(onetile));
         }
 
         if (has_other_grad) {
-            dfb_in1.wait_front(onetile);
-
-            tile_regs_acquire();
-            mul_tiles_bcast<BroadcastType::SCALAR>(dfb::in1, dfb::in0, 0, 0, 0);
-            tile_regs_commit();
-
-            dfb_in1.pop_front(onetile);
-
-            tile_regs_wait();
-            pack_tile(0, dfb::out1);
-            tile_regs_release();
-
-            dfb_out1.push_back(onetile);
+            ckl::mul<
+                ckl::input(
+                    dfb::in1, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+                ckl::input(
+                    dfb::in0,
+                    ckl::BroadcastDim::Scalar,
+                    ckl::WaitPolicy::None,
+                    ckl::PopPolicy::None,
+                    ckl::DataFormatReconfig::Disabled),
+                ckl::output(
+                    dfb::out1,
+                    ckl::ReservePolicy::PerTile,
+                    ckl::PushPolicy::PerTile,
+                    ckl::DataFormatReconfig::Disabled)>(ckl::IterationShape::tiles(onetile));
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
@@ -9,21 +9,22 @@
 #include "api/compute/reduce.h"
 #include "api/compute/tile_move_copy.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Mask
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
 void kernel_main() {
-    uint32_t Ht = get_arg(args::Ht);
-    // Carries the per-core work-split count (the host's units_per_core_group_N), not a tile width.
-    uint32_t Wt = get_arg(args::units_per_core);
-    uint32_t NC = get_arg(args::NC);
+    const auto Ht = get_arg(args::Ht);
+    const auto Wt = get_arg(args::units_per_core);  // Per-core output-column count, not tile width.
+    const auto NC = get_arg(args::NC);
     constexpr uint32_t origin_H = get_arg(args::origin_H);
 
-    DataflowBuffer dfb_input_obj(dfb::input);
     DataflowBuffer dfb_scaler_obj(dfb::scaler);
     DataflowBuffer dfb_mask_h_obj(dfb::mask_h);
-    DataflowBuffer dfb_masked_input_obj(dfb::masked_input);
     constexpr bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
 
     compute_kernel_hw_startup(dfb::input, dfb::input, dfb::out);
@@ -31,8 +32,6 @@ void kernel_main() {
     dfb_scaler_obj.wait_front(1);  // scaler tile from the reader
 
     constexpr int onetile = 1;
-    int reduce_dst_idx = 0;
-    const uint32_t mask_dst_idx = reduce_dst_idx + 1;
 
     if constexpr (do_mask_h) {
         dfb_mask_h_obj.wait_front(onetile);
@@ -47,45 +46,32 @@ void kernel_main() {
 
             // Phase 1: Reduce Ht-1 tiles into accumulator (if Ht > 1)
             if (!is_h_single_tile) {
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, dfb::input, dfb::scaler, dfb::accum_dst>(
-                    compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
+                ckl::reduce<REDUCE_OP, REDUCE_DIM, dfb::input, dfb::scaler, dfb::accum_dst>(
+                    ckl::ReduceInputBlockShape::col(Ht - 1));
             }
 
             // Optional masking of last H tile
             if constexpr (do_mask_h) {
-                tile_regs_acquire();
-                dfb_input_obj.wait_front(onetile);
-                copy_tile_init_with_dt(dfb_input_obj);
-                copy_tile(dfb::input, 0, reduce_dst_idx);
-
-                copy_tile_init_with_dt(dfb_mask_h_obj);
-                copy_tile(dfb::mask_h, 0, mask_dst_idx);
-
-                mask_tile_init();
-                mask_tile(reduce_dst_idx, mask_dst_idx);
-                tile_regs_commit();
-
-                dfb_masked_input_obj.reserve_back(onetile);
-                tile_regs_wait();
-                pack_tile_with_dt(reduce_dst_idx, dfb_masked_input_obj);
-                tile_regs_release();
-                dfb_masked_input_obj.push_back(onetile);
-
-                dfb_input_obj.pop_front(onetile);
+                ckl::eltwise_chain(
+                    ckl::IterationShape::tiles(onetile),
+                    ckl::CopyTile<ckl::input(dfb::input)>{},
+                    ckl::CopyTile<ckl::input(dfb::mask_h, ckl::WaitPolicy::None, ckl::PopPolicy::None), ckl::Dst::D1>{},
+                    ckl::Mask<DataFormat::Float16_b, ckl::Dst::D0>{},
+                    ckl::PackTile<ckl::output(dfb::masked_input)>{});
 
                 // Phase 2 with masked input: Reduce final masked tile with accumulation
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, dfb::masked_input, dfb::scaler, dfb::out>(
-                    compute_kernel_lib::ReduceInputBlockShape::single(),
-                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                    compute_kernel_lib::Accumulate::at(dfb::accum_dst, is_h_single_tile ? 0 : 1));
+                ckl::reduce<REDUCE_OP, REDUCE_DIM, dfb::masked_input, dfb::scaler, dfb::out>(
+                    ckl::ReduceInputBlockShape::single(),
+                    ckl::ReduceInputMemoryLayout::contiguous(),
+                    ckl::Accumulate::at(dfb::accum_dst, is_h_single_tile ? 0 : 1));
             } else {
                 // Phase 2 without masking: Reduce final tile with accumulation
                 // - If Ht == 1 (single tile): iteration=0, no accumulator reload
-                // - If Ht > 1 (multi-tile): iteration=1, reload accumulator from the accum_dst DFB
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, dfb::input, dfb::scaler, dfb::out>(
-                    compute_kernel_lib::ReduceInputBlockShape::single(),
-                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                    compute_kernel_lib::Accumulate::at(dfb::accum_dst, is_h_single_tile ? 0 : 1));
+                // - If Ht > 1 (multi-tile): iteration=1, reload accumulator from dfb::accum_dst
+                ckl::reduce<REDUCE_OP, REDUCE_DIM, dfb::input, dfb::scaler, dfb::out>(
+                    ckl::ReduceInputBlockShape::single(),
+                    ckl::ReduceInputMemoryLayout::contiguous(),
+                    ckl::Accumulate::at(dfb::accum_dst, is_h_single_tile ? 0 : 1));
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_nc.cpp
@@ -10,20 +10,18 @@
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     const auto num_input_tiles = get_arg(args::num_input_tiles);
     const auto num_output_tiles = get_arg(args::num_output_tiles);
 
-    DataflowBuffer dfb_in0_obj(dfb::input);
     DataflowBuffer dfb_in1_obj(dfb::in1);
     DataflowBuffer dfb_scalar_obj(dfb::scalar);
-    DataflowBuffer dfb_out0_obj(dfb::out);
-    DataflowBuffer dfb_intermed0_obj(dfb::intermed0);
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t dst1 = 1;
-    constexpr uint32_t first_tile = 0;
 
     compute_kernel_hw_startup(dfb::input, dfb::in1, dfb::out);
 
@@ -33,45 +31,23 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_output_tiles; i++) {
         bool enable_reload = false;
         for (uint32_t j = 0; j < num_input_tiles; ++j) {
-            bool last_out = (j == num_input_tiles - 1);
-
-            tile_regs_acquire();
-            dfb_in0_obj.wait_front(onetile);
             if (enable_reload) {
-                dfb_intermed0_obj.wait_front(onetile);
+                ckl::add<ckl::input(dfb::input), ckl::input(dfb::intermed0), ckl::output(dfb::intermed0)>(
+                    ckl::IterationShape::tiles(onetile));
+            } else {
+                ckl::add<
+                    ckl::input(dfb::input),
+                    ckl::input(dfb::in1, ckl::WaitPolicy::None, ckl::PopPolicy::None),
+                    ckl::output(dfb::intermed0)>(ckl::IterationShape::tiles(onetile));
             }
-
-            uint32_t cb_add = (enable_reload) ? (dfb::intermed0) : (dfb::in1);
-            add_tiles_init_with_dt(dfb_in0_obj, DataflowBuffer(cb_add));
-            add_tiles(dfb::input, cb_add, first_tile, first_tile, dst0);
-
-            dfb_in0_obj.pop_front(onetile);
-            if (enable_reload) {
-                dfb_intermed0_obj.pop_front(onetile);
-            }
-            tile_regs_commit();
-
-            dfb_intermed0_obj.reserve_back(onetile);
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_intermed0_obj);
-            tile_regs_release();
-            dfb_intermed0_obj.push_back(onetile);
 
             enable_reload = true;
         }
 
         // output * (1 / number_of_elements)
-        tile_regs_acquire();
-        dfb_intermed0_obj.wait_front(onetile);
-        mul_bcast_scalar_init_with_dt(dfb_intermed0_obj, dfb_scalar_obj);
-        mul_tiles_bcast<BroadcastType::SCALAR>(dfb::intermed0, dfb::scalar, 0, 0, 0);
-        tile_regs_commit();
-
-        dfb_out0_obj.reserve_back(onetile);
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_out0_obj);
-        tile_regs_release();
-        dfb_out0_obj.push_back(onetile);
-        dfb_intermed0_obj.pop_front(onetile);
+        ckl::mul<
+            ckl::input(dfb::intermed0),
+            ckl::input(dfb::scalar, ckl::BroadcastDim::Scalar, ckl::WaitPolicy::None, ckl::PopPolicy::None),
+            ckl::output(dfb::out)>(ckl::IterationShape::tiles(onetile));
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_w.cpp
@@ -12,54 +12,64 @@
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Mask
+
+namespace ckl = compute_kernel_lib;
+
+#if defined(FP32_DEST_ACC_EN)
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Enabled;
+#else
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Disabled;
+#endif
 
 void kernel_main() {
-    // Carries the per-core work-split count (the host's units_per_core_group_N), not a tile height.
-    uint32_t Ht = get_arg(args::units_per_core);
-    uint32_t Wt = get_arg(args::Wt);
-    uint32_t NC = get_arg(args::NC);
+    constexpr uint32_t Ht = get_arg(args::units_per_core);  // Per-core output-row count, not tile height.
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr uint32_t NC = get_arg(args::NC);
     constexpr uint32_t origin_W = get_arg(args::origin_W);
 
-    // Selected at runtime between the input DFB and the masked-input DFB; stays uint32_t-valued so the
-    // reassignment below is legal (DFBAccessor converts to uint32_t at compile time).
-    uint32_t cb_input = dfb::input;
+    // This switches between two named DFBs below, so keep the resolved index rather than
+    // the accessor type inferred by auto.
+    uint32_t dfb_input_id = dfb::input;
+    DataflowBuffer dfb_input_obj(dfb::input);
     DataflowBuffer dfb_scaler_obj(dfb::scaler);
     DataflowBuffer dfb_mask_w_obj(dfb::mask_w);
     DataflowBuffer dfb_accum_dst_obj(dfb::accum_dst);
     DataflowBuffer dfb_masked_input_obj(dfb::masked_input);
     DataflowBuffer dfb_out_obj(dfb::out);
     constexpr bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
+    constexpr bool is_w_single_tile = Wt == 1;
+    DataflowBuffer& dfb_reduction_input_obj = do_mask_w ? dfb_masked_input_obj : dfb_input_obj;
 
-    compute_kernel_hw_startup(cb_input, cb_input, dfb::out);
+    compute_kernel_hw_startup(dfb_input_id, dfb_input_id, dfb::out);
 
     dfb_scaler_obj.wait_front(1);  // scaler tile from the reader
 
     constexpr int onetile = 1;
     int reduce_dst_idx = 0;
-    const uint32_t mask_dst_idx = reduce_dst_idx + 1;
 
-    if (do_mask_w) {
+    if constexpr (do_mask_w) {
         dfb_mask_w_obj.wait_front(onetile);
     }
 
     for (uint32_t nc = 0; nc < NC; nc++) {
+        // Input is W-contiguous; each output tile reduces one row of W tiles.
+        // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
+        // in this case we just sequentially add to accumulator all the W-tiles in a row
         for (uint32_t ht = 0; ht < Ht; ++ht) {
-            // tiles are expected to be coming in in NCHW order (W-contiguous)
-            // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
-            // in this case we just sequentially add to accumulator all the W-tiles in a row
-            cb_input = dfb::input;
-            bool is_w_single_tile = (Wt == 1);
-            if (!is_w_single_tile) {
+            dfb_input_id = dfb::input;
+            if constexpr (!is_w_single_tile) {
                 tile_regs_acquire();
 
                 for (uint32_t wt = 0; wt < Wt - 1; ++wt) {
-                    DataflowBuffer(cb_input).wait_front(onetile);
+                    dfb_input_obj.wait_front(onetile);
 #if defined FP32_DEST_ACC_EN
-                    reconfig_data_format(cb_input, dfb::scaler);
+                    reconfig_data_format(dfb_input_id, dfb::scaler);
 #endif
-                    matmul_init(cb_input, dfb::scaler, false);
-                    matmul_tiles(cb_input, dfb::scaler, 0, 0, reduce_dst_idx);
-                    DataflowBuffer(cb_input).pop_front(onetile);
+                    matmul_init(dfb_input_id, dfb::scaler, false);
+                    matmul_tiles(dfb_input_id, dfb::scaler, 0, 0, reduce_dst_idx);
+                    dfb_input_obj.pop_front(onetile);
                 }
                 tile_regs_commit();
 
@@ -70,44 +80,36 @@ void kernel_main() {
                 dfb_accum_dst_obj.push_back(onetile);
             }
 
-            if (do_mask_w) {
-                tile_regs_acquire();
-                DataflowBuffer(cb_input).wait_front(onetile);
-
-                copy_tile_init_with_dt(DataflowBuffer(cb_input));
-                copy_tile(cb_input, 0, reduce_dst_idx);
-
-                copy_tile_init_with_dt(dfb_mask_w_obj);
-                copy_tile(dfb::mask_w, 0, mask_dst_idx);
-
-                mask_tile_init();
-                mask_tile(reduce_dst_idx, mask_dst_idx);
-                tile_regs_commit();
-
-                dfb_masked_input_obj.reserve_back(onetile);
-                tile_regs_wait();
-                pack_tile_with_dt(reduce_dst_idx, dfb_masked_input_obj);
-                tile_regs_release();
-                dfb_masked_input_obj.push_back(onetile);
-
-                DataflowBuffer(cb_input).pop_front(onetile);
-                cb_input = dfb::masked_input;
+            if constexpr (do_mask_w) {
+                ckl::eltwise_chain(
+                    ckl::IterationShape::tiles(onetile),
+                    ckl::CopyTile<ckl::input(
+                        dfb::input, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig)>{},
+                    ckl::CopyTile<
+                        ckl::input(dfb::mask_w, ckl::WaitPolicy::None, ckl::PopPolicy::None, kDataFormatReconfig),
+                        ckl::Dst::D1>{},
+                    ckl::Mask<DataFormat::Float16_b, ckl::Dst::D0>{},
+                    ckl::PackTile<ckl::output(
+                        dfb::masked_input,
+                        ckl::ReservePolicy::PerTile,
+                        ckl::PushPolicy::PerTile,
+                        kDataFormatReconfig)>{});
+                dfb_input_id = dfb::masked_input;
             }
 
             tile_regs_acquire();
-            DataflowBuffer(cb_input).wait_front(onetile);
-            if (!is_w_single_tile) {
+            dfb_reduction_input_obj.wait_front(onetile);
+            if constexpr (!is_w_single_tile) {
                 dfb_accum_dst_obj.wait_front(onetile);
-
                 copy_tile_init_with_dt(dfb_accum_dst_obj);
                 copy_tile(dfb::accum_dst, 0, reduce_dst_idx);
             }
 
 #if defined FP32_DEST_ACC_EN
-            reconfig_data_format(cb_input, dfb::scaler);
+            reconfig_data_format(dfb_input_id, dfb::scaler);
 #endif
-            matmul_init(cb_input, dfb::scaler, false);
-            matmul_tiles(cb_input, dfb::scaler, 0, 0, reduce_dst_idx);
+            matmul_init(dfb_input_id, dfb::scaler, false);
+            matmul_tiles(dfb_input_id, dfb::scaler, 0, 0, reduce_dst_idx);
             tile_regs_commit();
 
             dfb_out_obj.reserve_back(onetile);
@@ -116,14 +118,14 @@ void kernel_main() {
             tile_regs_release();
             dfb_out_obj.push_back(onetile);
 
-            DataflowBuffer(cb_input).pop_front(onetile);
-            if (!is_w_single_tile) {
+            dfb_reduction_input_obj.pop_front(onetile);
+            if constexpr (!is_w_single_tile) {
                 dfb_accum_dst_obj.pop_front(onetile);
             }
         }
     }
 
-    if (do_mask_w) {
+    if constexpr (do_mask_w) {
         dfb_mask_w_obj.pop_front(onetile);
     }
     dfb_scaler_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/moreh_mean_backward.cpp
@@ -10,6 +10,11 @@
 #include "api/compute/tile_move_copy.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     // compile-time args
@@ -17,58 +22,36 @@ void kernel_main() {
     constexpr bool wt_need_bcast = (get_arg(args::wt_need_bcast) == 1);
     constexpr bool ht_need_bcast = (get_arg(args::ht_need_bcast) == 1);
 
-    DataflowBuffer dfb_in0_obj(dfb::in);         // input
-    DataflowBuffer dfb_in1_obj(dfb::zero);       // zero tile
-    DataflowBuffer dfb_scalar_obj(dfb::scalar);  // 1/num_dim bcast scalar
-    DataflowBuffer dfb_out0_obj(dfb::out);       // output
-    DataflowBuffer dfb_intermed0_obj(dfb::intermed);
+    DataflowBuffer dfb_zero_obj(dfb::zero);  // zero tile
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
 
     compute_kernel_hw_startup(dfb::in, dfb::zero, dfb::out);
-    dfb_in1_obj.wait_front(onetile);
+    dfb_zero_obj.wait_front(onetile);
+
+    constexpr bool has_bcast = ht_need_bcast || wt_need_bcast;
+    constexpr auto bcast_dim = (ht_need_bcast && wt_need_bcast) ? ckl::BroadcastDim::Scalar
+                               : ht_need_bcast                  ? ckl::BroadcastDim::Row
+                               : wt_need_bcast                  ? ckl::BroadcastDim::Col
+                                                                : ckl::BroadcastDim::None;
+
     for (uint32_t i = 0; i < num_output_tiles; i++) {
-        tile_regs_acquire();
-        dfb_in0_obj.wait_front(onetile);
-        if (ht_need_bcast && wt_need_bcast) {
-            add_bcast_scalar_init_with_dt(dfb_in1_obj, dfb_in0_obj);
-            add_tiles_bcast_scalar(dfb::zero, dfb::in, 0, 0, dst0);
-        } else if (ht_need_bcast) {
-            add_bcast_rows_init_with_dt(dfb_in1_obj, dfb_in0_obj);
-            add_tiles_bcast_rows(dfb::zero, dfb::in, 0, 0, dst0);
-        } else if (wt_need_bcast) {
-            add_bcast_cols_init_with_dt(dfb_in1_obj, dfb_in0_obj);
-            add_tiles_bcast_cols(dfb::zero, dfb::in, 0, 0, dst0);
-        } else {
-            copy_tile_init_with_dt(dfb_in0_obj);
-            copy_tile(dfb::in, 0, dst0);
-        }
-        tile_regs_commit();
-
-        dfb_intermed0_obj.reserve_back(onetile);
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_intermed0_obj);
-        tile_regs_release();
-
-        dfb_intermed0_obj.push_back(onetile);
-        dfb_in0_obj.pop_front(onetile);
+        ckl::eltwise_chain(
+            ckl::IterationShape::tiles(onetile),
+            ckl::Optional<
+                has_bcast,
+                ckl::BinaryFpu<
+                    ckl::BinaryFpuOp::Add,
+                    ckl::input(dfb::zero, ckl::WaitPolicy::None, ckl::PopPolicy::None),
+                    ckl::input(dfb::in, bcast_dim)>>{},
+            ckl::Optional<!has_bcast, ckl::CopyTile<ckl::input(dfb::in)>>{},
+            ckl::PackTile<ckl::output(dfb::intermed)>{});
 
         // output * (1 / number_of_elements)
-        tile_regs_acquire();
-        dfb_intermed0_obj.wait_front(onetile);
-        mul_bcast_scalar_init_with_dt(dfb_intermed0_obj, dfb_scalar_obj);
-        mul_tiles_bcast<BroadcastType::SCALAR>(dfb::intermed, dfb::scalar, 0, 0, 0);
-        tile_regs_commit();
-
-        dfb_out0_obj.reserve_back(onetile);
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_out0_obj);
-        tile_regs_release();
-
-        dfb_out0_obj.push_back(onetile);
-        dfb_intermed0_obj.pop_front(onetile);
+        ckl::mul<
+            ckl::input(dfb::intermed),
+            // 1/num_dim bcast scalar
+            ckl::input(dfb::scalar, ckl::BroadcastDim::Scalar, ckl::WaitPolicy::None, ckl::PopPolicy::None),
+            ckl::output(dfb::out)>(ckl::IterationShape::tiles(onetile));
     }
-    dfb_in1_obj.pop_front(onetile);
+    dfb_zero_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/moreh_nll_loss_step2_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/moreh_nll_loss_step2_kernel.cpp
@@ -7,144 +7,122 @@
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     constexpr auto per_core_tile_cnt = get_arg(args::per_core_tile_cnt);
+    using D = ckl::Dst;
 
-    DataflowBuffer dfb_tmp_weight_obj(dfb::tmp_weight);
-    DataflowBuffer dfb_tmp_input_obj(dfb::tmp_input);
-    DataflowBuffer dfb_tmp1_obj(dfb::tmp1);
-    DataflowBuffer dfb_divisor_recip_obj(dfb::divisor_recip);  // 1/divisor
-    DataflowBuffer dfb_tmp3_obj(dfb::tmp3);
+#if defined(WEIGHT)
+    constexpr bool has_weight = true;
+#else
+    constexpr bool has_weight = false;
+#endif
 
-    DataflowBuffer dfb_output_obj(dfb::output);
-
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t onetile = 1;
+#if defined(DIVISOR)
+    constexpr bool has_divisor = true;
+#else
+    constexpr bool has_divisor = false;
+#endif
 
     compute_kernel_hw_startup(dfb::tmp_weight, dfb::tmp_input, dfb::output);
 
+    // `dfb::divisor` is not declared at all in the sum-reduction program.  This
+    // must be a preprocessor guard rather than `if constexpr`: non-dependent
+    // DFB token names are resolved before the discarded branch is eliminated.
 #if defined(DIVISOR)
-    // The divisor buffer only exists when a divisor tensor was supplied, so both the accessor and
-    // everything that touches it are gated on the same condition as the host-side binding.
-    DataflowBuffer dfb_divisor_obj(dfb::divisor);
-
-    dfb_divisor_obj.wait_front(onetile);
-
-    tile_regs_acquire();
-    copy_tile_init_with_dt(dfb_divisor_obj);
-    copy_tile(dfb::divisor, 0, dst0);
-    recip_tile_init();
-    recip_tile(dst0);
-    tile_regs_commit();
-
-    dfb_divisor_obj.pop_front(onetile);
-    dfb_divisor_recip_obj.reserve_back(onetile);
-    tile_regs_wait();
-    pack_tile_with_dt(dst0, dfb_divisor_recip_obj);
-    tile_regs_release();
-    dfb_divisor_recip_obj.push_back(onetile);
+    {
+        ckl::unary<
+            ckl::Recip<D::D0>,
+            ckl::input(
+                dfb::divisor, ckl::WaitPolicy::Upfront, ckl::PopPolicy::AtEnd, ckernel::moreh_data_format_reconfig),
+            ckl::output(
+                dfb::divisor_recip,
+                ckl::ReservePolicy::PerTile,
+                ckl::PushPolicy::PerTile,
+                ckernel::moreh_data_format_reconfig)>(ckl::IterationShape::one_tile());
+    }
 #endif
 
-    for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
-        dfb_tmp_input_obj.wait_front(onetile);
-
-        tile_regs_acquire();
-        copy_tile_init_with_dt(dfb_tmp_input_obj);
-        copy_tile(dfb::tmp_input, 0, dst0);
-
-        negative_tile_init();
-        negative_tile(dst0);
-        tile_regs_commit();
-
-        dfb_tmp_input_obj.pop_front(onetile);
-
-#if defined(WEIGHT)
-        dfb_tmp1_obj.reserve_back(onetile);
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_tmp1_obj);
-        tile_regs_release();
-        dfb_tmp1_obj.push_back(onetile);
-
-        // multiply weight
-        dfb_tmp1_obj.wait_front(onetile);
-        dfb_tmp_weight_obj.wait_front(onetile);
-
-        tile_regs_acquire();
-        mul_tiles_init_with_dt(dfb_tmp1_obj, dfb_tmp_weight_obj);
-        mul_tiles(dfb::tmp1, dfb::tmp_weight, 0, 0, dst0);
-        tile_regs_commit();
-
-        dfb_tmp_weight_obj.pop_front(onetile);
-        dfb_tmp1_obj.pop_front(onetile);
-
-#if defined(DIVISOR)
-        dfb_tmp3_obj.reserve_back(onetile);
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_tmp3_obj);
-        tile_regs_release();
-        dfb_tmp3_obj.push_back(onetile);
-
-        dfb_tmp3_obj.wait_front(onetile);
-        dfb_divisor_recip_obj.wait_front(onetile);
-        tile_regs_acquire();
-#if defined FP32_DEST_ACC_EN
-        reconfig_data_format(dfb::tmp3, dfb::divisor_recip);
-#endif
-        mul_bcast_scalar_init(dfb::tmp3, dfb::divisor_recip);
-        mul_tiles_bcast_scalar(dfb::tmp3, dfb::divisor_recip, 0, 0, dst0);
-        tile_regs_commit();
-        dfb_tmp3_obj.pop_front(onetile);
-
-        dfb_output_obj.reserve_back(onetile);
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_output_obj);
-        tile_regs_release();
-        dfb_output_obj.push_back(onetile);
-#else
-        dfb_output_obj.reserve_back(onetile);
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_output_obj);
-        tile_regs_release();
-        dfb_output_obj.push_back(onetile);
-#endif
-#else
-#if defined(DIVISOR)
-        dfb_tmp1_obj.reserve_back(onetile);
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_tmp1_obj);
-        tile_regs_release();
-        dfb_tmp1_obj.push_back(onetile);
-
-        dfb_divisor_recip_obj.wait_front(onetile);
-        dfb_tmp1_obj.wait_front(onetile);
-
-        tile_regs_acquire();
-#if defined FP32_DEST_ACC_EN
-        reconfig_data_format(dfb::tmp1, dfb::divisor_recip);
-#endif
-        mul_bcast_scalar_init(dfb::tmp1, dfb::divisor_recip);
-        mul_tiles_bcast_scalar(dfb::tmp1, dfb::divisor_recip, 0, 0, dst0);
-        tile_regs_commit();
-
-        dfb_tmp1_obj.pop_front(onetile);
-
-        dfb_output_obj.reserve_back(onetile);
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_output_obj);
-        tile_regs_release();
-        dfb_output_obj.push_back(onetile);
-#else
-        dfb_output_obj.reserve_back(onetile);
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_output_obj);
-        tile_regs_release();
-        dfb_output_obj.push_back(onetile);
-#endif
-#endif
+    // Keep the current algorithm's operation order: negate, then apply the optional weight,
+    // then the scalar reciprocal. Re-associating these products changes low-precision rounding.
+    if constexpr (has_weight || has_divisor) {
+        ckl::eltwise_chain(
+            ckl::IterationShape::tiles(per_core_tile_cnt),
+            ckl::CopyTile<ckl::input(
+                dfb::tmp_input,
+                ckl::WaitPolicy::PerTile,
+                ckl::PopPolicy::PerTile,
+                ckernel::moreh_data_format_reconfig)>{},
+            ckl::Negative<D::D0>{},
+            ckl::PackTile<ckl::output(
+                dfb::tmp1,
+                ckl::ReservePolicy::PerTile,
+                ckl::PushPolicy::PerTile,
+                ckernel::moreh_data_format_reconfig)>{});
     }
 
-#if defined(DIVISOR)
-    dfb_divisor_recip_obj.pop_front(onetile);
-#endif
+    if constexpr (has_weight) {
+        ckl::eltwise_chain(
+            ckl::IterationShape::tiles(per_core_tile_cnt),
+            ckl::BinaryFpu<
+                ckl::BinaryFpuOp::Mul,
+                ckl::input(
+                    dfb::tmp1, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckernel::moreh_data_format_reconfig),
+                ckl::input(
+                    dfb::tmp_weight,
+                    ckl::BroadcastDim::None,
+                    ckl::WaitPolicy::PerTile,
+                    ckl::PopPolicy::PerTile,
+                    ckl::InputTileMapping::Scalar,
+                    ckernel::moreh_data_format_reconfig)>{},
+            ckl::PackTile<ckl::output(
+                has_divisor ? dfb::tmp3 : dfb::output,
+                ckl::ReservePolicy::PerTile,
+                ckl::PushPolicy::PerTile,
+                ckernel::moreh_data_format_reconfig)>{});
+    }
+
+    if constexpr (has_divisor) {
+        ckl::eltwise_chain(
+            ckl::IterationShape::tiles(per_core_tile_cnt),
+            ckl::BinaryFpu<
+                ckl::BinaryFpuOp::Mul,
+                ckl::input(
+                    has_weight ? dfb::tmp3 : dfb::tmp1,
+                    ckl::WaitPolicy::PerTile,
+                    ckl::PopPolicy::PerTile,
+                    ckernel::moreh_data_format_reconfig),
+                ckl::input(
+                    dfb::divisor_recip,
+                    ckl::BroadcastDim::Scalar,
+                    ckl::WaitPolicy::Upfront,
+                    ckl::PopPolicy::AtEnd,
+                    ckl::InputTileMapping::Scalar,
+                    ckernel::moreh_data_format_reconfig)>{},
+            ckl::PackTile<ckl::output(
+                dfb::output,
+                ckl::ReservePolicy::PerTile,
+                ckl::PushPolicy::PerTile,
+                ckernel::moreh_data_format_reconfig)>{});
+    }
+
+    if constexpr (!has_weight && !has_divisor) {
+        ckl::eltwise_chain(
+            ckl::IterationShape::tiles(per_core_tile_cnt),
+            ckl::CopyTile<ckl::input(
+                dfb::tmp_input,
+                ckl::WaitPolicy::PerTile,
+                ckl::PopPolicy::PerTile,
+                ckernel::moreh_data_format_reconfig)>{},
+            ckl::Negative<D::D0>{},
+            ckl::PackTile<ckl::output(
+                dfb::output,
+                ckl::ReservePolicy::PerTile,
+                ckl::PushPolicy::PerTile,
+                ckernel::moreh_data_format_reconfig)>{});
+    }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/moreh_nll_loss_backward_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/moreh_nll_loss_backward_kernel.cpp
@@ -5,108 +5,103 @@
 #include <cstdint>
 
 #include "ttnn/kernel/compute/moreh_common.hpp"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     constexpr auto per_core_tile_cnt = get_arg(args::per_core_tile_cnt);
+    using D = ckl::Dst;
 
-#if defined(DIVISOR)
-    DataflowBuffer dfb_divisor_obj(dfb::divisor);
-#endif
     DataflowBuffer dfb_output_grad_obj(dfb::output_grad);
-    DataflowBuffer dfb_tmp_weight_obj(dfb::tmp_weight);
-#if defined(DIVISOR)
+#ifdef DIVISOR
+    // These buffers are bound only for the divisor variant; keep their names out of the other variant.
     DataflowBuffer dfb_tmp1_obj(dfb::tmp1);
-    DataflowBuffer dfb_tmp2_obj(dfb::tmp2);
-#endif
-    DataflowBuffer dfb_input_grad_obj(dfb::input_grad);
 
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t onetile = 1;
+    compute_kernel_hw_startup(dfb::divisor, dfb::tmp1);
+    ckl::unary<
+        ckl::Recip<D::D0>,
+        ckl::input(dfb::divisor, ckl::WaitPolicy::Upfront, ckl::PopPolicy::AtEnd, ckernel::moreh_data_format_reconfig),
+        ckl::output(
+            dfb::tmp1, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, ckernel::moreh_data_format_reconfig)>(
+        ckl::IterationShape::one_tile());
 
-    compute_kernel_hw_startup(dfb::output_grad, dfb::input_grad);
-
-#if defined(DIVISOR)
-    dfb_divisor_obj.wait_front(onetile);
-    dfb_tmp1_obj.reserve_back(onetile);
-
-    tile_regs_acquire();
-    copy_tile_init_with_dt(dfb_divisor_obj);
-    copy_tile(dfb::divisor, 0, dst0);
-    recip_tile_init();
-    recip_tile(dst0);
-    tile_regs_commit();
-
-    tile_regs_wait();
-    pack_tile_with_dt(dst0, dfb_tmp1_obj);
-    tile_regs_release();
-
-    dfb_tmp1_obj.push_back(onetile);
-#endif
-
-    dfb_output_grad_obj.wait_front(onetile);
-
+    dfb_tmp1_obj.wait_front(1);
+    dfb_output_grad_obj.wait_front(1);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
-#if defined(DIVISOR)
-        dfb_tmp_weight_obj.wait_front(onetile);
-        dfb_tmp2_obj.reserve_back(onetile);
-
-        tile_regs_acquire();
-        mul_bcast_scalar_init_with_dt(dfb_tmp_weight_obj, dfb_output_grad_obj);
-        mul_tiles_bcast_scalar(dfb::tmp_weight, dfb::output_grad, 0, 0, dst0);
-        negative_tile_init();
-        negative_tile(dst0);
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_tmp2_obj);
-        tile_regs_release();
-
-        dfb_tmp2_obj.push_back(onetile);
-        dfb_tmp_weight_obj.pop_front(onetile);
-
-        dfb_input_grad_obj.reserve_back(onetile);
-        dfb_tmp2_obj.wait_front(onetile);
-        dfb_tmp1_obj.wait_front(onetile);
-
-        tile_regs_acquire();
-        mul_bcast_scalar_init_with_dt(dfb_tmp2_obj, dfb_tmp1_obj);
-        mul_tiles_bcast_scalar(dfb::tmp2, dfb::tmp1, 0, 0, dst0);
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_input_grad_obj);
-        tile_regs_release();
-
-        dfb_input_grad_obj.push_back(onetile);
-        dfb_tmp2_obj.pop_front(onetile);
-
-#else
-        dfb_tmp_weight_obj.wait_front(onetile);
-
-        dfb_input_grad_obj.reserve_back(onetile);
-
-        tile_regs_acquire();
-        mul_bcast_scalar_init_with_dt(dfb_tmp_weight_obj, dfb_output_grad_obj);
-        mul_tiles_bcast_scalar(dfb::tmp_weight, dfb::output_grad, 0, 0, dst0);
-        negative_tile_init();
-        negative_tile(dst0);
-
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_input_grad_obj);
-        tile_regs_release();
-
-        dfb_input_grad_obj.push_back(onetile);
-
-        dfb_tmp_weight_obj.pop_front(onetile);
-#endif
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::BinaryFpu<
+                ckl::BinaryFpuOp::Mul,
+                ckl::input(
+                    dfb::tmp_weight,
+                    ckl::WaitPolicy::PerTile,
+                    ckl::PopPolicy::PerTile,
+                    ckernel::moreh_data_format_reconfig),
+                ckl::input(
+                    dfb::output_grad,
+                    ckl::BroadcastDim::Scalar,
+                    ckl::WaitPolicy::None,
+                    ckl::PopPolicy::None,
+                    ckl::InputTileMapping::Scalar,
+                    ckernel::moreh_data_format_reconfig)>{},
+            ckl::Negative<D::D0>{},
+            ckl::PackTile<ckl::output(
+                dfb::tmp2,
+                ckl::ReservePolicy::PerTile,
+                ckl::PushPolicy::PerTile,
+                ckernel::moreh_data_format_reconfig)>{});
+        ckl::mul<
+            ckl::input(
+                dfb::tmp2, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckernel::moreh_data_format_reconfig),
+            ckl::input(
+                dfb::tmp1,
+                ckl::BroadcastDim::Scalar,
+                ckl::WaitPolicy::None,
+                ckl::PopPolicy::None,
+                ckl::InputTileMapping::Scalar,
+                ckernel::moreh_data_format_reconfig),
+            ckl::output(
+                dfb::input_grad,
+                ckl::ReservePolicy::PerTile,
+                ckl::PushPolicy::PerTile,
+                ckernel::moreh_data_format_reconfig)>(ckl::IterationShape::one_tile());
     }
+    dfb_output_grad_obj.pop_front(1);
+    dfb_tmp1_obj.pop_front(1);
+#else
+    compute_kernel_hw_startup(dfb::tmp_weight, dfb::output_grad, dfb::input_grad);
 
-#if defined(DIVISOR)
-    dfb_divisor_obj.pop_front(onetile);
+    dfb_output_grad_obj.wait_front(1);
+    for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::BinaryFpu<
+                ckl::BinaryFpuOp::Mul,
+                ckl::input(
+                    dfb::tmp_weight,
+                    ckl::WaitPolicy::PerTile,
+                    ckl::PopPolicy::PerTile,
+                    ckernel::moreh_data_format_reconfig),
+                ckl::input(
+                    dfb::output_grad,
+                    ckl::BroadcastDim::Scalar,
+                    ckl::WaitPolicy::None,
+                    ckl::PopPolicy::None,
+                    ckl::InputTileMapping::Scalar,
+                    ckernel::moreh_data_format_reconfig)>{},
+            ckl::Negative<D::D0>{},
+            ckl::PackTile<ckl::output(
+                dfb::input_grad,
+                ckl::ReservePolicy::PerTile,
+                ckl::PushPolicy::PerTile,
+                ckernel::moreh_data_format_reconfig)>{});
+    }
+    dfb_output_grad_obj.pop_front(1);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -3,8 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"  // PowerIterative, Recip, Log, Exp
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Mask, Abs
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
+
+namespace ckl = compute_kernel_lib;
+
+#if defined(FP32_DEST_ACC_EN)
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Enabled;
+#else
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Disabled;
+#endif
+
+ALWI bool need_to_do_mask_h(uint32_t row_idx, uint32_t Ht) { return (row_idx + 1) % Ht == 0; }
 
 void kernel_main() {
     int i{0};
@@ -16,49 +31,35 @@ void kernel_main() {
     const auto recip_p = get_arg_val<uint32_t>(i++);
     const bool recip_p_is_negative = get_arg_val<uint32_t>(i++) == 1;
 
-    std::uint8_t input_id{tt::CBIndex::c_0};
-    const auto cb_x = input_id++;
-    DataflowBuffer dfb_x_obj(cb_x);  // input
-    const auto cb_one = input_id++;
-    DataflowBuffer dfb_one_obj(cb_one);  // one
-    const auto cb_decimal = input_id++;
-    DataflowBuffer dfb_decimal_obj(cb_decimal);  // decimal
-    const auto cb_recip_p_decimal = input_id++;
-    DataflowBuffer dfb_recip_p_decimal_obj(cb_recip_p_decimal);  // recip_p_decimal
-    const auto cb_mask_h = input_id++;
-    DataflowBuffer dfb_mask_h_obj(cb_mask_h);  // mask_h
+    constexpr uint32_t dfb_x_id = tt::CBIndex::c_0;
+    constexpr uint32_t dfb_one_id = tt::CBIndex::c_1;
+    DataflowBuffer dfb_one_obj(dfb_one_id);
+    constexpr uint32_t dfb_decimal_id = tt::CBIndex::c_2;
+    DataflowBuffer dfb_decimal_obj(dfb_decimal_id);
+    constexpr uint32_t dfb_recip_p_decimal_id = tt::CBIndex::c_3;  // recip_p_decimal
+    DataflowBuffer dfb_recip_p_decimal_obj(dfb_recip_p_decimal_id);
+    constexpr uint32_t dfb_mask_h_id = tt::CBIndex::c_4;
+    DataflowBuffer dfb_mask_h_obj(dfb_mask_h_id);
 
-    std::uint8_t output_id{tt::CBIndex::c_16};
-    const auto cb_y = output_id++;  // output
-    DataflowBuffer dfb_y_obj(cb_y);
+    constexpr uint32_t dfb_y_id = tt::CBIndex::c_16;
 
-    std::uint8_t intermed_id{tt::CBIndex::c_24};
-    const auto cb_tmp0 = intermed_id++;
-    const auto cb_tmp1 = intermed_id++;
-    const auto cb_tmp2 = intermed_id++;
-    const auto cb_tmp3 = intermed_id++;
-    const auto cb_tmp4 = intermed_id++;
-    const auto cb_tmp5 = intermed_id++;
-    const auto cb_tmp6 = intermed_id++;
+    constexpr uint32_t dfb_tmp0_id = tt::CBIndex::c_24;
+    constexpr uint32_t dfb_tmp1_id = tt::CBIndex::c_25;
+    constexpr uint32_t dfb_tmp2_id = tt::CBIndex::c_26;
+    constexpr uint32_t dfb_tmp3_id = tt::CBIndex::c_27;
+    constexpr uint32_t dfb_tmp4_id = tt::CBIndex::c_28;
+    constexpr uint32_t dfb_tmp5_id = tt::CBIndex::c_29;
+    constexpr uint32_t dfb_tmp6_id = tt::CBIndex::c_30;
 
-    const auto cb_xabs = cb_tmp0;
-    DataflowBuffer dfb_xabs_obj(cb_xabs);  // |x|
-    const auto cb_xpow = cb_tmp1;          // |x|^p
-    DataflowBuffer dfb_xpow_obj(cb_xpow);
-    const auto cb_logx = cb_tmp2;          // log(|x|)
-    DataflowBuffer dfb_logx_obj(cb_logx);
-    const auto cb_exp_lxmd = cb_tmp3;      // exp(log(|x|) * decimal)
-    DataflowBuffer dfb_exp_lxmd_obj(cb_exp_lxmd);
-    const auto cb_correct_xpow = cb_tmp4;
-    DataflowBuffer dfb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
-    const auto cb_xpowadd = cb_tmp5;
-    DataflowBuffer dfb_xpowadd_obj(cb_xpowadd);  // Add(|x + decimal|^p)
-    const auto cb_xpowsum = cb_tmp6;       // Sum(|x + decimal|^p)
-    DataflowBuffer dfb_xpowsum_obj(cb_xpowsum);
+    constexpr uint32_t dfb_xabs_id = dfb_tmp0_id;          // |x|
+    constexpr uint32_t dfb_xpow_id = dfb_tmp1_id;          // |x|^p
+    constexpr uint32_t dfb_logx_id = dfb_tmp2_id;          // log(|x|)
+    constexpr uint32_t dfb_exp_lxmd_id = dfb_tmp3_id;      // exp(log(|x|) * decimal)
+    constexpr uint32_t dfb_correct_xpow_id = dfb_tmp4_id;  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
+    constexpr uint32_t dfb_xpowadd_id = dfb_tmp5_id;       // Add(|x + decimal|^p)
+    constexpr uint32_t dfb_xpowsum_id = dfb_tmp6_id;       // Sum(|x + decimal|^p)
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t dst1 = 1;
 
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
@@ -76,91 +77,42 @@ void kernel_main() {
 
     for (uint32_t col_idx = 0; col_idx < num_cols_per_core; ++col_idx) {
         for (uint32_t row_idx = 0; row_idx < Ht; ++row_idx) {
-            // |x|
-            tile_regs_acquire();
-            dfb_x_obj.wait_front(onetile);  // comes from the reader
-            dfb_xabs_obj.reserve_back(onetile);
+            const bool mask_this = do_mask_h && need_to_do_mask_h(row_idx, Ht);
+            ckl::eltwise_chain(
+                ckl::IterationShape::tiles(onetile),
+                ckl::CopyTile<ckl::input(
+                    dfb_x_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig)>{},
+                ckl::runtime_if(
+                    mask_this,
+                    ckl::CopyTile<
+                        ckl::input(dfb_mask_h_id, ckl::WaitPolicy::None, ckl::PopPolicy::None, kDataFormatReconfig),
+                        ckl::Dst::D1>{},
+                    ckl::Mask<DataFormat::Float16_b, ckl::Dst::D0>{}),
+                ckl::Abs<ckl::Dst::D0>{},
+                ckl::PackTile<ckl::output(
+                    dfb_xabs_id, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>{});
 
-            copy_tile_init_with_dt(dfb_x_obj);
-            copy_tile(cb_x, 0, dst0);
-
-            if (do_mask_h && (row_idx == Ht - 1)) {
-                copy_tile_init_with_dt(dfb_mask_h_obj);
-                copy_tile(cb_mask_h, 0, dst1);
-
-                mask_tile_init();
-                mask_tile(dst0, dst1);
-            }
-
-            abs_tile_init();
-            abs_tile(dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_xabs_obj);
-            tile_regs_release();
-
-            dfb_x_obj.pop_front(onetile);
-            dfb_xabs_obj.push_back(onetile);
-
-            power_tile_to_cb(
-                dfb_xabs_obj,
-                dfb_xpow_obj,
-                dfb_logx_obj,
-                dfb_decimal_obj,
-                dfb_exp_lxmd_obj,
-                dfb_correct_xpow_obj,
-                p,
-                p_is_negative);
+            power_tile_to_dfb<
+                dfb_xabs_id,
+                dfb_xpow_id,
+                dfb_logx_id,
+                dfb_decimal_id,
+                dfb_exp_lxmd_id,
+                dfb_correct_xpow_id>(p, p_is_negative);
 
             // Add(|x|^p)
             if (row_idx == 0) {
-                tile_regs_acquire();
-                dfb_correct_xpow_obj.wait_front(onetile);
-                dfb_xpowadd_obj.reserve_back(onetile);
-
-                copy_tile_init_with_dt(dfb_correct_xpow_obj);
-                copy_tile(cb_correct_xpow, 0, dst0);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
-                tile_regs_release();
-
-                dfb_correct_xpow_obj.pop_front(onetile);
-                dfb_xpowadd_obj.push_back(onetile);
+                copy_tile_to_dfb<dfb_correct_xpow_id, dfb_xpowadd_id>();
             } else {
-                tile_regs_acquire();
-                dfb_correct_xpow_obj.wait_front(onetile);
-                dfb_xpowadd_obj.wait_front(onetile);
-                dfb_xpowadd_obj.reserve_back(onetile);
-
-                add_tiles_init_with_dt(dfb_correct_xpow_obj, dfb_xpowadd_obj);
-                add_tiles(cb_correct_xpow, cb_xpowadd, 0, 0, dst0);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
-                tile_regs_release();
-
-                dfb_correct_xpow_obj.pop_front(onetile);
-                dfb_xpowadd_obj.pop_front(onetile);
-                dfb_xpowadd_obj.push_back(onetile);
+                add_tiles_to_dfb<dfb_correct_xpow_id, dfb_xpowadd_id, dfb_xpowadd_id>();
             }
         }
         // Sum(|x|^p) - reduce single pre-accumulated tile
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xpowadd, cb_one, cb_xpowsum>(
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, dfb_xpowadd_id, dfb_one_id, dfb_xpowsum_id>(
             compute_kernel_lib::ReduceInputBlockShape::single());
 
-        power_tile_to_cb(
-            dfb_xpowsum_obj,
-            dfb_xabs_obj,
-            dfb_xpow_obj,
-            dfb_recip_p_decimal_obj,
-            dfb_logx_obj,
-            dfb_y_obj,
-            recip_p,
-            recip_p_is_negative);
+        power_tile_to_dfb<dfb_xpowsum_id, dfb_xabs_id, dfb_xpow_id, dfb_recip_p_decimal_id, dfb_logx_id, dfb_y_id>(
+            recip_p, recip_p_is_negative);
     }
 
     dfb_one_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_other/kernels/moreh_norm_other_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_other/kernels/moreh_norm_other_kernel.cpp
@@ -2,8 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"  // PowerIterative, Recip, Log, Exp
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Abs
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
+
+namespace ckl = compute_kernel_lib;
+
+#if defined(FP32_DEST_ACC_EN)
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Enabled;
+#else
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Disabled;
+#endif
 
 void kernel_main() {
     int i{0};
@@ -14,44 +27,24 @@ void kernel_main() {
     const auto recip_p = get_arg_val<uint32_t>(i++);
     const bool recip_p_is_negative = get_arg_val<uint32_t>(i++) == 1;
 
-    std::uint8_t input_id{tt::CBIndex::c_0};
-    const auto cb_x = input_id++;
-    DataflowBuffer dfb_x_obj(cb_x);  // input
-    const auto cb_one = input_id++;
-    DataflowBuffer dfb_one_obj(cb_one);  // one
-    const auto cb_decimal = input_id++;
-    DataflowBuffer dfb_decimal_obj(cb_decimal);  // decimal
-    const auto cb_recip_p_decimal = input_id++;
-    DataflowBuffer dfb_recip_p_decimal_obj(cb_recip_p_decimal);  // recip_p_decimal
+    constexpr uint32_t dfb_x_id = tt::CBIndex::c_0;
+    constexpr uint32_t dfb_one_id = tt::CBIndex::c_1;
+    DataflowBuffer dfb_one_obj(dfb_one_id);
+    constexpr uint32_t dfb_decimal_id = tt::CBIndex::c_2;
+    DataflowBuffer dfb_decimal_obj(dfb_decimal_id);
+    constexpr uint32_t dfb_recip_p_decimal_id = tt::CBIndex::c_3;  // recip_p_decimal
+    DataflowBuffer dfb_recip_p_decimal_obj(dfb_recip_p_decimal_id);
 
-    std::uint8_t output_id{tt::CBIndex::c_16};
-    const auto cb_y = output_id++;  // output
-    DataflowBuffer dfb_y_obj(cb_y);
+    constexpr uint32_t dfb_y_id = tt::CBIndex::c_16;
 
-    std::uint8_t intermed_id{tt::CBIndex::c_24};
-    const auto cb_tmp0 = intermed_id++;
-    const auto cb_tmp1 = intermed_id++;
-    const auto cb_tmp2 = intermed_id++;
-    const auto cb_tmp3 = intermed_id++;
-    const auto cb_tmp4 = intermed_id++;
-    const auto cb_tmp5 = intermed_id++;
-
-    const auto cb_xabs = cb_tmp0;
-    DataflowBuffer dfb_xabs_obj(cb_xabs);  // |x|
-    const auto cb_xpow = cb_tmp1;          // |x|^p
-    DataflowBuffer dfb_xpow_obj(cb_xpow);
-    const auto cb_logx = cb_tmp2;          // log(|x|)
-    DataflowBuffer dfb_logx_obj(cb_logx);
-    const auto cb_exp_lxmd = cb_tmp3;      // exp(log(|x|) * decimal)
-    DataflowBuffer dfb_exp_lxmd_obj(cb_exp_lxmd);
-    const auto cb_correct_xpow = cb_tmp4;
-    DataflowBuffer dfb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
-    const auto cb_xpowadd = cb_tmp5;
-    DataflowBuffer dfb_xpowadd_obj(cb_xpowadd);  // Add(|x + decimal|^p)
+    constexpr uint32_t dfb_xabs_id = tt::CBIndex::c_24;          // |x|
+    constexpr uint32_t dfb_xpow_id = tt::CBIndex::c_25;          // |x|^p
+    constexpr uint32_t dfb_logx_id = tt::CBIndex::c_26;          // log(|x|)
+    constexpr uint32_t dfb_exp_lxmd_id = tt::CBIndex::c_27;      // exp(log(|x|) * decimal)
+    constexpr uint32_t dfb_correct_xpow_id = tt::CBIndex::c_28;  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
+    constexpr uint32_t dfb_xpowadd_id = tt::CBIndex::c_29;       // Add(|x + decimal|^p)
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t dst1 = 1;
 
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
@@ -62,80 +55,34 @@ void kernel_main() {
     for (uint32_t outer_idx = 0; outer_idx < num_output_tiles_per_core; ++outer_idx) {
         for (uint32_t inner_idx = 0; inner_idx < num_reduced_tiles_along_dim; ++inner_idx) {
             // |x|
-            tile_regs_acquire();
-            dfb_x_obj.wait_front(onetile);  // comes from the reader
-            dfb_xabs_obj.reserve_back(onetile);
+            ckl::eltwise_chain(
+                ckl::IterationShape::one_tile(),
+                ckl::CopyTile<
+                    ckl::input(dfb_x_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig),
+                    ckl::Dst::D0>{},
+                ckl::Abs<ckl::Dst::D0>{},
+                ckl::PackTile<ckl::output(
+                    dfb_xabs_id, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>{});
 
-            copy_tile_init_with_dt(dfb_x_obj);
-            copy_tile(cb_x, 0, dst0);
-
-            abs_tile_init();
-            abs_tile(dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_xabs_obj);
-            tile_regs_release();
-
-            dfb_x_obj.pop_front(onetile);
-            dfb_xabs_obj.push_back(onetile);
-
-            power_tile_to_cb(
-                dfb_xabs_obj,
-                dfb_xpow_obj,
-                dfb_logx_obj,
-                dfb_decimal_obj,
-                dfb_exp_lxmd_obj,
-                dfb_correct_xpow_obj,
-                p,
-                p_is_negative);
+            power_tile_to_dfb<
+                dfb_xabs_id,
+                dfb_xpow_id,
+                dfb_logx_id,
+                dfb_decimal_id,
+                dfb_exp_lxmd_id,
+                dfb_correct_xpow_id>(p, p_is_negative);
 
             // Add(|x|^p)
             if (inner_idx == 0) {
-                tile_regs_acquire();
-                dfb_correct_xpow_obj.wait_front(onetile);
-                dfb_xpowadd_obj.reserve_back(onetile);
-
-                copy_tile_init_with_dt(dfb_correct_xpow_obj);
-                copy_tile(cb_correct_xpow, 0, dst0);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
-                tile_regs_release();
-
-                dfb_correct_xpow_obj.pop_front(onetile);
-                dfb_xpowadd_obj.push_back(onetile);
+                copy_tile_to_dfb<dfb_correct_xpow_id, dfb_xpowadd_id>();
             } else {
-                tile_regs_acquire();
-                dfb_correct_xpow_obj.wait_front(onetile);
-                dfb_xpowadd_obj.wait_front(onetile);
-                dfb_xpowadd_obj.reserve_back(onetile);
-
-                add_tiles_init_with_dt(dfb_correct_xpow_obj, dfb_xpowadd_obj);
-                add_tiles(cb_correct_xpow, cb_xpowadd, 0, 0, dst0);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
-                tile_regs_release();
-
-                dfb_correct_xpow_obj.pop_front(onetile);
-                dfb_xpowadd_obj.pop_front(onetile);
-                dfb_xpowadd_obj.push_back(onetile);
+                add_tiles_to_dfb<dfb_correct_xpow_id, dfb_xpowadd_id, dfb_xpowadd_id>();
             }
         }
 
-        // Compute cb_y
-        power_tile_to_cb(
-            dfb_xpowadd_obj,
-            dfb_xabs_obj,
-            dfb_xpow_obj,
-            dfb_recip_p_decimal_obj,
-            dfb_logx_obj,
-            dfb_y_obj,
-            recip_p,
-            recip_p_is_negative);
+        // Compute dfb_y_id
+        power_tile_to_dfb<dfb_xpowadd_id, dfb_xabs_id, dfb_xpow_id, dfb_recip_p_decimal_id, dfb_logx_id, dfb_y_id>(
+            recip_p, recip_p_is_negative);
     }
     dfb_one_obj.pop_front(onetile);
     dfb_decimal_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -3,8 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"  // PowerIterative, Recip, Log, Exp
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Mask, Abs
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
+
+namespace ckl = compute_kernel_lib;
+
+#if defined(FP32_DEST_ACC_EN)
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Enabled;
+#else
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Disabled;
+#endif
 
 void kernel_main() {
     int i{0};
@@ -16,49 +29,27 @@ void kernel_main() {
     const auto recip_p = get_arg_val<uint32_t>(i++);
     const bool recip_p_is_negative = get_arg_val<uint32_t>(i++) == 1;
 
-    std::uint8_t input_id{tt::CBIndex::c_0};
-    const auto cb_x = input_id++;
-    DataflowBuffer dfb_x_obj(cb_x);  // input
-    const auto cb_one = input_id++;
-    DataflowBuffer dfb_one_obj(cb_one);  // one
-    const auto cb_decimal = input_id++;
-    DataflowBuffer dfb_decimal_obj(cb_decimal);  // decimal
-    const auto cb_recip_p_decimal = input_id++;
-    DataflowBuffer dfb_recip_p_decimal_obj(cb_recip_p_decimal);  // recip_p_decimal
-    const auto cb_mask_w = input_id++;
-    DataflowBuffer dfb_mask_w_obj(cb_mask_w);  // mask_w
+    constexpr uint32_t dfb_x_id = tt::CBIndex::c_0;
+    constexpr uint32_t dfb_one_id = tt::CBIndex::c_1;
+    DataflowBuffer dfb_one_obj(dfb_one_id);
+    constexpr uint32_t dfb_decimal_id = tt::CBIndex::c_2;
+    DataflowBuffer dfb_decimal_obj(dfb_decimal_id);
+    constexpr uint32_t dfb_recip_p_decimal_id = tt::CBIndex::c_3;  // recip_p_decimal
+    DataflowBuffer dfb_recip_p_decimal_obj(dfb_recip_p_decimal_id);
+    constexpr uint32_t dfb_mask_w_id = tt::CBIndex::c_4;
+    DataflowBuffer dfb_mask_w_obj(dfb_mask_w_id);
 
-    std::uint8_t output_id{tt::CBIndex::c_16};
-    const auto cb_y = output_id++;  // output
-    DataflowBuffer dfb_y_obj(cb_y);
+    constexpr uint32_t dfb_y_id = tt::CBIndex::c_16;
 
-    std::uint8_t intermed_id{tt::CBIndex::c_24};
-    const auto cb_tmp0 = intermed_id++;
-    const auto cb_tmp1 = intermed_id++;
-    const auto cb_tmp2 = intermed_id++;
-    const auto cb_tmp3 = intermed_id++;
-    const auto cb_tmp4 = intermed_id++;
-    const auto cb_tmp5 = intermed_id++;
-    const auto cb_tmp6 = intermed_id++;
-
-    const auto cb_xabs = cb_tmp0;
-    DataflowBuffer dfb_xabs_obj(cb_xabs);  // |x|
-    const auto cb_xpow = cb_tmp1;          // |x|^p
-    DataflowBuffer dfb_xpow_obj(cb_xpow);
-    const auto cb_logx = cb_tmp2;          // log(|x|)
-    DataflowBuffer dfb_logx_obj(cb_logx);
-    const auto cb_exp_lxmd = cb_tmp3;      // exp(log(|x|) * decimal)
-    DataflowBuffer dfb_exp_lxmd_obj(cb_exp_lxmd);
-    const auto cb_correct_xpow = cb_tmp4;
-    DataflowBuffer dfb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
-    const auto cb_xpowadd = cb_tmp5;
-    DataflowBuffer dfb_xpowadd_obj(cb_xpowadd);  // Add(|x + decimal|^p)
-    const auto cb_xpowsum = cb_tmp6;       // Sum(|x + decimal|^p)
-    DataflowBuffer dfb_xpowsum_obj(cb_xpowsum);
+    constexpr uint32_t dfb_xabs_id = tt::CBIndex::c_24;          // |x|
+    constexpr uint32_t dfb_xpow_id = tt::CBIndex::c_25;          // |x|^p
+    constexpr uint32_t dfb_logx_id = tt::CBIndex::c_26;          // log(|x|)
+    constexpr uint32_t dfb_exp_lxmd_id = tt::CBIndex::c_27;      // exp(log(|x|) * decimal)
+    constexpr uint32_t dfb_correct_xpow_id = tt::CBIndex::c_28;  // |x|^p * exp(log(|x|) * decimal)(==|x + decimal|^p)
+    constexpr uint32_t dfb_xpowadd_id = tt::CBIndex::c_29;       // Add(|x + decimal|^p)
+    constexpr uint32_t dfb_xpowsum_id = tt::CBIndex::c_30;       // Sum(|x + decimal|^p)
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t dst1 = 1;
 
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
@@ -76,91 +67,42 @@ void kernel_main() {
 
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; ++row_idx) {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
-            // |x|
-            tile_regs_acquire();
-            dfb_x_obj.wait_front(onetile);  // comes from the reader
-            dfb_xabs_obj.reserve_back(onetile);
+            const bool mask_this = do_mask_w && (col_idx == Wt - 1);
+            ckl::eltwise_chain(
+                ckl::IterationShape::tiles(onetile),
+                ckl::CopyTile<ckl::input(
+                    dfb_x_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig)>{},
+                ckl::runtime_if(
+                    mask_this,
+                    ckl::CopyTile<
+                        ckl::input(dfb_mask_w_id, ckl::WaitPolicy::None, ckl::PopPolicy::None, kDataFormatReconfig),
+                        ckl::Dst::D1>{},
+                    ckl::Mask<DataFormat::Float16_b, ckl::Dst::D0>{}),
+                ckl::Abs<ckl::Dst::D0>{},
+                ckl::PackTile<ckl::output(
+                    dfb_xabs_id, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>{});
 
-            copy_tile_init_with_dt(dfb_x_obj);
-            copy_tile(cb_x, 0, dst0);
-
-            if (do_mask_w && (col_idx == Wt - 1)) {
-                copy_tile_init_with_dt(dfb_mask_w_obj);
-                copy_tile(cb_mask_w, 0, dst1);
-
-                mask_tile_init();
-                mask_tile(dst0, dst1);
-            }
-
-            abs_tile_init();
-            abs_tile(dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_xabs_obj);
-            tile_regs_release();
-
-            dfb_x_obj.pop_front(onetile);
-            dfb_xabs_obj.push_back(onetile);
-
-            power_tile_to_cb(
-                dfb_xabs_obj,
-                dfb_xpow_obj,
-                dfb_logx_obj,
-                dfb_decimal_obj,
-                dfb_exp_lxmd_obj,
-                dfb_correct_xpow_obj,
-                p,
-                p_is_negative);
+            power_tile_to_dfb<
+                dfb_xabs_id,
+                dfb_xpow_id,
+                dfb_logx_id,
+                dfb_decimal_id,
+                dfb_exp_lxmd_id,
+                dfb_correct_xpow_id>(p, p_is_negative);
 
             // Add(|x|^p)
             if (col_idx == 0) {
-                tile_regs_acquire();
-                dfb_correct_xpow_obj.wait_front(onetile);
-                dfb_xpowadd_obj.reserve_back(onetile);
-
-                copy_tile_init_with_dt(dfb_correct_xpow_obj);
-                copy_tile(cb_correct_xpow, 0, dst0);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
-                tile_regs_release();
-
-                dfb_correct_xpow_obj.pop_front(onetile);
-                dfb_xpowadd_obj.push_back(onetile);
+                copy_tile_to_dfb<dfb_correct_xpow_id, dfb_xpowadd_id>();
             } else {
-                tile_regs_acquire();
-                dfb_correct_xpow_obj.wait_front(onetile);
-                dfb_xpowadd_obj.wait_front(onetile);
-                dfb_xpowadd_obj.reserve_back(onetile);
-
-                add_tiles_init_with_dt(dfb_correct_xpow_obj, dfb_xpowadd_obj);
-                add_tiles(cb_correct_xpow, cb_xpowadd, 0, 0, dst0);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_xpowadd_obj);
-                tile_regs_release();
-
-                dfb_correct_xpow_obj.pop_front(onetile);
-                dfb_xpowadd_obj.pop_front(onetile);
-                dfb_xpowadd_obj.push_back(onetile);
+                add_tiles_to_dfb<dfb_correct_xpow_id, dfb_xpowadd_id, dfb_xpowadd_id>();
             }
         }
         // Sum(|x|^p)
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xpowadd, cb_one, cb_xpowsum>(
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, dfb_xpowadd_id, dfb_one_id, dfb_xpowsum_id>(
             compute_kernel_lib::ReduceInputBlockShape::single());
 
-        power_tile_to_cb(
-            dfb_xpowsum_obj,
-            dfb_xabs_obj,
-            dfb_xpow_obj,
-            dfb_recip_p_decimal_obj,
-            dfb_logx_obj,
-            dfb_y_obj,
-            recip_p,
-            recip_p_is_negative);
+        power_tile_to_dfb<dfb_xpowsum_id, dfb_xabs_id, dfb_xpow_id, dfb_recip_p_decimal_id, dfb_logx_id, dfb_y_id>(
+            recip_p, recip_p_is_negative);
     }
 
     dfb_one_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -1,31 +1,29 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Abs, Negative, Mask, MaskPosInf
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/minmax.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/predicates.hpp"  // UnaryNe
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"     // Optional
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     const auto num_cols_per_core = get_arg(args::num_cols_per_core);
     const auto Ht = get_arg(args::Ht);
     const auto origin_h = get_arg(args::origin_h);
 
-    DataflowBuffer dfb_x_obj(dfb::x);            // input
-    DataflowBuffer dfb_one_obj(dfb::one);        // one
-    DataflowBuffer dfb_mask_h_obj(dfb::mask_h);  // mask_h
-
-    DataflowBuffer dfb_y_obj(dfb::y);  // output
-
-    // Compute-private intermediates: this kernel is their only toucher, so each is self-looped on the
-    // host (bound PRODUCER and CONSUMER under one accessor name) and one object drives both directions.
-    DataflowBuffer dfb_val_obj(dfb::val);        // f(x)
-    DataflowBuffer dfb_cal_obj(dfb::cal);        // calculate f(x) over dimension
-    DataflowBuffer dfb_reduce_obj(dfb::reduce);  // reduce f(x)
+    DataflowBuffer dfb_one_obj(dfb::one);
+    DataflowBuffer dfb_mask_h_obj(dfb::mask_h);
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t dst1 = 1;
 
     compute_kernel_hw_startup(dfb::x, dfb::x, dfb::y);
 
@@ -33,122 +31,58 @@ void kernel_main() {
 
     constexpr uint32_t TILE_H = 32;
     const bool do_mask_h = (origin_h % TILE_H) != 0;
-    const auto mask_h = do_mask_h ? (origin_h % TILE_H) : TILE_H;
 
     if (do_mask_h) {
         dfb_mask_h_obj.wait_front(onetile);  // comes from the reader
     }
+
+    constexpr bool is_zero = get_arg(args::is_zero) != 0;
+    constexpr bool minus_inf = get_arg(args::minus_inf) != 0;
+    using MaskOp =
+        std::conditional_t<minus_inf, ckl::MaskPosInf<ckl::Dst::D0>, ckl::Mask<DataFormat::Float16_b, ckl::Dst::D0>>;
+    // Compute-private intermediates (dfb::val, dfb::cal, dfb::reduce): this kernel is their only toucher, so each is
+    // self-looped on the host (bound PRODUCER and CONSUMER under one accessor name).
     for (uint32_t col_idx = 0; col_idx < num_cols_per_core; ++col_idx) {
         for (uint32_t row_idx = 0; row_idx < Ht; ++row_idx) {
+            const bool mask_this = do_mask_h && (row_idx == Ht - 1);
             // f(x)
-            tile_regs_acquire();
-            dfb_x_obj.wait_front(onetile);  // comes from the reader
-            dfb_val_obj.reserve_back(onetile);
-
-            copy_tile_init_with_dt(dfb_x_obj);
-            copy_tile(dfb::x, 0, dst0);
-
-            if (do_mask_h && (row_idx == Ht - 1)) {
-                copy_tile_init_with_dt(dfb_mask_h_obj);
-                copy_tile(dfb::mask_h, 0, dst1);
-
-                mask_tile_init();
-#ifdef MINUS_INF
-                mask_posinf_tile(dst0, dst1);
-#else
-                mask_tile(dst0, dst1);
-#endif
-            }
-#ifdef IS_ZERO
-            unary_ne_tile_init();
-            unary_ne_tile(dst0, 0);
-#else
-            abs_tile_init();
-            abs_tile(dst0);
-#endif
-
-#ifdef MINUS_INF
-            negative_tile_init();
-            negative_tile(dst0);
-#endif
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_val_obj);
-            tile_regs_release();
-
-            dfb_x_obj.pop_front(onetile);
-            dfb_val_obj.push_back(onetile);
+            ckl::eltwise_chain(
+                ckl::IterationShape::tiles(onetile),
+                ckl::CopyTile<ckl::input(dfb::x)>{},
+                ckl::runtime_if(
+                    mask_this,
+                    ckl::CopyTile<ckl::input(dfb::mask_h, ckl::WaitPolicy::None, ckl::PopPolicy::None), ckl::Dst::D1>{},
+                    MaskOp{}),
+                ckl::Optional<is_zero, ckl::UnaryNe<ckl::Dst::D0>>{0u},
+                ckl::Optional<!is_zero, ckl::Abs<ckl::Dst::D0>>{},
+                ckl::Optional<minus_inf, ckl::Negative<ckl::Dst::D0>>{},
+                ckl::PackTile<ckl::output(dfb::val)>{});
 
             // calculate f(x) over dimension
             if (row_idx == 0) {
-                tile_regs_acquire();
-                dfb_val_obj.wait_front(onetile);
-                dfb_cal_obj.reserve_back(onetile);
-
-                copy_tile_init_with_dt(dfb_val_obj);
-                copy_tile(dfb::val, 0, dst0);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_cal_obj);
-                tile_regs_release();
-
-                dfb_val_obj.pop_front(onetile);
-                dfb_cal_obj.push_back(onetile);
-
+                ckl::copy<ckl::input(dfb::val), ckl::output(dfb::cal)>(ckl::IterationShape::tiles(onetile));
             } else {
-                tile_regs_acquire();
-                dfb_val_obj.wait_front(onetile);
-                dfb_cal_obj.wait_front(onetile);
-                dfb_cal_obj.reserve_back(onetile);
-#ifdef IS_ZERO
-                add_tiles_init_with_dt(dfb_val_obj, dfb_cal_obj);
-                add_tiles(dfb::val, dfb::cal, 0, 0, dst0);
-#else
-                copy_tile_init_with_dt(dfb_val_obj);
-                copy_tile(dfb::val, 0, dst0);
-
-                copy_tile_init_with_dt(dfb_cal_obj);
-                copy_tile(dfb::cal, 0, dst1);
-
-                binary_max_tile_init();
-                binary_max_tile(dst0, dst1, dst0);
-#endif
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_cal_obj);
-                tile_regs_release();
-
-                dfb_val_obj.pop_front(onetile);
-                dfb_cal_obj.pop_front(onetile);
-                dfb_cal_obj.push_back(onetile);
+                if constexpr (is_zero) {
+                    ckl::add<ckl::input(dfb::val), ckl::input(dfb::cal), ckl::output(dfb::cal)>(
+                        ckl::IterationShape::tiles(onetile));
+                } else {
+                    ckl::binary_sfpu<
+                        ckl::BinaryMax<>,
+                        ckl::input(dfb::val),
+                        ckl::input(dfb::cal),
+                        ckl::output(dfb::cal)>(ckl::IterationShape::tiles(onetile));
+                }
             }
         }
+
         // reduce f(x)
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, dfb::cal, dfb::one, dfb::reduce>(
-            compute_kernel_lib::ReduceInputBlockShape::single());
+        ckl::reduce<REDUCE_OP, REDUCE_DIM, dfb::cal, dfb::one, dfb::reduce>(ckl::ReduceInputBlockShape::single());
 
-        tile_regs_acquire();
-
-        dfb_reduce_obj.wait_front(onetile);
-        dfb_y_obj.reserve_back(onetile);
-
-        copy_tile_init_with_dt(dfb_reduce_obj);
-        copy_tile(dfb::reduce, 0, dst0);
-#ifdef MINUS_INF
-        negative_tile_init();
-        negative_tile(dst0);
-#endif
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_y_obj);
-        tile_regs_release();
-
-        dfb_reduce_obj.pop_front(onetile);
-        dfb_y_obj.push_back(onetile);
+        ckl::eltwise_chain(
+            ckl::IterationShape::tiles(onetile),
+            ckl::CopyTile<ckl::input(dfb::reduce)>{},
+            ckl::Optional<minus_inf, ckl::Negative<ckl::Dst::D0>>{},
+            ckl::PackTile<ckl::output(dfb::y)>{});
     }
 
     dfb_one_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/moreh_norm_nc_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/moreh_norm_nc_kernel.cpp
@@ -1,129 +1,74 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Abs, Negative
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/minmax.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/predicates.hpp"  // UnaryNe
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"     // Optional
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     const auto num_output_tiles_per_core = get_arg(args::num_output_tiles_per_core);
     const auto num_reduced_tiles_along_dim = get_arg(args::num_reduced_tiles_along_dim);
 
-    DataflowBuffer dfb_x_obj(dfb::x);      // input
-    DataflowBuffer dfb_one_obj(dfb::one);  // one
-
-    DataflowBuffer dfb_y_obj(dfb::y);  // output
-
-    // Compute-private intermediates: this kernel is their only toucher, so each is self-looped on the
-    // host (bound PRODUCER and CONSUMER under one accessor name) and one object drives both directions.
-    DataflowBuffer dfb_val_obj(dfb::val);  // f(x)
-    DataflowBuffer dfb_cal_obj(dfb::cal);  // calculate f(x) over dimensions
+    DataflowBuffer dfb_one_obj(dfb::one);
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t dst1 = 1;
 
     compute_kernel_hw_startup(dfb::x, dfb::x, dfb::y);
 
     dfb_one_obj.wait_front(onetile);  // comes from the reader
 
+#ifdef MINUS_INF
+    constexpr bool minus_inf = true;
+#else
+    constexpr bool minus_inf = false;
+#endif
+#ifdef IS_ZERO
+    constexpr bool is_zero = true;
+#else
+    constexpr bool is_zero = false;
+#endif
+    // Compute-private intermediates (dfb::val, dfb::cal): this kernel is their only toucher, so each is
+    // self-looped on the host (bound PRODUCER and CONSUMER under one accessor name).
     for (uint32_t outer_idx = 0; outer_idx < num_output_tiles_per_core; ++outer_idx) {
         for (uint32_t inner_idx = 0; inner_idx < num_reduced_tiles_along_dim; ++inner_idx) {
             // x != 0
-            tile_regs_acquire();
-            dfb_x_obj.wait_front(onetile);  // comes from the reader
-            dfb_val_obj.reserve_back(onetile);
+            ckl::eltwise_chain(
+                ckl::IterationShape::tiles(onetile),
+                ckl::CopyTile<ckl::input(dfb::x)>{},
+                ckl::Optional<is_zero, ckl::UnaryNe<ckl::Dst::D0>>{0u},
+                ckl::Optional<!is_zero, ckl::Abs<ckl::Dst::D0>>{},
+                ckl::Optional<minus_inf, ckl::Negative<ckl::Dst::D0>>{},
+                ckl::PackTile<ckl::output(dfb::val)>{});
 
-            copy_tile_init_with_dt(dfb_x_obj);
-            copy_tile(dfb::x, 0, dst0);
-#ifdef IS_ZERO
-            unary_ne_tile_init();
-            unary_ne_tile(dst0, 0);
-#else
-            abs_tile_init();
-            abs_tile(dst0);
-#endif
-
-#ifdef MINUS_INF
-            negative_tile_init();
-            negative_tile(dst0);
-#endif
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_val_obj);
-            tile_regs_release();
-
-            dfb_x_obj.pop_front(onetile);
-            dfb_val_obj.push_back(onetile);
-
-            // Add(x != 0)
+            // calculate f(x) over dimensions
             if (inner_idx == 0) {
-                tile_regs_acquire();
-                dfb_val_obj.wait_front(onetile);
-                dfb_cal_obj.reserve_back(onetile);
-
-                copy_tile_init_with_dt(dfb_val_obj);
-                copy_tile(dfb::val, 0, dst0);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_cal_obj);
-                tile_regs_release();
-
-                dfb_val_obj.pop_front(onetile);
-                dfb_cal_obj.push_back(onetile);
-
+                ckl::copy<ckl::input(dfb::val), ckl::output(dfb::cal)>(ckl::IterationShape::tiles(onetile));
             } else {
-                tile_regs_acquire();
-                dfb_val_obj.wait_front(onetile);
-                dfb_cal_obj.wait_front(onetile);
-                dfb_cal_obj.reserve_back(onetile);
 #ifdef IS_ZERO
-                add_tiles_init_with_dt(dfb_val_obj, dfb_cal_obj);
-                add_tiles(dfb::val, dfb::cal, 0, 0, dst0);
+                ckl::add<ckl::input(dfb::val), ckl::input(dfb::cal), ckl::output(dfb::cal)>(
+                    ckl::IterationShape::tiles(onetile));
 #else
-                copy_tile_init_with_dt(dfb_val_obj);
-                copy_tile(dfb::val, 0, dst0);
-
-                copy_tile_init_with_dt(dfb_cal_obj);
-                copy_tile(dfb::cal, 0, dst1);
-
-                binary_max_tile_init();
-                binary_max_tile(dst0, dst1, dst0);
+                ckl::binary_sfpu<ckl::BinaryMax<>, ckl::input(dfb::val), ckl::input(dfb::cal), ckl::output(dfb::cal)>(
+                    ckl::IterationShape::tiles(onetile));
 #endif
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_cal_obj);
-                tile_regs_release();
-
-                dfb_val_obj.pop_front(onetile);
-                dfb_cal_obj.pop_front(onetile);
-                dfb_cal_obj.push_back(onetile);
             }
         }
 
-        // Compute cb_y
-        tile_regs_acquire();
-
-        dfb_cal_obj.wait_front(onetile);
-        dfb_y_obj.reserve_back(onetile);
-
-        copy_tile_init_with_dt(dfb_cal_obj);
-        copy_tile(dfb::cal, 0, dst0);
-#ifdef MINUS_INF
-        negative_tile_init();
-        negative_tile(dst0);
-#endif
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_y_obj);
-        tile_regs_release();
-
-        dfb_cal_obj.pop_front(onetile);
-        dfb_y_obj.push_back(onetile);
+        // Compute dfb::y
+        ckl::eltwise_chain(
+            ckl::IterationShape::tiles(onetile),
+            ckl::CopyTile<ckl::input(dfb::cal)>{},
+            ckl::Optional<minus_inf, ckl::Negative<ckl::Dst::D0>>{},
+            ckl::PackTile<ckl::output(dfb::y)>{});
     }
     dfb_one_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_h_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_h_other.cpp
@@ -225,13 +225,14 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryHOthe
     compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_COL";
     if (p == 0.0f) {
         compute_defines["REDUCE_OP"] = "PoolType::SUM";
-        compute_defines["IS_ZERO"] = "1";
     } else {
         compute_defines["REDUCE_OP"] = "PoolType::MAX";
-        if (p == -std::numeric_limits<float>::infinity()) {
-            compute_defines["MINUS_INF"] = "1";
-        }
     }
+
+    const KernelSpec::CompileTimeArgs compute_compile_time_args{
+        {"is_zero", static_cast<uint32_t>(p == 0.0f)},
+        {"minus_inf", static_cast<uint32_t>(p == -std::numeric_limits<float>::infinity())},
+    };
 
     const auto* const compute_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/"
@@ -326,6 +327,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryHOthe
                         .endpoint_type = DFBEndpointType::CONSUMER,
                     },
                 },
+            .compile_time_args = compute_compile_time_args,
             .runtime_arg_schema =
                 {
                     .runtime_arg_names = {"num_cols_per_core", "Ht", "origin_h"},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_w_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_w_other.cpp
@@ -230,13 +230,14 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryWOthe
     compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
     if (p == 0.0f) {
         compute_defines["REDUCE_OP"] = "PoolType::SUM";
-        compute_defines["IS_ZERO"] = "1";
     } else {
         compute_defines["REDUCE_OP"] = "PoolType::MAX";
-        if (p == -std::numeric_limits<float>::infinity()) {
-            compute_defines["MINUS_INF"] = "1";
-        }
     }
+
+    const KernelSpec::CompileTimeArgs compute_compile_time_args{
+        {"is_zero", static_cast<uint32_t>(p == 0.0f)},
+        {"minus_inf", static_cast<uint32_t>(p == -std::numeric_limits<float>::infinity())},
+    };
 
     const auto* const compute_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/"
@@ -331,6 +332,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryWOthe
                         .endpoint_type = DFBEndpointType::CONSUMER,
                     },
                 },
+            .compile_time_args = compute_compile_time_args,
             .runtime_arg_schema =
                 {
                     .runtime_arg_names = {"num_rows_per_core", "Wt", "origin_w"},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -1,31 +1,29 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Abs, Negative, Mask, MaskPosInf
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/minmax.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/predicates.hpp"  // UnaryNe
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"     // Optional
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     const auto num_rows_per_core = get_arg(args::num_rows_per_core);
     const auto Wt = get_arg(args::Wt);
     const auto origin_w = get_arg(args::origin_w);
 
-    DataflowBuffer dfb_x_obj(dfb::x);            // input
-    DataflowBuffer dfb_one_obj(dfb::one);        // one
-    DataflowBuffer dfb_mask_w_obj(dfb::mask_w);  // mask_w
-
-    DataflowBuffer dfb_y_obj(dfb::y);  // output
-
-    // Compute-private intermediates: this kernel is their only toucher, so each is self-looped on the
-    // host (bound PRODUCER and CONSUMER under one accessor name) and one object drives both directions.
-    DataflowBuffer dfb_val_obj(dfb::val);        // f(x)
-    DataflowBuffer dfb_cal_obj(dfb::cal);        // calculate f(x) over dimension
-    DataflowBuffer dfb_reduce_obj(dfb::reduce);  // reduce f(x)
+    DataflowBuffer dfb_one_obj(dfb::one);
+    DataflowBuffer dfb_mask_w_obj(dfb::mask_w);
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t dst1 = 1;
 
     compute_kernel_hw_startup(dfb::x, dfb::x, dfb::y);
 
@@ -33,121 +31,58 @@ void kernel_main() {
 
     constexpr uint32_t TILE_W = 32;
     const bool do_mask_w = (origin_w % TILE_W) != 0;
-    const auto mask_w = do_mask_w ? (origin_w % TILE_W) : TILE_W;
 
     if (do_mask_w) {
         dfb_mask_w_obj.wait_front(onetile);  // comes from the reader
     }
 
+    constexpr bool is_zero = get_arg(args::is_zero) != 0;
+    constexpr bool minus_inf = get_arg(args::minus_inf) != 0;
+    using MaskOp =
+        std::conditional_t<minus_inf, ckl::MaskPosInf<ckl::Dst::D0>, ckl::Mask<DataFormat::Float16_b, ckl::Dst::D0>>;
+    // Compute-private intermediates (dfb::val, dfb::cal, dfb::reduce): this kernel is their only toucher, so each is
+    // self-looped on the host (bound PRODUCER and CONSUMER under one accessor name).
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; ++row_idx) {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
+            const bool mask_this = do_mask_w && (col_idx == Wt - 1);
             // f(x)
-            tile_regs_acquire();
-            dfb_x_obj.wait_front(onetile);  // comes from the reader
-            dfb_val_obj.reserve_back(onetile);
-
-            copy_tile_init_with_dt(dfb_x_obj);
-            copy_tile(dfb::x, 0, dst0);
-
-            if (do_mask_w && (col_idx == Wt - 1)) {
-                copy_tile_init_with_dt(dfb_mask_w_obj);
-                copy_tile(dfb::mask_w, 0, dst1);
-                mask_tile_init();
-#ifdef MINUS_INF
-                mask_posinf_tile(dst0, dst1);
-#else
-                mask_tile(dst0, dst1);
-#endif
-            }
-#ifdef IS_ZERO
-            unary_ne_tile_init();
-            unary_ne_tile(dst0, 0);
-#else
-            abs_tile_init();
-            abs_tile(dst0);
-#endif
-
-#ifdef MINUS_INF
-            negative_tile_init();
-            negative_tile(dst0);
-#endif
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_val_obj);
-            tile_regs_release();
-
-            dfb_x_obj.pop_front(onetile);
-            dfb_val_obj.push_back(onetile);
+            ckl::eltwise_chain(
+                ckl::IterationShape::tiles(onetile),
+                ckl::CopyTile<ckl::input(dfb::x)>{},
+                ckl::runtime_if(
+                    mask_this,
+                    ckl::CopyTile<ckl::input(dfb::mask_w, ckl::WaitPolicy::None, ckl::PopPolicy::None), ckl::Dst::D1>{},
+                    MaskOp{}),
+                ckl::Optional<is_zero, ckl::UnaryNe<ckl::Dst::D0>>{0u},
+                ckl::Optional<!is_zero, ckl::Abs<ckl::Dst::D0>>{},
+                ckl::Optional<minus_inf, ckl::Negative<ckl::Dst::D0>>{},
+                ckl::PackTile<ckl::output(dfb::val)>{});
 
             // calculate f(x) over dimension
             if (col_idx == 0) {
-                tile_regs_acquire();
-                dfb_val_obj.wait_front(onetile);
-                dfb_cal_obj.reserve_back(onetile);
-
-                copy_tile_init_with_dt(dfb_val_obj);
-                copy_tile(dfb::val, 0, dst0);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_cal_obj);
-                tile_regs_release();
-
-                dfb_val_obj.pop_front(onetile);
-                dfb_cal_obj.push_back(onetile);
+                ckl::copy<ckl::input(dfb::val), ckl::output(dfb::cal)>(ckl::IterationShape::tiles(onetile));
             } else {
-                tile_regs_acquire();
-                dfb_val_obj.wait_front(onetile);
-                dfb_cal_obj.wait_front(onetile);
-                dfb_cal_obj.reserve_back(onetile);
-#ifdef IS_ZERO
-                add_tiles_init_with_dt(dfb_val_obj, dfb_cal_obj);
-                add_tiles(dfb::val, dfb::cal, 0, 0, dst0);
-#else
-                copy_tile_init_with_dt(dfb_val_obj);
-                copy_tile(dfb::val, 0, dst0);
-
-                copy_tile_init_with_dt(dfb_cal_obj);
-                copy_tile(dfb::cal, 0, dst1);
-
-                binary_max_tile_init();
-                binary_max_tile(dst0, dst1, dst0);
-#endif
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_cal_obj);
-                tile_regs_release();
-
-                dfb_val_obj.pop_front(onetile);
-                dfb_cal_obj.pop_front(onetile);
-                dfb_cal_obj.push_back(onetile);
+                if constexpr (is_zero) {
+                    ckl::add<ckl::input(dfb::val), ckl::input(dfb::cal), ckl::output(dfb::cal)>(
+                        ckl::IterationShape::tiles(onetile));
+                } else {
+                    ckl::binary_sfpu<
+                        ckl::BinaryMax<>,
+                        ckl::input(dfb::val),
+                        ckl::input(dfb::cal),
+                        ckl::output(dfb::cal)>(ckl::IterationShape::tiles(onetile));
+                }
             }
         }
+
         // reduce f(x)
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, dfb::cal, dfb::one, dfb::reduce>(
-            compute_kernel_lib::ReduceInputBlockShape::single());
+        ckl::reduce<REDUCE_OP, REDUCE_DIM, dfb::cal, dfb::one, dfb::reduce>(ckl::ReduceInputBlockShape::single());
 
-        tile_regs_acquire();
-
-        dfb_reduce_obj.wait_front(onetile);
-        dfb_y_obj.reserve_back(onetile);
-
-        copy_tile_init_with_dt(dfb_reduce_obj);
-        copy_tile(dfb::reduce, 0, dst0);
-#ifdef MINUS_INF
-        negative_tile_init();
-        negative_tile(dst0);
-#endif
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_y_obj);
-        tile_regs_release();
-
-        dfb_reduce_obj.pop_front(onetile);
-        dfb_y_obj.push_back(onetile);
+        ckl::eltwise_chain(
+            ckl::IterationShape::tiles(onetile),
+            ckl::CopyTile<ckl::input(dfb::reduce)>{},
+            ckl::Optional<minus_inf, ckl::Negative<ckl::Dst::D0>>{},
+            ckl::PackTile<ckl::output(dfb::y)>{});
     }
 
     dfb_one_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/moreh_norm_backward_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/moreh_norm_backward_kernel.cpp
@@ -2,15 +2,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"  // unary
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"       // PowerIterative, Recip, Log, Exp
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"       // Abs, Sign
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
+#if defined(FP32_DEST_ACC_EN)
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Enabled;
+#else
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Disabled;
+#endif
+
 void kernel_main() {
     // compile-time args
-    constexpr auto num_output_tiles = get_arg(args::num_output_tiles);
     constexpr bool wt_need_bcast = (get_arg(args::wt_need_bcast) == 1);
     constexpr bool ht_need_bcast = (get_arg(args::ht_need_bcast) == 1);
+
+    constexpr auto kBcast = (ht_need_bcast && wt_need_bcast) ? ckl::BroadcastDim::Scalar
+                            : ht_need_bcast                  ? ckl::BroadcastDim::Row
+                            : wt_need_bcast                  ? ckl::BroadcastDim::Col
+                                                             : ckl::BroadcastDim::None;
 
     // runtime args
     const auto num_input_tiles_per_core = get_arg(args::num_input_tiles_per_core);
@@ -24,20 +41,7 @@ void kernel_main() {
     DataflowBuffer dfb_dy_obj(dfb::dy);            // output_grad(==dy), c_2
     DataflowBuffer dfb_decimal_obj(dfb::decimal);  // decimal, c_3
 
-    DataflowBuffer dfb_dx_obj(dfb::dx);  // input_grad(==dx), c_16
-
-    // Compute-only intermediates (c_24..c_31), each filled and drained by this kernel (self-loop).
-    DataflowBuffer dfb_xpow_obj(dfb::xpow);
-    DataflowBuffer dfb_logx_obj(dfb::logx);
-    DataflowBuffer dfb_exp_lxmd_obj(dfb::exp_lxmd);
-    DataflowBuffer dfb_correct_xpow_obj(dfb::correct_xpow);
-    DataflowBuffer dfb_tmp4_obj(dfb::tmp4);
-    DataflowBuffer dfb_tmp5_obj(dfb::tmp5);
-    DataflowBuffer dfb_recip_ypow_obj(dfb::recip_ypow);
-    DataflowBuffer dfb_sign_obj(dfb::sign);
-
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
 
     compute_kernel_hw_startup(dfb::x, dfb::x, dfb::dx);
     dfb_decimal_obj.wait_front(onetile);  // comes from the reader
@@ -47,117 +51,65 @@ void kernel_main() {
         dfb_y_obj.wait_front(onetile);   // comes from the reader
         dfb_dy_obj.wait_front(onetile);  // comes from the reader
 
-        sign_tile_to_cb(dfb_x_obj, dfb_sign_obj, 0, /*pop=*/0);
+        sign_tile_to_dfb<dfb::x, dfb::sign>(0, /*pop=*/0);
 
         // x^(p - 1)
-        power_tile_with_abs_x_to_cb(
-            dfb_x_obj,
-            dfb_xpow_obj,
-            dfb_logx_obj,
-            dfb_decimal_obj,
-            dfb_exp_lxmd_obj,
-            dfb_correct_xpow_obj,
-            p_minus_one,
-            p_minus_one_is_negative);
+        power_tile_with_abs_x_to_dfb<dfb::x, dfb::xpow, dfb::logx, dfb::decimal, dfb::exp_lxmd, dfb::correct_xpow>(
+            p_minus_one, p_minus_one_is_negative);
 
-        // x^(p - 1) * y -> cb_tmp4
-        dfb_correct_xpow_obj.wait_front(onetile);
-        dfb_tmp4_obj.reserve_back(onetile);
+        // x^(p - 1) * y -> dfb::tmp4
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::BinaryFpu<
+                ckl::BinaryFpuOp::Mul,
+                ckl::input(dfb::correct_xpow, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig),
+                ckl::input(
+                    dfb::y,
+                    kBcast,
+                    ckl::WaitPolicy::None,
+                    ckl::PopPolicy::None,
+                    ckl::InputTileMapping::Scalar,
+                    kDataFormatReconfig,
+                    ckl::TileAddressing::Offset)>{},
+            ckl::PackTile<ckl::output(
+                dfb::tmp4, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>{});
 
-        tile_regs_acquire();
-        if (ht_need_bcast && wt_need_bcast) {
-            mul_bcast_scalar_init_with_dt(dfb_correct_xpow_obj, dfb_y_obj);
-            mul_tiles_bcast_scalar(dfb::correct_xpow, dfb::y, 0, 0, dst0);
-        } else if (ht_need_bcast) {
-            mul_bcast_rows_init_with_dt(dfb_correct_xpow_obj, dfb_y_obj);
-            mul_tiles_bcast_rows(dfb::correct_xpow, dfb::y, 0, 0, dst0);
-        } else if (wt_need_bcast) {
-            mul_bcast_cols_init_with_dt(dfb_correct_xpow_obj, dfb_y_obj);
-            mul_tiles_bcast_cols(dfb::correct_xpow, dfb::y, 0, 0, dst0);
-        } else {
-            mul_tiles_init_with_dt(dfb_correct_xpow_obj, dfb_y_obj);
-            mul_tiles(dfb::correct_xpow, dfb::y, 0, 0, dst0);
-        }
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_tmp4_obj);
-        tile_regs_release();
-
-        dfb_correct_xpow_obj.pop_front(onetile);
-        dfb_tmp4_obj.push_back(onetile);
-
-        // x^(p - 1) * y * dy -> cb_tmp5
-        dfb_tmp4_obj.wait_front(onetile);
-        dfb_tmp5_obj.reserve_back(onetile);
-
-        tile_regs_acquire();
-        if (ht_need_bcast && wt_need_bcast) {
-            mul_bcast_scalar_init_with_dt(dfb_tmp4_obj, dfb_dy_obj);
-            mul_tiles_bcast_scalar(dfb::tmp4, dfb::dy, 0, 0, dst0);
-        } else if (ht_need_bcast) {
-            mul_bcast_rows_init_with_dt(dfb_tmp4_obj, dfb_dy_obj);
-            mul_tiles_bcast_rows(dfb::tmp4, dfb::dy, 0, 0, dst0);
-        } else if (wt_need_bcast) {
-            mul_bcast_cols_init_with_dt(dfb_tmp4_obj, dfb_dy_obj);
-            mul_tiles_bcast_cols(dfb::tmp4, dfb::dy, 0, 0, dst0);
-        } else {
-            mul_tiles_init_with_dt(dfb_tmp4_obj, dfb_dy_obj);
-            mul_tiles(dfb::tmp4, dfb::dy, 0, 0, dst0);
-        }
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_tmp5_obj);
-        tile_regs_release();
-
-        dfb_tmp4_obj.pop_front(onetile);
-        dfb_tmp5_obj.push_back(onetile);
+        // x^(p - 1) * y * dy -> dfb::tmp5
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::BinaryFpu<
+                ckl::BinaryFpuOp::Mul,
+                ckl::input(dfb::tmp4, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig),
+                ckl::input(
+                    dfb::dy,
+                    kBcast,
+                    ckl::WaitPolicy::None,
+                    ckl::PopPolicy::None,
+                    ckl::InputTileMapping::Scalar,
+                    kDataFormatReconfig,
+                    ckl::TileAddressing::Offset)>{},
+            ckl::PackTile<ckl::output(
+                dfb::tmp5, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>{});
 
         // 1 / y^p
-        power_and_recip_tile_to_cb(
-            dfb_y_obj,
-            dfb_xpow_obj,
-            dfb_logx_obj,
-            dfb_decimal_obj,
-            dfb_exp_lxmd_obj,
-            dfb_recip_ypow_obj,
-            p,
-            p_is_negative);
+        power_and_recip_tile_to_dfb<dfb::y, dfb::xpow, dfb::logx, dfb::decimal, dfb::exp_lxmd, dfb::recip_ypow>(
+            p, p_is_negative);
 
-        // (x^(p - 1) * y * dy) / y^p -> cb_dx
-        dfb_tmp5_obj.wait_front(onetile);
-        dfb_recip_ypow_obj.wait_front(onetile);
-        dfb_tmp4_obj.reserve_back(onetile);
-
-        tile_regs_acquire();
-        if (ht_need_bcast && wt_need_bcast) {
-            mul_bcast_scalar_init_with_dt(dfb_tmp5_obj, dfb_recip_ypow_obj);
-            mul_tiles_bcast_scalar(dfb::tmp5, dfb::recip_ypow, 0, 0, dst0);
-        } else if (ht_need_bcast) {
-            mul_bcast_rows_init_with_dt(dfb_tmp5_obj, dfb_recip_ypow_obj);
-            mul_tiles_bcast_rows(dfb::tmp5, dfb::recip_ypow, 0, 0, dst0);
-        } else if (wt_need_bcast) {
-            mul_bcast_cols_init_with_dt(dfb_tmp5_obj, dfb_recip_ypow_obj);
-            mul_tiles_bcast_cols(dfb::tmp5, dfb::recip_ypow, 0, 0, dst0);
-        } else {
-            mul_tiles_init_with_dt(dfb_tmp5_obj, dfb_recip_ypow_obj);
-            mul_tiles(dfb::tmp5, dfb::recip_ypow, 0, 0, dst0);
-        }
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, dfb_tmp4_obj);
-        tile_regs_release();
-
-        dfb_tmp5_obj.pop_front(onetile);
-        dfb_recip_ypow_obj.pop_front(onetile);
-        dfb_tmp4_obj.push_back(onetile);
+        // (x^(p - 1) * y * dy) / y^p -> dfb::tmp4
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::BinaryFpu<
+                ckl::BinaryFpuOp::Mul,
+                ckl::input(dfb::tmp5, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig),
+                ckl::input(
+                    dfb::recip_ypow, kBcast, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig)>{},
+            ckl::PackTile<ckl::output(
+                dfb::tmp4, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>{});
 
         dfb_dy_obj.pop_front(onetile);
 
         // multiply abs sign
-        mul_tiles_to_cb(dfb_sign_obj, dfb_tmp4_obj, dfb_dx_obj, 0, 0);
+        mul_tiles_to_dfb<dfb::sign, dfb::tmp4, dfb::dx>();
     }
 
     dfb_decimal_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_c_large.cpp
@@ -4,127 +4,107 @@
 
 #include <cstdint>
 
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"  // Exp, Log, Recip
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Negative
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/minmax.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
-void kernel_main() {
-    constexpr auto dfb_in0 = dfb::in0;
-    DataflowBuffer dfb_in0_obj(dfb_in0);
-    constexpr auto dfb_out0 = dfb::out0;
-    DataflowBuffer dfb_out0_obj(dfb_out0);
-    constexpr auto dfb_exps = dfb::exps;
-    DataflowBuffer dfb_exps_obj(dfb_exps);
-    constexpr auto dfb_recipsumexps = dfb::recip_sum_exps;
-    DataflowBuffer dfb_recipsumexps_obj(dfb_recipsumexps);
-    constexpr auto dfb_add = dfb::add;
-    DataflowBuffer dfb_add_obj(dfb_add);
-    constexpr auto dfb_max = dfb::max;
-    DataflowBuffer dfb_max_obj(dfb_max);
-    constexpr auto dfb_tmp = dfb::tmp;
-    DataflowBuffer dfb_tmp_obj(dfb_tmp);
+namespace ckl = compute_kernel_lib;
 
-    constexpr std::uint32_t onetile = 1;
-    constexpr int dst0 = 0;
-    constexpr int dst1 = 1;
+#if defined(FP32_DEST_ACC_EN)
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Enabled;
+#else
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Disabled;
+#endif
+
+void kernel_main() {
+    DataflowBuffer dfb_recipsumexps_obj(dfb::recip_sum_exps);
+    DataflowBuffer dfb_max_obj(dfb::max);
+
+    constexpr uint32_t onetile = 1;
 
     // Plain uint32_t (not constexpr) to match legacy get_compile_time_arg_val typing and avoid
     // force-unrolling the per-dim_size loops (see moreh_softmax_w_large.cpp for the LTO/addrmod rationale).
-    std::uint32_t N = get_arg(args::N);
-    std::uint32_t dim_size = get_arg(args::dim_size);
+    uint32_t N = get_arg(args::N);
+    uint32_t dim_size = get_arg(args::dim_size);
 
-    compute_kernel_hw_startup(dfb_in0, dfb_exps, dfb_out0);
+    compute_kernel_hw_startup(dfb::in0, dfb::exps, dfb::out0);
 
-    for (std::uint32_t n = 0; n < N; ++n) {
-        // find max
-        for (std::uint32_t i = 0; i < dim_size; ++i) {
+    for (uint32_t n = 0; n < N; ++n) {
+        for (uint32_t i = 0; i < dim_size; ++i) {
             if (i == 0) {
-                copy_tile_to_cb(dfb_in0_obj, dfb_max_obj);
+                copy_tile_to_dfb<dfb::in0, dfb::max>();
             } else {
-                dfb_in0_obj.wait_front(onetile);
-                dfb_max_obj.wait_front(onetile);
-
-                tile_regs_acquire();
-
-                copy_tile_init_with_dt(dfb_in0_obj);
-                copy_tile(dfb_in0, 0, dst0);
-
-                copy_tile_init_with_dt(dfb_max_obj);
-                copy_tile(dfb_max, 0, dst1);
-
-                binary_max_tile_init();
-                binary_max_tile(dst0, dst1, dst0);
-                tile_regs_commit();
-
-                dfb_max_obj.pop_front(onetile);
-                dfb_max_obj.reserve_back(onetile);
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_max_obj);
-                tile_regs_release();
-
-                dfb_max_obj.push_back(onetile);
-                dfb_in0_obj.pop_front(onetile);
+                ckl::binary_sfpu<
+                    ckl::BinaryMax<>,
+                    ckl::input(dfb::in0, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig),
+                    ckl::input(dfb::max, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig),
+                    ckl::output(dfb::max, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>(
+                    ckl::IterationShape::tiles(onetile));
             }
         }
 
         // compute exp(x - max(x))
-        for (std::uint32_t i = 0; i < dim_size; ++i) {
+        for (uint32_t i = 0; i < dim_size; ++i) {
 #ifdef SOFTMAX
-            sub_tiles_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+            exp_tile_to_dfb<dfb::tmp, dfb::exps>();
 #else
-            sub_tiles_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+            rexp_tile_to_dfb<dfb::tmp, dfb::exps>();
 #endif
 
             if (i == 0) {
-                copy_tile_to_cb(dfb_exps_obj, dfb_add_obj);
+                copy_tile_to_dfb<dfb::exps, dfb::add>();
             } else {
-                add_tiles_to_cb(dfb_add_obj, dfb_exps_obj, dfb_add_obj);
+                add_tiles_to_dfb<dfb::add, dfb::exps, dfb::add>();
             }
         }
 
 #ifdef LOG
         // compute log(sum)
-        log_tile_to_cb(dfb_add_obj, dfb_recipsumexps_obj);
+        log_tile_to_dfb<dfb::add, dfb::recip_sum_exps>();
 #else
         // compute 1/sum(exp(x))
-        recip_tile_to_cb(dfb_add_obj, dfb_recipsumexps_obj);
+        recip_tile_to_dfb<dfb::add, dfb::recip_sum_exps>();
 #endif
 
         // step 3, compute final result
         dfb_recipsumexps_obj.wait_front(onetile);
-        for (std::uint32_t i = 0; i < dim_size; ++i) {
+        for (uint32_t i = 0; i < dim_size; ++i) {
 #ifdef LOG
 #ifdef SOFTMAX
             // x - max - log(sum)
-            sub_tiles_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            sub_tiles_to_cb(dfb_tmp_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_dfb<dfb::tmp, dfb::recip_sum_exps, dfb::out0>(0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // -x + max - log(sum)
-            sub_tiles_to_cb(dfb_max_obj, dfb_in0_obj, dfb_tmp_obj, 0, 0, /*pop0=*/0, /*pop1=*/1);
+            sub_tiles_to_dfb<dfb::max, dfb::in0, dfb::tmp>(0, 0, /*pop0=*/0, /*pop1=*/1);
 
-            sub_tiles_to_cb(dfb_tmp_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_dfb<dfb::tmp, dfb::recip_sum_exps, dfb::out0>(0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #else
 #ifdef SOFTMAX
             // exp(x - max) / sum
-            sub_tiles_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+            exp_tile_to_dfb<dfb::tmp, dfb::exps>();
 
-            mul_tiles_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_to_dfb<dfb::exps, dfb::recip_sum_exps, dfb::out0>(0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // rexp(x - max) / sum
-            sub_tiles_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+            rexp_tile_to_dfb<dfb::tmp, dfb::exps>();
 
-            mul_tiles_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_to_dfb<dfb::exps, dfb::recip_sum_exps, dfb::out0>(0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #endif
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
@@ -5,42 +5,37 @@
 #include <cstdint>
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"  // Exp
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Mask, Negative
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
+#if defined(FP32_DEST_ACC_EN)
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Enabled;
+#else
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Disabled;
+#endif
+
 void kernel_main() {
-    constexpr auto dfb_in0 = dfb::in0;
-    DataflowBuffer dfb_in0_obj(dfb_in0);
-    constexpr auto dfb_mask = dfb::mask;
-    DataflowBuffer dfb_mask_obj(dfb_mask);
-    constexpr auto dfb_max_scaler = dfb::max_scaler;
-    DataflowBuffer dfb_max_scaler_obj(dfb_max_scaler);
-    constexpr auto dfb_sum_scaler = dfb::sum_scaler;
-    DataflowBuffer dfb_sum_scaler_obj(dfb_sum_scaler);
-    constexpr auto dfb_out0 = dfb::out0;
-    DataflowBuffer dfb_out0_obj(dfb_out0);
-    constexpr auto dfb_exps = dfb::exps;
-    DataflowBuffer dfb_exps_obj(dfb_exps);
-    constexpr auto dfb_recipsumexps = dfb::recip_sum_exps;
-    DataflowBuffer dfb_recipsumexps_obj(dfb_recipsumexps);
-    constexpr auto dfb_max = dfb::max;
-    DataflowBuffer dfb_max_obj(dfb_max);
-    constexpr auto dfb_x_m_max = dfb::x_minus_max;
-    DataflowBuffer dfb_x_m_max_obj(dfb_x_m_max);
-    constexpr auto dfb_tmp = dfb::tmp;
-    DataflowBuffer dfb_tmp_obj(dfb_tmp);
+    DataflowBuffer dfb_mask_obj(dfb::mask);
+    DataflowBuffer dfb_max_scaler_obj(dfb::max_scaler);
+    DataflowBuffer dfb_sum_scaler_obj(dfb::sum_scaler);
+    DataflowBuffer dfb_x_m_max_obj(dfb::x_minus_max);
 
-    constexpr int dst0 = 0;
-    constexpr int dst1 = 1;
-    constexpr std::uint32_t onetile = 1;
+    constexpr uint32_t onetile = 1;
 
-    compute_kernel_hw_startup(dfb_in0, dfb_max_scaler, dfb_out0);
+    compute_kernel_hw_startup(dfb::in0, dfb::max_scaler, dfb::out0);
 
     // Plain uint32_t (not constexpr) to match legacy get_compile_time_arg_val typing and avoid
     // force-unrolling the per-Ht loops (see moreh_softmax_w_large.cpp for the LTO/addrmod rationale).
-    std::uint32_t N = get_arg(args::N);
-    std::uint32_t Ht = get_arg(args::Ht);
+    uint32_t N = get_arg(args::N);
+    uint32_t Ht = get_arg(args::Ht);
 
     dfb_mask_obj.wait_front(onetile);
     dfb_max_scaler_obj.wait_front(onetile);
@@ -49,148 +44,151 @@ void kernel_main() {
     for (std::uint32_t n = 0; n < N; ++n) {
         // find max value
         if (Ht == 1) {
-            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/0, /*popm=*/0);
+            mask_tile_to_dfb<dfb::in0, dfb::mask, dfb::tmp>(0, 0, /*pop0=*/0, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, dfb_tmp, dfb_max_scaler, dfb_max>(
-                compute_kernel_lib::ReduceInputBlockShape::single());
+            ckl::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, dfb::tmp, dfb::max_scaler, dfb::max>(
+                ckl::ReduceInputBlockShape::single());
         } else {
-            compute_kernel_lib::reduce<
+            ckl::reduce<
                 PoolType::MAX,
                 ReduceDim::REDUCE_COL,
-                dfb_in0,
-                dfb_max_scaler,
-                dfb_max,
+                dfb::in0,
+                dfb::max_scaler,
+                dfb::max,
                 compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
                 compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
 
-            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, Ht - 1, 0, /*pop0=*/0, /*popm=*/0);
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, dfb_tmp, dfb_max_scaler, dfb_max>(
+            mask_tile_to_dfb<dfb::in0, dfb::mask, dfb::tmp>(Ht - 1, 0, /*pop0=*/0, /*popm=*/0);
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, dfb::tmp, dfb::max_scaler, dfb::max>(
                 compute_kernel_lib::ReduceInputBlockShape::single(),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::Accumulate::at(dfb_max, 1));  // iteration=1, reload from dfb_max
+                compute_kernel_lib::Accumulate::at(dfb::max, 1));  // iteration=1, reload from dfb::max
         }
 
         // compute x - max(x)
-        dfb_x_m_max_obj.reserve_back(Ht);
-        dfb_in0_obj.wait_front(Ht);
-        dfb_max_obj.wait_front(1);
-
-        for (std::uint32_t h = 0; h < Ht; ++h) {
-            tile_regs_acquire();
-            sub_bcast_rows_init_with_dt(dfb_in0_obj, dfb_max_obj);
-            sub_tiles_bcast<BroadcastType::ROW>(dfb_in0, dfb_max, h, 0, dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_x_m_max_obj);
-            tile_regs_release();
-        }
-        dfb_max_obj.pop_front(1);
-        dfb_in0_obj.pop_front(Ht);
-        dfb_x_m_max_obj.push_back(Ht);
+        ckl::sub<
+            ckl::input(
+                dfb::in0,
+                ckl::WaitPolicy::Upfront,
+                ckl::PopPolicy::AtEnd,
+                ckl::InputTileMapping::Block,
+                kDataFormatReconfig),
+            ckl::input(
+                dfb::max, ckl::BroadcastDim::Row, ckl::WaitPolicy::Upfront, ckl::PopPolicy::AtEnd, kDataFormatReconfig),
+            ckl::output(dfb::x_minus_max, ckl::ReservePolicy::Upfront, ckl::PushPolicy::AtEnd, kDataFormatReconfig)>(
+            ckl::IterationShape::tiles(Ht));
 
         // compute exp(x - max(x))
-        dfb_exps_obj.reserve_back(Ht);
         dfb_x_m_max_obj.wait_front(Ht);
-        for (std::uint32_t h = 0; h < Ht; ++h) {
-            tile_regs_acquire();
-            copy_tile_init_with_dt(dfb_x_m_max_obj);
-            copy_tile(dfb_x_m_max, h, dst0);
-
-#ifndef SOFTMAX
-            negative_tile_init();
-            negative_tile(dst0);
+#ifdef SOFTMAX
+        constexpr bool is_softmax = true;
+#else
+        constexpr bool is_softmax = false;
 #endif
+        ckl::eltwise_chain(
+            ckl::IterationShape::tiles(Ht - 1),
+            ckl::CopyTile<
+                ckl::input(
+                    dfb::x_minus_max,
+                    ckl::WaitPolicy::None,
+                    ckl::PopPolicy::None,
+                    ckl::InputTileMapping::Block,
+                    kDataFormatReconfig),
+                ckl::Dst::D0>{},
+            ckl::Optional<!is_softmax, ckl::Negative<ckl::Dst::D0>>{},
+            ckl::Exp<ckl::Approx::Exact, ckl::Dst::D0>{},
+            ckl::PackTile<ckl::output(
+                dfb::exps, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>{});
 
-            exp_tile_init();
-            exp_tile(dst0);
-
-            if (h == Ht - 1) {
-                copy_tile_init_with_dt(dfb_mask_obj);
-                copy_tile(dfb_mask, 0, dst1);
-
-                mask_tile_init();
-                mask_tile(dst0, dst1);
-            }
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_exps_obj);
-            tile_regs_release();
-        }
-        dfb_exps_obj.push_back(Ht);
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::CopyTile<
+                ckl::input(
+                    dfb::x_minus_max,
+                    ckl::WaitPolicy::None,
+                    ckl::PopPolicy::None,
+                    ckl::InputTileMapping::Block,
+                    kDataFormatReconfig,
+                    ckl::TileAddressing::Offset),
+                ckl::Dst::D0>{Ht - 1},
+            ckl::Optional<!is_softmax, ckl::Negative<ckl::Dst::D0>>{},
+            ckl::Exp<ckl::Approx::Exact, ckl::Dst::D0>{},
+            ckl::CopyTile<
+                ckl::input(dfb::mask, ckl::WaitPolicy::None, ckl::PopPolicy::None, kDataFormatReconfig),
+                ckl::Dst::D1>{},
+            ckl::Mask<DataFormat::Float16_b, ckl::Dst::D0>{},
+            ckl::PackTile<ckl::output(
+                dfb::exps, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>{});
 
 #ifdef LOG
         // log(sum) - pop tiles after reduce
-        compute_kernel_lib::reduce<
+        ckl::reduce<
             PoolType::SUM,
             ReduceDim::REDUCE_COL,
-            dfb_exps,
-            dfb_sum_scaler,
-            dfb_recipsumexps,
-            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-            compute_kernel_lib::ReduceInputBlockShape::col(Ht),
-            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-            compute_kernel_lib::NoAccumulation{},
-            [](std::uint32_t dst_idx) {
+            dfb::exps,
+            dfb::sum_scaler,
+            dfb::recip_sum_exps,
+            ckl::ReduceInputPolicy::BulkWaitBulkPop>(
+            ckl::ReduceInputBlockShape::col(Ht),
+            ckl::ReduceInputMemoryLayout::contiguous(),
+            ckl::NoAccumulation{},
+            [](uint32_t dst_idx) {
                 log_tile_init();
                 log_tile(dst_idx);
             });
 #else
         // 1/sum - keep tiles for subsequent multiplication
-        compute_kernel_lib::reduce<
+        ckl::reduce<
             PoolType::SUM,
             ReduceDim::REDUCE_COL,
-            dfb_exps,
-            dfb_sum_scaler,
-            dfb_recipsumexps,
-            compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-            compute_kernel_lib::ReduceInputBlockShape::col(Ht),
-            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-            compute_kernel_lib::NoAccumulation{},
-            [](std::uint32_t dst_idx) {
+            dfb::exps,
+            dfb::sum_scaler,
+            dfb::recip_sum_exps,
+            ckl::ReduceInputPolicy::WaitUpfrontNoPop>(
+            ckl::ReduceInputBlockShape::col(Ht),
+            ckl::ReduceInputMemoryLayout::contiguous(),
+            ckl::NoAccumulation{},
+            [](uint32_t dst_idx) {
                 recip_tile_init();
                 recip_tile(dst_idx);
             });
 #endif
 
         // compute final result
-        dfb_out0_obj.reserve_back(Ht);
         dfb_x_m_max_obj.wait_front(Ht);
-        dfb_recipsumexps_obj.wait_front(1);
-#ifndef LOG
-        dfb_exps_obj.wait_front(Ht);
-#endif
-
-        for (std::uint32_t h = 0; h < Ht; h += onetile) {
 #ifdef LOG
-            // x - max - log(sum)
-            tile_regs_acquire();
-            sub_bcast_rows_init_with_dt(dfb_x_m_max_obj, dfb_recipsumexps_obj);
-            sub_tiles_bcast<BroadcastType::ROW>(dfb_x_m_max, dfb_recipsumexps, h, 0, dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_out0_obj);
-            tile_regs_release();
+        ckl::sub<
+            ckl::input(
+                dfb::x_minus_max,
+                ckl::WaitPolicy::None,
+                ckl::PopPolicy::None,
+                ckl::InputTileMapping::Block,
+                kDataFormatReconfig),
+            ckl::input(
+                dfb::recip_sum_exps,
+                ckl::BroadcastDim::Row,
+                ckl::WaitPolicy::Upfront,
+                ckl::PopPolicy::AtEnd,
+                kDataFormatReconfig),
+            ckl::output(dfb::out0, ckl::ReservePolicy::Upfront, ckl::PushPolicy::AtEnd, kDataFormatReconfig)>(
+            ckl::IterationShape::tiles(Ht));
 #else
-            // exp(x - max) / psum
-            tile_regs_acquire();
-            mul_bcast_rows_init_with_dt(dfb_exps_obj, dfb_recipsumexps_obj);
-            mul_tiles_bcast_rows(dfb_exps, dfb_recipsumexps, h, 0, dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_out0_obj);
-            tile_regs_release();
+        ckl::mul<
+            ckl::input(
+                dfb::exps,
+                ckl::WaitPolicy::Upfront,
+                ckl::PopPolicy::AtEnd,
+                ckl::InputTileMapping::Block,
+                kDataFormatReconfig),
+            ckl::input(
+                dfb::recip_sum_exps,
+                ckl::BroadcastDim::Row,
+                ckl::WaitPolicy::Upfront,
+                ckl::PopPolicy::AtEnd,
+                kDataFormatReconfig),
+            ckl::output(dfb::out0, ckl::ReservePolicy::Upfront, ckl::PushPolicy::AtEnd, kDataFormatReconfig)>(
+            ckl::IterationShape::tiles(Ht));
 #endif
-        }
-
-        dfb_recipsumexps_obj.pop_front(1);
         dfb_x_m_max_obj.pop_front(Ht);
-        dfb_out0_obj.push_back(Ht);
-#ifndef LOG
-        dfb_exps_obj.pop_front(Ht);
-#endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
@@ -5,80 +5,63 @@
 #include <cstdint>
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"  // Exp, Log, Recip
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Mask, Negative
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
 void kernel_main() {
-    constexpr auto dfb_in0 = dfb::in0;
-    DataflowBuffer dfb_in0_obj(dfb_in0);
-    constexpr auto dfb_mask = dfb::mask;
-    DataflowBuffer dfb_mask_obj(dfb_mask);
-    constexpr auto dfb_max_scaler = dfb::max_scaler;
-    constexpr auto dfb_sum_scaler = dfb::sum_scaler;
-    constexpr auto dfb_out0 = dfb::out0;
-    DataflowBuffer dfb_out0_obj(dfb_out0);
-    constexpr auto dfb_exps = dfb::exps;
-    DataflowBuffer dfb_exps_obj(dfb_exps);
-    constexpr auto dfb_recipsumexps = dfb::recip_sum_exps;
-    DataflowBuffer dfb_recipsumexps_obj(dfb_recipsumexps);
-    constexpr auto dfb_add = dfb::add;
-    DataflowBuffer dfb_add_obj(dfb_add);
-    constexpr auto dfb_max = dfb::max;
-    DataflowBuffer dfb_max_obj(dfb_max);
-    constexpr auto dfb_tmp = dfb::tmp;
-    DataflowBuffer dfb_tmp_obj(dfb_tmp);
+    DataflowBuffer dfb_recipsumexps_obj(dfb::recip_sum_exps);
+    DataflowBuffer dfb_max_obj(dfb::max);
 
-    compute_kernel_hw_startup(dfb_in0, dfb_max_scaler, dfb_out0);
+    compute_kernel_hw_startup(dfb::in0, dfb::max_scaler, dfb::out0);
 
-    constexpr std::uint32_t onetile = 1;
-    constexpr int dst0 = 0;
+    constexpr uint32_t onetile = 1;
 
     // Plain uint32_t (not constexpr) to match legacy get_compile_time_arg_val typing and avoid
     // force-unrolling the per-Ht loops (see moreh_softmax_w_large.cpp for the LTO/addrmod rationale).
-    std::uint32_t N = get_arg(args::N);
-    std::uint32_t Ht = get_arg(args::Ht);
+    uint32_t N = get_arg(args::N);
+    uint32_t Ht = get_arg(args::Ht);
 
     for (std::uint32_t n = 0; n < N; ++n) {
         // find max
         if (Ht == 1) {
-            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
+            mask_tile_to_dfb<dfb::in0, dfb::mask, dfb::tmp>(0, 0, /*pop0=*/1, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, dfb_tmp, dfb_max_scaler, dfb_max>(
-                compute_kernel_lib::ReduceInputBlockShape::single());
+            ckl::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, dfb::tmp, dfb::max_scaler, dfb::max>(
+                ckl::ReduceInputBlockShape::single());
         } else {
             // Phase 1: Reduce Ht-1 tiles
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, dfb_in0, dfb_max_scaler, dfb_max>(
-                compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
+            ckl::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, dfb::in0, dfb::max_scaler, dfb::max>(
+                ckl::ReduceInputBlockShape::col(Ht - 1));
 
-            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
+            mask_tile_to_dfb<dfb::in0, dfb::mask, dfb::tmp>(0, 0, /*pop0=*/1, /*popm=*/0);
 
             // Phase 2: Reduce final masked tile with accumulation
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, dfb_tmp, dfb_max_scaler, dfb_max>(
-                compute_kernel_lib::ReduceInputBlockShape::single(),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::Accumulate::at(dfb_max, 1));  // iteration=1, reload from dfb_max
+            ckl::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, dfb::tmp, dfb::max_scaler, dfb::max>(
+                ckl::ReduceInputBlockShape::single(),
+                ckl::ReduceInputMemoryLayout::contiguous(),
+                ckl::Accumulate::at(dfb::max, 1));  // iteration=1, reload from dfb::max
         }
 
         for (std::uint32_t h = 0; h < Ht; h += onetile) {
             // compute exp(x - max(x))
             if (h == Ht - 1) {
 #ifdef SOFTMAX
-                sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_rows_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                exp_tile_and_mask_tile_to_cb(
-                    dfb_tmp_obj,
-                    dfb_mask_obj,
-                    dfb_exps_obj,
+                exp_tile_and_mask_tile_to_dfb<dfb::tmp, dfb::mask, dfb::exps>(
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
                     /*popm=*/0);
 #else
-                rexp_tile_and_mask_tile_to_cb(
-                    dfb_in0_obj,
-                    dfb_mask_obj,
-                    dfb_exps_obj,
+                rexp_tile_and_mask_tile_to_dfb<dfb::in0, dfb::mask, dfb::exps>(
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
@@ -86,52 +69,52 @@ void kernel_main() {
 #endif
             } else {
 #ifdef SOFTMAX
-                sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_rows_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+                exp_tile_to_dfb<dfb::tmp, dfb::exps>();
 #else
-                sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_rows_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+                rexp_tile_to_dfb<dfb::tmp, dfb::exps>();
 #endif
             }
 
             if (h == 0) {
-                copy_tile_to_cb(dfb_exps_obj, dfb_add_obj);
+                copy_tile_to_dfb<dfb::exps, dfb::add>();
             } else {
-                add_tiles_to_cb(dfb_add_obj, dfb_exps_obj, dfb_add_obj);
+                add_tiles_to_dfb<dfb::add, dfb::exps, dfb::add>();
             }
         }
 
 #ifdef LOG
         // compute log(sum) - pop tile after reduce
-        compute_kernel_lib::reduce<
+        ckl::reduce<
             PoolType::SUM,
             ReduceDim::REDUCE_COL,
-            dfb_add,
-            dfb_sum_scaler,
-            dfb_recipsumexps,
-            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-            compute_kernel_lib::ReduceInputBlockShape::single(),
-            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-            compute_kernel_lib::NoAccumulation{},
-            [](std::uint32_t dst_idx) {
+            dfb::add,
+            dfb::sum_scaler,
+            dfb::recip_sum_exps,
+            ckl::ReduceInputPolicy::BulkWaitBulkPop>(
+            ckl::ReduceInputBlockShape::single(),
+            ckl::ReduceInputMemoryLayout::contiguous(),
+            ckl::NoAccumulation{},
+            [](uint32_t dst_idx) {
                 log_tile_init();
                 log_tile(dst_idx);
             });
 #else
         // compute 1/sum(exp(x)) - pop tile after reduce
-        compute_kernel_lib::reduce<
+        ckl::reduce<
             PoolType::SUM,
             ReduceDim::REDUCE_COL,
-            dfb_add,
-            dfb_sum_scaler,
-            dfb_recipsumexps,
-            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-            compute_kernel_lib::ReduceInputBlockShape::single(),
-            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-            compute_kernel_lib::NoAccumulation{},
-            [](std::uint32_t dst_idx) {
+            dfb::add,
+            dfb::sum_scaler,
+            dfb::recip_sum_exps,
+            ckl::ReduceInputPolicy::BulkWaitBulkPop>(
+            ckl::ReduceInputBlockShape::single(),
+            ckl::ReduceInputMemoryLayout::contiguous(),
+            ckl::NoAccumulation{},
+            [](uint32_t dst_idx) {
                 recip_tile_init();
                 recip_tile(dst_idx);
             });
@@ -142,28 +125,27 @@ void kernel_main() {
 #ifdef LOG
 #ifdef SOFTMAX
             // x - max - log(sum)
-            sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            sub_tiles_bcast_rows_to_cb(dfb_tmp_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_dfb<dfb::tmp, dfb::recip_sum_exps, dfb::out0>(0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
-            // -x + max - log(sum)
             // logsoftmin not implemented
 #endif
 #else
 #ifdef SOFTMAX
             // exp(x - max) / sum
-            sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+            exp_tile_to_dfb<dfb::tmp, dfb::exps>();
 
-            mul_tiles_bcast_rows_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_dfb<dfb::exps, dfb::recip_sum_exps, dfb::out0>(0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // rexp(x - max) / sum
-            sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+            rexp_tile_to_dfb<dfb::tmp, dfb::exps>();
 
-            mul_tiles_bcast_rows_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_dfb<dfb::exps, dfb::recip_sum_exps, dfb::out0>(0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #endif
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
@@ -5,42 +5,37 @@
 #include <cstdint>
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"  // sub
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"       // Exp
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"       // Mask, Negative
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
+#if defined(FP32_DEST_ACC_EN)
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Enabled;
+#else
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Disabled;
+#endif
+
 void kernel_main() {
-    constexpr auto dfb_in0 = dfb::in0;
-    DataflowBuffer dfb_in0_obj(dfb_in0);
-    constexpr auto dfb_mask = dfb::mask;
-    DataflowBuffer dfb_mask_obj(dfb_mask);
-    constexpr auto dfb_max_scaler = dfb::max_scaler;
-    DataflowBuffer dfb_max_scaler_obj(dfb_max_scaler);
-    constexpr auto dfb_sum_scaler = dfb::sum_scaler;
-    DataflowBuffer dfb_sum_scaler_obj(dfb_sum_scaler);
-    constexpr auto dfb_out0 = dfb::out0;
-    DataflowBuffer dfb_out0_obj(dfb_out0);
-    constexpr auto dfb_exps = dfb::exps;
-    DataflowBuffer dfb_exps_obj(dfb_exps);
-    constexpr auto dfb_recipsumexps = dfb::recip_sum_exps;
-    DataflowBuffer dfb_recipsumexps_obj(dfb_recipsumexps);
-    constexpr auto dfb_max = dfb::max;
-    DataflowBuffer dfb_max_obj(dfb_max);
-    constexpr auto dfb_x_m_max = dfb::x_minus_max;
-    DataflowBuffer dfb_x_m_max_obj(dfb_x_m_max);
-    constexpr auto dfb_tmp = dfb::tmp;
-    DataflowBuffer dfb_tmp_obj(dfb_tmp);
+    DataflowBuffer dfb_mask_obj(dfb::mask);
+    DataflowBuffer dfb_max_scaler_obj(dfb::max_scaler);
+    DataflowBuffer dfb_sum_scaler_obj(dfb::sum_scaler);
+    DataflowBuffer dfb_x_m_max_obj(dfb::x_minus_max);
 
-    compute_kernel_hw_startup(dfb_in0, dfb_max_scaler, dfb_out0);
+    compute_kernel_hw_startup(dfb::in0, dfb::max_scaler, dfb::out0);
 
-    constexpr int dst0 = 0;
-    constexpr int dst1 = 1;
-    constexpr std::uint32_t onetile = 1;
+    constexpr uint32_t onetile = 1;
 
     // Plain uint32_t (not constexpr) to match legacy get_compile_time_arg_val typing and avoid
     // force-unrolling the per-Wt loops (see moreh_softmax_w_large.cpp for the LTO/addrmod rationale).
-    std::uint32_t N = get_arg(args::N);
-    std::uint32_t Wt = get_arg(args::Wt);
+    uint32_t N = get_arg(args::N);
+    uint32_t Wt = get_arg(args::Wt);
 
     dfb_mask_obj.wait_front(onetile);
     dfb_max_scaler_obj.wait_front(onetile);
@@ -49,155 +44,156 @@ void kernel_main() {
     for (std::uint32_t n = 0; n < N; ++n) {
         // find max value
         if (Wt == 1) {
-            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/0, /*popm=*/0);
+            mask_tile_to_dfb<dfb::in0, dfb::mask, dfb::tmp>(0, 0, /*pop0=*/0, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, dfb_tmp, dfb_max_scaler, dfb_max>(
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, dfb::tmp, dfb::max_scaler, dfb::max>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
-            // Phase 1: reduce Wt-1 full tiles into dfb_max via the helper.
-            // dfb_in0 holds all Wt tiles persistently for later steps, so use
+            // Phase 1: reduce Wt-1 full tiles into dfb::max via the helper.
+            // dfb::in0 holds all Wt tiles persistently for later steps, so use
             // WaitUpfrontNoPop — the helper waits for the slice it needs and never pops.
-            compute_kernel_lib::reduce<
+            ckl::reduce<
                 PoolType::MAX,
                 ReduceDim::REDUCE_ROW,
-                dfb_in0,
-                dfb_max_scaler,
-                dfb_max,
-                compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-                compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
+                dfb::in0,
+                dfb::max_scaler,
+                dfb::max,
+                ckl::ReduceInputPolicy::WaitUpfrontNoPop>(ckl::ReduceInputBlockShape::row(Wt - 1));
 
             // Phase 2: mask the last tile (index Wt-1, no pop) and continue reducing
-            // into dfb_max via Accumulate. The accumulator and output are both dfb_max:
+            // into dfb::max via Accumulate. The accumulator and output are both dfb::max:
             // the helper waits+pops the previous tile, then packs+pushes the new one.
-            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, Wt - 1, 0, /*pop0=*/0, /*popm=*/0);
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, dfb_tmp, dfb_max_scaler, dfb_max>(
+            mask_tile_to_dfb<dfb::in0, dfb::mask, dfb::tmp>(Wt - 1, 0, /*pop0=*/0, /*popm=*/0);
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, dfb::tmp, dfb::max_scaler, dfb::max>(
                 compute_kernel_lib::ReduceInputBlockShape::row(1),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::Accumulate::at(dfb_max, /*iter=*/1));
+                compute_kernel_lib::Accumulate::at(dfb::max, /*iter=*/1));
         }
 
         // compute x - max(x)
-        dfb_x_m_max_obj.reserve_back(Wt);
-        dfb_in0_obj.wait_front(Wt);
-        dfb_max_obj.wait_front(1);
-
-        for (std::uint32_t w = 0; w < Wt; ++w) {
-            tile_regs_acquire();
-            sub_bcast_cols_init_with_dt(dfb_in0_obj, dfb_max_obj);
-            sub_tiles_bcast<BroadcastType::COL>(dfb_in0, dfb_max, w, 0, dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_x_m_max_obj);
-            tile_regs_release();
-        }
-        dfb_max_obj.pop_front(1);
-        dfb_in0_obj.pop_front(Wt);
-        dfb_x_m_max_obj.push_back(Wt);
+        ckl::sub<
+            ckl::input(
+                dfb::in0,
+                ckl::WaitPolicy::Upfront,
+                ckl::PopPolicy::AtEnd,
+                ckl::InputTileMapping::Block,
+                kDataFormatReconfig),
+            ckl::input(
+                dfb::max, ckl::BroadcastDim::Col, ckl::WaitPolicy::Upfront, ckl::PopPolicy::AtEnd, kDataFormatReconfig),
+            ckl::output(dfb::x_minus_max, ckl::ReservePolicy::Upfront, ckl::PushPolicy::AtEnd, kDataFormatReconfig)>(
+            ckl::IterationShape::tiles(Wt));
 
         // compute exp(x - max(x))
-        dfb_exps_obj.reserve_back(Wt);
         dfb_x_m_max_obj.wait_front(Wt);
-        for (std::uint32_t w = 0; w < Wt; ++w) {
-            tile_regs_acquire();
-            copy_tile_init_with_dt(dfb_x_m_max_obj);
-            copy_tile(dfb_x_m_max, w, dst0);
-
-#ifndef SOFTMAX
-            negative_tile_init();
-            negative_tile(dst0);
+#ifdef SOFTMAX
+        constexpr bool is_softmax = true;
+#else
+        constexpr bool is_softmax = false;
 #endif
+        ckl::eltwise_chain(
+            ckl::IterationShape::tiles(Wt - 1),
+            ckl::CopyTile<
+                ckl::input(
+                    dfb::x_minus_max,
+                    ckl::WaitPolicy::None,
+                    ckl::PopPolicy::None,
+                    ckl::InputTileMapping::Block,
+                    kDataFormatReconfig),
+                ckl::Dst::D0>{},
+            ckl::Optional<!is_softmax, ckl::Negative<ckl::Dst::D0>>{},
+            ckl::Exp<ckl::Approx::Exact, ckl::Dst::D0>{},
+            ckl::PackTile<ckl::output(
+                dfb::exps, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>{});
 
-            exp_tile_init();
-            exp_tile(dst0);
-
-            if (w == Wt - 1) {
-                copy_tile_init_with_dt(dfb_mask_obj);
-                copy_tile(dfb_mask, 0, dst1);
-
-                mask_tile_init();
-                mask_tile(dst0, dst1);
-            }
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_exps_obj);
-            tile_regs_release();
-        }
-        dfb_exps_obj.push_back(Wt);
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::CopyTile<
+                ckl::input(
+                    dfb::x_minus_max,
+                    ckl::WaitPolicy::None,
+                    ckl::PopPolicy::None,
+                    ckl::InputTileMapping::Block,
+                    kDataFormatReconfig,
+                    ckl::TileAddressing::Offset),
+                ckl::Dst::D0>{Wt - 1},
+            ckl::Optional<!is_softmax, ckl::Negative<ckl::Dst::D0>>{},
+            ckl::Exp<ckl::Approx::Exact, ckl::Dst::D0>{},
+            ckl::CopyTile<
+                ckl::input(dfb::mask, ckl::WaitPolicy::None, ckl::PopPolicy::None, kDataFormatReconfig),
+                ckl::Dst::D1>{},
+            ckl::Mask<DataFormat::Float16_b, ckl::Dst::D0>{},
+            ckl::PackTile<ckl::output(
+                dfb::exps, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, kDataFormatReconfig)>{});
 
 #ifdef LOG
         // log(sum) - pop tiles after reduce
-        compute_kernel_lib::reduce<
+        ckl::reduce<
             PoolType::SUM,
             ReduceDim::REDUCE_ROW,
-            dfb_exps,
-            dfb_sum_scaler,
-            dfb_recipsumexps,
-            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-            compute_kernel_lib::ReduceInputBlockShape::row(Wt),
-            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-            compute_kernel_lib::NoAccumulation{},
-            [](std::uint32_t dst_idx) {
+            dfb::exps,
+            dfb::sum_scaler,
+            dfb::recip_sum_exps,
+            ckl::ReduceInputPolicy::BulkWaitBulkPop>(
+            ckl::ReduceInputBlockShape::row(Wt),
+            ckl::ReduceInputMemoryLayout::contiguous(),
+            ckl::NoAccumulation{},
+            [](uint32_t dst_idx) {
                 log_tile_init();
                 log_tile(dst_idx);
             });
 #else
         // 1/sum - keep tiles for subsequent multiplication
-        compute_kernel_lib::reduce<
+        ckl::reduce<
             PoolType::SUM,
             ReduceDim::REDUCE_ROW,
-            dfb_exps,
-            dfb_sum_scaler,
-            dfb_recipsumexps,
-            compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-            compute_kernel_lib::ReduceInputBlockShape::row(Wt),
-            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-            compute_kernel_lib::NoAccumulation{},
-            [](std::uint32_t dst_idx) {
+            dfb::exps,
+            dfb::sum_scaler,
+            dfb::recip_sum_exps,
+            ckl::ReduceInputPolicy::WaitUpfrontNoPop>(
+            ckl::ReduceInputBlockShape::row(Wt),
+            ckl::ReduceInputMemoryLayout::contiguous(),
+            ckl::NoAccumulation{},
+            [](uint32_t dst_idx) {
                 recip_tile_init();
                 recip_tile(dst_idx);
             });
 #endif
 
         // compute final result
-        dfb_out0_obj.reserve_back(Wt);
         dfb_x_m_max_obj.wait_front(Wt);
-        dfb_recipsumexps_obj.wait_front(1);
-
-#ifndef LOG
-        dfb_exps_obj.wait_front(Wt);
-#endif
-
-        for (std::uint32_t w = 0; w < Wt; w += onetile) {
 #ifdef LOG
-            // x - max - log(sum)
-            tile_regs_acquire();
-            sub_bcast_cols_init_with_dt(dfb_x_m_max_obj, dfb_recipsumexps_obj);
-            sub_tiles_bcast<BroadcastType::COL>(dfb_x_m_max, dfb_recipsumexps, w, 0, dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_out0_obj);
-            tile_regs_release();
+        ckl::sub<
+            ckl::input(
+                dfb::x_minus_max,
+                ckl::WaitPolicy::None,
+                ckl::PopPolicy::None,
+                ckl::InputTileMapping::Block,
+                kDataFormatReconfig),
+            ckl::input(
+                dfb::recip_sum_exps,
+                ckl::BroadcastDim::Col,
+                ckl::WaitPolicy::Upfront,
+                ckl::PopPolicy::AtEnd,
+                kDataFormatReconfig),
+            ckl::output(dfb::out0, ckl::ReservePolicy::Upfront, ckl::PushPolicy::AtEnd, kDataFormatReconfig)>(
+            ckl::IterationShape::tiles(Wt));
 #else
-            // exp(x - max) / psum
-            tile_regs_acquire();
-            mul_bcast_cols_init_with_dt(dfb_exps_obj, dfb_recipsumexps_obj);
-            mul_tiles_bcast_cols(dfb_exps, dfb_recipsumexps, w, 0, dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, dfb_out0_obj);
-            tile_regs_release();
+        ckl::mul<
+            ckl::input(
+                dfb::exps,
+                ckl::WaitPolicy::Upfront,
+                ckl::PopPolicy::AtEnd,
+                ckl::InputTileMapping::Block,
+                kDataFormatReconfig),
+            ckl::input(
+                dfb::recip_sum_exps,
+                ckl::BroadcastDim::Col,
+                ckl::WaitPolicy::Upfront,
+                ckl::PopPolicy::AtEnd,
+                kDataFormatReconfig),
+            ckl::output(dfb::out0, ckl::ReservePolicy::Upfront, ckl::PushPolicy::AtEnd, kDataFormatReconfig)>(
+            ckl::IterationShape::tiles(Wt));
 #endif
-        }
-
-        dfb_recipsumexps_obj.pop_front(1);
         dfb_x_m_max_obj.pop_front(Wt);
-        dfb_out0_obj.push_back(Wt);
-#ifndef LOG
-        dfb_exps_obj.pop_front(Wt);
-#endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
@@ -10,78 +10,60 @@
 #include <cstdint>
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"  // Exp, Log, Recip
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Mask, Negative
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
-void kernel_main() {
-    constexpr auto dfb_in0 = dfb::in0;
-    DataflowBuffer dfb_in0_obj(dfb_in0);
-    constexpr auto dfb_mask = dfb::mask;
-    DataflowBuffer dfb_mask_obj(dfb_mask);
-    constexpr auto dfb_max_scaler = dfb::max_scaler;
-    constexpr auto dfb_sum_scaler = dfb::sum_scaler;
-    constexpr auto dfb_out0 = dfb::out0;
-    DataflowBuffer dfb_out0_obj(dfb_out0);
-    constexpr auto dfb_exps = dfb::exps;
-    DataflowBuffer dfb_exps_obj(dfb_exps);
-    constexpr auto dfb_recipsumexps = dfb::recip_sum_exps;
-    DataflowBuffer dfb_recipsumexps_obj(dfb_recipsumexps);
-    constexpr auto dfb_add = dfb::add;
-    DataflowBuffer dfb_add_obj(dfb_add);
-    constexpr auto dfb_max = dfb::max;
-    DataflowBuffer dfb_max_obj(dfb_max);
-    constexpr auto dfb_tmp = dfb::tmp;
-    DataflowBuffer dfb_tmp_obj(dfb_tmp);
+namespace ckl = compute_kernel_lib;
 
-    compute_kernel_hw_startup(dfb_in0, dfb_max_scaler, dfb_out0);
+void kernel_main() {
+    DataflowBuffer dfb_recipsumexps_obj(dfb::recip_sum_exps);
+    DataflowBuffer dfb_max_obj(dfb::max);
+
+    compute_kernel_hw_startup(dfb::in0, dfb::max_scaler, dfb::out0);
 
     constexpr std::uint32_t onetile = 1;
 
     // Plain uint32_t (not constexpr) to match legacy get_compile_time_arg_val typing.
-    std::uint32_t N = get_arg(args::N);
-    std::uint32_t Wt = get_arg(args::Wt);
+    uint32_t N = get_arg(args::N);
+    uint32_t Wt = get_arg(args::Wt);
 
     for (std::uint32_t n = 0; n < N; ++n) {
         // find max
         if (Wt == 1) {
-            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
+            mask_tile_to_dfb<dfb::in0, dfb::mask, dfb::tmp>(0, 0, /*pop0=*/1, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, dfb_tmp, dfb_max_scaler, dfb_max>(
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, dfb::tmp, dfb::max_scaler, dfb::max>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
-            // Phase 1: reduce Wt-1 full tiles into dfb_max (no accumulation, first call).
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, dfb_in0, dfb_max_scaler, dfb_max>(
+            // Phase 1: reduce Wt-1 full tiles into dfb::max (no accumulation, first call).
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, dfb::in0, dfb::max_scaler, dfb::max>(
                 compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
 
-            // Phase 2: mask the last tile and continue reducing into dfb_max via Accumulate.
-            mask_tile_to_cb(dfb_in0_obj, dfb_mask_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*popm=*/0);
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, dfb_tmp, dfb_max_scaler, dfb_max>(
+            // Phase 2: mask the last tile and continue reducing into dfb::max via Accumulate.
+            mask_tile_to_dfb<dfb::in0, dfb::mask, dfb::tmp>(0, 0, /*pop0=*/1, /*popm=*/0);
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, dfb::tmp, dfb::max_scaler, dfb::max>(
                 compute_kernel_lib::ReduceInputBlockShape::row(1),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::Accumulate::at(dfb_max, /*iter=*/1));
+                compute_kernel_lib::Accumulate::at(dfb::max, /*iter=*/1));
         }
 
-        // step 1
-        for (std::uint32_t w = 0; w < Wt; ++w) {
-            // compute exp(x)
+        for (uint32_t w = 0; w < Wt; ++w) {
             if (w == Wt - 1) {
 #ifdef SOFTMAX
-                sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_cols_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                exp_tile_and_mask_tile_to_cb(
-                    dfb_tmp_obj,
-                    dfb_mask_obj,
-                    dfb_exps_obj,
+                exp_tile_and_mask_tile_to_dfb<dfb::tmp, dfb::mask, dfb::exps>(
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
                     /*popm=*/0);
 #else
-                rexp_tile_and_mask_tile_to_cb(
-                    dfb_in0_obj,
-                    dfb_mask_obj,
-                    dfb_exps_obj,
+                rexp_tile_and_mask_tile_to_dfb<dfb::in0, dfb::mask, dfb::exps>(
                     /*itile=*/0,
                     /*mtile=*/0,
                     /*pop=*/1,
@@ -89,52 +71,52 @@ void kernel_main() {
 #endif
             } else {
 #ifdef SOFTMAX
-                sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_cols_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+                exp_tile_to_dfb<dfb::tmp, dfb::exps>();
 #else
-                sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+                sub_tiles_bcast_cols_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-                rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+                rexp_tile_to_dfb<dfb::tmp, dfb::exps>();
 #endif
             }
 
             if (w == 0) {
-                copy_tile_to_cb(dfb_exps_obj, dfb_add_obj);
+                copy_tile_to_dfb<dfb::exps, dfb::add>();
             } else {
-                add_tiles_to_cb(dfb_add_obj, dfb_exps_obj, dfb_add_obj);
+                add_tiles_to_dfb<dfb::add, dfb::exps, dfb::add>();
             }
         }
 
 #ifdef LOG
         // compute log(sum) - pop tile after reduce
-        compute_kernel_lib::reduce<
+        ckl::reduce<
             PoolType::SUM,
             ReduceDim::REDUCE_ROW,
-            dfb_add,
-            dfb_sum_scaler,
-            dfb_recipsumexps,
-            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-            compute_kernel_lib::ReduceInputBlockShape::single(),
-            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-            compute_kernel_lib::NoAccumulation{},
-            [](std::uint32_t dst_idx) {
+            dfb::add,
+            dfb::sum_scaler,
+            dfb::recip_sum_exps,
+            ckl::ReduceInputPolicy::BulkWaitBulkPop>(
+            ckl::ReduceInputBlockShape::single(),
+            ckl::ReduceInputMemoryLayout::contiguous(),
+            ckl::NoAccumulation{},
+            [](uint32_t dst_idx) {
                 log_tile_init();
                 log_tile(dst_idx);
             });
 #else
         // compute 1/sum(exp(x)) - pop tile after reduce
-        compute_kernel_lib::reduce<
+        ckl::reduce<
             PoolType::SUM,
             ReduceDim::REDUCE_ROW,
-            dfb_add,
-            dfb_sum_scaler,
-            dfb_recipsumexps,
-            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-            compute_kernel_lib::ReduceInputBlockShape::single(),
-            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-            compute_kernel_lib::NoAccumulation{},
-            [](std::uint32_t dst_idx) {
+            dfb::add,
+            dfb::sum_scaler,
+            dfb::recip_sum_exps,
+            ckl::ReduceInputPolicy::BulkWaitBulkPop>(
+            ckl::ReduceInputBlockShape::single(),
+            ckl::ReduceInputMemoryLayout::contiguous(),
+            ckl::NoAccumulation{},
+            [](uint32_t dst_idx) {
                 recip_tile_init();
                 recip_tile(dst_idx);
             });
@@ -145,28 +127,27 @@ void kernel_main() {
 #ifdef LOG
 #ifdef SOFTMAX
             // x - max - log(sum)
-            sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            sub_tiles_bcast_cols_to_cb(dfb_tmp_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_dfb<dfb::tmp, dfb::recip_sum_exps, dfb::out0>(0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
-            // -x + max - log(sum)
             // logsoftmin not implemented
 #endif
 #else
 #ifdef SOFTMAX
             // exp(x - max) / sum
-            sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            exp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+            exp_tile_to_dfb<dfb::tmp, dfb::exps>();
 
-            mul_tiles_bcast_cols_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_dfb<dfb::exps, dfb::recip_sum_exps, dfb::out0>(0, 0, /*pop0=*/1, /*pop1=*/0);
 #else
             // rexp(x - max) / sum
-            sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_dfb<dfb::in0, dfb::max, dfb::tmp>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
-            rexp_tile_to_cb(dfb_tmp_obj, dfb_exps_obj);
+            rexp_tile_to_dfb<dfb::tmp, dfb::exps>();
 
-            mul_tiles_bcast_cols_to_cb(dfb_exps_obj, dfb_recipsumexps_obj, dfb_out0_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_dfb<dfb::exps, dfb::recip_sum_exps, dfb::out0>(0, 0, /*pop0=*/1, /*pop1=*/0);
 #endif
 #endif
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_c_large.cpp
@@ -4,68 +4,62 @@
 
 #include <cstdint>
 
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"  // Exp
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Negative
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
 void kernel_main() {
     constexpr uint32_t onetile = 1;
 
-    DataflowBuffer dfb_y_obj(dfb::y);
-    DataflowBuffer dfb_dy_obj(dfb::dy);
-    DataflowBuffer dfb_dx_obj(dfb::dx);
-
-    DataflowBuffer dfb_ydy_obj(dfb::ydy);  // y * dy
     DataflowBuffer dfb_sum_obj(dfb::sum);
-    DataflowBuffer dfb_dy_m_sum_obj(dfb::dy_m_sum);  // dy - sum
 
     uint32_t N = get_arg(args::N);
     uint32_t dim_size = get_arg(args::dim_size);
 
     compute_kernel_hw_startup(dfb::dy, dfb::y, dfb::dx);
 
-    constexpr int dst0 = 0;
     for (uint32_t n = 0; n < N; ++n) {
 #ifdef LOG
         for (uint32_t i = 0; i < dim_size; ++i) {
             if (i == 0) {
-                copy_tile_to_cb(dfb_dy_obj, dfb_sum_obj);
+                copy_tile_to_dfb<dfb::dy, dfb::sum>();
             } else {
-                add_tiles_to_cb(dfb_sum_obj, dfb_dy_obj, dfb_sum_obj);
+                add_tiles_to_dfb<dfb::sum, dfb::dy, dfb::sum>();
             }
         }
 
         for (uint32_t i = 0; i < dim_size; ++i) {
-            // exp(y)
-            auto& dfb_exp_obj = dfb_ydy_obj;  // the y * dy buffer, reused to hold exp(y)
-            exp_tile_to_cb(dfb_y_obj, dfb_exp_obj);
+            constexpr auto dfb_exp_id = dfb::ydy;  // the y * dy buffer, reused to hold exp(y)
+            exp_tile_to_dfb<dfb::y, dfb_exp_id>();
 
-            // sum * exp(y)
-            mul_tiles_to_cb(dfb_sum_obj, dfb_exp_obj, dfb_dy_m_sum_obj, 0, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_to_dfb<dfb::sum, dfb_exp_id, dfb::dy_m_sum>(0, 0, /*pop0=*/0, /*pop1=*/1);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(dfb_dy_obj, dfb_dy_m_sum_obj, dfb_dx_obj);
+            sub_tiles_to_dfb<dfb::dy, dfb::dy_m_sum, dfb::dx>();
         }
         dfb_sum_obj.pop_front(onetile);
 #else
         // compute sum(y * dy)
         for (uint32_t i = 0; i < dim_size; ++i) {
-            mul_tiles_to_cb(dfb_y_obj, dfb_dy_obj, dfb_ydy_obj);
+            mul_tiles_to_dfb<dfb::y, dfb::dy, dfb::ydy>();
 
             if (i == 0) {
-                copy_tile_to_cb(dfb_ydy_obj, dfb_sum_obj);
+                copy_tile_to_dfb<dfb::ydy, dfb::sum>();
             } else {
-                add_tiles_to_cb(dfb_sum_obj, dfb_ydy_obj, dfb_sum_obj);
+                add_tiles_to_dfb<dfb::sum, dfb::ydy, dfb::sum>();
             }
         }
 
         // compute final result
         for (uint32_t i = 0; i < dim_size; ++i) {
             // dy - sum
-            sub_tiles_to_cb(
-                dfb_dy_obj,
-                dfb_sum_obj,
-                dfb_dy_m_sum_obj,
+            sub_tiles_to_dfb<dfb::dy, dfb::sum, dfb::dy_m_sum>(
                 /*itile0=*/0,
                 /*itile1=*/0,
                 /*pop0=*/1,
@@ -73,10 +67,10 @@ void kernel_main() {
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(dfb_dy_m_sum_obj, dfb_y_obj, dfb_dx_obj);
+            mul_tiles_to_dfb<dfb::dy_m_sum, dfb::y, dfb::dx>();
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(dfb_dy_m_sum_obj, dfb_y_obj, dfb_dx_obj);
+            mul_tiles_and_negative_to_dfb<dfb::dy_m_sum, dfb::y, dfb::dx>();
 #endif
         }
         dfb_sum_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
@@ -14,12 +14,8 @@ void kernel_main() {
 
     DataflowBuffer dfb_y_obj(dfb::y);
     DataflowBuffer dfb_dy_obj(dfb::dy);
-    DataflowBuffer dfb_mask_obj(dfb::mask);
-    DataflowBuffer dfb_dx_obj(dfb::dx);
 
-    DataflowBuffer dfb_ydy_obj(dfb::ydy);  // y * dy
     DataflowBuffer dfb_sum_obj(dfb::sum);
-    DataflowBuffer dfb_dy_m_sum_obj(dfb::dy_m_sum);
 
     compute_kernel_hw_startup(dfb::y, dfb::scaler, dfb::dx);
 
@@ -31,48 +27,45 @@ void kernel_main() {
         // sum(dy)
         if (Ht == 1) {
             // apply mask
-            mask_tile_to_cb(
-                dfb_dy_obj, dfb_mask_obj, dfb_dy_m_sum_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+            mask_tile_to_dfb<dfb::dy, dfb::mask, dfb::dy_m_sum>(
+                /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, dfb::dy_m_sum, dfb::scaler, dfb::sum>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
             // On this path the y*dy and sum buffers hold two partial sums instead; the second
             // names below are handle aliases for those same two FIFOs, not extra buffers.
-            constexpr auto dfb_inter0 = dfb::ydy;
+            constexpr auto dfb_inter0_id = dfb::ydy;
             compute_kernel_lib::reduce<
                 PoolType::SUM,
                 ReduceDim::REDUCE_COL,
                 dfb::dy,
                 dfb::scaler,
-                dfb_inter0,
+                dfb_inter0_id,
                 compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
                 compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
 
-            constexpr auto dfb_inter1 = dfb::sum;
-            auto& dfb_inter1_obj = dfb_sum_obj;
-            mask_tile_to_cb(
-                dfb_dy_obj, dfb_mask_obj, dfb_inter1_obj, /*itile=*/Ht - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+            constexpr auto dfb_inter1_id = dfb::sum;
+            mask_tile_to_dfb<dfb::dy, dfb::mask, dfb_inter1_id>(
+                /*itile=*/Ht - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, dfb_inter1, dfb::scaler, dfb::dy_m_sum>(
+            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, dfb_inter1_id, dfb::scaler, dfb::dy_m_sum>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
 
-            auto& dfb_inter0_obj = dfb_ydy_obj;
-            add_tiles_to_cb(dfb_inter0_obj, dfb_dy_m_sum_obj, dfb_sum_obj);
+            add_tiles_to_dfb<dfb_inter0_id, dfb::dy_m_sum, dfb::sum>();
         }
 
         // dy - sum * exp(y)
-        auto& dfb_exp_obj = dfb_ydy_obj;  // the y * dy buffer, reused to hold exp(y)
-
+        constexpr auto dfb_exp_id = dfb::ydy;  // the y * dy buffer, reused to hold exp(y)
         for (uint32_t w = 0; w < Ht; w += onetile) {
             // exp(y)
-            exp_tile_to_cb(dfb_y_obj, dfb_exp_obj, w, /*dst=*/0, /*pop=*/0);
+            exp_tile_to_dfb<dfb::y, dfb_exp_id>(w, /*pop=*/0);
 
             // sum * exp(y)
-            mul_tiles_bcast_rows_to_cb(dfb_exp_obj, dfb_sum_obj, dfb_dy_m_sum_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_dfb<dfb_exp_id, dfb::sum, dfb::dy_m_sum>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(dfb_dy_obj, dfb_dy_m_sum_obj, dfb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
+            sub_tiles_to_dfb<dfb::dy, dfb::dy_m_sum, dfb::dx>(w, 0, /*pop0=*/0, /*pop1=*/1);
         }
 
         dfb_sum_obj.pop_front(onetile);
@@ -82,10 +75,10 @@ void kernel_main() {
         // step 1, compute y * dy
         for (uint32_t h = 0; h < Ht; ++h) {
             if (h == Ht - 1) {
-                mul_tiles_and_mask_tile_to_cb(
-                    dfb_y_obj, dfb_dy_obj, dfb_mask_obj, dfb_ydy_obj, h, h, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
+                mul_tiles_and_mask_tile_to_dfb<dfb::y, dfb::dy, dfb::mask, dfb::ydy>(
+                    h, h, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(dfb_y_obj, dfb_dy_obj, dfb_ydy_obj, h, h, /*pop0=*/0, /*pop1=*/0);
+                mul_tiles_to_dfb<dfb::y, dfb::dy, dfb::ydy>(h, h, /*pop0=*/0, /*pop1=*/0);
             }
         }
 
@@ -101,14 +94,14 @@ void kernel_main() {
         // step 3, compute final result
         for (uint32_t h = 0; h < Ht; ++h) {
             // dy - sum
-            sub_tiles_bcast_rows_to_cb(dfb_dy_obj, dfb_sum_obj, dfb_dy_m_sum_obj, h, 0, /*pop0=*/0, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_dfb<dfb::dy, dfb::sum, dfb::dy_m_sum>(h, 0, /*pop0=*/0, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(dfb_y_obj, dfb_dy_m_sum_obj, dfb_dx_obj, h, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_to_dfb<dfb::y, dfb::dy_m_sum, dfb::dx>(h, 0, /*pop0=*/0, /*pop1=*/1);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(dfb_y_obj, dfb_dy_m_sum_obj, dfb_dx_obj, h, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_and_negative_to_dfb<dfb::y, dfb::dy_m_sum, dfb::dx>(h, 0, /*pop0=*/0, /*pop1=*/1);
 #endif
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
@@ -5,22 +5,20 @@
 #include <cstdint>
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"  // Exp
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Mask, Negative
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
 void kernel_main() {
     constexpr uint32_t onetile = 1;
 
-    DataflowBuffer dfb_y_obj(dfb::y);
-    DataflowBuffer dfb_dy_obj(dfb::dy);
-    DataflowBuffer dfb_mask_obj(dfb::mask);
-    DataflowBuffer dfb_dx_obj(dfb::dx);
-
-    DataflowBuffer dfb_ydy_obj(dfb::ydy);  // y * dy
     DataflowBuffer dfb_sum_obj(dfb::sum);
-    DataflowBuffer dfb_dy_m_sum_obj(dfb::dy_m_sum);
-    DataflowBuffer dfb_add_obj(dfb::add);
 
     compute_kernel_hw_startup(dfb::y, dfb::scaler, dfb::dx);
 
@@ -33,38 +31,37 @@ void kernel_main() {
         for (uint32_t h = 0; h < Ht; ++h) {
             if (h == Ht - 1) {
                 if (h == 0) {
-                    mask_tile_to_cb(
-                        dfb_dy_obj, dfb_mask_obj, dfb_add_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                    mask_tile_to_dfb<dfb::dy, dfb::mask, dfb::add>(
+                        /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
                 } else {
                     // The y*dy buffer under a second name; one FIFO, not an extra buffer.
-                    auto& dfb_inter0_obj = dfb_ydy_obj;
-                    mask_tile_to_cb(
-                        dfb_dy_obj, dfb_mask_obj, dfb_inter0_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                    constexpr auto dfb_inter0_id = dfb::ydy;
+                    mask_tile_to_dfb<dfb::dy, dfb::mask, dfb_inter0_id>(
+                        /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
 
-                    add_tiles_to_cb(dfb_add_obj, dfb_inter0_obj, dfb_add_obj);
+                    add_tiles_to_dfb<dfb::add, dfb_inter0_id, dfb::add>();
                 }
             } else {
                 if (h == 0) {
-                    copy_tile_to_cb(dfb_dy_obj, dfb_add_obj);
+                    copy_tile_to_dfb<dfb::dy, dfb::add>();
                 } else {
-                    add_tiles_to_cb(dfb_add_obj, dfb_dy_obj, dfb_add_obj);
+                    add_tiles_to_dfb<dfb::add, dfb::dy, dfb::add>();
                 }
             }
         }
 
-        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, dfb::add, dfb::scaler, dfb::sum>(
-            compute_kernel_lib::ReduceInputBlockShape::single());
+        ckl::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, dfb::add, dfb::scaler, dfb::sum>(
+            ckl::ReduceInputBlockShape::single());
 
         for (uint32_t h = 0; h < Ht; ++h) {
-            // exp(y)
-            auto& dfb_exp_obj = dfb_ydy_obj;  // the y * dy buffer, reused to hold exp(y)
-            exp_tile_to_cb(dfb_y_obj, dfb_exp_obj, 0);
+            constexpr auto dfb_exp_id = dfb::ydy;  // the y * dy buffer, reused to hold exp(y)
+            exp_tile_to_dfb<dfb::y, dfb_exp_id>();
 
             // sum * exp(y)
-            mul_tiles_bcast_rows_to_cb(dfb_exp_obj, dfb_sum_obj, dfb_dy_m_sum_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_rows_to_dfb<dfb_exp_id, dfb::sum, dfb::dy_m_sum>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(dfb_dy_obj, dfb_dy_m_sum_obj, dfb_dx_obj);
+            sub_tiles_to_dfb<dfb::dy, dfb::dy_m_sum, dfb::dx>();
         }
 
         dfb_sum_obj.pop_front(onetile);
@@ -73,34 +70,34 @@ void kernel_main() {
         // step 1, compute y * dy
         for (uint32_t h = 0; h < Ht; ++h) {
             if (h == Ht - 1) {
-                mul_tiles_and_mask_tile_to_cb(
-                    dfb_y_obj, dfb_dy_obj, dfb_mask_obj, dfb_ydy_obj, 0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
+                mul_tiles_and_mask_tile_to_dfb<dfb::y, dfb::dy, dfb::mask, dfb::ydy>(
+                    0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(dfb_y_obj, dfb_dy_obj, dfb_ydy_obj);
+                mul_tiles_to_dfb<dfb::y, dfb::dy, dfb::ydy>();
             }
 
             if (h == 0) {
-                copy_tile_to_cb(dfb_ydy_obj, dfb_add_obj);
+                copy_tile_to_dfb<dfb::ydy, dfb::add>();
             } else {
-                add_tiles_to_cb(dfb_add_obj, dfb_ydy_obj, dfb_add_obj);
+                add_tiles_to_dfb<dfb::add, dfb::ydy, dfb::add>();
             }
         }
 
         // step 2, compute sum(y * dy)
-        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, dfb::add, dfb::scaler, dfb::sum>(
-            compute_kernel_lib::ReduceInputBlockShape::single());
+        ckl::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, dfb::add, dfb::scaler, dfb::sum>(
+            ckl::ReduceInputBlockShape::single());
 
         // step 3, compute final result
         for (uint32_t h = 0; h < Ht; ++h) {
             // dy - sum
-            sub_tiles_bcast_rows_to_cb(dfb_dy_obj, dfb_sum_obj, dfb_dy_m_sum_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_rows_to_dfb<dfb::dy, dfb::sum, dfb::dy_m_sum>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(dfb_y_obj, dfb_dy_m_sum_obj, dfb_dx_obj);
+            mul_tiles_to_dfb<dfb::y, dfb::dy_m_sum, dfb::dx>();
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(dfb_y_obj, dfb_dy_m_sum_obj, dfb_dx_obj);
+            mul_tiles_and_negative_to_dfb<dfb::y, dfb::dy_m_sum, dfb::dx>();
 #endif
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
@@ -14,12 +14,8 @@ void kernel_main() {
 
     DataflowBuffer dfb_y_obj(dfb::y);
     DataflowBuffer dfb_dy_obj(dfb::dy);
-    DataflowBuffer dfb_mask_obj(dfb::mask);
-    DataflowBuffer dfb_dx_obj(dfb::dx);
 
-    DataflowBuffer dfb_ydy_obj(dfb::ydy);  // y * dy
     DataflowBuffer dfb_sum_obj(dfb::sum);
-    DataflowBuffer dfb_dy_m_sum_obj(dfb::dy_m_sum);
 
     compute_kernel_hw_startup(dfb::y, dfb::scaler, dfb::dx);
 
@@ -31,48 +27,45 @@ void kernel_main() {
         // sum(dy)
         if (Wt == 1) {
             // apply mask
-            mask_tile_to_cb(
-                dfb_dy_obj, dfb_mask_obj, dfb_dy_m_sum_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+            mask_tile_to_dfb<dfb::dy, dfb::mask, dfb::dy_m_sum>(
+                /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, dfb::dy_m_sum, dfb::scaler, dfb::sum>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
             // On this path the y*dy and sum buffers hold two partial sums instead; the second
             // names below are handle aliases for those same two FIFOs, not extra buffers.
-            constexpr auto dfb_inter0 = dfb::ydy;
+            constexpr auto dfb_inter0_id = dfb::ydy;
             compute_kernel_lib::reduce<
                 PoolType::SUM,
                 ReduceDim::REDUCE_ROW,
                 dfb::dy,
                 dfb::scaler,
-                dfb_inter0,
+                dfb_inter0_id,
                 compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
                 compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
 
-            constexpr auto dfb_inter1 = dfb::sum;
-            auto& dfb_inter1_obj = dfb_sum_obj;
-            mask_tile_to_cb(
-                dfb_dy_obj, dfb_mask_obj, dfb_inter1_obj, /*itile=*/Wt - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
+            constexpr auto dfb_inter1_id = dfb::sum;
+            mask_tile_to_dfb<dfb::dy, dfb::mask, dfb_inter1_id>(
+                /*itile=*/Wt - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, dfb_inter1, dfb::scaler, dfb::dy_m_sum>(
+            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, dfb_inter1_id, dfb::scaler, dfb::dy_m_sum>(
                 compute_kernel_lib::ReduceInputBlockShape::single());
 
-            auto& dfb_inter0_obj = dfb_ydy_obj;
-            add_tiles_to_cb(dfb_inter0_obj, dfb_dy_m_sum_obj, dfb_sum_obj);
+            add_tiles_to_dfb<dfb_inter0_id, dfb::dy_m_sum, dfb::sum>();
         }
 
         // dy - sum * exp(y)
-        auto& dfb_exp_obj = dfb_ydy_obj;  // the y * dy buffer, reused to hold exp(y)
-
+        constexpr auto dfb_exp_id = dfb::ydy;  // the y * dy buffer, reused to hold exp(y)
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // exp(y)
-            exp_tile_to_cb(dfb_y_obj, dfb_exp_obj, w, /*dst=*/0, /*pop=*/0);
+            exp_tile_to_dfb<dfb::y, dfb_exp_id>(w, /*pop=*/0);
 
             // sum * exp(y)
-            mul_tiles_bcast_cols_to_cb(dfb_exp_obj, dfb_sum_obj, dfb_dy_m_sum_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_dfb<dfb_exp_id, dfb::sum, dfb::dy_m_sum>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(dfb_dy_obj, dfb_dy_m_sum_obj, dfb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
+            sub_tiles_to_dfb<dfb::dy, dfb::dy_m_sum, dfb::dx>(w, 0, /*pop0=*/0, /*pop1=*/1);
         }
 
         dfb_sum_obj.pop_front(onetile);
@@ -82,10 +75,10 @@ void kernel_main() {
         // step 1, compute y * dy
         for (uint32_t w = 0; w < Wt; ++w) {
             if (w == Wt - 1) {
-                mul_tiles_and_mask_tile_to_cb(
-                    dfb_y_obj, dfb_dy_obj, dfb_mask_obj, dfb_ydy_obj, w, w, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
+                mul_tiles_and_mask_tile_to_dfb<dfb::y, dfb::dy, dfb::mask, dfb::ydy>(
+                    w, w, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(dfb_y_obj, dfb_dy_obj, dfb_ydy_obj, w, w, /*pop0=*/0, /*pop1=*/0);
+                mul_tiles_to_dfb<dfb::y, dfb::dy, dfb::ydy>(w, w, /*pop0=*/0, /*pop1=*/0);
             }
         }
 
@@ -101,14 +94,14 @@ void kernel_main() {
         // step 3, compute final result
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // dy - sum
-            sub_tiles_bcast_cols_to_cb(dfb_dy_obj, dfb_sum_obj, dfb_dy_m_sum_obj, w, 0, /*pop0=*/0, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_dfb<dfb::dy, dfb::sum, dfb::dy_m_sum>(w, 0, /*pop0=*/0, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(dfb_y_obj, dfb_dy_m_sum_obj, dfb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_to_dfb<dfb::y, dfb::dy_m_sum, dfb::dx>(w, 0, /*pop0=*/0, /*pop1=*/1);
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(dfb_y_obj, dfb_dy_m_sum_obj, dfb_dx_obj, w, 0, /*pop0=*/0, /*pop1=*/1);
+            mul_tiles_and_negative_to_dfb<dfb::y, dfb::dy_m_sum, dfb::dx>(w, 0, /*pop0=*/0, /*pop1=*/1);
 #endif
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
@@ -5,22 +5,20 @@
 #include <cstdint>
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"  // Exp
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Mask, Negative
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
 void kernel_main() {
     constexpr uint32_t onetile = 1;
 
-    DataflowBuffer dfb_y_obj(dfb::y);
-    DataflowBuffer dfb_dy_obj(dfb::dy);
-    DataflowBuffer dfb_mask_obj(dfb::mask);
-    DataflowBuffer dfb_dx_obj(dfb::dx);
-
-    DataflowBuffer dfb_ydy_obj(dfb::ydy);  // y * dy
     DataflowBuffer dfb_sum_obj(dfb::sum);
-    DataflowBuffer dfb_dy_m_sum_obj(dfb::dy_m_sum);
-    DataflowBuffer dfb_add_obj(dfb::add);
 
     compute_kernel_hw_startup(dfb::y, dfb::scaler, dfb::dx);
 
@@ -29,41 +27,39 @@ void kernel_main() {
 
     for (uint32_t n = 0; n < N; ++n) {
 #ifdef LOG
-        // sum(dy)
         for (uint32_t w = 0; w < Wt; ++w) {
             if (w == Wt - 1) {
                 if (w == 0) {
-                    mask_tile_to_cb(
-                        dfb_dy_obj, dfb_mask_obj, dfb_add_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                    mask_tile_to_dfb<dfb::dy, dfb::mask, dfb::add>(
+                        /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
                 } else {
                     // The y*dy buffer under a second name; one FIFO, not an extra buffer.
-                    auto& dfb_inter0_obj = dfb_ydy_obj;
-                    mask_tile_to_cb(
-                        dfb_dy_obj, dfb_mask_obj, dfb_inter0_obj, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
+                    constexpr auto dfb_inter0_id = dfb::ydy;
+                    mask_tile_to_dfb<dfb::dy, dfb::mask, dfb_inter0_id>(
+                        /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
 
-                    add_tiles_to_cb(dfb_add_obj, dfb_inter0_obj, dfb_add_obj);
+                    add_tiles_to_dfb<dfb::add, dfb_inter0_id, dfb::add>();
                 }
             } else {
                 if (w == 0) {
-                    copy_tile_to_cb(dfb_dy_obj, dfb_add_obj);
+                    copy_tile_to_dfb<dfb::dy, dfb::add>();
                 } else {
-                    add_tiles_to_cb(dfb_add_obj, dfb_dy_obj, dfb_add_obj);
+                    add_tiles_to_dfb<dfb::add, dfb::dy, dfb::add>();
                 }
             }
         }
 
-        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, dfb::add, dfb::scaler, dfb::sum>(
-            compute_kernel_lib::ReduceInputBlockShape::single());
+        ckl::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, dfb::add, dfb::scaler, dfb::sum>(
+            ckl::ReduceInputBlockShape::single());
 
         for (uint32_t w = 0; w < Wt; w += onetile) {
-            // exp(y)
-            auto& dfb_exp_obj = dfb_ydy_obj;  // the y * dy buffer, reused to hold exp(y)
-            exp_tile_to_cb(dfb_y_obj, dfb_exp_obj, 0);
+            constexpr auto dfb_exp_id = dfb::ydy;  // the y * dy buffer, reused to hold exp(y)
+            exp_tile_to_dfb<dfb::y, dfb_exp_id>();
             // sum * exp(y)
-            mul_tiles_bcast_cols_to_cb(dfb_exp_obj, dfb_sum_obj, dfb_dy_m_sum_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            mul_tiles_bcast_cols_to_dfb<dfb_exp_id, dfb::sum, dfb::dy_m_sum>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
             // dy - sum * exp(y)
-            sub_tiles_to_cb(dfb_dy_obj, dfb_dy_m_sum_obj, dfb_dx_obj);
+            sub_tiles_to_dfb<dfb::dy, dfb::dy_m_sum, dfb::dx>();
         }
 
         dfb_sum_obj.pop_front(onetile);
@@ -71,34 +67,34 @@ void kernel_main() {
         // step 1, compute y * dy
         for (uint32_t w = 0; w < Wt; ++w) {
             if (w == Wt - 1) {
-                mul_tiles_and_mask_tile_to_cb(
-                    dfb_y_obj, dfb_dy_obj, dfb_mask_obj, dfb_ydy_obj, 0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
+                mul_tiles_and_mask_tile_to_dfb<dfb::y, dfb::dy, dfb::mask, dfb::ydy>(
+                    0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
             } else {
-                mul_tiles_to_cb(dfb_y_obj, dfb_dy_obj, dfb_ydy_obj);
+                mul_tiles_to_dfb<dfb::y, dfb::dy, dfb::ydy>();
             }
 
             if (w == 0) {
-                copy_tile_to_cb(dfb_ydy_obj, dfb_add_obj);
+                copy_tile_to_dfb<dfb::ydy, dfb::add>();
             } else {
-                add_tiles_to_cb(dfb_add_obj, dfb_ydy_obj, dfb_add_obj);
+                add_tiles_to_dfb<dfb::add, dfb::ydy, dfb::add>();
             }
         }
 
         // step 2, compute sum(y * dy)
-        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, dfb::add, dfb::scaler, dfb::sum>(
-            compute_kernel_lib::ReduceInputBlockShape::single());
+        ckl::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, dfb::add, dfb::scaler, dfb::sum>(
+            ckl::ReduceInputBlockShape::single());
 
         // step 3, compute final result
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // dy - sum
-            sub_tiles_bcast_cols_to_cb(dfb_dy_obj, dfb_sum_obj, dfb_dy_m_sum_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+            sub_tiles_bcast_cols_to_dfb<dfb::dy, dfb::sum, dfb::dy_m_sum>(0, 0, /*pop0=*/1, /*pop1=*/0);
 
 #ifdef SOFTMAX
             // (dy - sum) * y
-            mul_tiles_to_cb(dfb_y_obj, dfb_dy_m_sum_obj, dfb_dx_obj);
+            mul_tiles_to_dfb<dfb::y, dfb::dy_m_sum, dfb::dx>();
 #else
             // -(dy - sum) * y
-            mul_tiles_and_negative_to_cb(dfb_y_obj, dfb_dy_m_sum_obj, dfb_dx_obj);
+            mul_tiles_and_negative_to_dfb<dfb::y, dfb::dy_m_sum, dfb::dx>();
 #endif
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
@@ -3,21 +3,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"  // Mask
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
+namespace ckl = compute_kernel_lib;
+
+#if defined(FP32_DEST_ACC_EN)
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Enabled;
+#else
+constexpr auto kDataFormatReconfig = ckl::DataFormatReconfig::Disabled;
+#endif
+
 void kernel_main() {
-    uint32_t Ht = get_arg(args::Ht);
+    constexpr uint32_t Ht = get_arg(args::Ht);
     // Carries the per-core work-split count (the host's num_cols_per_core_group_N), not a tile width.
     uint32_t Wt = get_arg(args::units_per_core);
     uint32_t NC = get_arg(args::NC);
     constexpr uint32_t origin_H = get_arg(args::origin_H);
 
-    DataflowBuffer dfb_input_obj(dfb::input);
     DataflowBuffer dfb_scaler_obj(dfb::scaler);
     DataflowBuffer dfb_mask_h_obj(dfb::mask_h);
-    DataflowBuffer dfb_masked_input_obj(dfb::masked_input);
     constexpr uint32_t TILE_H = 32;
     constexpr bool do_mask_h = (origin_H % TILE_H) != 0;
 
@@ -29,7 +37,7 @@ void kernel_main() {
     int reduce_dst_idx = 0;
     const uint32_t mask_dst_idx = reduce_dst_idx + 1;
 
-    if (do_mask_h) {
+    if constexpr (do_mask_h) {
         dfb_mask_h_obj.wait_front(onetile);
     }
 
@@ -38,57 +46,48 @@ void kernel_main() {
             // tiles are expected to be coming in in NCWH order (H-contiguous)
             // reducing in W means out[0][w] = sum(h=0..H-1, in[h][w])
             // in this case we just sequentially add to accumulator all the H-tiles in a column
-            bool is_h_single_tile = (Ht == 1);
+            constexpr bool is_h_single_tile = Ht == 1;
 
             // Phase 1: Reduce Ht-1 tiles into accumulator (if Ht > 1)
-            if (!is_h_single_tile) {
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, dfb::input, dfb::scaler, dfb::accum_dst>(
-                    compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
+            if constexpr (!is_h_single_tile) {
+                ckl::reduce<REDUCE_OP, REDUCE_DIM, dfb::input, dfb::scaler, dfb::accum_dst>(
+                    ckl::ReduceInputBlockShape::col(Ht - 1));
             }
 
-            // Optional masking of last H tile
+            // Optional masking of last H tile.
             if constexpr (do_mask_h) {
-                tile_regs_acquire();
-                dfb_input_obj.wait_front(onetile);
-#if defined FP32_DEST_ACC_EN
-                reconfig_data_format_srca(dfb::input);
-#endif
-                copy_init(dfb::input);
-                copy_tile(dfb::input, 0, reduce_dst_idx);
-                copy_tile(dfb::mask_h, 0, mask_dst_idx);
-                mask_tile_init();
-                mask_tile(reduce_dst_idx, mask_dst_idx);
-                tile_regs_commit();
-
-                dfb_masked_input_obj.reserve_back(onetile);
-                tile_regs_wait();
-#if defined FP32_DEST_ACC_EN
-                pack_reconfig_data_format(dfb::masked_input);
-#endif
-                pack_tile(reduce_dst_idx, dfb::masked_input);
-                tile_regs_release();
-                dfb_masked_input_obj.push_back(onetile);
-
-                dfb_input_obj.pop_front(onetile);
+                ckl::eltwise_chain(
+                    ckl::IterationShape::tiles(onetile),
+                    ckl::CopyTile<ckl::input(
+                        dfb::input, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, kDataFormatReconfig)>{},
+                    ckl::CopyTile<
+                        ckl::input(dfb::mask_h, ckl::WaitPolicy::None, ckl::PopPolicy::None, kDataFormatReconfig),
+                        ckl::Dst::D1>{},
+                    ckl::Mask<DataFormat::Float16_b, ckl::Dst::D0>{},
+                    ckl::PackTile<ckl::output(
+                        dfb::masked_input,
+                        ckl::ReservePolicy::PerTile,
+                        ckl::PushPolicy::PerTile,
+                        kDataFormatReconfig)>{});
 
                 // Phase 2 with masked input: Reduce final masked tile with accumulation
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, dfb::masked_input, dfb::scaler, dfb::out>(
-                    compute_kernel_lib::ReduceInputBlockShape::single(),
-                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                    compute_kernel_lib::Accumulate::at(dfb::accum_dst, is_h_single_tile ? 0 : 1));
+                ckl::reduce<REDUCE_OP, REDUCE_DIM, dfb::masked_input, dfb::scaler, dfb::out>(
+                    ckl::ReduceInputBlockShape::single(),
+                    ckl::ReduceInputMemoryLayout::contiguous(),
+                    ckl::Accumulate::at(dfb::accum_dst, is_h_single_tile ? 0 : 1));
             } else {
                 // Phase 2 without masking: Reduce final tile with accumulation
                 // - If Ht == 1 (single tile): iteration=0, no accumulator reload
-                // - If Ht > 1 (multi-tile): iteration=1, reload accumulator from the accum_dst DFB
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, dfb::input, dfb::scaler, dfb::out>(
-                    compute_kernel_lib::ReduceInputBlockShape::single(),
-                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                    compute_kernel_lib::Accumulate::at(dfb::accum_dst, is_h_single_tile ? 0 : 1));
+                // - If Ht > 1 (multi-tile): iteration=1, reload accumulator from dfb::accum_dst
+                ckl::reduce<REDUCE_OP, REDUCE_DIM, dfb::input, dfb::scaler, dfb::out>(
+                    ckl::ReduceInputBlockShape::single(),
+                    ckl::ReduceInputMemoryLayout::contiguous(),
+                    ckl::Accumulate::at(dfb::accum_dst, is_h_single_tile ? 0 : 1));
             }
         }
     }
 
-    if (do_mask_h) {
+    if constexpr (do_mask_h) {
         dfb_mask_h_obj.pop_front(onetile);
     }
     dfb_scaler_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
@@ -215,9 +215,8 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumHFactory::cr
     // unconditionally and gates only some of its FIFO calls on do_mask_h. When masking is off the
     // reader does not produce into it, leaving compute the single toucher — bound as both PRODUCER
     // and CONSUMER (self-loop) so the DFB still presents one endpoint of each kind per node.
-    // masked_input is bound PRODUCER+CONSUMER in *every* configuration: the kernel constructs its
-    // buffer object outside the do_mask_h guard, so the dfb::masked_input token has to exist even
-    // where the guard discards all of its FIFO traffic.
+    // masked_input is bound PRODUCER+CONSUMER in *every* configuration so its DFB token exists while
+    // the kernel's discarded do_mask_h branch is still type-checked.
     auto make_compute = [&](const KernelSpecName& unique_id, uint32_t units_per_core) {
         Group<DFBBinding> dfb_bindings = {
             DFBBinding{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc.cpp
@@ -2,48 +2,36 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "api/compute/compute_kernel_hw_startup.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
 
 void kernel_main() {
+    namespace ckl = compute_kernel_lib;
+
     // compile-time args
     // num_output_tiles carries the per-core work-split count (the host's num_cols_per_core_group_N).
     constexpr uint32_t num_output_tiles = get_arg(args::num_output_tiles);
     constexpr uint32_t num_input_tiles = get_arg(args::num_input_tiles);
 
-    DataflowBuffer dfb_in0_obj(dfb::input);
-    DataflowBuffer dfb_in1_obj(dfb::zero);
-    DataflowBuffer dfb_out0_obj(dfb::out);
-    constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t dst1 = 1;
-    constexpr uint32_t idx0 = 0;
-    constexpr bool acc_to_dest = true;
-
     compute_kernel_hw_startup(dfb::input, dfb::zero, dfb::out);
-    dfb_in1_obj.wait_front(onetile);
 
-    for (uint32_t i = 0; i < num_output_tiles; i++) {
-        tile_regs_acquire();
-        add_init(dfb::input, dfb::zero, acc_to_dest);
-        for (uint32_t j = 0; j < num_input_tiles; ++j) {
-            dfb_in0_obj.wait_front(onetile);
-#if defined FP32_DEST_ACC_EN
-            reconfig_data_format(dfb::input, dfb::zero);
-#endif
-            add_tiles(dfb::input, dfb::zero, idx0, idx0, dst0);
-            dfb_in0_obj.pop_front(onetile);
-        }
-        tile_regs_commit();
-
-        dfb_out0_obj.reserve_back(onetile);
-        tile_regs_wait();
-#if defined FP32_DEST_ACC_EN
-        pack_reconfig_data_format(dfb::out);
-#endif
-        pack_tile(dst0, dfb::out);
-        tile_regs_release();
-        dfb_out0_obj.push_back(onetile);
-    }
+    ckl::eltwise_chain(
+        ckl::IterationShape::grid(num_output_tiles, num_input_tiles),
+        ckl::BinaryFpu<
+            ckl::BinaryFpuOp::Add,
+            ckl::input(
+                dfb::input, ckl::WaitPolicy::PerBlockSize, ckl::PopPolicy::PerBlockSize, ckl::InputTileMapping::Block),
+            ckl::input(dfb::zero, ckl::WaitPolicy::Upfront, ckl::PopPolicy::AtEnd, ckl::InputTileMapping::Scalar),
+            ckl::Dst::D0,
+            ckl::DestAccumulation::PerRow>{},
+        ckl::PackTile<ckl::output(
+            dfb::out,
+            ckl::ReservePolicy::PerOuter,
+            ckl::PushPolicy::PerOuter,
+            ckl::DataFormatReconfig::Enabled,
+            ckl::TileAddressing::Direct,
+            ckl::DestAccumulation::PerRow)>{});
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_sum_w.cpp
@@ -6,6 +6,13 @@
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+
+#if defined(FP32_DEST_ACC_EN)
+constexpr auto kDataFormatReconfig = compute_kernel_lib::DataFormatReconfig::Enabled;
+#else
+constexpr auto kDataFormatReconfig = compute_kernel_lib::DataFormatReconfig::Disabled;
+#endif
 
 void kernel_main() {
     // Carries the per-core work-split count (the host's num_rows_per_core_group_N), not a tile height.
@@ -16,7 +23,8 @@ void kernel_main() {
 
     // Selected at runtime between the input DFB and the masked-input DFB; stays uint32_t-valued so the
     // reassignment below is legal — the generated dfb:: handles convert to uint32_t at compile time.
-    uint32_t input_dfb = dfb::input;
+    uint32_t dfb_input_id = dfb::input;
+    DataflowBuffer dfb_input_obj(dfb::input);
     DataflowBuffer dfb_scaler_obj(dfb::scaler);
     DataflowBuffer dfb_mask_w_obj(dfb::mask_w);
     DataflowBuffer dfb_accum_dst_obj(dfb::accum_dst);
@@ -24,14 +32,14 @@ void kernel_main() {
     DataflowBuffer dfb_out_obj(dfb::out);
     constexpr uint32_t TILE_W = 32;
     constexpr bool do_mask_w = (origin_W % TILE_W) != 0;
+    DataflowBuffer& dfb_reduction_input_obj = do_mask_w ? dfb_masked_input_obj : dfb_input_obj;
 
-    compute_kernel_hw_startup(dfb::input, dfb::scaler, dfb::out);
+    compute_kernel_hw_startup(dfb_input_id, dfb::scaler, dfb::out);
 
     dfb_scaler_obj.wait_front(1);  // scaler tile from the reader
 
     constexpr int onetile = 1;
     int reduce_dst_idx = 0;
-    const uint32_t mask_dst_idx = reduce_dst_idx + 1;
 
     if (do_mask_w) {
         dfb_mask_w_obj.wait_front(onetile);
@@ -42,19 +50,19 @@ void kernel_main() {
             // tiles are expected to be coming in in NCHW order (W-contiguous)
             // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
             // in this case we just sequentially add to accumulator all the W-tiles in a row
-            input_dfb = dfb::input;
+            dfb_input_id = dfb::input;
             bool is_w_single_tile = (Wt == 1);
             if (!is_w_single_tile) {
                 tile_regs_acquire();
                 for (uint32_t wt = 0; wt < Wt - 1; ++wt) {
-                    DataflowBuffer(input_dfb).wait_front(onetile);
+                    dfb_input_obj.wait_front(onetile);
 #if defined FP32_DEST_ACC_EN
-                    reconfig_data_format(input_dfb, dfb::scaler);
+                    reconfig_data_format(dfb_input_id, dfb::scaler);
 #endif
-                    matmul_init(input_dfb, dfb::scaler, false);
-                    matmul_tiles(input_dfb, dfb::scaler, 0, 0, reduce_dst_idx);
+                    matmul_init(dfb_input_id, dfb::scaler, false);
+                    matmul_tiles(dfb_input_id, dfb::scaler, 0, 0, reduce_dst_idx);
 
-                    DataflowBuffer(input_dfb).pop_front(onetile);
+                    dfb_input_obj.pop_front(onetile);
                 }
                 tile_regs_commit();
                 dfb_accum_dst_obj.reserve_back(onetile);
@@ -68,47 +76,42 @@ void kernel_main() {
             }
 
             if (do_mask_w) {
-                tile_regs_acquire();
-                DataflowBuffer(input_dfb).wait_front(onetile);
-#if defined FP32_DEST_ACC_EN
-                reconfig_data_format_srca(input_dfb);
-#endif
-                copy_init(input_dfb);
-                copy_tile(input_dfb, 0, reduce_dst_idx);
-                copy_tile(dfb::mask_w, 0, mask_dst_idx);
-                mask_tile_init();
-                mask_tile(reduce_dst_idx, mask_dst_idx);
-                tile_regs_commit();
-
-                dfb_masked_input_obj.reserve_back(onetile);
-                tile_regs_wait();
-#if defined FP32_DEST_ACC_EN
-                pack_reconfig_data_format(dfb::masked_input);
-#endif
-                pack_tile(reduce_dst_idx, dfb::masked_input);
-                tile_regs_release();
-                dfb_masked_input_obj.push_back(onetile);
-
-                DataflowBuffer(input_dfb).pop_front(onetile);
-                input_dfb = dfb::masked_input;
+                compute_kernel_lib::binary_sfpu<
+                    compute_kernel_lib::Mask<DataFormat::Float16_b>,
+                    compute_kernel_lib::input(
+                        dfb::input,
+                        compute_kernel_lib::WaitPolicy::PerTile,
+                        compute_kernel_lib::PopPolicy::PerTile,
+                        kDataFormatReconfig),
+                    compute_kernel_lib::input(
+                        dfb::mask_w,
+                        compute_kernel_lib::WaitPolicy::None,
+                        compute_kernel_lib::PopPolicy::None,
+                        kDataFormatReconfig),
+                    compute_kernel_lib::output(
+                        dfb::masked_input,
+                        compute_kernel_lib::ReservePolicy::PerTile,
+                        compute_kernel_lib::PushPolicy::PerTile,
+                        kDataFormatReconfig)>(compute_kernel_lib::IterationShape::tiles(onetile));
+                dfb_input_id = dfb::masked_input;
             }
 
             tile_regs_acquire();
-            DataflowBuffer(input_dfb).wait_front(onetile);
+            dfb_reduction_input_obj.wait_front(onetile);
             if (!is_w_single_tile) {
 #if defined FP32_DEST_ACC_EN
                 reconfig_data_format_srca(dfb::accum_dst);
 #endif
                 dfb_accum_dst_obj.wait_front(onetile);
-                copy_init(dfb::accum_dst);
+                copy_tile_to_dst_init_short(dfb::accum_dst);
                 copy_tile(dfb::accum_dst, 0, reduce_dst_idx);
             }
 
 #if defined FP32_DEST_ACC_EN
-            reconfig_data_format(input_dfb, dfb::scaler);
+            reconfig_data_format(dfb_input_id, dfb::scaler);
 #endif
-            matmul_init(input_dfb, dfb::scaler, false);
-            matmul_tiles(input_dfb, dfb::scaler, 0, 0, reduce_dst_idx);
+            matmul_init(dfb_input_id, dfb::scaler, false);
+            matmul_tiles(dfb_input_id, dfb::scaler, 0, 0, reduce_dst_idx);
             tile_regs_commit();
 
             dfb_out_obj.reserve_back(onetile);
@@ -120,7 +123,7 @@ void kernel_main() {
             tile_regs_release();
             dfb_out_obj.push_back(onetile);
 
-            DataflowBuffer(input_dfb).pop_front(onetile);
+            dfb_reduction_input_obj.pop_front(onetile);
             if (!is_w_single_tile) {
                 dfb_accum_dst_obj.pop_front(onetile);
             }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/kernels/moreh_sum_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/kernels/moreh_sum_backward.cpp
@@ -5,43 +5,49 @@
 #include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
+
+namespace ckl = compute_kernel_lib;
+
 void kernel_main() {
     // compile-time args
     constexpr uint32_t num_output_tiles = get_arg(args::num_output_tiles);
     constexpr bool wt_need_bcast = (get_arg(args::wt_need_bcast) == 1);
     constexpr bool ht_need_bcast = (get_arg(args::ht_need_bcast) == 1);
 
-    DataflowBuffer dfb_in0_obj(dfb::in0);  // input
-    DataflowBuffer dfb_in1_obj(dfb::in1);  // zero tile
-    DataflowBuffer dfb_out0_obj(dfb::out0);
-    constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-
     compute_kernel_hw_startup(dfb::in1, dfb::in0, dfb::out0);
-    dfb_in1_obj.wait_front(onetile);
-    for (uint32_t i = 0; i < num_output_tiles; i++) {
-        tile_regs_acquire();
-        dfb_in0_obj.wait_front(onetile);
-        if (ht_need_bcast && wt_need_bcast) {
-            add_bcast_scalar_init(dfb::in1, dfb::in0);
-            add_tiles_bcast_scalar(dfb::in1, dfb::in0, 0, 0, dst0);
-        } else if (ht_need_bcast) {
-            add_bcast_rows_init(dfb::in1, dfb::in0);
-            add_tiles_bcast_rows(dfb::in1, dfb::in0, 0, 0, dst0);
-        } else if (wt_need_bcast) {
-            add_bcast_cols_init(dfb::in1, dfb::in0);
-            add_tiles_bcast_cols(dfb::in1, dfb::in0, 0, 0, dst0);
-        } else {
-            copy_init(dfb::in0);
-            copy_tile(dfb::in0, 0, dst0);
-        }
-        tile_regs_commit();
-        dfb_out0_obj.reserve_back(onetile);
-        tile_regs_wait();
-        pack_tile(dst0, dfb::out0);
-        tile_regs_release();
-        dfb_out0_obj.push_back(onetile);
-        dfb_in0_obj.pop_front(onetile);
-    }
-    dfb_in1_obj.pop_front(onetile);
+
+    constexpr bool has_bcast = ht_need_bcast || wt_need_bcast;
+    constexpr auto bcast_dim = (ht_need_bcast && wt_need_bcast) ? ckl::BroadcastDim::Scalar
+                               : ht_need_bcast                  ? ckl::BroadcastDim::Row
+                               : wt_need_bcast                  ? ckl::BroadcastDim::Col
+                                                                : ckl::BroadcastDim::None;
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::tiles(num_output_tiles),
+        ckl::Optional<
+            has_bcast,
+            ckl::BinaryFpu<
+                ckl::BinaryFpuOp::Add,
+                ckl::input(
+                    dfb::in1,
+                    ckl::WaitPolicy::Upfront,
+                    ckl::PopPolicy::AtEnd,
+                    ckl::InputTileMapping::Scalar,
+                    ckl::DataFormatReconfig::Disabled),
+                ckl::input(
+                    dfb::in0,
+                    bcast_dim,
+                    ckl::WaitPolicy::PerTile,
+                    ckl::PopPolicy::PerTile,
+                    ckl::DataFormatReconfig::Disabled)>>{},
+        ckl::Optional<
+            !has_bcast,
+            ckl::CopyTile<
+                ckl::input(
+                    dfb::in0, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+                ckl::Dst::D0>>{},
+        ckl::PackTile<ckl::output(
+            dfb::out0, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, ckl::DataFormatReconfig::Disabled)>{});
 }


### PR DESCRIPTION
# [llk_helper_library] 6/8 eltwise helpers: migrate Moreh reduction kernels

## Summary

PR 6 of the #49991 split. It depends on #55446 (PR 1, the helper framework),
which has merged, and is independent of PRs 2-5. It migrates the Moreh
reduction and softmax compute kernels to `eltwise_chain`, keeping their
existing TTNN APIs and kernel behaviour.

## Migrated kernels

- Reductions: `moreh_mean` (h/nc/w) and `moreh_mean_backward`, `moreh_sum`
  variants, `moreh_dot` and `moreh_dot_backward`.
- Norms: `moreh_norm` (h/w/other, including the `ord_other` variants) and
  `moreh_norm_backward`, plus `moreh_abs_pow`.
- Softmax: `moreh_softmax` and `moreh_softmax_backward` (h/w/c, small and
  large variants).
- NLL loss: `moreh_nll_loss_step2` and `moreh_nll_loss_backward`.
- Shared helpers in `ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp`.

## Review guide

1. `kernel/compute/moreh_common.hpp` first — the shared helper signatures every
   other file in this PR depends on.
2. The softmax kernels, which carry the most intricate lifecycle changes.
3. The norm and reduction kernels.

## Status

**Draft.** Rebased onto current `main`; the PR-1 framework commit that this
branch previously carried is dropped, since it merged as #55446. Not yet
validated on device.

Note for reviewers: `moreh_common.hpp` signature changes are resolved at JIT
time, not by the host build, so a green build is not sufficient evidence here —
this needs on-device coverage of every Moreh op in the list before it leaves
draft.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=astancov/eltwise_helper_migration_6)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:astancov/eltwise_helper_migration_6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=astancov/eltwise_helper_migration_6)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:astancov/eltwise_helper_migration_6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=astancov/eltwise_helper_migration_6)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:astancov/eltwise_helper_migration_6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=astancov/eltwise_helper_migration_6)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:astancov/eltwise_helper_migration_6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=astancov/eltwise_helper_migration_6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:astancov/eltwise_helper_migration_6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=astancov/eltwise_helper_migration_6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:astancov/eltwise_helper_migration_6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=astancov/eltwise_helper_migration_6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:astancov/eltwise_helper_migration_6)