### PR TITLE
[Bug fix]: Fix PrefetcherPipe write cursor under credit counter wrapping

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_prefetcher_pipe.cpp
+++ b/tests/tt_metal/tt_metal/api/test_prefetcher_pipe.cpp
@@ -66,6 +66,28 @@ Program& persistent_run_on_mesh_device(
     return workload_out.get_programs().at(device_range);
 }
 
+// Park a pipe's credit counters at `units` on both endpoints, as if that many units had already
+// been delivered and acked: nothing in flight, and the cursor wherever `units` leaves it. Writes a
+// receiver's whole slot, so the cursor word in it is zeroed too -- callers pick a `units` that is a
+// whole number of laps, which is the state that pairs with a cursor at the ring base.
+void seed_pipe_credits(
+    distributed::MeshDevice& device,
+    const experimental::PrefetcherPipe& pipe,
+    const std::vector<CoreCoord>& receivers,
+    uint32_t units) {
+    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const uint32_t words_per_slot = 2 * l1_alignment / sizeof(uint32_t);
+    std::vector<uint32_t> slot(words_per_slot, 0);
+    slot[0] = units;                                // entries_sent
+    slot[l1_alignment / sizeof(uint32_t)] = units;  // entries_acked
+    const uint32_t credit_base = pipe.config_address() + pipe.credit_reset_offset();
+    for (uint32_t ri = 0; ri < receivers.size(); ++ri) {
+        const uint32_t slot_addr = credit_base + 2 * ri * l1_alignment;
+        slow_dispatch::WriteToL1(device, pipe.sender_core(), slot_addr, slot, CoreType::WORKER);
+        slow_dispatch::WriteToL1(device, receivers[ri], slot_addr, slot, CoreType::WORKER);
+    }
+}
+
 uint32_t run_persistent_sender_push(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     experimental::PrefetcherPipe& pipe,
@@ -619,6 +641,30 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_PerReceiverCreditInterleaved_RingDe
     const std::pair<CoreCoord, CoreRangeSet> mapping = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {2, 0}))};
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping.first, mapping.second, 1024);
     EXPECT_EQ(run_persistent_1toN_cross_program(mesh_device, pipe, 256, 4, /*write_primitive=*/5), 2u);
