### PR TITLE
[Cleanup] Quasar SDPA: convert page_table DM self-loop DFB to a scratchpad

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -13,6 +13,7 @@
 #include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "api/scratchpad.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 #include "dataflow_common.hpp"
@@ -208,9 +209,7 @@ void kernel_main() {
     constexpr auto dfb_attention_sink = dfb::q_in;  // placeholder
 #endif
 #ifdef IS_CHUNKED
-    constexpr auto dfb_id_page_table = dfb::page_table;
-#else
-    constexpr auto dfb_id_page_table = dfb::q_in;  // placeholder
+    constexpr auto scratch_id_page_table = scratch::page_table;
 #endif
 #ifdef FLEXIBLE_CHUNKED
     constexpr auto dfb_id_chunk_start_idx_compute = dfb::chunk_start_idx_compute;
@@ -279,7 +278,9 @@ void kernel_main() {
     DataflowBuffer dfb_attn_sink(dfb_attention_sink);
 #endif
 #ifdef IS_CHUNKED
-    DataflowBuffer dfb_page_table(dfb_id_page_table);
+    // Single-entry private scratchpad: the reader stages the page table here and indexes it via
+    // page_table_ptr. The read pointer stays at the base, so there is no rotation to track.
+    Scratchpad<volatile uint32_t> page_table_scratch(scratch_id_page_table);
 #endif
 
     uint32_t chunked_q_chunk_offset = 0;
@@ -376,27 +377,22 @@ void kernel_main() {
                 }
 #ifdef IS_CHUNKED
                 {
-                    if (prev_nb != static_cast<uint32_t>(-1)) {
-                        dfb_page_table.pop_front(1);
-                    }
-                    dfb_page_table.reserve_back(1);
-                    // Inlined page-table read. It is kept here rather than in a shared dataflow_common.hpp
-                    // helper because such a helper would take a TensorAccessorArgs + raw address, and a
-                    // tensor:: binding token cannot cross into a shared header -- so the read is inlined
-                    // against the page_table TensorBinding. The redundant page-size 3rd accessor arg is
-                    // dropped (the binding supplies the aligned page size); page_table_stick_size remains
-                    // the read size.
-                    uint32_t page_table_dfb_wr_ptr = dfb_page_table.get_write_ptr();
+                    // Inlined page-table read into the single-entry scratchpad. It is kept here rather than
+                    // in a shared dataflow_common.hpp helper because such a helper would take a
+                    // TensorAccessorArgs + raw address, and a tensor:: binding token cannot cross into a
+                    // shared header -- so the read is inlined against the page_table TensorBinding. The
+                    // redundant page-size 3rd accessor arg is dropped (the binding supplies the aligned
+                    // page size); page_table_stick_size remains the read size.
+                    const uint32_t page_table_addr = page_table_scratch.get_base_address();
                     const auto page_table_reader = TensorAccessor(tensor::page_table);
                     noc.async_read(
                         page_table_reader,
-                        CoreLocalMem<uint32_t>(page_table_dfb_wr_ptr),
+                        CoreLocalMem<uint32_t>(page_table_addr),
                         page_table_stick_size,
                         {.page_id = decoded.nb},
                         {});
                     noc.async_read_barrier();
-                    page_table_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_dfb_wr_ptr);
-                    dfb_page_table.push_back(1);
+                    page_table_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_addr);
                 }
 #endif
             }
@@ -853,10 +849,5 @@ void kernel_main() {
 #endif
             }  // close k_chunk
         }  // close global_q_iter
-#ifdef IS_CHUNKED
-        if (prev_nb != static_cast<uint32_t>(-1)) {
-            dfb_page_table.pop_front(1);
-        }
-#endif
     }  // close phase
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -532,7 +532,7 @@ ttnn::device_operation::ProgramArtifacts SDPAOperation::SDPAProgramFactory::crea
     const DFBSpecName CU_WINDOW{"cu_window_seqlens"};
     const DFBSpecName IDENTITY_SCALE_IN{"identity_scale_in"};
     const DFBSpecName COL_IDENTITY{"col_identity"};
-    const DFBSpecName PAGE_TABLE{"page_table"};
+    const ScratchpadSpecName PAGE_TABLE_SCRATCH{"page_table"};
     const DFBSpecName CHUNK_START_IDX_COMPUTE{"chunk_start_idx_compute"};
     const DFBSpecName CHUNK_START_IDX_WRITER{"chunk_start_idx_writer"};
     const DFBSpecName ATTENTION_SINK{"attention_sink"};
@@ -735,13 +735,8 @@ ttnn::device_operation::ProgramArtifacts SDPAOperation::SDPAProgramFactory::crea
                 .data_format_metadata = off_df});
         }
     }
