### PR TITLE
[Test Only] Parametrize the binary compute LLK tests over MathFidelity

### DIFF
--- a/tests/pipeline_reorg/llk_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/llk_merge_gate_tests.yaml
@@ -79,7 +79,7 @@
 
 # --- SD-only / Quasar slice ---
 - name: LLK SD wormhole (Quasar slice)
-  cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='LLKMeshDeviceFixtureSlowDispatchOnly.*:LLKQuasarMeshDeviceSingleCardFixture.*:QuasarMeshDeviceSingleCardFixture.*'
+  cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='*LLKMeshDeviceFixtureSlowDispatchOnly*:LLKQuasarMeshDeviceSingleCardFixture.*:QuasarMeshDeviceSingleCardFixture.*'
   skus:
     wh_n150_civ2:
       timeout: 10
@@ -89,7 +89,7 @@
   dispatch_mode: sd
 
 - name: LLK SD blackhole (Quasar slice)
-  cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='LLKMeshDeviceFixtureSlowDispatchOnly.*:LLKBlackholeSingleCardFixture.*:*MulReduceScalarTest*:LLKQuasarMeshDeviceSingleCardFixture.*:QuasarMeshDeviceSingleCardFixture.*-LLKBlackholeSingleCardFixture.TensixComputeUnpackTilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixComputePackUntilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixFp8e4m3ToFp8e4m3'
+  cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='*LLKMeshDeviceFixtureSlowDispatchOnly*:LLKBlackholeSingleCardFixture.*:*MulReduceScalarTest*:LLKQuasarMeshDeviceSingleCardFixture.*:QuasarMeshDeviceSingleCardFixture.*-LLKBlackholeSingleCardFixture.TensixComputeUnpackTilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixComputePackUntilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixFp8e4m3ToFp8e4m3'
   skus:
     bh_p150b_civ2_viommu:
       timeout: 10

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -660,7 +660,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "add",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 1;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
     }
 }
@@ -674,7 +674,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "sub",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 1;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
     }
 }
@@ -688,7 +688,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "mul",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 1;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
     }
 }
@@ -702,7 +702,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "add",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 1;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
     }
 }
@@ -716,7 +716,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "sub",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 1;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
     }
 }
@@ -730,7 +730,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "mul",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 1;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
     }
 }