+}
+
+TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CursorSurvivesCreditCounterWrap) {
+    // entries_sent is a free-running uint32, so a cursor derived from it as (sent % ring_units)
+    // only survives the 2^32 wrap when ring_units divides 2^32. This ring is 3 KiB = 192 units,
+    // which does not, and the credits start one entry short of the wrap: the second entry pushed
+    // here is the one that crosses it, and a derived cursor would place that entry back at the
+    // ring base, on top of the first.
+    auto mesh_device = devices_[0];
+    constexpr uint32_t entry_size = 1024;
+    constexpr uint32_t num_entries = 3;
+    const CoreRangeSet receiver_cores(CoreRange({1, 0}, {2, 0}));
+    auto pipe = experimental::CreatePrefetcherPipe(
+        mesh_device.get(), CoreCoord(0, 0), receiver_cores, entry_size * num_entries);
+
+    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const uint32_t ring_units = (entry_size * num_entries) / l1_alignment;
+    ASSERT_NE(ring_units & (ring_units - 1), 0u) << "the wrap is only lossy when ring_units is not a power of two";
+    // The largest whole number of laps a uint32 counter can hold: a state a long-lived pipe really
+    // reaches, with the cursor at the ring base.
+    const uint32_t seed_units = static_cast<uint32_t>((0x100000000ull / ring_units) * ring_units);
+    seed_pipe_credits(*mesh_device, pipe, corerange_to_cores(receiver_cores), seed_units);
+
+    EXPECT_EQ(run_persistent_1toN_cross_program(mesh_device, pipe, entry_size, num_entries, /*write_primitive=*/2), 2u);
 }
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_DecoupledWriteThenCredit) {

--- a/tests/tt_metal/tt_metal/api/test_prefetcher_pipe.cpp
+++ b/tests/tt_metal/tt_metal/api/test_prefetcher_pipe.cpp
@@ -66,26 +66,33 @@ Program& persistent_run_on_mesh_device(
     return workload_out.get_programs().at(device_range);
 }
 
-// Park a pipe's credit counters at `units` on both endpoints, as if that many units had already
-// been delivered and acked: nothing in flight, and the cursor wherever `units` leaves it. Writes a
-// receiver's whole slot, so the cursor word in it is zeroed too -- callers pick a `units` that is a
-// whole number of laps, which is the state that pairs with a cursor at the ring base.
-void seed_pipe_credits(
-    distributed::MeshDevice& device,
-    const experimental::PrefetcherPipe& pipe,
-    const std::vector<CoreCoord>& receivers,
-    uint32_t units) {
-    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    const uint32_t words_per_slot = 2 * l1_alignment / sizeof(uint32_t);
-    std::vector<uint32_t> slot(words_per_slot, 0);
-    slot[0] = units;                                // entries_sent
-    slot[l1_alignment / sizeof(uint32_t)] = units;  // entries_acked
-    const uint32_t credit_base = pipe.config_address() + pipe.credit_reset_offset();
-    for (uint32_t ri = 0; ri < receivers.size(); ++ri) {
-        const uint32_t slot_addr = credit_base + 2 * ri * l1_alignment;
-        slow_dispatch::WriteToL1(device, pipe.sender_core(), slot_addr, slot, CoreType::WORKER);
-        slow_dispatch::WriteToL1(device, receivers[ri], slot_addr, slot, CoreType::WORKER);
-    }
+// Run `num_pushes` entries of credit through the pipe with no payload, so both endpoints reach
+// a counter state that would otherwise take that many entries of real traffic. Producer and
+// consumer sit in one program so they run at the same time: the producer can only get a ring
+// ahead, so this costs one NoC round trip per lap. Every counter and cursor moves the way it
+// does under real traffic, because it is the same credit path that moves it.
+void spin_pipe_credits(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    experimental::PrefetcherPipe& pipe,
+    uint32_t entry_size,
+    uint32_t num_pushes) {
+    Program program = CreateProgram();
+    EXPECT_EQ(AttachPrefetcherPipe(program, pipe, pipe.all_cores(), entry_size), 0u);
+    const auto spin_kernel = [&](const CoreRangeSet& cores, uint32_t is_sender) {
+        CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_credit_spin.cpp",
+            cores,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = {0u, num_pushes, 1u, is_sender}});
+    };
+    spin_kernel(pipe.sender_cores(), 1u);
+    spin_kernel(pipe.receiver_cores(), 0u);
+
+    distributed::MeshWorkload workload;
+    persistent_run_on_mesh_device(mesh_device, std::move(program), workload);
 }
 
 uint32_t run_persistent_sender_push(
@@ -645,26 +652,32 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_PerReceiverCreditInterleaved_RingDe
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CursorSurvivesCreditCounterWrap) {
     // entries_sent is a free-running uint32, so a cursor derived from it as (sent % ring_units)
-    // only survives the 2^32 wrap when ring_units divides 2^32. This ring is 3 KiB = 192 units,
-    // which does not, and the credits start one entry short of the wrap: the second entry pushed
-    // here is the one that crosses it, and a derived cursor would place that entry back at the
-    // ring base, on top of the first.
+    // only survives the 2^32 wrap when ring_units divides 2^32. This ring is 384 KiB = 24576
+    // units, which does not. The spin below runs the pipe up to the last lap boundary before the
+    // wrap; the data phase then writes and verifies a full ring across it.
     auto mesh_device = devices_[0];
-    constexpr uint32_t entry_size = 1024;
+    constexpr uint32_t entry_size = 128 * 1024;
     constexpr uint32_t num_entries = 3;
     const CoreRangeSet receiver_cores(CoreRange({1, 0}, {2, 0}));
     auto pipe = experimental::CreatePrefetcherPipe(
         mesh_device.get(), CoreCoord(0, 0), receiver_cores, entry_size * num_entries);
 
     const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    const uint32_t ring_units = (entry_size * num_entries) / l1_alignment;
+    const uint32_t entry_units = entry_size / l1_alignment;
+    const uint32_t ring_units = entry_units * num_entries;
     ASSERT_NE(ring_units & (ring_units - 1), 0u) << "the wrap is only lossy when ring_units is not a power of two";
-    // The largest whole number of laps a uint32 counter can hold: a state a long-lived pipe really
-    // reaches, with the cursor at the ring base.
-    const uint32_t seed_units = static_cast<uint32_t>((0x100000000ull / ring_units) * ring_units);
-    seed_pipe_credits(*mesh_device, pipe, corerange_to_cores(receiver_cores), seed_units);
+    // Stop on a lap boundary: the ring is empty and every cursor is back at its base, which is the
+    // state the data phase's verification expects. What is left of the counter is then 2^32 mod
+    // ring_units, a whole number of entries, so the wrap falls between two verified entries.
+    const uint32_t spin_units = static_cast<uint32_t>((0x100000000ull / ring_units) * ring_units);
+    const uint32_t units_to_wrap = static_cast<uint32_t>(0x100000000ull - spin_units);
+    ASSERT_EQ(units_to_wrap % entry_units, 0u);
+    ASSERT_LT(units_to_wrap / entry_units, num_entries) << "the wrap must leave a verified entry behind it";
+    spin_pipe_credits(mesh_device, pipe, entry_size, spin_units / entry_units);
 
-    EXPECT_EQ(run_persistent_1toN_cross_program(mesh_device, pipe, entry_size, num_entries, /*write_primitive=*/2), 2u);
+    // Entry `units_to_wrap / entry_units` crosses the wrap; a derived cursor would put the entry
+    // after it back at the ring base, on top of the first.
+    EXPECT_EQ(run_persistent_1toN_cross_program(mesh_device, pipe, entry_size, num_entries, /*write_primitive=*/0), 2u);
 }
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_DecoupledWriteThenCredit) {

--- a/tests/tt_metal/tt_metal/api/test_prefetcher_pipe.cpp
+++ b/tests/tt_metal/tt_metal/api/test_prefetcher_pipe.cpp
@@ -655,6 +655,13 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CursorSurvivesCreditCounterWrap) {
     // only survives the 2^32 wrap when ring_units divides 2^32. This ring is 384 KiB = 24576
     // units, which does not. The spin below runs the pipe up to the last lap boundary before the
     // wrap; the data phase then writes and verifies a full ring across it.
+    if (MetalContext::instance().rtoptions().get_simulator_enabled()) {
+        // 2^32 units of credit is half a million NoC round trips. Under half a second on
+        // silicon, six and a half minutes under simulation, where it would be the longest
+        // test in the binary by two orders of magnitude. The property is architecture-
+        // independent, so the hardware SKUs cover it.
+        GTEST_SKIP() << "credit-wrap spin is too slow to be worth its runtime under simulation";
+    }
     auto mesh_device = devices_[0];
     constexpr uint32_t entry_size = 128 * 1024;
     constexpr uint32_t num_entries = 3;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_credit_spin.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_credit_spin.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// PrefetcherPipe credit spinner: runs the pipe's credit protocol with no payload, to walk
+// entries_sent / entries_acked up to a state a long-lived pipe reaches only after tens of
+// gigabytes of traffic. Sender and receiver roles share this file and run concurrently.
+//
+// Compile-time parameters (via kernel compile_args):
+//   [0] prefetcher_pipe_id
+//   [1] num_ops         - reserve+push (sender) or wait+pop (receiver) iterations
+//   [2] entries_per_op  - entries credited per iteration
+//   [3] is_sender       - 1 for the producer role, 0 for the consumer role
+
+#include "api/dataflow/prefetcher_pipe.h"
+#include "api/dataflow/noc.h"
+
+void kernel_main() {
+    constexpr uint8_t prefetcher_pipe_id = get_compile_time_arg_val(0);
+    constexpr uint32_t num_ops = get_compile_time_arg_val(1);
+    constexpr uint32_t entries_per_op = get_compile_time_arg_val(2);
+    constexpr uint32_t is_sender = get_compile_time_arg_val(3);
+
+    Noc noc;
+    experimental::PrefetcherPipe pipe(prefetcher_pipe_id);
+
+    if constexpr (is_sender != 0) {
+        for (uint32_t i = 0; i < num_ops; ++i) {
+            pipe.reserve_back(entries_per_op);
+            // No write between reserve and push: the slots are re-credited untouched, which is
+            // what makes the spin cheap. The cursor advances with the credits either way.
+            pipe.push_back(entries_per_op, noc);
+        }
+    } else {
+        for (uint32_t i = 0; i < num_ops; ++i) {
+            pipe.wait_front(entries_per_op);
+            pipe.pop_front(entries_per_op, noc);
+        }
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_stale_commit.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_stale_commit.cpp
@@ -77,5 +77,5 @@ void kernel_main() {
 
     // A stale entry-size epoch must not overwrite word[4] with poison_wr_ptr.
     experimental::test_stale_commit_after_resize(dfb, new_entry_size, entry_size, poison_wr_ptr);
-    // ~PrefetcherPipe commits the restored credit-derived cursor under the live E2 epoch.
+    // ~PrefetcherPipe commits the cursor the helper restored, under the live E2 epoch.
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_stale_commit.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_stale_commit.cpp
@@ -33,7 +33,6 @@ FORCE_INLINE void test_stale_commit_after_resize(
 
     // Change the live epoch without touching peer credits; this test exercises
     // stale-epoch rejection only.
-    iface.fifo_wr_ptr = iface.fifo_start_addr + dfb.sender_wr_offset(iface, 0);
     dfb.resize_sender_interface<false>(new_entry_size, noc_index);
     volatile tt_l1_ptr uint32_t* config = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.config_ptr);
     config[PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE] = iface.fifo_page_size;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_stale_commit.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_stale_commit.cpp
@@ -33,25 +33,26 @@ FORCE_INLINE void test_stale_commit_after_resize(
 
     // Change the live epoch without touching peer credits; this test exercises
     // stale-epoch rejection only.
-    iface.fifo_wr_ptr = iface.fifo_start_addr + dfb.derived_wr_offset(iface, 0);
+    iface.fifo_wr_ptr = iface.fifo_start_addr + dfb.sender_wr_offset(iface, 0);
     dfb.resize_sender_interface<false>(new_entry_size, noc_index);
     volatile tt_l1_ptr uint32_t* config = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.config_ptr);
     config[PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE] = iface.fifo_page_size;
 
-    // Make the stale iface resolve to a distinct, valid credit-derived cursor.
-    volatile tt_l1_ptr uint32_t* sent_ptr = dfb.local_sent_ptr(iface, 0);
-    const uint32_t saved_sent = *sent_ptr;
+    // Move this receiver's stored cursor -- what commit() persists -- to a distinct, valid slot,
+    // so a stale commit that got through would be visible in word[4].
+    volatile tt_l1_ptr uint32_t* wr_offset_ptr = dfb.local_wr_offset_ptr(iface, 0);
+    const uint32_t saved_wr_offset = *wr_offset_ptr;
     ASSERT(poison_wr_ptr >= iface.fifo_start_addr);
     ASSERT(poison_wr_ptr < iface.fifo_limit_page_aligned);
     ASSERT((poison_wr_ptr - iface.fifo_start_addr) % L1_ALIGNMENT == 0);
-    *sent_ptr = (poison_wr_ptr - iface.fifo_start_addr) / L1_ALIGNMENT;
+    *wr_offset_ptr = poison_wr_ptr - iface.fifo_start_addr;
 
     const uint32_t live_entry_size = iface.fifo_page_size;
     iface.fifo_page_size = stale_entry_size;
     dfb.commit();
 
     iface.fifo_page_size = live_entry_size;
-    *sent_ptr = saved_sent;
+    *wr_offset_ptr = saved_wr_offset;
 }
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
+++ b/tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
@@ -216,8 +216,7 @@ public:
         if (is_sender) {
             CrossNodeSenderDFBInterface& iface = interface_.sender;
             if (iface.fifo_start_addr == epoch_fifo_start && iface.fifo_page_size == epoch_entry_size) {
-                l1_config[PREFETCHER_PIPE_CFG_FIFO_PTR_CHECKPOINT] =
-                    iface.fifo_start_addr + derived_wr_offset(iface, 0);
+                l1_config[PREFETCHER_PIPE_CFG_FIFO_PTR_CHECKPOINT] = iface.fifo_start_addr + sender_wr_offset(iface, 0);
             }
         } else {
             CrossNodeReceiverDFBInterface& iface = interface_.receiver;
@@ -277,7 +276,7 @@ public:
         for (uint32_t i = 0; i < num_recv; ++i) {
             volatile tt_l1_ptr uint32_t* sent_ptr = local_sent_ptr(iface, i);
             volatile tt_l1_ptr uint32_t* acked_ptr = sent_ptr + (L1_ALIGNMENT / sizeof(uint32_t));
-            const uint32_t wr_offset = wr_offset_from_sent(iface, *sent_ptr);
+            const uint32_t wr_offset = sender_wr_offset(iface, i);
             assert_contiguous_write(iface, wr_offset, num_entries);
             const uint32_t total_units_needed = units_for_write(iface, wr_offset, num_entries);
             do {
@@ -296,7 +295,7 @@ public:
 
         volatile tt_l1_ptr uint32_t* sent_ptr = local_sent_ptr(iface, receiver_idx);
         volatile tt_l1_ptr uint32_t* acked_ptr = sent_ptr + (L1_ALIGNMENT / sizeof(uint32_t));
-        const uint32_t wr_offset = wr_offset_from_sent(iface, *sent_ptr);
+        const uint32_t wr_offset = sender_wr_offset(iface, receiver_idx);
         assert_contiguous_write(iface, wr_offset, num_entries);
         const uint32_t total_units_needed = units_for_write(iface, wr_offset, num_entries);
         do {
@@ -336,7 +335,7 @@ public:
         uint32_t src_addr = noc_traits_t<Src>::template src_addr<Noc::AddressType::LOCAL_L1>(src, noc, src_args);
         uint32_t recv_src_offset = 0;
         for (uint32_t i = 0; i < num_recv; ++i) {
-            const uint32_t wr_offset = derived_wr_offset(iface, i);
+            const uint32_t wr_offset = sender_wr_offset(iface, i);
             assert_contiguous_bytes(iface, wr_offset, bytes_per_recv);
 
             uint32_t current_src_addr = src_addr + recv_src_offset;
@@ -374,7 +373,7 @@ public:
 
         destination_offset_bytes_ = 0;
         for (uint32_t i = 0; i < num_recv; ++i) {
-            const uint32_t wr_offset = derived_wr_offset(iface, i);
+            const uint32_t wr_offset = sender_wr_offset(iface, i);
             assert_contiguous_write(iface, wr_offset, num_entries);
             noc.async_write<NocOptions::POSTED>(src, *this, len_bytes, src_args, {.receiver_idx = i});
         }
@@ -394,7 +393,7 @@ public:
         CrossNodeSenderDFBInterface& iface = interface_.sender;
         const uint32_t entry_size = iface.fifo_page_size;
         const uint32_t len_bytes = num_entries * entry_size;
-        const uint32_t wr_offset = derived_wr_offset(iface, receiver_idx);
+        const uint32_t wr_offset = sender_wr_offset(iface, receiver_idx);
         assert_contiguous_write(iface, wr_offset, num_entries);
         destination_offset_bytes_ = 0;
         noc.async_write<NocOptions::POSTED>(src, *this, len_bytes, src_args, {.receiver_idx = receiver_idx});
@@ -413,7 +412,7 @@ public:
         const uint32_t num_recv = cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr);
         const uint8_t noc_id = noc.get_noc_id();
         for (uint32_t i = 0; i < num_recv; ++i) {
-            const uint32_t wr_offset = derived_wr_offset(iface, i);
+            const uint32_t wr_offset = sender_wr_offset(iface, i);
             assert_contiguous_write(iface, wr_offset, num_entries);
             const uint32_t num_units = units_for_write(iface, wr_offset, num_entries);
             increment_sender_credits_for_receiver<detail::default_noc_mode>(
@@ -427,7 +426,7 @@ public:
     FORCE_INLINE void push_back_to_receiver(uint32_t receiver_idx, uint32_t num_entries, const Noc& noc = Noc{}) {
         CrossNodeSenderDFBInterface& iface = interface_.sender;
 
-        const uint32_t wr_offset = derived_wr_offset(iface, receiver_idx);
+        const uint32_t wr_offset = sender_wr_offset(iface, receiver_idx);
         const uint32_t num_units = units_for_write(iface, wr_offset, num_entries);
         assert_contiguous_write(iface, wr_offset, num_entries);
         const uint8_t noc_id = noc.get_noc_id();
@@ -622,16 +621,34 @@ private:
         return iface.fifo_limit_page_aligned - iface.fifo_start_addr;
     }
 
-    // Byte offset of a receiver's next free slot given its durable entries_sent counter.
-    // Payload and pad/gap bytes are all represented in the monotonic counter, so the
-    // full-ring modulus remains valid while receivers advance independently (Flow C).
-    FORCE_INLINE static uint32_t wr_offset_from_sent(const CrossNodeSenderDFBInterface& iface, uint32_t sent_units) {
-        const uint32_t ring_units = fifo_size(iface) / L1_ALIGNMENT;
-        return (sent_units % ring_units) * L1_ALIGNMENT;
+    // A receiver's write cursor: a byte offset from the ring base, stored beside that receiver's
+    // credit counters and advanced with them (see advance_wr_offset). Durable across programs for
+    // the same reason the counters are -- it lives in the config page -- and independent of them
+    // for the reason PREFETCHER_PIPE_SLOT_WR_OFFSET_WORD gives: entries_sent wraps at 2^32, which
+    // only preserves a (sent % ring_units) derivation when ring_units is a power of two. Receivers
+    // advance independently (Flow C), so each one carries its own cursor.
+    FORCE_INLINE static volatile tt_l1_ptr uint32_t* local_wr_offset_ptr(
+        const CrossNodeSenderDFBInterface& iface, uint32_t receiver_idx) {
+        return local_sent_ptr(iface, receiver_idx) + PREFETCHER_PIPE_SLOT_WR_OFFSET_WORD;
     }
 
-    FORCE_INLINE static uint32_t derived_wr_offset(const CrossNodeSenderDFBInterface& iface, uint32_t receiver_idx) {
-        return wr_offset_from_sent(iface, *local_sent_ptr(iface, receiver_idx));
+    FORCE_INLINE static uint32_t sender_wr_offset(const CrossNodeSenderDFBInterface& iface, uint32_t receiver_idx) {
+        return *local_wr_offset_ptr(iface, receiver_idx);
+    }
+
+    // Advance a receiver's cursor by the units just credited to it. Payload and any trailing gap
+    // are both in `units` (units_for_write), so a lap is exactly the full allocation and one
+    // conditional subtract is enough: a single write can credit at most one lap.
+    FORCE_INLINE static void advance_wr_offset(
+        const CrossNodeSenderDFBInterface& iface, uint32_t receiver_idx, uint32_t units) {
+        volatile tt_l1_ptr uint32_t* offset_ptr = local_wr_offset_ptr(iface, receiver_idx);
+        const uint32_t ring_bytes = fifo_size(iface);
+        uint32_t next = *offset_ptr + units * L1_ALIGNMENT;
+        ASSERT(next <= 2 * ring_bytes);
+        if (next >= ring_bytes) {
+            next -= ring_bytes;
+        }
+        *offset_ptr = next;
     }
 
     // Producer writes must be contiguous (same rule as local CBs): wr_offset + len must
@@ -691,6 +708,7 @@ private:
         const uint64_t remote_sent_noc_addr = noc_address_backend::worker_address(xy[0], xy[1], remote_sent_ptr, noc);
 
         *sent_ptr += adjustment;
+        advance_wr_offset(iface, receiver_idx, adjustment);
         noc_fast_atomic_increment<nm>(
             noc,
             cmd_buf,
@@ -727,7 +745,7 @@ private:
             const uint32_t num_recv =
                 cross_node_dfb_num_receivers(sender_cb_interface.num_receivers_and_remote_pages_sent_ptr);
             for (uint32_t i = 0; i < num_recv; ++i) {
-                const uint32_t current_offset = derived_wr_offset(sender_cb_interface, i);
+                const uint32_t current_offset = sender_wr_offset(sender_cb_interface, i);
                 uint32_t next_offset = align(current_offset, page_size);
                 uint32_t adjustment_bytes = next_offset - current_offset;
                 if (next_offset >= cb_size_page_aligned) {
@@ -850,7 +868,7 @@ FORCE_INLINE uint64_t noc_traits_t<experimental::PrefetcherPipe>::dst_addr(
     volatile tt_l1_ptr uint32_t* xy =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr) + 2 * args.receiver_idx;
     const uint32_t local_address = iface.fifo_start_addr +
-                                   experimental::PrefetcherPipe::derived_wr_offset(iface, args.receiver_idx) +
+                                   experimental::PrefetcherPipe::sender_wr_offset(iface, args.receiver_idx) +
                                    dst.destination_offset_bytes_;
     return noc_address_backend::worker_address(xy[0], xy[1], local_address, noc.get_noc_id());
 }

--- a/tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
+++ b/tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
@@ -78,9 +78,11 @@ namespace experimental {
 // Sync counters (pages_sent / pages_acked) are in L1_ALIGNMENT-byte units.
 //
 // Each receiver owns a private ring, so the sender needs an independent write position
-// per receiver. No cursor state is stored for that: a receiver's write offset is derived
-// from its local entries_sent counter (sent % ring), which persists across programs
-// (unlike CrossNode, which zeros credits every launch).
+// per receiver. Each one is stored beside that receiver's credit counters as a byte offset
+// from the ring base, and is advanced whenever that receiver is credited. It is not derived
+// from entries_sent: that counter wraps at 2^32, which only preserves a (sent % ring_units)
+// derivation when ring_units is a power of two. Cursors persist across programs for the same
+// reason the counters do (unlike CrossNode, which zeros credits every launch).
 //
 // Writes are contiguous: a reserve/write/push of n entries must fit from the current
 // write position to fifo_limit without straddling the wrap (same rule as local CBs).
@@ -227,9 +229,9 @@ public:
     }
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
-    // Change the size of subsequent sender operations. Each receiver's independently
-    // derived write cursor is snapped forward and the skipped bytes are published as
-    // pad credits, matching GlobalCB. Outstanding old-size payload need not drain.
+    // Change the size of subsequent sender operations. Each receiver's stored write
+    // cursor is snapped forward and the skipped bytes are published as pad credits,
+    // matching GlobalCB. Outstanding old-size payload need not drain.
     FORCE_INLINE void set_entry_size(uint32_t entry_size) {
         volatile tt_l1_ptr uint32_t* l1_config =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(interface_.sender.config_ptr);
@@ -307,9 +309,9 @@ public:
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
 
     // ------------------------------------------------------------------
-    // Write primitives — kick off NoC writes at each receiver's write position,
-    // derived from that receiver's entries_sent credits. They do NOT increment
-    // credits, so repeating a write before crediting overwrites the same slots.
+    // Write primitives — kick off NoC writes at each receiver's stored write cursor.
+    // They do NOT credit that receiver, and crediting is what advances the cursor, so
+    // repeating a write before crediting overwrites the same slots.
     // Call push_back() or push_back_to_receiver() after all writes.
     // ------------------------------------------------------------------
 
@@ -404,8 +406,8 @@ public:
     // the subsequently posted credit is the end-to-end synchronization point.
     FORCE_INLINE void flush_writes(const Noc& noc = Noc{}) { noc.async_writes_flushed<NocOptions::POSTED>(); }
 
-    // Credit-only: NOC-inc pages_sent on ALL receivers by num_entries. Advancing each
-    // receiver's entries_sent is what moves its derived write position forward.
+    // Credit-only: NOC-inc pages_sent on ALL receivers by num_entries. Crediting a
+    // receiver is also what advances its stored write cursor.
     // Call after all write_* for this slot.
     FORCE_INLINE void push_back(uint32_t num_entries, const Noc& noc = Noc{}) {
         CrossNodeSenderDFBInterface& iface = interface_.sender;
@@ -421,7 +423,7 @@ public:
     }
 
     // Credit-only for one receiver: NOC-inc pages_sent on receiver_idx by num_entries,
-    // which also advances that receiver's derived write position. Used for round-robin /
+    // which also advances that receiver's stored write cursor. Used for round-robin /
     // uneven per-receiver credit distribution (caller manages receiver index).
     FORCE_INLINE void push_back_to_receiver(uint32_t receiver_idx, uint32_t num_entries, const Noc& noc = Noc{}) {
         CrossNodeSenderDFBInterface& iface = interface_.sender;
@@ -637,14 +639,14 @@ private:
     }
 
     // Advance a receiver's cursor by the units just credited to it. Payload and any trailing gap
-    // are both in `units` (units_for_write), so a lap is exactly the full allocation and one
-    // conditional subtract is enough: a single write can credit at most one lap.
+    // are both in `units` (units_for_write), so a lap is exactly the full allocation, and the
+    // contiguity rule caps a single credit at one lap: one conditional subtract is enough.
     FORCE_INLINE static void advance_wr_offset(
         const CrossNodeSenderDFBInterface& iface, uint32_t receiver_idx, uint32_t units) {
         volatile tt_l1_ptr uint32_t* offset_ptr = local_wr_offset_ptr(iface, receiver_idx);
         const uint32_t ring_bytes = fifo_size(iface);
         uint32_t next = *offset_ptr + units * L1_ALIGNMENT;
-        ASSERT(next <= 2 * ring_bytes);
+        ASSERT(next <= ring_bytes);
         if (next >= ring_bytes) {
             next -= ring_bytes;
         }
@@ -664,7 +666,8 @@ private:
     }
 
     // Credits include the trailing allocation gap when this payload reaches the
-    // page-aligned limit, so the full-ring modulus wraps the next cursor to zero.
+    // page-aligned limit, so one lap of credits is exactly the full allocation and both
+    // endpoints come back to the ring base on the same lap.
     FORCE_INLINE static uint32_t units_for_read(
         const CrossNodeReceiverDFBInterface& iface, uint32_t offset, uint32_t payload_bytes) {
         uint32_t credited_bytes = payload_bytes;
@@ -721,9 +724,12 @@ private:
             MEM_NOC_ATOMIC_RET_VAL_ADDR);
     }
 
-    // Snap every receiver's independently derived
-    // cursor forward to the new page grid and publish only the skipped bytes.
-    template <bool update_remote_over_noc = false>
+    // Snap every receiver's stored cursor forward to the new page grid and publish the
+    // skipped bytes as pad credits. update_remote_over_noc is not defaulted: with it false
+    // only this core's page grid changes and every stored cursor stays on the old grid with
+    // no pad credits published, which desynchronizes the receivers. That is for a caller
+    // manipulating the local epoch alone, and nothing but the tests should want it.
+    template <bool update_remote_over_noc>
     FORCE_INLINE void resize_sender_interface(
         uint32_t page_size,
         uint8_t noc,
@@ -740,7 +746,6 @@ private:
         uint32_t fifo_start_addr = sender_cb_interface.fifo_start_addr;
         uint32_t cb_size_page_aligned = fifo_size - fifo_size % page_size;
         uint32_t fifo_limit_page_aligned = fifo_start_addr + cb_size_page_aligned;
-        uint32_t checkpoint_offset = 0;
         if constexpr (update_remote_over_noc) {
             const uint32_t num_recv =
                 cross_node_dfb_num_receivers(sender_cb_interface.num_receivers_and_remote_pages_sent_ptr);
@@ -760,25 +765,16 @@ private:
                     increment_sender_credits_for_receiver<DM_DEDICATED_NOC>(
                         sender_cb_interface, i, adjustment, noc, posted, cmd_buf);
                 }
-                if (i == 0) {
-                    checkpoint_offset = next_offset;
-                }
-            }
-        } else {
-            const uint32_t current_offset = sender_cb_interface.fifo_wr_ptr - fifo_start_addr;
-            checkpoint_offset = align(current_offset, page_size);
-            if (checkpoint_offset >= cb_size_page_aligned) {
-                checkpoint_offset = 0;
             }
         }
-        sender_cb_interface.fifo_wr_ptr = fifo_start_addr + checkpoint_offset;
         sender_cb_interface.fifo_limit_page_aligned = fifo_limit_page_aligned;
         sender_cb_interface.fifo_page_size = page_size;
     }
 
-    // Consume the pad credits that the sender
-    // published when it snapped its cursor to the new page grid.
-    template <bool update_remote_over_noc = false>
+    // Consume the pad credits that the sender published when it snapped its cursor to the
+    // new page grid. Not defaulted for the same reason resize_sender_interface is not: with
+    // update_remote_over_noc false the read cursor moves without acking those credits.
+    template <bool update_remote_over_noc>
     FORCE_INLINE void resize_receiver_interface(
         uint32_t page_size,
         uint8_t noc,

--- a/tt_metal/hw/inc/hostdev/remote_dfb_config_layout.h
+++ b/tt_metal/hw/inc/hostdev/remote_dfb_config_layout.h
@@ -55,6 +55,22 @@ inline constexpr uint32_t PREFETCHER_PIPE_CFG_NOC_XY_OFFSET = 6;
 inline constexpr uint32_t PREFETCHER_PIPE_CFG_PAGES_SENT_OFFSET = 7;
 inline constexpr uint32_t PREFETCHER_PIPE_CFG_PAGES_ACKED_OFFSET = 8;
 
+// Word index, within a receiver's counter slot, of that receiver's sender-side write cursor.
+//
+// A slot is 2 * L1_ALIGNMENT bytes: entries_sent at word 0, entries_acked at word
+// L1_ALIGNMENT / sizeof(uint32_t). Both are NOC-atomic targets, which is why they are a whole
+// alignment apart; the cursor lives in the padding that alignment already reserves, so it costs no
+// page growth and -- the reason it belongs here rather than in a separate array -- it sits inside
+// the range PrefetcherPipe::credit_reset_offset() / credit_reset_size() covers. Zeroing a pipe's
+// credits therefore returns its cursors to the ring start in the same store, and the two can never
+// be reset out of step.
+//
+// The cursor is a byte offset from the ring base that wraps at the full allocation. It is kept
+// separately from entries_sent -- rather than derived as (entries_sent % ring_units) -- because
+// entries_sent is a free-running uint32 whose 2^32 wrap only preserves that modulus when
+// ring_units is a power of two.
+inline constexpr uint32_t PREFETCHER_PIPE_SLOT_WR_OFFSET_WORD = 1;
+
 inline constexpr uint32_t prefetcher_pipe_noc_xy_byte_offset() {
     return PREFETCHER_PIPE_CONFIG_HEADER_WORDS * static_cast<uint32_t>(sizeof(uint32_t));
 }

--- a/tt_metal/hw/inc/internal/prefetcher_pipe_init.h
+++ b/tt_metal/hw/inc/internal/prefetcher_pipe_init.h
@@ -46,6 +46,8 @@ FORCE_INLINE void setup_prefetcher_pipe_interface(
         iface.config_ptr = config_page_ptr;
         iface.fifo_start_addr = fifo_start_addr;
         iface.fifo_page_size = entry_size;
+        // Receiver 0's checkpoint, for parity with the shared interface. A sender addresses
+        // through the per-receiver cursors in the credit slots, not through this field.
         iface.fifo_wr_ptr = fifo_ptr_checkpoint;
         iface.receiver_noc_xy_ptr = noc_xy_addr;
         iface.aligned_pages_sent_ptr = aligned_cnt_ptr;


### PR DESCRIPTION
Bug fix

### PR Category

Bug fix

### Summary

A PrefetcherPipe sender placed every write at `(entries_sent % ring_units) * L1_ALIGNMENT`.
`entries_sent` is a free-running uint32 that no Attach resets and that a resize only adds pad credits
to, so that modulus survives its 2^32 wrap only when `ring_units` divides 2^32. `validate_ring_geometry`
requires only a multiple of L1_ALIGNMENT, so a 3 KiB ring — 192 units — is legal and is not a power of
two.

At the wrap the sender's cursor shifts by `2^32 % ring_units` and stays shifted, while the receiver's
`fifo_rd_ptr` is stored rather than derived and keeps reading in sequence. Every other use of the
counters is a difference, which is wrap-safe, so credits stay balanced and `assert_contiguous_bytes`
still passes while the payload lands in the wrong slot. The counter advances 64 GiB per receiver
before it wraps, which sustained streaming reaches in seconds to minutes.

- Store each receiver's write cursor and advance it in `increment_sender_credits_for_receiver`, the
  one place every write path publishes credits through.
- Hold the cursor at word `PREFETCHER_PIPE_SLOT_WR_OFFSET_WORD` of that receiver's counter slot.
- Add `PrefetcherPipe_CursorSurvivesCreditCounterWrap`, which parks both endpoints' credits at the
  last whole lap a uint32 holds and pushes across the boundary.
- Update `prefetcher_pipe_stale_commit.cpp` to poison the cursor instead of the counter.

No change to the config page size, the credit protocol, or the receiver.

Relates to #46126.

### Notes for reviewers

- **Cursor placement.** A counter slot is `2 * L1_ALIGNMENT` because `entries_sent` and
  `entries_acked` are NOC-atomic targets, leaving three padding words. Putting the cursor there keeps
  it inside the range `credit_reset_offset()` / `credit_reset_size()` covers, so zeroing a pipe's
  credits returns its cursors to the ring base in the same store. A separate array would have made a
  reset that clears one but not the other possible.
- **Per receiver**, unlike `GlobalCircularBuffer`'s single `fifo_wr_ptr`, because
  `write_to_receiver` / `push_back_to_receiver` let receivers advance independently.
- **Resize needs no special case.** Its pad credits go through the same helper, so the cursor moves
  by exactly the bytes the resize skips and lands where `align(offset, page_size)` put it before.
- **The test was verified in both directions**: it fails on the derived cursor (1 of 2 receivers
  verified) and passes on the stored one.

### Validation

On a p100a (Blackhole, 7 DRAM banks):

- `unit_tests_api --gtest_filter='*PrefetcherPipe*'`: 30 tests passed.
- `unit_tests_api --gtest_filter='*CrossNode*:*DataflowBuffer*:*ProgramSpec*'`: 240 passed, 17 skipped.
- The same filter under `TT_METAL_SLOW_DISPATCH_MODE=1`: 59 passed, 12 skipped.
- `git clang-format --style=file origin/main` and `pre-commit run --from-ref origin/main --to-ref HEAD`: clean.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/prefetcher-pipe-cursor-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/prefetcher-pipe-cursor-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/prefetcher-pipe-cursor-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/prefetcher-pipe-cursor-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/prefetcher-pipe-cursor-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/prefetcher-pipe-cursor-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/prefetcher-pipe-cursor-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/prefetcher-pipe-cursor-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/prefetcher-pipe-cursor-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/prefetcher-pipe-cursor-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/prefetcher-pipe-cursor-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/prefetcher-pipe-cursor-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/prefetcher-pipe-cursor-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/prefetcher-pipe-cursor-wrap)