-    if (is_chunked) {
-        dfbs.push_back(DataflowBufferSpec{
-            .unique_id = PAGE_TABLE,
-            .entry_size = page_table_stick_size,
-            .num_entries = 1,
-            .data_format_metadata = page_table_df});
-    }
+    // Chunked page table: the reader both fills and reads it (former DM self-loop DFB). Converted to a
+    // private node-local Scratchpad -- registered on spec.scratchpads and bound to the reader below.
     if (flexible_chunked) {
         constexpr uint32_t chunk_start_idx_page_size = 32;
         dfbs.push_back(DataflowBufferSpec{
@@ -1377,12 +1372,12 @@ ttnn::device_operation::ProgramArtifacts SDPAOperation::SDPAProgramFactory::crea
             TensorBinding{.tensor_parameter_name = T_ATTENTION_SINK, .accessor_name = "attention_sink"});
         reader_defines.insert({"USE_ATTENTION_SINK", "1"});
     }
+    Group<ScratchpadBinding> reader_scratch;
     if (is_chunked) {
-        // Page table is filled and read within the reader — self-loop.
-        reader_dfbs.push_back(DFBBinding{
-            .dfb_spec_name = PAGE_TABLE, .accessor_name = "page_table", .endpoint_type = DFBEndpointType::PRODUCER});
-        reader_dfbs.push_back(DFBBinding{
-            .dfb_spec_name = PAGE_TABLE, .accessor_name = "page_table", .endpoint_type = DFBEndpointType::CONSUMER});
+        // Page table is filled and read within the reader. Formerly a DM self-loop DFB; now a private
+        // node-local Scratchpad the reader stages into and indexes directly.
+        reader_scratch.push_back(
+            ScratchpadBinding{.scratchpad_spec_name = PAGE_TABLE_SCRATCH, .accessor_name = "page_table"});
         reader_tensors.push_back(TensorBinding{.tensor_parameter_name = T_PAGE_TABLE, .accessor_name = "page_table"});
         reader_defines.insert({"IS_CHUNKED", "1"});
     }
@@ -1452,10 +1447,13 @@ ttnn::device_operation::ProgramArtifacts SDPAOperation::SDPAProgramFactory::crea
 
     KernelSpec reader{
         .unique_id = READER,
-        .source = "ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp",
+        .source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/"
+            "reader_interleaved.cpp",
         .compiler_options = {.defines = reader_defines},
         .dfb_bindings = reader_dfbs,
         .semaphore_bindings = reader_sems,
+        .scratchpad_bindings = reader_scratch,
         .tensor_bindings = reader_tensors,
         .compile_time_args = reader_cta,
         .runtime_arg_schema = {.runtime_arg_names = reader_rta_names},
@@ -1713,11 +1711,18 @@ ttnn::device_operation::ProgramArtifacts SDPAOperation::SDPAProgramFactory::crea
 
     // ---- ProgramSpec ----
 
+    Group<ScratchpadSpec> scratchpads;
+    if (is_chunked) {
+        // size_per_node = entry_size * num_entries = page_table_stick_size * 1 (single entry).
+        scratchpads.push_back(ScratchpadSpec{.unique_id = PAGE_TABLE_SCRATCH, .size_per_node = page_table_stick_size});
+    }
+
     ProgramSpec spec{
         .name = "sdpa_quasar",
         .kernels = {reader, writer, compute},
         .dataflow_buffers = dfbs,
         .semaphores = sems,
+        .scratchpads = scratchpads,
         .tensor_parameters = tensor_params,
         .work_units = {WorkUnitSpec{.name = "main", .kernels = {READER, WRITER, COMPUTE}, .target_nodes = core_grid}},
     };


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
The chunked prefill reader in the quasar-fork SDPA op bound the `page_table` DataflowBuffer as both producer and consumer on a single data-movement kernel — a DM self-loop. Quasar does not support DM self-loop DFBs, so this shape blocks the sdpa uplift to Gen2.

The buffer is single-entry: the reader stages the page table and reads it back within the same kernel, and the FIFO calls were only tracking an address. This converts it to a private node-local `Scratchpad`:

- Host: drop the `page_table` `DataflowBufferSpec` and its two `DFBBinding`s; register a `ScratchpadSpec` (`size_per_node = page_table_stick_size`) and bind it to the reader, under the same `is_chunked` guard.
- Kernel: replace the `DataflowBuffer` with `Scratchpad<volatile uint32_t>`; delete the four fake-FIFO calls (`reserve_back`/`push_back`/`pop_front` + the end-of-phase `pop_front`); the NOC destination and `page_table_ptr` now come from the scratchpad base address (the read pointer never leaves the base on a single-entry buffer).

Behaviour is unchanged — the reader performs the same NOC reads to the same L1 region. Follows the Metal 2.0 post-port self-loop-DFB recipe (`dm_self_loop_dfbs.md`).

This is one site of a broader audit; the remaining page_table / windowed / OUT_O self-loops in sdpa and sdpa_decode stop on conditions the recipe defers to the API owner (borrowed memory, `get_tile_size` format consults, helper-hidden FIFO calls) and are left as-is.

### Notes for reviewers
- Verified on Wormhole n150: chunked (`test_chunked_scaled_dot_product_attention`, 3/3) and non-chunked prefill (`test_scaled_dot_product_attention`, 3/3) quasar per-op tests pass. The `is_chunked` reader kernel recompiles under JIT; only the factory needs a host rebuild.
- The `.source` string in the reader `KernelSpec` was re-wrapped by clang-format (pre-existing over-long line in the edited struct) — no functional change.