@@ -744,7 +744,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "add_with_dest_reuse",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 4;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         // TODO: Remove early return once back-to-back tests are passing on Quasar
         if (this->arch_ == ARCH::QUASAR) {
@@ -762,7 +762,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "sub_with_dest_reuse",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 4;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         // TODO: Remove early return once back-to-back tests are passing on Quasar
         if (this->arch_ == ARCH::QUASAR) {
@@ -780,7 +780,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "mul_with_dest_reuse",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 4;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         // TODO: Remove early return once back-to-back tests are passing on Quasar
         if (this->arch_ == ARCH::QUASAR) {
@@ -901,7 +901,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "add",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 4;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         // TODO: Remove early return once back-to-back tests are passing on Quasar
         if (this->arch_ == ARCH::QUASAR) {
@@ -919,7 +919,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "sub",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 4;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         // TODO: Remove early return once back-to-back tests are passing on Quasar
         if (this->arch_ == ARCH::QUASAR) {
@@ -937,7 +937,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .binary_op = "mul",
         .math_fidelity = GetParam()};
     test_config.num_tiles = 4;
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         // TODO: Remove early return once back-to-back tests are passing on Quasar
         if (this->arch_ == ARCH::QUASAR) {
@@ -957,7 +957,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .acc_to_dest = true,
         .math_fidelity = GetParam(),
     };
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         // TODO: Remove early return once back-to-back tests are passing on Quasar
         if (this->arch_ == ARCH::QUASAR) {
@@ -977,7 +977,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .acc_to_dest = true,
         .math_fidelity = GetParam(),
     };
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         // TODO: Remove early return once back-to-back tests are passing on Quasar
         if (this->arch_ == ARCH::QUASAR) {
@@ -997,7 +997,7 @@ TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCo
         .acc_to_dest = true,
         .math_fidelity = GetParam(),
     };
-    for (auto& device : this->devices_) {
+    for (const auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         // TODO: Remove early return once back-to-back tests are passing on Quasar
         if (this->arch_ == ARCH::QUASAR) {

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -644,194 +644,147 @@ bool single_core_binary(
 
 }  // namespace unit_tests::compute::binary
 
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileAdd) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "add",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 1;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+// Parametrized over fidelity so a single variant can be selected from the command
+// line (e.g. --gtest_filter='*TensixBinaryComputeSingleCoreSingleTileAdd/LoFi'),
+// which matters on simulator targets where one iteration costs about a minute.
+// MathFidelity is a sparse enum, so the valid values are listed rather than counted.
+class LLKMeshDeviceFixtureSlowDispatchOnlyFidelity : public LLKMeshDeviceFixtureSlowDispatchOnly,
+                                                     public testing::WithParamInterface<MathFidelity> {};
+
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreSingleTileAdd) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "add",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 1;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+    }
+}
+
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreSingleTileSub) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "sub",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 1;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+    }
+}
+
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreSingleTileMul) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "mul",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 1;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+    }
+}
+
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreSingleTileAddFullInit) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "add",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 1;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+    }
+}
+
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreSingleTileSubFullInit) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "sub",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 1;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+    }
+}
+
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "mul",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 1;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+    }
+}
+
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "add_with_dest_reuse",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 4;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+        // TODO: Remove early return once back-to-back tests are passing on Quasar
+        if (this->arch_ == ARCH::QUASAR) {
+            return;
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileSub) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "sub",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 1;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "sub_with_dest_reuse",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 4;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+        // TODO: Remove early return once back-to-back tests are passing on Quasar
+        if (this->arch_ == ARCH::QUASAR) {
+            return;
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileMul) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "mul",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 1;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-        }
-    }
-}
-
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileAddFullInit) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "add",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 1;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-        }
-    }
-}
-
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileSubFullInit) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "sub",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 1;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-        }
-    }
-}
-
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "mul",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 1;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-        }
-    }
-}
-
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "add_with_dest_reuse",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 4;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
-        }
-    }
-}
-
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "sub_with_dest_reuse",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 4;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
-        }
-    }
-}
-
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileMulWithDestReuse) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "mul_with_dest_reuse",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 4;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreMultiTileMulWithDestReuse) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "mul_with_dest_reuse",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 4;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+        // TODO: Remove early return once back-to-back tests are passing on Quasar
+        if (this->arch_ == ARCH::QUASAR) {
+            return;
         }
     }
 }
@@ -939,155 +892,130 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeColBroadcastThen
     }
 }
 
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileAdd) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "add",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 4;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreMultiTileAdd) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "add",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 4;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+        // TODO: Remove early return once back-to-back tests are passing on Quasar
+        if (this->arch_ == ARCH::QUASAR) {
+            return;
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileSub) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "sub",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 4;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreMultiTileSub) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "sub",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 4;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+        // TODO: Remove early return once back-to-back tests are passing on Quasar
+        if (this->arch_ == ARCH::QUASAR) {
+            return;
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileMul) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "mul",
-            .math_fidelity = MathFidelity(i)};
-        test_config.num_tiles = 4;
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreMultiTileMul) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "mul",
+        .math_fidelity = GetParam()};
+    test_config.num_tiles = 4;
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+        // TODO: Remove early return once back-to-back tests are passing on Quasar
+        if (this->arch_ == ARCH::QUASAR) {
+            return;
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .num_tiles = 4,
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "add",
-            .acc_to_dest = true,
-            .math_fidelity = MathFidelity(i),
-        };
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .num_tiles = 4,
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "add",
+        .acc_to_dest = true,
+        .math_fidelity = GetParam(),
+    };
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+        // TODO: Remove early return once back-to-back tests are passing on Quasar
+        if (this->arch_ == ARCH::QUASAR) {
+            return;
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .num_tiles = 4,
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "sub",
-            .acc_to_dest = true,
-            .math_fidelity = MathFidelity(i),
-        };
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .num_tiles = 4,
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "sub",
+        .acc_to_dest = true,
+        .math_fidelity = GetParam(),
+    };
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+        // TODO: Remove early return once back-to-back tests are passing on Quasar
+        if (this->arch_ == ARCH::QUASAR) {
+            return;
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileMulDestAcc) {
-    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
-        if (i == 1) {
-            continue;
-        }
-        unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
-            .num_tiles = 4,
-            .tile_byte_size = 2 * 32 * 32,
-            .l1_input_data_format = tt::DataFormat::Float16_b,
-            .l1_output_data_format = tt::DataFormat::Float16_b,
-            .core = CoreCoord(0, 0),
-            .binary_op = "mul",
-            .acc_to_dest = true,
-            .math_fidelity = MathFidelity(i),
-        };
-        log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (auto& device : this->devices_) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
+TEST_P(LLKMeshDeviceFixtureSlowDispatchOnlyFidelity, TensixBinaryComputeSingleCoreMultiTileMulDestAcc) {
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .num_tiles = 4,
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .core = CoreCoord(0, 0),
+        .binary_op = "mul",
+        .acc_to_dest = true,
+        .math_fidelity = GetParam(),
+    };
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
+        // TODO: Remove early return once back-to-back tests are passing on Quasar
+        if (this->arch_ == ARCH::QUASAR) {
+            return;
         }
     }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    MathFidelities,
