### PR TITLE
[Bug fix] Release the GIL around blocking host sockets

### DIFF
--- a/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
@@ -118,6 +118,9 @@ void py_module_types(nb::module_& mod) {
             &tt::tt_metal::distributed::H2DSocket::write,
             nb::arg("data"),
             nb::arg("num_pages"),
+            // Blocks on device progress. Holding the GIL across that wait deadlocks any peer sharing
+            // the interpreter, since under emulation the device only advances when a thread runs it.
+            nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
                 Writes data pages to the socket FIFO.
 
@@ -150,6 +153,7 @@ void py_module_types(nb::module_& mod) {
                 }
             },
             nb::arg("tensor"),
+            nb::call_guard<nb::gil_scoped_release>(),  // loops over the blocking write(); see above
             R"doc(
                 Writes a host tensor's data to the socket FIFO.
 
@@ -179,6 +183,7 @@ void py_module_types(nb::module_& mod) {
                 }
             },
             nb::arg("tensor"),
+            nb::call_guard<nb::gil_scoped_release>(),  // loops over the blocking write(); see above
             R"doc(
                 Writes a (CPU) torch tensor's data to the socket FIFO.
 
@@ -195,6 +200,7 @@ void py_module_types(nb::module_& mod) {
             "barrier",
             &tt::tt_metal::distributed::H2DSocket::barrier,
             nb::arg("timeout_ms") = nb::none(),
+            nb::call_guard<nb::gil_scoped_release>(),  // blocks on device acks; see write() above
             R"doc(
                 Blocks until the device has acknowledged all written data.
 
@@ -247,6 +253,7 @@ void py_module_types(nb::module_& mod) {
             &tt::tt_metal::distributed::H2DSocket::connect,
             nb::arg("socket_id"),
             nb::arg("timeout_ms") = nb::none(),
+            nb::call_guard<nb::gil_scoped_release>(),  // waits for the exporting side; see write() above
             R"doc(
                 Connects to an existing H2DSocket from another process.
             )doc");
@@ -323,6 +330,8 @@ void py_module_types(nb::module_& mod) {
             nb::arg("data"),
             nb::arg("num_pages"),
             nb::arg("notify_sender") = true,
+            // Blocks pumping the device until the pages arrive; see H2DSocket::write above.
+            nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
                 Reads data pages from the socket FIFO.
 
@@ -365,6 +374,7 @@ void py_module_types(nb::module_& mod) {
             },
             nb::arg("tensor"),
             nb::arg("notify_sender") = true,
+            nb::call_guard<nb::gil_scoped_release>(),  // loops over the blocking read(); see above
             R"doc(
                 Reads data from the socket FIFO into a host tensor.
 
@@ -404,6 +414,7 @@ void py_module_types(nb::module_& mod) {
             },
             nb::arg("tensor"),
             nb::arg("notify_sender") = true,
+            nb::call_guard<nb::gil_scoped_release>(),  // loops over the blocking read(); see above
             R"doc(
                 Reads data from the socket FIFO into a (CPU) torch tensor.
 
@@ -422,6 +433,7 @@ void py_module_types(nb::module_& mod) {
             "barrier",
             &tt::tt_metal::distributed::D2HSocket::barrier,
             nb::arg("timeout_ms") = nb::none(),
+            nb::call_guard<nb::gil_scoped_release>(),  // blocks on device acks; see read() above
             R"doc(
                 Blocks until all sent data has been acknowledged.
 
@@ -485,6 +497,7 @@ void py_module_types(nb::module_& mod) {
             &tt::tt_metal::distributed::D2HSocket::connect,
             nb::arg("socket_id"),
             nb::arg("timeout_ms") = nb::none(),
+            nb::call_guard<nb::gil_scoped_release>(),  // waits for the exporting side; see read() above
             R"doc(
                 Connects to an existing D2HSocket from another process.
             )doc");


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Release the Python GIL while the host/device socket bindings execute operations that may block on peer or device progress:

- `H2DSocket`: all `write` overloads, `barrier`, and `connect`
- `D2HSocket`: all `read` overloads, `barrier`, and `connect`

Holding the GIL across these calls can prevent another Python thread from feeding the peer socket or otherwise driving the work needed to unblock the call. This is a binding-only change; the C++ socket API and behavior are unchanged.

This focused change was split from #53673 so it can be reviewed and merged independently of the multi-rank emulation work.

### Notes for reviewers

The change uses nanobind's `nb::call_guard<nb::gil_scoped_release>()` on each blocking binding. The raw-page, host-tensor, and torch-tensor overloads are all covered.

Verification:

- pre-commit checks passed for the changed file
- Clang 20 emulation configuration completed successfully
- full `ttnn` target build completed successfully (1169/1169 targets)
- `.github/scripts/copilot-build.sh` could not run in this environment because Docker is unavailable

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/hd-socket-release-gil)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/hd-socket-release-gil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/hd-socket-release-gil)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/hd-socket-release-gil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/hd-socket-release-gil)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/hd-socket-release-gil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/hd-socket-release-gil)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/hd-socket-release-gil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/hd-socket-release-gil)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/hd-socket-release-gil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/hd-socket-release-gil)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/hd-socket-release-gil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/hd-socket-release-gil)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/hd-socket-release-gil)