+    LLKMeshDeviceFixtureSlowDispatchOnlyFidelity,
+    testing::Values(MathFidelity::LoFi, MathFidelity::HiFi2, MathFidelity::HiFi3, MathFidelity::HiFi4),
+    [](const testing::TestParamInfo<MathFidelity>& info) {
+        // fmt renders the enum as "MathFidelity::LoFi"; gtest only accepts
+        // alphanumerics and underscore in a parameter name.
+        const std::string name = fmt::format("{}", info.param);
+        return name.substr(name.rfind(':') + 1);
+    });
 
 // ============================================================================
 // Id-free (2.0) eltwise binary ADD family, validated against a C++ host golden (elementwise A + B in


### PR DESCRIPTION

### PR Category
Test Only

### Summary
The 15 binary compute tests each looped over every MathFidelity inside a single
test, so a caller could not run just one fidelity. On simulator targets one
iteration costs about a minute of wall clock.

Convert them to TEST_P over the four valid fidelities. Coverage is unchanged, all
four still run by default, but a single variant is now selectable:

  --gtest_filter='*TensixBinaryComputeSingleCoreSingleTileAdd/LoFi'
  --gtest_filter='*LLKMeshDeviceFixtureSlowDispatchOnlyFidelity*/LoFi'   # all 15

Listing the enumerators also removes 15 copies of `if (i == 1) continue;`.
MathFidelity is sparse (LoFi=0, HiFi2=2, HiFi3=3, HiFi4=4) and the loop counted
integers across it, so that guard was load-bearing: MathFidelity(1) throws.

Relates to https://github.com/tenstorrent/tt-umd-internal/issues/33

### Notes for reviewers
- Behaviour change on Quasar. Nine of these tests return early out of the device
  loop on Quasar, which previously also exited the fidelity loop, so only LoFi ran
  there. Each instance is now its own test, so Quasar runs all four. Happy to gate
  the extra fidelities behind a skip if that back-to-back limitation still applies.
- The parametrized fixture derives from LLKMeshDeviceFixtureSlowDispatchOnly and
  keeps its name as a prefix, so the two filters in llk_merge_gate_tests.yaml only
  needed widening to *LLKMeshDeviceFixtureSlowDispatchOnly*. Verified the gate
  resolves to 149 tests either way, now including all 60 instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brosko/parametrize-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brosko/parametrize-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brosko/parametrize-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brosko/parametrize-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brosko/parametrize-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brosko/parametrize-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brosko/parametrize-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brosko/parametrize-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brosko/parametrize-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brosko/parametrize-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brosko/parametrize-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brosko/parametrize-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brosko/parametrize-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brosko/parametrize-binary-fidelity)