### PR TITLE
[Cleanup] Reduce `MeshDispatchFixture` usage

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -27,6 +27,7 @@
 #include "context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
 #include "mesh_dispatch_fixture.hpp"
+#include "impl/program/program_impl.hpp"
 #include "gtest/gtest.h"
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -70,14 +71,9 @@ tt::tt_metal::KernelHandle CreateKernelFromVariant(tt::tt_metal::Program& progra
     return kernel;
 }
 
-bool dram_single_core_db(
-    tt::tt_metal::MeshDispatchFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+bool dram_single_core_db(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     tt_metal::Program program = tt_metal::CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
+    auto& cq = mesh_device->mesh_command_queue();
 
     CoreCoord core = {0, 0};
 
@@ -103,7 +99,7 @@ bool dram_single_core_db(
     uint32_t output_dram_buffer_addr = output_dram_buffer->address();
 
     auto dram_copy_kernel = tt_metal::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_db.cpp",
         core,
         tt_metal::DataMovementConfig{
@@ -111,10 +107,10 @@ bool dram_single_core_db(
 
     std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
         dram_buffer_size_bytes, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    fixture->WriteBuffer(mesh_device, input_dram_buffer, input_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, input_vec);
 
     tt_metal::SetRuntimeArgs(
-        program_,
+        program,
         dram_copy_kernel,
         core,
         {input_dram_buffer_addr,
@@ -127,28 +123,20 @@ bool dram_single_core_db(
          total_l1_buffer_size_tiles,
          total_l1_buffer_size_bytes});
 
-    fixture->RunProgram(mesh_device, workload);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> result_vec;
-    fixture->ReadBuffer(mesh_device, output_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, output_dram_buffer);
 
     return input_vec == result_vec;
 }
 
-bool dram_single_core(
-    tt::tt_metal::MeshDispatchFixture* fixture,
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const DRAMConfig& cfg) {
-    std::vector<uint32_t> src_vec =
-        create_random_vector_of_bfloat16(cfg.dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
+bool dram_single_core(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const DRAMConfig& cfg) {
+    std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
+        cfg.dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    // Create a program
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
+    auto& cq = mesh_device->mesh_command_queue();
 
     distributed::DeviceLocalBufferConfig dram_config{
         .page_size = cfg.dram_buffer_size, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
@@ -165,12 +153,12 @@ bool dram_single_core(
     log_info(tt::LogTest, "Output DRAM Address = {:#x}", output_dram_buffer_addr);
     log_info(tt::LogTest, "L1 Buffer Address   = {:#x}", cfg.l1_buffer_addr);
     // Create the kernel
-    tt::tt_metal::KernelHandle kernel = CreateKernelFromVariant(program_, cfg);
+    tt::tt_metal::KernelHandle kernel = CreateKernelFromVariant(program, cfg);
 
-    fixture->WriteBuffer(mesh_device, input_dram_buffer, src_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, src_vec);
 
     tt_metal::SetRuntimeArgs(
-        program_,
+        program,
         kernel,
         cfg.core_range,
         {cfg.l1_buffer_addr,
@@ -180,27 +168,20 @@ bool dram_single_core(
          (std::uint32_t)0,
          cfg.dram_buffer_size});
 
-    fixture->RunProgram(mesh_device, workload, true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> result_vec(cfg.dram_buffer_size / sizeof(uint32_t));
-    fixture->ReadBuffer(mesh_device, output_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, output_dram_buffer);
 
     return result_vec == src_vec;
 }
 
 bool dram_single_core_pre_allocated(
-    tt::tt_metal::MeshDispatchFixture* fixture,
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const DRAMConfig& cfg) {
-    std::vector<uint32_t> src_vec =
-        create_random_vector_of_bfloat16(cfg.dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    // Create a program
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const DRAMConfig& cfg) {
+    std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
+        cfg.dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
     tt_metal::Program program = tt_metal::CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
+    auto& cq = mesh_device->mesh_command_queue();
 
     distributed::DeviceLocalBufferConfig dram_config{
         .page_size = cfg.dram_buffer_size, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
@@ -223,11 +204,11 @@ bool dram_single_core_pre_allocated(
     EXPECT_EQ(output_dram_buffer_addr, output_dram_pre_allocated_buffer_addr);
 
     // Create the kernel
-    tt::tt_metal::KernelHandle dram_kernel = CreateKernelFromVariant(program_, cfg);
-    fixture->WriteBuffer(mesh_device, input_dram_pre_allocated_buffer, src_vec);
+    tt::tt_metal::KernelHandle dram_kernel = CreateKernelFromVariant(program, cfg);
+    distributed::EnqueueWriteMeshBuffer(cq, input_dram_pre_allocated_buffer, src_vec);
 
     tt_metal::SetRuntimeArgs(
-        program_,
+        program,
         dram_kernel,
         cfg.core_range,
         {cfg.l1_buffer_addr,
@@ -237,10 +218,10 @@ bool dram_single_core_pre_allocated(
          (std::uint32_t)0,
          cfg.dram_buffer_size});
 
-    fixture->RunProgram(mesh_device, workload);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> result_vec;
-    fixture->ReadBuffer(mesh_device, output_dram_pre_allocated_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, output_dram_pre_allocated_buffer);
 
     return result_vec == src_vec;
 }
@@ -255,10 +236,11 @@ TEST_F(MeshDispatchFixture, TensixDRAMLoopbackSingleCore) {
         .dram_buffer_size = buffer_size,
         .l1_buffer_addr = 400 * 1024,
         .kernel_cfg =
-            tt::tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
     };
     for (const auto& mesh_device : devices_) {
-        ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(this, mesh_device, dram_test_config));
+        ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(mesh_device, dram_test_config));
     }
 }
 
@@ -270,11 +252,11 @@ TEST_F(MeshDispatchFixture, TensixDRAMLoopbackSingleCorePreAllocated) {
         .dram_buffer_size = buffer_size,
         .l1_buffer_addr = 400 * 1024,
         .kernel_cfg =
-            tt::tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
     };
     for (const auto& mesh_device : devices_) {
-        ASSERT_TRUE(
-            unit_tests_common::dram::test_dram::dram_single_core_pre_allocated(this, mesh_device, dram_test_config));
+        ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core_pre_allocated(mesh_device, dram_test_config));
     }
 }
 
@@ -284,7 +266,7 @@ TEST_F(MeshDispatchFixture, TensixDRAMLoopbackSingleCoreDB) {
         GTEST_SKIP();
     }
     for (const auto& mesh_device : devices_) {
-        ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core_db(this, mesh_device));
+        ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core_db(mesh_device));
     }
 }
 
@@ -314,7 +296,7 @@ TEST_F(MeshDispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
                     .eth_mode = Eth::RECEIVER,
                     .noc = static_cast<tt_metal::NOC>(erisc_idx),
                     .processor = static_cast<DataMovementProcessor>(erisc_idx)};
-                ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(this, mesh_device, dram_test_config));
+                ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(mesh_device, dram_test_config));
             }
         }
     }
@@ -351,7 +333,7 @@ TEST_F(MeshDispatchFixture, IdleEthDRAMLoopbackSingleCore) {
                     .eth_mode = Eth::IDLE,
                     .noc = static_cast<tt_metal::NOC>(erisc_idx),
                     .processor = static_cast<DataMovementProcessor>(erisc_idx)};
-                ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(this, mesh_device, dram_test_config));
+                ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(mesh_device, dram_test_config));
             }
         }
     }
@@ -360,7 +342,8 @@ TEST_F(MeshDispatchFixture, IdleEthDRAMLoopbackSingleCore) {
 // This test will hang on BH when both nocs use the same DRAM endpoint due to SYS-1419, hang can be reproduced by
 // increasing `num_iterations` DRAM arbiter seems to drop requests from one noc when both nocs are issuing requests to
 // the same DRAM endpoint at a fast rate.
-// This test should be kept to facilitate getting a scandump for root-causing SYS-1419 but keep it DISABLED so it doesn't run on CI
+// This test should be kept to facilitate getting a scandump for root-causing SYS-1419 but keep it DISABLED so it
+// doesn't run on CI
 TEST_F(MeshDispatchFixture, DISABLED_TensixLoopDRAMReadSingleCoreBothProcessors) {
     if (this->arch_ != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "This test has hardcoded parameters for Blackhole to repro hang described in SYS-1419";

--- a/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/device.hpp>
 #include "mesh_dispatch_fixture.hpp"
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include "gtest/gtest.h"
@@ -44,18 +45,11 @@ struct DRAMtoL1MulticastConfig {
 };
 
 bool dram_to_l1_multicast(
-    tt::tt_metal::MeshDispatchFixture* fixture,
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const DRAMtoL1MulticastConfig& cfg) {
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const DRAMtoL1MulticastConfig& cfg) {
     bool pass = true;
 
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    workload.add_program(device_range, std::move(program));
-
-    auto& program_ = workload.get_programs().at(device_range);
+    auto& cq = mesh_device->mesh_command_queue();
 
     CoreCoord core = {0, 0};
     uint32_t single_tile_size = 2 * 1024;
@@ -75,7 +69,6 @@ bool dram_to_l1_multicast(
     distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
     auto dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
     uint32_t dram_buffer_addr = dram_buffer->address();
-
 
     CoreCoord core_start = {0, 0};
     CoreCoord grid_size = mesh_device->logical_grid_size();
@@ -111,7 +104,7 @@ bool dram_to_l1_multicast(
     log_debug(LogTest, "End = {}, {}", core_end_physical.x, core_end_physical.y);
     log_debug(LogTest, "Exclude = {}, {}", core_exclude_physical.x, core_exclude_physical.y);
     auto mcast_reader_kernel = tt_metal::CreateKernel(
-        program_,
+        program,
         cfg.kernel_file,
         core,
         tt_metal::DataMovementConfig{
@@ -121,12 +114,12 @@ bool dram_to_l1_multicast(
     tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(
         shape, tt::deprecated::Initialize::RANDOM, 0, 100, std::chrono::system_clock::now().time_since_epoch().count());
     auto activations = pack_bfloat16_vec_into_uint32_vec(tensor.get_values());
-    fixture->WriteBuffer(mesh_device, dram_buffer, activations);
+    distributed::EnqueueWriteMeshBuffer(cq, dram_buffer, activations);
 
-    tt_metal::SetRuntimeArgs(program_, mcast_reader_kernel, core, mcast_reader_args);
+    tt_metal::SetRuntimeArgs(program, mcast_reader_kernel, core, mcast_reader_args);
 
     log_debug(LogTest, "Launching kernels");
-    fixture->RunProgram(mesh_device, workload);
+    LaunchProgram(*mesh_device, std::move(program));
     log_debug(LogTest, "Kernels done");
 
     for (int i = 0; i < grid_size.y; i++) {
@@ -163,8 +156,7 @@ TEST_F(MeshDispatchFixture, TensixDRAMtoL1Multicast) {
     };
 
     for (const auto& mesh_device : devices_) {
-        ASSERT_TRUE(
-            unit_tests_common::dram::test_dram_to_l1_multicast::dram_to_l1_multicast(this, mesh_device, test_config));
+        ASSERT_TRUE(unit_tests_common::dram::test_dram_to_l1_multicast::dram_to_l1_multicast(mesh_device, test_config));
     }
 }
 TEST_F(MeshDispatchFixture, TensixDRAMtoL1MulticastLoopbackSrc) {
@@ -175,8 +167,7 @@ TEST_F(MeshDispatchFixture, TensixDRAMtoL1MulticastLoopbackSrc) {
     };
 
     for (const auto& mesh_device : devices_) {
-        ASSERT_TRUE(
-            unit_tests_common::dram::test_dram_to_l1_multicast::dram_to_l1_multicast(this, mesh_device, test_config));
+        ASSERT_TRUE(unit_tests_common::dram::test_dram_to_l1_multicast::dram_to_l1_multicast(mesh_device, test_config));
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -556,7 +556,6 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDynamicNoc) {
 }
 
 void run_local_noc_stream_reg_inc(
-    MeshDispatchFixture* /*fixture*/,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const CoreCoord& core,
     const HalProgrammableCoreType& hal_programmable_core_type) {
@@ -652,7 +651,7 @@ TEST_F(MeshDeviceFixture, TensixTestNocStreamRegs) {
     // Get first tensix core (0,0)
     CoreCoord tensix_core(0, 0);
 
-    run_local_noc_stream_reg_inc(this, mesh_device, tensix_core, HalProgrammableCoreType::TENSIX);
+    run_local_noc_stream_reg_inc(mesh_device, tensix_core, HalProgrammableCoreType::TENSIX);
 }
 
 TEST_F(MeshDeviceFixture, ActiveEthTestNocStreamRegs) {
@@ -667,7 +666,7 @@ TEST_F(MeshDeviceFixture, ActiveEthTestNocStreamRegs) {
     // Get first active ethernet core
     CoreCoord eth_core = *(device->get_active_ethernet_cores(true).begin());
 
-    run_local_noc_stream_reg_inc(this, mesh_device, eth_core, HalProgrammableCoreType::ACTIVE_ETH);
+    run_local_noc_stream_reg_inc(mesh_device, eth_core, HalProgrammableCoreType::ACTIVE_ETH);
 }
 
 TEST_F(MeshDeviceFixture, IdleEthTestNocStreamRegs) {
@@ -682,7 +681,7 @@ TEST_F(MeshDeviceFixture, IdleEthTestNocStreamRegs) {
     // Get first idle ethernet core
     CoreCoord eth_core = *(device->get_inactive_ethernet_cores().begin());
 
-    run_local_noc_stream_reg_inc(this, mesh_device, eth_core, HalProgrammableCoreType::IDLE_ETH);
+    run_local_noc_stream_reg_inc(mesh_device, eth_core, HalProgrammableCoreType::IDLE_ETH);
 }
 
 // Increment and read back local DRISC Stream Registers
@@ -694,7 +693,7 @@ TEST_F(BlackholeSingleCardFixture, DramKernelStreamRegInc) {
 
     auto mesh_device = this->devices_[0];
     // Subchannel 0 is the syseng-owned NOC0 DRAM endpoint (no DRISC firmware); use subchannel 1.
-    run_local_noc_stream_reg_inc(this, mesh_device, CoreCoord{0, 1}, HalProgrammableCoreType::DRAM);
+    run_local_noc_stream_reg_inc(mesh_device, CoreCoord{0, 1}, HalProgrammableCoreType::DRAM);
 }
 
 // Tensix to DRISC stream register round trip DRISC test:

--- a/tests/tt_metal/tt_metal/deployment/dram/dram_base.cpp
+++ b/tests/tt_metal/tt_metal/deployment/dram/dram_base.cpp
@@ -5,6 +5,8 @@
 #include "tt_metal/tt_metal/deployment/deployment_common.hpp"
 
 #include "dram_base.hpp"
+#include "impl/program/program_impl.hpp"
+#include <tt-metalium/distributed.hpp>
 
 #include <gtest/gtest.h>
 #include <tt-logger/tt-logger.hpp>
@@ -321,7 +323,6 @@ static inline const char* dram_watchdog_reason_name(uint32_t reason) {
 }
 
 DramRunSummary run_dram_base_test(
-    MeshDispatchFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const CoreCoord& core,
     const DramDeploymentConfig& cfg,
@@ -347,10 +348,6 @@ DramRunSummary run_dram_base_test(
     MetalContext::instance().get_cluster().write_core(
         device->id(), device->worker_core_from_logical_core(core), zero_result, result_l1_address);
 
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-
-    distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::Program();
 
     auto kernel_config = tt_metal::DataMovementConfig{
@@ -412,10 +409,7 @@ DramRunSummary run_dram_base_test(
             //            params.insert_read_errors,
         });
 
-    workload.add_program(device_range, std::move(program));
-
-    fixture->RunProgram(mesh_device, workload, true);
-    fixture->FinishCommands(mesh_device);
+    LaunchProgram(*mesh_device, std::move(program));
 
     auto raw_result = MetalContext::instance().get_cluster().read_core(
         device->id(), device->worker_core_from_logical_core(core), result_l1_address, sizeof(DramBaseResult));
@@ -439,7 +433,6 @@ DramRunSummary run_dram_base_test(
 }
 
 DramRunSummary run_dram_multi_core_single_controller_test(
-    tt::tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     const std::vector<CoreCoord>& cores,
     const DramDeploymentConfig& cfg,
@@ -479,10 +472,6 @@ DramRunSummary run_dram_multi_core_single_controller_test(
             device->id(), device->worker_core_from_logical_core(core), zero_result, result_l1_address);
     }
 
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-
-    distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::Program();
 
     auto kernel_config = tt_metal::DataMovementConfig{
@@ -533,10 +522,7 @@ DramRunSummary run_dram_multi_core_single_controller_test(
             });
     }
 
-    workload.add_program(device_range, std::move(program));
-
-    fixture->RunProgram(mesh_device, workload, true);
-    fixture->FinishCommands(mesh_device);
+    LaunchProgram(*mesh_device, std::move(program));
 
     DramRunSummary summary{};
     summary.pass = true;
@@ -562,7 +548,6 @@ DramRunSummary run_dram_multi_core_single_controller_test(
 }
 
 DramRunSummary run_dram_multi_core_all_controllers_test(
-    tt::tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     const std::vector<CoreCoord>& cores,
     uint32_t total_bytes_per_controller,
@@ -604,10 +589,6 @@ DramRunSummary run_dram_multi_core_all_controllers_test(
             device->id(), device->worker_core_from_logical_core(core), zero_result, result_l1_address);
     }
 
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-
-    distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::Program();
 
     auto kernel_config = tt_metal::DataMovementConfig{
@@ -684,10 +665,7 @@ DramRunSummary run_dram_multi_core_all_controllers_test(
         core_begin += cores_in_this_controller;
     }
 
-    workload.add_program(device_range, std::move(program));
-
-    fixture->RunProgram(mesh_device, workload, true);
-    fixture->FinishCommands(mesh_device);
+    LaunchProgram(*mesh_device, std::move(program));
 
     DramRunSummary summary{};
     summary.pass = true;
@@ -713,7 +691,6 @@ DramRunSummary run_dram_multi_core_all_controllers_test(
 }
 
 DramRunSummary run_dram_eight_single_core_single_controller_test(
-    tt::tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     const std::vector<CoreCoord>& cores,
     uint64_t bank_offset,
@@ -766,10 +743,6 @@ DramRunSummary run_dram_eight_single_core_single_controller_test(
             device->id(), device->worker_core_from_logical_core(core), zero_result, result_l1_address);
     }
 
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-
-    distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::Program();
 
     auto kernel_config = tt_metal::DataMovementConfig{
@@ -810,10 +783,7 @@ DramRunSummary run_dram_eight_single_core_single_controller_test(
             });
     }
 
-    workload.add_program(device_range, std::move(program));
-
-    fixture->RunProgram(mesh_device, workload, true);
-    fixture->FinishCommands(mesh_device);
+    LaunchProgram(*mesh_device, std::move(program));
 
     DramRunSummary summary{};
     summary.pass = true;
@@ -840,7 +810,6 @@ DramRunSummary run_dram_eight_single_core_single_controller_test(
 
 [[maybe_unused]]
 DramMultiInstanceSummary run_dram_eight_single_core_single_controller_test_verbose(
-    tt::tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     const std::vector<CoreCoord>& cores,
     uint64_t bank_offset,
@@ -892,10 +861,6 @@ DramMultiInstanceSummary run_dram_eight_single_core_single_controller_test_verbo
             device->id(), device->worker_core_from_logical_core(core), zero_result, result_l1_address);
     }
 
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-
-    distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::Program();
 
     auto kernel_config = tt_metal::DataMovementConfig{
@@ -936,10 +901,7 @@ DramMultiInstanceSummary run_dram_eight_single_core_single_controller_test_verbo
             });
     }
 
-    workload.add_program(device_range, std::move(program));
-
-    fixture->RunProgram(mesh_device, workload, true);
-    fixture->FinishCommands(mesh_device);
+    LaunchProgram(*mesh_device, std::move(program));
 
     DramMultiInstanceSummary out{};
     out.summary.pass = true;
@@ -978,7 +940,6 @@ static inline void write_core_u32(IDevice* device, const CoreCoord& core, uint32
 
 [[maybe_unused]]
 DramMultiInstanceSummary run_dram_persistent_jobs_test_verbose(
-    tt::tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     const std::vector<CoreCoord>& worker_cores,
     const std::vector<std::vector<DramWorkItem>>& jobs_per_core,
@@ -1052,10 +1013,6 @@ DramMultiInstanceSummary run_dram_persistent_jobs_test_verbose(
     std::vector<PerCorePersistentResources> per_core;
     per_core.reserve(worker_cores.size());
 
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-
-    distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::Program();
 
     auto brisc_kernel_config = tt_metal::DataMovementConfig{
@@ -1231,8 +1188,6 @@ DramMultiInstanceSummary run_dram_persistent_jobs_test_verbose(
                     },
             });
     }
-
-    workload.add_program(device_range, std::move(program));
 
     for (size_t core_idx = 0; core_idx < per_core.size(); core_idx++) {
         auto& r = per_core[core_idx];
@@ -1932,7 +1887,7 @@ DramMultiInstanceSummary run_dram_persistent_jobs_test_verbose(
             total_jobs);
     }
 
-    fixture->RunProgram(mesh_device, workload, false);
+    LaunchProgram(*mesh_device, std::move(program));
 
     auto end_time = std::chrono::steady_clock::now();
     auto duration_sec = std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count();
@@ -1949,7 +1904,7 @@ DramMultiInstanceSummary run_dram_persistent_jobs_test_verbose(
         refill_thread.join();
     }
 
-    fixture->FinishCommands(mesh_device);
+    distributed::Finish(mesh_device->mesh_command_queue());
 
     return out;
 }

--- a/tests/tt_metal/tt_metal/deployment/dram/dram_base.hpp
+++ b/tests/tt_metal/tt_metal/deployment/dram/dram_base.hpp
@@ -71,7 +71,6 @@ struct DramMultiInstanceSummary {
 };
 
 DramMultiInstanceSummary run_dram_persistent_jobs_test_verbose(
-    tt::tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     const std::vector<CoreCoord>& worker_cores,
     const std::vector<std::vector<DramWorkItem>>& jobs_per_core,
@@ -79,7 +78,6 @@ DramMultiInstanceSummary run_dram_persistent_jobs_test_verbose(
     DataMovementProcessor processor);
 
 DramMultiInstanceSummary run_dram_persistent_all_workers_dram_bank_sweep_test_verbose(
-    tt::tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     const std::vector<CoreCoord>& worker_cores,
     const std::vector<DramWorkItem>& all_jobs,
@@ -87,7 +85,6 @@ DramMultiInstanceSummary run_dram_persistent_all_workers_dram_bank_sweep_test_ve
     DataMovementProcessor processor);
 
 DramRunSummary run_dram_base_test(
-    MeshDispatchFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const CoreCoord& core,
     const DramDeploymentConfig& cfg,
@@ -97,7 +94,6 @@ DramRunSummary run_dram_base_test(
     DataMovementProcessor processor = DataMovementProcessor::RISCV_0);
 
 DramRunSummary run_dram_multi_core_single_controller_test(
-    tt::tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     const std::vector<CoreCoord>& cores,
     const DramDeploymentConfig& cfg,
@@ -107,7 +103,6 @@ DramRunSummary run_dram_multi_core_single_controller_test(
     DataMovementProcessor processor = DataMovementProcessor::RISCV_0);
 
 DramRunSummary run_dram_multi_core_all_controllers_test(
-    tt::tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     const std::vector<CoreCoord>& cores,
     uint32_t total_bytes_per_controller,

--- a/tests/tt_metal/tt_metal/deployment/dram/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/deployment/dram/test_dram.cpp
@@ -998,12 +998,7 @@ TEST_F(MeshDispatchFixture, DramDeployment_PersistentOptimalWorkersAllDramBanks)
         const auto subtest_start = std::chrono::steady_clock::now();
 
         DramMultiInstanceSummary run = run_dram_persistent_jobs_test_verbose(
-            static_cast<MeshDispatchFixture*>(this),
-            mesh_device,
-            worker_cores,
-            jobs_per_core,
-            chunk_bytes,
-            DataMovementProcessor::RISCV_0);
+            mesh_device, worker_cores, jobs_per_core, chunk_bytes, DataMovementProcessor::RISCV_0);
 
         const auto subtest_end = std::chrono::steady_clock::now();
 
@@ -1296,12 +1291,7 @@ TEST_F(MeshDispatchFixture, DramDeployment_PersistentAllWorkersSingleDramSequent
             const auto bank_start = std::chrono::steady_clock::now();
 
             DramMultiInstanceSummary run = run_dram_persistent_jobs_test_verbose(
-                static_cast<MeshDispatchFixture*>(this),
-                mesh_device,
-                worker_cores,
-                jobs_per_core,
-                chunk_bytes,
-                DataMovementProcessor::RISCV_0);
+                mesh_device, worker_cores, jobs_per_core, chunk_bytes, DataMovementProcessor::RISCV_0);
 
             const auto bank_end = std::chrono::steady_clock::now();
 
@@ -1658,12 +1648,7 @@ TEST_F(MeshDispatchFixture, DramDeployment_PersistentPartitionedWorkersAllDramBa
         const auto start = std::chrono::steady_clock::now();
 
         DramMultiInstanceSummary run = run_dram_persistent_jobs_test_verbose(
-            static_cast<MeshDispatchFixture*>(this),
-            mesh_device,
-            worker_cores,
-            jobs_per_core,
-            chunk_bytes,
-            DataMovementProcessor::RISCV_0);
+            mesh_device, worker_cores, jobs_per_core, chunk_bytes, DataMovementProcessor::RISCV_0);
 
         const auto end = std::chrono::steady_clock::now();
 

--- a/tests/tt_metal/tt_metal/deployment/eth/common.hpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/common.hpp
@@ -164,26 +164,6 @@ static void prepare_bidir(
 }
 
 [[maybe_unused]]
-static void wait_to_finish(
-    tt_metal::Program send_program,
-    tt_metal::Program recv_program,
-    const std::shared_ptr<distributed::MeshDevice>& send_mesh_device,
-    const std::shared_ptr<distributed::MeshDevice>& recv_mesh_device) {
-    /* ==================== */
-    bool same_device = send_mesh_device == recv_mesh_device;
-
-    [[maybe_unused]] distributed::MeshWorkload send_workload =
-        LaunchProgramAsync(*send_mesh_device, std::move(send_program));
-    [[maybe_unused]] distributed::MeshWorkload recv_workload =
-        same_device ? distributed::MeshWorkload() : LaunchProgramAsync(*recv_mesh_device, std::move(recv_program));
-
-    distributed::Finish(send_mesh_device->mesh_command_queue());
-    if (!same_device) {
-        distributed::Finish(recv_mesh_device->mesh_command_queue());
-    }
-}
-
-[[maybe_unused]]
 static void track_eth_progress_timeout(
     tt::tt_metal::IDevice* const send_device,
     tt::tt_metal::IDevice* const recv_device,
@@ -259,6 +239,10 @@ static void track_eth_progress_timeout_cores(std::span<struct core_setup> cores)
     }
 }
 
+// The helpers below launch every program with the non-blocking `LaunchProgramAsync` and only wait afterwards, so all
+// programs are co-resident regardless of dispatch mode. This is why they need no per-device thread, unlike
+// `launch_on_eth_pair` in tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp, which uses the blocking
+// `LaunchProgram` under slow dispatch.
 [[maybe_unused]]
 static void wait_to_finish_eth_timeout_cores(
     std::span<struct core_setup> cores,

--- a/tests/tt_metal/tt_metal/deployment/eth/common.hpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/common.hpp
@@ -163,35 +163,23 @@ static void prepare_bidir(
     tt_metal::SetRuntimeArgs(*send_program, send_kernel, send_core, {});
 }
 
-template <typename FIXTURE>
 [[maybe_unused]]
 static void wait_to_finish(
-    FIXTURE* fixture,
-    tt_metal::Program& send_program,
-    tt_metal::Program& recv_program,
+    tt_metal::Program send_program,
+    tt_metal::Program recv_program,
     const std::shared_ptr<distributed::MeshDevice>& send_mesh_device,
-    const std::shared_ptr<distributed::MeshDevice>& recv_mesh_device,
-    distributed::MeshCoordinateRange& device_range) {
+    const std::shared_ptr<distributed::MeshDevice>& recv_mesh_device) {
     /* ==================== */
     bool same_device = send_mesh_device == recv_mesh_device;
 
-    distributed::MeshWorkload send_workload;
-    distributed::MeshWorkload recv_workload_;
-    distributed::MeshWorkload& recv_workload = same_device ? send_workload : recv_workload_;
+    [[maybe_unused]] distributed::MeshWorkload send_workload =
+        LaunchProgramAsync(*send_mesh_device, std::move(send_program));
+    [[maybe_unused]] distributed::MeshWorkload recv_workload =
+        same_device ? distributed::MeshWorkload() : LaunchProgramAsync(*recv_mesh_device, std::move(recv_program));
 
-    send_workload.add_program(device_range, std::move(send_program));
+    distributed::Finish(send_mesh_device->mesh_command_queue());
     if (!same_device) {
-        recv_workload.add_program(device_range, std::move(recv_program));
-    }
-
-    fixture->RunProgram(send_mesh_device, send_workload, true);
-    if (!same_device) {
-        fixture->RunProgram(recv_mesh_device, recv_workload, true);
-    }
-
-    fixture->FinishCommands(send_mesh_device);
-    if (!same_device) {
-        fixture->FinishCommands(recv_mesh_device);
+        distributed::Finish(recv_mesh_device->mesh_command_queue());
     }
 }
 
@@ -271,46 +259,29 @@ static void track_eth_progress_timeout_cores(std::span<struct core_setup> cores)
     }
 }
 
-template <typename FIXTURE>
 [[maybe_unused]]
 static void wait_to_finish_eth_timeout_cores(
-    FIXTURE* fixture,
     std::span<struct core_setup> cores,
     std::map<std::shared_ptr<distributed::MeshDevice>, std::shared_ptr<tt_metal::Program>>& programs) {
     /* ==================== */
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    std::map<std::shared_ptr<distributed::MeshDevice>, std::shared_ptr<distributed::MeshWorkload>> devices;
-
-    for (const auto& [dev, _] : programs) {
-        devices[dev] = std::make_shared<distributed::MeshWorkload>();
-    }
-
-    for (const auto& [dev, workload] : devices) {
-        programs[dev]->impl().compile(dev.get());
-        devices[dev]->add_program(device_range, std::move(*programs[dev]));
-    }
-
-    for (const auto& [dev, workload] : devices) {
-        fixture->RunProgram(dev, *workload, true);
+    std::map<std::shared_ptr<distributed::MeshDevice>, distributed::MeshWorkload> devices;
+    for (auto& [dev, program] : programs) {
+        devices[dev] = LaunchProgramAsync(*dev, std::move(*program));
     }
 
     track_eth_progress_timeout_cores(cores);
 
     for (const auto& [dev, _] : devices) {
-        fixture->FinishCommands(dev);
+        distributed::Finish(dev->mesh_command_queue());
     }
 }
 
-template <typename FIXTURE>
 [[maybe_unused]]
 static void wait_to_finish_eth_timeout(
-    FIXTURE* fixture,
-    tt_metal::Program& send_program,
-    tt_metal::Program& recv_program,
+    tt_metal::Program send_program,
+    tt_metal::Program recv_program,
     const std::shared_ptr<distributed::MeshDevice>& send_mesh_device,
     const std::shared_ptr<distributed::MeshDevice>& recv_mesh_device,
-    distributed::MeshCoordinateRange& device_range,
     const CoreCoord& send_core,
     const CoreCoord& recv_core,
     uint32_t iter_l1_addr,
@@ -318,27 +289,18 @@ static void wait_to_finish_eth_timeout(
     /* ==================== */
     bool same_device = send_mesh_device == recv_mesh_device;
 
-    distributed::MeshWorkload send_workload;
-    distributed::MeshWorkload recv_workload_;
-    distributed::MeshWorkload& recv_workload = same_device ? send_workload : recv_workload_;
-
-    send_workload.add_program(device_range, std::move(send_program));
-    if (!same_device) {
-        recv_workload.add_program(device_range, std::move(recv_program));
-    }
-
-    fixture->RunProgram(send_mesh_device, send_workload, true);
-    if (!same_device) {
-        fixture->RunProgram(recv_mesh_device, recv_workload, true);
-    }
+    [[maybe_unused]] distributed::MeshWorkload send_workload =
+        LaunchProgramAsync(*send_mesh_device, std::move(send_program));
+    [[maybe_unused]] distributed::MeshWorkload recv_workload =
+        same_device ? distributed::MeshWorkload() : LaunchProgramAsync(*recv_mesh_device, std::move(recv_program));
 
     auto* const send_device = send_mesh_device->get_devices()[0];
     auto* const recv_device = recv_mesh_device->get_devices()[0];
     track_eth_progress_timeout(send_device, recv_device, send_core, recv_core, iter_l1_addr, expected_count);
 
-    fixture->FinishCommands(send_mesh_device);
+    distributed::Finish(send_mesh_device->mesh_command_queue());
     if (!same_device) {
-        fixture->FinishCommands(recv_mesh_device);
+        distributed::Finish(recv_mesh_device->mesh_command_queue());
     }
 }
 
@@ -443,10 +405,8 @@ static bool data_dram_check(
     return !total_mismatches;
 }
 
-template <typename FIXTURE>
 [[maybe_unused]]
 static void tensix_zero_dram(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t dram_start_addr,
     uint32_t dram_end_addr,
@@ -468,9 +428,6 @@ static void tensix_zero_dram(
     struct l1_allocator alloc = new_erisc_allocator();
     uint32_t buffer0 = l1_alloc(&alloc, transfer_size);
 
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::MeshWorkload workload;
     DataMovementConfig config = {
         .compile_args =
             {
@@ -513,17 +470,13 @@ static void tensix_zero_dram(
         }
     }
 
-    workload.add_program(device_range, std::move(zero_program));
-    fixture->RunProgram(mesh_device, workload, true);
-    fixture->FinishCommands(mesh_device);
+    LaunchProgram(*mesh_device, std::move(zero_program));
 
     // log_info(tt::LogTest, "      done zeroing bank {}", dram_bank_id);
 }
 
-template <typename FIXTURE>
 [[maybe_unused]]
 static void tensix_counter_dram(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t dram_start_addr,
     uint32_t dram_end_addr,
@@ -546,9 +499,6 @@ static void tensix_counter_dram(
     struct l1_allocator alloc = new_erisc_allocator();
     uint32_t buffer0 = l1_alloc(&alloc, transfer_size);
 
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::MeshWorkload workload;
     DataMovementConfig config = {
         .compile_args =
             {
@@ -591,17 +541,13 @@ static void tensix_counter_dram(
         }
     }
 
-    workload.add_program(device_range, std::move(zero_program));
-    fixture->RunProgram(mesh_device, workload, true);
-    fixture->FinishCommands(mesh_device);
+    LaunchProgram(*mesh_device, std::move(zero_program));
 
     // log_info(tt::LogTest, "      done zeroing bank {}", dram_bank_id);
 }
 
-template <typename FIXTURE>
 [[maybe_unused]]
 static bool tensix_compare_dram_banks(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t dram_start_addr,
     uint32_t dram_end_addr,
@@ -629,10 +575,6 @@ static bool tensix_compare_dram_banks(
     uint32_t last_error_addr = l1_alloc(&alloc, sizeof(uint32_t));
     uint32_t buffer0 = l1_alloc(&alloc, transfer_size + 64);
     uint32_t buffer1 = l1_alloc(&alloc, transfer_size + 64);
-
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::MeshWorkload workload;
 
     // log_info(tt::LogTest, "      bank0 {}, bank1 {}", dram_bank_id0, dram_bank_id1);
     // log_info(tt::LogTest, "      start {:8x}", dram_start_addr);
@@ -682,9 +624,7 @@ static bool tensix_compare_dram_banks(
         }
     }
 
-    workload.add_program(device_range, std::move(cmp_program));
-    fixture->RunProgram(mesh_device, workload, true);
-    fixture->FinishCommands(mesh_device);
+    LaunchProgram(*mesh_device, std::move(cmp_program));
 
     uint64_t total_errors = 0;
     uint32_t first_error = -1;

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth.cpp
@@ -19,9 +19,7 @@ using namespace std;
 using namespace tt;
 using namespace tt::test_utils;
 
-template <typename FIXTURE>
 static bool run_test_bandwidth(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& send_mesh_device,
     const std::shared_ptr<distributed::MeshDevice>& recv_mesh_device,
     const CoreCoord& send_core,
@@ -96,7 +94,7 @@ static bool run_test_bandwidth(
             .expected_count = transfer_count,
         },
     };
-    wait_to_finish_eth_timeout_cores(fixture, cores, programs);
+    wait_to_finish_eth_timeout_cores(cores, programs);
 
     double threshold = get_eth_bw() * 0.75;
 
@@ -151,7 +149,7 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet01Bandwidth) {
 
                     log_info(tt::LogTest, "    running on {}", processor);
                     bool passed = run_test_bandwidth(
-                        this, sender_mesh_device, receiver_mesh_device, sender_core, receiver_core, processor);
+                        sender_mesh_device, receiver_mesh_device, sender_core, receiver_core, processor);
                     if (!passed) {
                         errors.emplace_back(
                             sender_device->id(), receiver_device->id(), sender_core, receiver_core, processor);

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth_bidir.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth_bidir.cpp
@@ -20,9 +20,7 @@ using namespace std;
 using namespace tt;
 using namespace tt::test_utils;
 
-template <typename FIXTURE>
 static bool run_test_bandwidth_bidir(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& send_mesh_device,
     const std::shared_ptr<distributed::MeshDevice>& recv_mesh_device,
     const CoreCoord& send_core,
@@ -101,7 +99,7 @@ static bool run_test_bandwidth_bidir(
             .expected_count = transfer_count,
         },
     };
-    wait_to_finish_eth_timeout_cores(fixture, cores, programs);
+    wait_to_finish_eth_timeout_cores(cores, programs);
 
     double threshold = get_eth_bw() * 0.7;
 
@@ -162,7 +160,7 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet02BandwidthBidir) {
 
                     log_info(tt::LogTest, "    running on {}", processor);
                     bool passed = run_test_bandwidth_bidir(
-                        this, sender_mesh_device, receiver_mesh_device, sender_core, receiver_core, processor, inputs);
+                        sender_mesh_device, receiver_mesh_device, sender_core, receiver_core, processor, inputs);
                     if (!passed) {
                         errors.emplace_back(
                             sender_device->id(), receiver_device->id(), sender_core, receiver_core, processor);

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram.cpp
@@ -20,9 +20,7 @@ using namespace std;
 using namespace tt;
 using namespace tt::test_utils;
 
-template <typename FIXTURE>
 static void prepare_receiver_integrity_dram(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& recv_mesh_device,
     const CoreCoord& recv_core,
     uint32_t transfer_size,
@@ -37,10 +35,10 @@ static void prepare_receiver_integrity_dram(
     tt_metal::Program* recv_program,
     bool init_recv_dram) {
     /* ============= */
-    tensix_zero_dram(fixture, recv_mesh_device, dram_start_addr, dram_end_addr, dram_bank_id);
+    tensix_zero_dram(recv_mesh_device, dram_start_addr, dram_end_addr, dram_bank_id);
     if (init_recv_dram) {
         log_info(tt::LogTest, "      initing ram bank {}", dram_bank_id);
-        tensix_counter_dram(fixture, recv_mesh_device, dram_start_addr, dram_end_addr, send_bank_id);
+        tensix_counter_dram(recv_mesh_device, dram_start_addr, dram_end_addr, send_bank_id);
     }
 
     auto recv_eth_config = tt_metal::EthernetConfig{
@@ -68,9 +66,7 @@ static void prepare_receiver_integrity_dram(
     tt_metal::SetRuntimeArgs(*recv_program, recv_kernel, recv_core, {});
 }
 
-template <typename FIXTURE>
 static void prepare_sender_integrity_dram(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& send_mesh_device,
     const CoreCoord& send_core,
     uint32_t transfer_size,
@@ -91,7 +87,7 @@ static void prepare_sender_integrity_dram(
 
     if (init_send_dram) {
         log_info(tt::LogTest, "      initing ram bank {}", dram_bank_id);
-        tensix_counter_dram(fixture, send_mesh_device, dram_start_addr, dram_end_addr, dram_bank_id);
+        tensix_counter_dram(send_mesh_device, dram_start_addr, dram_end_addr, dram_bank_id);
     }
 
     auto send_eth_config = tt_metal::EthernetConfig{
@@ -130,9 +126,7 @@ struct test_config {
     uint32_t num_bytes_per_send;
 };
 
-template <typename FIXTURE>
 static bool run_test_integrity_dram(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& send_mesh_device,
     const std::shared_ptr<distributed::MeshDevice>& recv_mesh_device,
     const CoreCoord& send_core,
@@ -175,7 +169,6 @@ static bool run_test_integrity_dram(
 
     /* Receivers */
     prepare_receiver_integrity_dram(
-        fixture,
         recv_mesh_device,
         recv_core,
         transfer_size,
@@ -192,7 +185,6 @@ static bool run_test_integrity_dram(
 
     /* Senders */
     prepare_sender_integrity_dram(
-        fixture,
         send_mesh_device,
         send_core,
         transfer_size,
@@ -226,15 +218,14 @@ static bool run_test_integrity_dram(
             .expected_count = dram_end_addr,
         },
     };
-    wait_to_finish_eth_timeout_cores(fixture, cores, programs);
+    wait_to_finish_eth_timeout_cores(cores, programs);
 
     auto* const send_device = send_mesh_device->get_devices()[0];
     double threshold = get_eth_bw() * 0.5;
 
     bool pass = true;
     pass &= bandwidth_check(send_device, send_core, send_delta_addr, total_transferred, threshold);
-    pass &= tensix_compare_dram_banks(
-        fixture, recv_mesh_device, dram_start_addr, dram_end_addr, send_bank_id, recv_bank_id);
+    pass &= tensix_compare_dram_banks(recv_mesh_device, dram_start_addr, dram_end_addr, send_bank_id, recv_bank_id);
 
     return pass;
 }
@@ -288,7 +279,6 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet03DataIntegrityDram) {
                     log_info(tt::LogTest, "    running on {}", processor);
 
                     bool passed = run_test_integrity_dram(
-                        this,
                         sender_mesh_device,
                         receiver_mesh_device,
                         sender_core,

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram_bidir.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram_bidir.cpp
@@ -20,9 +20,7 @@ using namespace std;
 using namespace tt;
 using namespace tt::test_utils;
 
-template <typename FIXTURE>
 static void prepare_bidir_integrity(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const CoreCoord& send_core,
     uint32_t transfer_size,
@@ -42,8 +40,8 @@ static void prepare_bidir_integrity(
     uint32_t recvbuf1,
     tt_metal::Program* send_program) {
     /* =================== */
-    tensix_counter_dram(fixture, mesh_device, dram_start_addr, dram_end_addr, read_bank);
-    tensix_zero_dram(fixture, mesh_device, dram_start_addr, dram_end_addr, write_bank);
+    tensix_counter_dram(mesh_device, dram_start_addr, dram_end_addr, read_bank);
+    tensix_zero_dram(mesh_device, dram_start_addr, dram_end_addr, write_bank);
 
     auto send_eth_config = tt_metal::EthernetConfig{
         .noc = tt_metal::NOC::NOC_0,
@@ -82,9 +80,7 @@ static void prepare_bidir_integrity(
         });
 }
 
-template <typename FIXTURE>
 static bool run_test_integrity_dram_bidir(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& send_mesh_device,
     const std::shared_ptr<distributed::MeshDevice>& recv_mesh_device,
     const CoreCoord& send_core,
@@ -130,7 +126,6 @@ static bool run_test_integrity_dram_bidir(
     };
 
     prepare_bidir_integrity(
-        fixture,
         send_mesh_device,
         send_core,
         transfer_size,
@@ -151,7 +146,6 @@ static bool run_test_integrity_dram_bidir(
         programs[send_mesh_device].get());
 
     prepare_bidir_integrity(
-        fixture,
         recv_mesh_device,
         recv_core,
         transfer_size,
@@ -171,9 +165,6 @@ static bool run_test_integrity_dram_bidir(
         recvbuf1,
         programs[recv_mesh_device].get());
 
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-
     vector<struct core_setup> cores = {
         {
             .program = programs[send_mesh_device],
@@ -190,7 +181,7 @@ static bool run_test_integrity_dram_bidir(
             .expected_count = dram_end_addr,
         },
     };
-    wait_to_finish_eth_timeout_cores(fixture, cores, programs);
+    wait_to_finish_eth_timeout_cores(cores, programs);
 
     double threshold = 140; /* NOTE: Same on both bh glx and p150 */
 
@@ -198,10 +189,8 @@ static bool run_test_integrity_dram_bidir(
     pass &= bandwidth_check(send_device, send_core, send_delta_addr, total_transferred, threshold);
     pass &= bandwidth_check(recv_device, recv_core, send_delta_addr, total_transferred, threshold);
 
-    pass &= tensix_compare_dram_banks(
-        fixture, send_mesh_device, dram_start_addr, dram_end_addr, send_bank_id0, recv_bank_id0);
-    pass &= tensix_compare_dram_banks(
-        fixture, recv_mesh_device, dram_start_addr, dram_end_addr, send_bank_id1, recv_bank_id1);
+    pass &= tensix_compare_dram_banks(send_mesh_device, dram_start_addr, dram_end_addr, send_bank_id0, recv_bank_id0);
+    pass &= tensix_compare_dram_banks(recv_mesh_device, dram_start_addr, dram_end_addr, send_bank_id1, recv_bank_id1);
 
     return pass;
 }
@@ -244,8 +233,8 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet04DataIntegrityDramBidir) {
                     receiver_core,
                     get_connector(sender_device, sender_core));
 
-                bool passed = run_test_integrity_dram_bidir(
-                    this, sender_mesh_device, receiver_mesh_device, sender_core, receiver_core);
+                bool passed =
+                    run_test_integrity_dram_bidir(sender_mesh_device, receiver_mesh_device, sender_core, receiver_core);
                 if (!passed) {
                     errors.emplace_back(
                         sender_device->id(),

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_link_up.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_link_up.cpp
@@ -19,9 +19,7 @@ using namespace std;
 using namespace tt;
 using namespace tt::test_utils;
 
-template <typename FIXTURE>
 static bool run_test(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& send_mesh_device,
     const std::shared_ptr<distributed::MeshDevice>& recv_mesh_device,
     const CoreCoord& send_core,
@@ -93,7 +91,7 @@ static bool run_test(
             .expected_count = transfer_count,
         },
     };
-    wait_to_finish_eth_timeout_cores(fixture, cores, programs);
+    wait_to_finish_eth_timeout_cores(cores, programs);
 
     bool pass = true;
     pass &= data_check(recv_device, recv_core, recv_l1_address, inputs);
@@ -146,7 +144,7 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet00LinkUp) {
 
                     log_info(tt::LogTest, "    running on {}", processor);
                     bool passed =
-                        run_test(this, sender_mesh_device, receiver_mesh_device, sender_core, receiver_core, processor);
+                        run_test(sender_mesh_device, receiver_mesh_device, sender_core, receiver_core, processor);
                     if (!passed) {
                         errors.emplace_back(
                             sender_device->id(), receiver_device->id(), sender_core, receiver_core, processor);

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_stress_test.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_stress_test.cpp
@@ -20,9 +20,7 @@ using namespace std;
 using namespace tt;
 using namespace tt::test_utils;
 
-template <typename FIXTURE>
 static void run_test_stress(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& send_mesh_device,
     const std::shared_ptr<distributed::MeshDevice>& recv_mesh_device,
     const CoreCoord& send_core,
@@ -33,7 +31,6 @@ static void run_test_stress(
     vector<struct core_setup>& cores,
     map<shared_ptr<distributed::MeshDevice>, shared_ptr<tt_metal::Program>> programs) {
     /* =================== */
-    (void)fixture;
     auto* const send_device = send_mesh_device->get_devices()[0];
     auto* const recv_device = recv_mesh_device->get_devices()[0];
 
@@ -185,7 +182,6 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet05StressTest) {
                 string locinfo = get_locinfo(sender_device, sender_core, receiver_device, receiver_core, processor);
 
                 run_test_stress(
-                    this,
                     sender_mesh_device,
                     receiver_mesh_device,
                     sender_core,
@@ -204,7 +200,7 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet05StressTest) {
         }
     }
 
-    wait_to_finish_eth_timeout_cores(this, cores, programs);
+    wait_to_finish_eth_timeout_cores(cores, programs);
 
     bool pass = true;
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -50,10 +50,7 @@ using std::vector;
 
 // Test sync w/ semaphores betweeen eth/tensix cores
 // Test will hang in the kernel if the sync doesn't work properly
-static void test_sems_across_core_types(
-    tt::tt_metal::MeshDispatchFixture* fixture,
-    vector<std::shared_ptr<distributed::MeshDevice>>& devices,
-    bool active_eth) {
+static void test_sems_across_core_types(vector<std::shared_ptr<distributed::MeshDevice>>& devices, bool active_eth) {
     // just something unique...
     constexpr uint32_t eth_sem_init_val = 33;
     constexpr uint32_t tensix_sem_init_val = 102;
@@ -94,9 +91,6 @@ static void test_sems_across_core_types(
                 continue;
             }
 
-            distributed::MeshWorkload workload;
-            auto zero_coord = distributed::MeshCoordinate(0, 0);
-            auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
             auto program = tt::tt_metal::CreateProgram();
 
             CoreCoord eth_core = *eth_cores.begin();
@@ -150,8 +144,7 @@ static void test_sems_across_core_types(
                 tensix_sem_init_val,
             };
             SetRuntimeArgs(program, tensix_kernel, tensix_core, tensix_rtas);
-            workload.add_program(device_range, std::move(program));
-            fixture->RunProgram(mesh_device, workload);
+            LaunchProgram(*mesh_device, std::move(program));
         }
     }
 }
@@ -272,14 +265,14 @@ TEST_F(MeshDispatchFixture, EthTestInitLocalMemory) {
     }
 }
 
-TEST_F(MeshDispatchFixture, TensixActiveEthTestSemaphores) { test_sems_across_core_types(this, this->devices_, true); }
+TEST_F(MeshDispatchFixture, TensixActiveEthTestSemaphores) { test_sems_across_core_types(this->devices_, true); }
 
 TEST_F(MeshDispatchFixture, TensixIdleEthTestSemaphores) {
     if (not this->slow_dispatch_) {
         GTEST_SKIP();
     }
 
-    test_sems_across_core_types(this, this->devices_, false);
+    test_sems_across_core_types(this->devices_, false);
 }
 
 // This test was written to cover issue #12738 (CBs for workers showing up on

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -24,7 +24,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/device.hpp>
 #include "device_fixture.hpp"
-#include "mesh_dispatch_fixture.hpp"
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include "llrt.hpp"
@@ -59,7 +59,6 @@ namespace unit_tests::erisc::kernels {
  */
 
 bool reader_kernel_no_send(
-    tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& mesh_device,
     const size_t& byte_size,
     const size_t& eth_l1_byte_address,
@@ -69,11 +68,9 @@ bool reader_kernel_no_send(
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::Program();
     auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
 
     distributed::DeviceLocalBufferConfig dram_config{
         .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM};
@@ -105,7 +102,7 @@ bool reader_kernel_no_send(
     ////////////////////////////////////////////////////////////////////////////
 
     auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
-    fixture->WriteBuffer(mesh_device, input_dram_buffer, inputs);
+    distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, inputs);
 
     // Clear expected value at ethernet L1 address
     std::vector<uint32_t> all_zeros(inputs.size(), 0);
@@ -123,8 +120,7 @@ bool reader_kernel_no_send(
             (uint32_t)eth_l1_byte_address,
         });
 
-    workload.add_program(device_range, std::move(program));
-    fixture->RunProgram(mesh_device, workload);
+    LaunchProgram(*mesh_device, std::move(program));
 
     auto readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         device->id(), eth_noc_xy, eth_l1_byte_address, byte_size);
@@ -136,7 +132,6 @@ bool reader_kernel_no_send(
 }
 
 bool writer_kernel_no_receive(
-    tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& mesh_device,
     const size_t& byte_size,
     const size_t& eth_l1_byte_address,
@@ -146,11 +141,9 @@ bool writer_kernel_no_receive(
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::Program();
     auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
 
     distributed::DeviceLocalBufferConfig dram_config{
         .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM};
@@ -185,7 +178,7 @@ bool writer_kernel_no_receive(
 
     // Clear expected value at ethernet L1 address
     std::vector<uint32_t> all_zeros(inputs.size(), 0);
-    fixture->WriteBuffer(mesh_device, output_dram_buffer, all_zeros);
+    distributed::EnqueueWriteMeshBuffer(cq, output_dram_buffer, all_zeros);
 
     tt_metal::SetRuntimeArgs(
         program,
@@ -198,11 +191,10 @@ bool writer_kernel_no_receive(
             (uint32_t)eth_l1_byte_address,
         });
 
-    workload.add_program(device_range, std::move(program));
-    fixture->RunProgram(mesh_device, workload);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> readback_vec;
-    fixture->ReadBuffer(mesh_device, output_dram_buffer, readback_vec);
+    distributed::EnqueueReadMeshBuffer(cq, readback_vec, output_dram_buffer);
     pass &= (readback_vec == inputs);
     if (not pass) {
         std::cout << "Mismatch" << std::endl;
@@ -220,9 +212,6 @@ bool noc_reader_and_writer_kernels(
     tt_metal::EthernetConfig writer_eth_config) {
     bool pass = true;
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::Program();
     auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
@@ -290,7 +279,7 @@ bool noc_reader_and_writer_kernels(
         });
 
     auto reader_inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
-    distributed::WriteShard(cq, reader_dram_buffer, reader_inputs, zero_coord);
+    distributed::EnqueueWriteMeshBuffer(cq, reader_dram_buffer, reader_inputs);
 
     auto writer_inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
@@ -300,11 +289,9 @@ bool noc_reader_and_writer_kernels(
     std::vector<uint32_t> all_zeros(byte_size / sizeof(uint32_t), 0);
     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         device->id(), eth_noc_xy, all_zeros, eth_dst_l1_address);
-    distributed::WriteShard(cq, writer_dram_buffer, all_zeros, zero_coord);
+    distributed::EnqueueWriteMeshBuffer(cq, writer_dram_buffer, all_zeros);
 
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(*mesh_device, std::move(program));
 
     auto eth_readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         device->id(), eth_noc_xy, eth_dst_l1_address, byte_size);
@@ -316,7 +303,7 @@ bool noc_reader_and_writer_kernels(
             logical_eth_core.str());
     }
     std::vector<uint32_t> dram_readback_vec;
-    distributed::ReadShard(cq, dram_readback_vec, writer_dram_buffer, zero_coord);
+    distributed::EnqueueReadMeshBuffer(cq, dram_readback_vec, writer_dram_buffer);
     pass &= (dram_readback_vec == writer_inputs);
     if (not pass) {
         log_info(
@@ -344,26 +331,11 @@ TEST_F(UnitMeshCQSingleCardProgramFixture, ActiveEthKernelsNocReadNoSend) {
                 const auto ethernet_config = tt_metal::EthernetConfig{
                     .noc = static_cast<NOC>(erisc_idx), .processor = static_cast<DataMovementProcessor>(erisc_idx)};
                 ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-                    static_cast<UnitMeshCQSingleCardProgramFixture*>(this),
-                    mesh_device,
-                    WORD_SIZE,
-                    src_eth_l1_byte_address,
-                    eth_core,
-                    ethernet_config));
+                    mesh_device, WORD_SIZE, src_eth_l1_byte_address, eth_core, ethernet_config));
                 ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-                    static_cast<UnitMeshCQSingleCardProgramFixture*>(this),
-                    mesh_device,
-                    WORD_SIZE * 1024,
-                    src_eth_l1_byte_address,
-                    eth_core,
-                    ethernet_config));
+                    mesh_device, WORD_SIZE * 1024, src_eth_l1_byte_address, eth_core, ethernet_config));
                 ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-                    static_cast<UnitMeshCQSingleCardProgramFixture*>(this),
-                    mesh_device,
-                    WORD_SIZE * 2048,
-                    src_eth_l1_byte_address,
-                    eth_core,
-                    ethernet_config));
+                    mesh_device, WORD_SIZE * 2048, src_eth_l1_byte_address, eth_core, ethernet_config));
             }
         }
     }
@@ -387,16 +359,11 @@ TEST_F(UnitMeshCQSingleCardProgramFixture, ActiveEthKernelsNocWriteNoReceive) {
                     .noc = static_cast<tt_metal::NOC>(erisc_idx),
                     .processor = static_cast<DataMovementProcessor>(erisc_idx)};
                 ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-                    static_cast<UnitMeshCQSingleCardProgramFixture*>(this), mesh_device, WORD_SIZE, src_eth_l1_byte_address, eth_core));
+                    mesh_device, WORD_SIZE, src_eth_l1_byte_address, eth_core));
                 ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-                    static_cast<UnitMeshCQSingleCardProgramFixture*>(this), mesh_device, WORD_SIZE * 1024, src_eth_l1_byte_address, eth_core));
+                    mesh_device, WORD_SIZE * 1024, src_eth_l1_byte_address, eth_core));
                 ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-                    static_cast<UnitMeshCQSingleCardProgramFixture*>(this),
-                    mesh_device,
-                    WORD_SIZE * 2048,
-                    src_eth_l1_byte_address,
-                    eth_core,
-                    ethernet_config));
+                    mesh_device, WORD_SIZE * 2048, src_eth_l1_byte_address, eth_core, ethernet_config));
             }
         }
     }
@@ -414,36 +381,20 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsNocReadNoSend) {
 
     for (const auto& eth_core : device_0->get_ethernet_sockets(device_1->id())) {
         ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-            static_cast<N300MeshDeviceFixture*>(this), mesh_device_0, WORD_SIZE, src_eth_l1_byte_address, eth_core));
+            mesh_device_0, WORD_SIZE, src_eth_l1_byte_address, eth_core));
         ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-            static_cast<N300MeshDeviceFixture*>(this),
-            mesh_device_0,
-            WORD_SIZE * 1024,
-            src_eth_l1_byte_address,
-            eth_core));
+            mesh_device_0, WORD_SIZE * 1024, src_eth_l1_byte_address, eth_core));
         ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-            static_cast<N300MeshDeviceFixture*>(this),
-            mesh_device_0,
-            WORD_SIZE * 2048,
-            src_eth_l1_byte_address,
-            eth_core));
+            mesh_device_0, WORD_SIZE * 2048, src_eth_l1_byte_address, eth_core));
     }
 
     for (const auto& eth_core : device_1->get_ethernet_sockets(device_0->id())) {
         ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-            static_cast<N300MeshDeviceFixture*>(this), mesh_device_1, WORD_SIZE, src_eth_l1_byte_address, eth_core));
+            mesh_device_1, WORD_SIZE, src_eth_l1_byte_address, eth_core));
         ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-            static_cast<N300MeshDeviceFixture*>(this),
-            mesh_device_1,
-            WORD_SIZE * 1024,
-            src_eth_l1_byte_address,
-            eth_core));
+            mesh_device_1, WORD_SIZE * 1024, src_eth_l1_byte_address, eth_core));
         ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-            static_cast<N300MeshDeviceFixture*>(this),
-            mesh_device_1,
-            WORD_SIZE * 2048,
-            src_eth_l1_byte_address,
-            eth_core));
+            mesh_device_1, WORD_SIZE * 2048, src_eth_l1_byte_address, eth_core));
     }
 }
 
@@ -459,36 +410,20 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsNocWriteNoReceive) {
 
     for (const auto& eth_core : device_0->get_ethernet_sockets(device_1->id())) {
         ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-            static_cast<N300MeshDeviceFixture*>(this), mesh_device_0, WORD_SIZE, src_eth_l1_byte_address, eth_core));
+            mesh_device_0, WORD_SIZE, src_eth_l1_byte_address, eth_core));
         ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-            static_cast<N300MeshDeviceFixture*>(this),
-            mesh_device_0,
-            WORD_SIZE * 1024,
-            src_eth_l1_byte_address,
-            eth_core));
+            mesh_device_0, WORD_SIZE * 1024, src_eth_l1_byte_address, eth_core));
         ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-            static_cast<N300MeshDeviceFixture*>(this),
-            mesh_device_0,
-            WORD_SIZE * 2048,
-            src_eth_l1_byte_address,
-            eth_core));
+            mesh_device_0, WORD_SIZE * 2048, src_eth_l1_byte_address, eth_core));
     }
 
     for (const auto& eth_core : device_1->get_ethernet_sockets(device_0->id())) {
         ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-            static_cast<N300MeshDeviceFixture*>(this), mesh_device_1, WORD_SIZE, src_eth_l1_byte_address, eth_core));
+            mesh_device_1, WORD_SIZE, src_eth_l1_byte_address, eth_core));
         ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-            static_cast<N300MeshDeviceFixture*>(this),
-            mesh_device_1,
-            WORD_SIZE * 1024,
-            src_eth_l1_byte_address,
-            eth_core));
+            mesh_device_1, WORD_SIZE * 1024, src_eth_l1_byte_address, eth_core));
         ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-            static_cast<N300MeshDeviceFixture*>(this),
-            mesh_device_1,
-            WORD_SIZE * 2048,
-            src_eth_l1_byte_address,
-            eth_core));
+            mesh_device_1, WORD_SIZE * 2048, src_eth_l1_byte_address, eth_core));
     }
 }
 
@@ -517,33 +452,13 @@ TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnIdleErisc0) {
 
     for (const auto& eth_core : device->get_inactive_ethernet_cores()) {
         ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-            static_cast<BlackholeSingleCardFixture*>(this),
-            mesh_device,
-            WORD_SIZE * 2048,
-            eth_l1_address,
-            eth_core,
-            noc0_ethernet_config));
+            mesh_device, WORD_SIZE * 2048, eth_l1_address, eth_core, noc0_ethernet_config));
         ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-            static_cast<BlackholeSingleCardFixture*>(this),
-            mesh_device,
-            WORD_SIZE * 2048,
-            eth_l1_address,
-            eth_core,
-            noc1_ethernet_config));
+            mesh_device, WORD_SIZE * 2048, eth_l1_address, eth_core, noc1_ethernet_config));
         ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-            static_cast<BlackholeSingleCardFixture*>(this),
-            mesh_device,
-            WORD_SIZE * 2048,
-            eth_l1_address,
-            eth_core,
-            noc0_ethernet_config));
+            mesh_device, WORD_SIZE * 2048, eth_l1_address, eth_core, noc0_ethernet_config));
         ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-            static_cast<BlackholeSingleCardFixture*>(this),
-            mesh_device,
-            WORD_SIZE * 2048,
-            eth_l1_address,
-            eth_core,
-            noc1_ethernet_config));
+            mesh_device, WORD_SIZE * 2048, eth_l1_address, eth_core, noc1_ethernet_config));
     }
 }
 
@@ -561,33 +476,13 @@ TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnIdleErisc1) {
 
     for (const auto& eth_core : device->get_inactive_ethernet_cores()) {
         ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-            static_cast<BlackholeSingleCardFixture*>(this),
-            mesh_device,
-            WORD_SIZE * 2048,
-            eth_l1_address,
-            eth_core,
-            noc0_ethernet_config));
+            mesh_device, WORD_SIZE * 2048, eth_l1_address, eth_core, noc0_ethernet_config));
         ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
-            static_cast<BlackholeSingleCardFixture*>(this),
-            mesh_device,
-            WORD_SIZE * 2048,
-            eth_l1_address,
-            eth_core,
-            noc1_ethernet_config));
+            mesh_device, WORD_SIZE * 2048, eth_l1_address, eth_core, noc1_ethernet_config));
         ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-            static_cast<BlackholeSingleCardFixture*>(this),
-            mesh_device,
-            WORD_SIZE * 2048,
-            eth_l1_address,
-            eth_core,
-            noc0_ethernet_config));
+            mesh_device, WORD_SIZE * 2048, eth_l1_address, eth_core, noc0_ethernet_config));
         ASSERT_TRUE(unit_tests::erisc::kernels::writer_kernel_no_receive(
-            static_cast<BlackholeSingleCardFixture*>(this),
-            mesh_device,
-            WORD_SIZE * 2048,
-            eth_l1_address,
-            eth_core,
-            noc1_ethernet_config));
+            mesh_device, WORD_SIZE * 2048, eth_l1_address, eth_core, noc1_ethernet_config));
     }
 }
 

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -5,6 +5,7 @@
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <cstddef>
+#include <cstdlib>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -30,6 +31,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "eth_test_common.hpp"
+#include "impl/program/program_impl.hpp"
 #include "mesh_dispatch_fixture.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "hal.hpp"
@@ -62,8 +64,29 @@ struct BankedConfig {
 using namespace tt::tt_metal;
 namespace unit_tests::erisc::kernels {
 
+void launch_on_eth_pair(
+    distributed::MeshDevice& sender,
+    Program&& sender_program,
+    distributed::MeshDevice& receiver,
+    Program&& receiver_program) {
+    const bool slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
+    if (slow_dispatch) {
+        std::thread t1([&sender, p = std::move(sender_program)]() mutable { LaunchProgram(sender, std::move(p)); });
+        std::thread t2(
+            [&receiver, p = std::move(receiver_program)]() mutable { LaunchProgram(receiver, std::move(p)); });
+        t1.join();
+        t2.join();
+    } else {
+        [[maybe_unused]] distributed::MeshWorkload sender_workload =
+            LaunchProgramAsync(sender, std::move(sender_program));
+        [[maybe_unused]] distributed::MeshWorkload receiver_workload =
+            LaunchProgramAsync(receiver, std::move(receiver_program));
+        distributed::Finish(sender.mesh_command_queue());
+        distributed::Finish(receiver.mesh_command_queue());
+    }
+}
+
 bool chip_to_chip_dram_buffer_transfer(
-    tt_metal::MeshDispatchFixture* fixture,
     std::shared_ptr<distributed::MeshDevice> sender_mesh_device,
     std::shared_ptr<distributed::MeshDevice> receiver_mesh_device,
     const CoreCoord& eth_sender_core,
@@ -108,7 +131,7 @@ bool chip_to_chip_dram_buffer_transfer(
     // Generate inputs
     auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
 
-    fixture->WriteBuffer(sender_mesh_device, input_dram_buffer, inputs);
+    distributed::EnqueueWriteMeshBuffer(sender_mesh_device->mesh_command_queue(), input_dram_buffer, inputs);
     uint32_t MAX_BUFFER = tt::tt_metal::MetalContext::instance().hal().get_dev_size(
         tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED);
 
@@ -117,14 +140,11 @@ bool chip_to_chip_dram_buffer_transfer(
     // Clear expected value at ethernet L1 address
     std::vector<uint32_t> all_zeros(inputs.size(), 0);
 
-    fixture->WriteBuffer(receiver_mesh_device, output_dram_buffer, all_zeros);
+    distributed::EnqueueWriteMeshBuffer(receiver_mesh_device->mesh_command_queue(), output_dram_buffer, all_zeros);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Sender Device
     ////////////////////////////////////////////////////////////////////////////
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::MeshWorkload sender_workload;
     tt_metal::Program sender_program = tt_metal::Program();
 
     auto sender_eth_config = tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_0, .processor = processor};
@@ -151,7 +171,6 @@ bool chip_to_chip_dram_buffer_transfer(
     ////////////////////////////////////////////////////////////////////////////
     //                      Receiver Device
     ////////////////////////////////////////////////////////////////////////////
-    distributed::MeshWorkload receiver_workload;
     tt_metal::Program receiver_program = tt_metal::Program();
 
     auto receiver_eth_config = tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_1, .processor = processor};
@@ -178,30 +197,11 @@ bool chip_to_chip_dram_buffer_transfer(
     ////////////////////////////////////////////////////////////////////////////
     //                      Execute Programs
     ////////////////////////////////////////////////////////////////////////////
-    std::thread t1;
-    std::thread t2;
-    if (fixture->IsSlowDispatch()) {
-        sender_workload.add_program(device_range, std::move(sender_program));
-        receiver_workload.add_program(device_range, std::move(receiver_program));
-        t1 = std::thread([&]() { fixture->RunProgram(sender_mesh_device, sender_workload); });
-        t2 = std::thread([&]() { fixture->RunProgram(receiver_mesh_device, receiver_workload); });
-    } else {
-        sender_workload.add_program(device_range, std::move(sender_program));
-        receiver_workload.add_program(device_range, std::move(receiver_program));
-        fixture->RunProgram(sender_mesh_device, sender_workload, true);
-        fixture->RunProgram(receiver_mesh_device, receiver_workload, true);
-    }
-
-    fixture->FinishCommands(sender_mesh_device);
-    fixture->FinishCommands(receiver_mesh_device);
-
-    if (fixture->IsSlowDispatch()) {
-        t1.join();
-        t2.join();
-    }
+    launch_on_eth_pair(
+        *sender_mesh_device, std::move(sender_program), *receiver_mesh_device, std::move(receiver_program));
 
     std::vector<uint32_t> dest_dram_data;
-    fixture->ReadBuffer(receiver_mesh_device, output_dram_buffer, dest_dram_data);
+    distributed::EnqueueReadMeshBuffer(receiver_mesh_device->mesh_command_queue(), dest_dram_data, output_dram_buffer);
     pass &= (dest_dram_data == inputs);
     if (not pass) {
         std::cout << "Mismatch" << std::endl;
@@ -211,7 +211,6 @@ bool chip_to_chip_dram_buffer_transfer(
 }
 
 bool chip_to_chip_interleaved_buffer_transfer(
-    tt_metal::MeshDispatchFixture* fixture,
     std::shared_ptr<distributed::MeshDevice> sender_mesh_device,
     std::shared_ptr<distributed::MeshDevice> receiver_mesh_device,
     const CoreCoord& eth_sender_core,
@@ -236,9 +235,6 @@ bool chip_to_chip_interleaved_buffer_transfer(
     ////////////////////////////////////////////////////////////////////////////
     //                      Sender Device
     ////////////////////////////////////////////////////////////////////////////
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::MeshWorkload sender_workload;
     tt_metal::Program sender_program = tt_metal::Program();
 
     auto input_packed = generate_uniform_random_vector<uint32_t>(0, 100, cfg.size_bytes / sizeof(uint32_t));
@@ -259,7 +255,7 @@ bool chip_to_chip_interleaved_buffer_transfer(
         distributed::MeshBuffer::create(sender_buffer_config, sender_dram_config, sender_mesh_device.get());
     bool input_is_dram = cfg.input_buffer_type == tt_metal::BufferType::DRAM;
 
-    fixture->WriteBuffer(sender_mesh_device, input_buffer, input_packed);
+    distributed::EnqueueWriteMeshBuffer(sender_mesh_device->mesh_command_queue(), input_buffer, input_packed);
 
     const uint32_t max_buffer = round_down(max_transfer_size, cfg.page_size_bytes);
     uint32_t pages_per_loop = max_buffer / cfg.page_size_bytes;
@@ -295,7 +291,6 @@ bool chip_to_chip_interleaved_buffer_transfer(
     ////////////////////////////////////////////////////////////////////////////
     //                      Receiver Device
     ////////////////////////////////////////////////////////////////////////////
-    distributed::MeshWorkload receiver_workload;
     tt_metal::Program receiver_program = tt_metal::Program();
 
     auto output_buffer =
@@ -303,7 +298,7 @@ bool chip_to_chip_interleaved_buffer_transfer(
     bool output_is_dram = cfg.output_buffer_type == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> all_zeros(cfg.size_bytes / sizeof(uint32_t), 0);
 
-    fixture->WriteBuffer(receiver_mesh_device, output_buffer, all_zeros);
+    distributed::EnqueueWriteMeshBuffer(receiver_mesh_device->mesh_command_queue(), output_buffer, all_zeros);
 
     std::vector<uint32_t> receiver_compile_args = {(uint32_t)output_is_dram};
     tt_metal::TensorAccessorArgs(output_buffer).append_to(receiver_compile_args);
@@ -335,30 +330,11 @@ bool chip_to_chip_interleaved_buffer_transfer(
     ////////////////////////////////////////////////////////////////////////////
     //                      Execute Programs
     ////////////////////////////////////////////////////////////////////////////
-    std::thread t1;
-    std::thread t2;
-    if (fixture->IsSlowDispatch()) {
-        sender_workload.add_program(device_range, std::move(sender_program));
-        receiver_workload.add_program(device_range, std::move(receiver_program));
-        t1 = std::thread([&]() { fixture->RunProgram(sender_mesh_device, sender_workload); });
-        t2 = std::thread([&]() { fixture->RunProgram(receiver_mesh_device, receiver_workload); });
-    } else {
-        sender_workload.add_program(device_range, std::move(sender_program));
-        receiver_workload.add_program(device_range, std::move(receiver_program));
-        fixture->RunProgram(sender_mesh_device, sender_workload, true);
-        fixture->RunProgram(receiver_mesh_device, receiver_workload, true);
-    }
-
-    fixture->FinishCommands(sender_mesh_device);
-    fixture->FinishCommands(receiver_mesh_device);
-
-    if (fixture->IsSlowDispatch()) {
-        t1.join();
-        t2.join();
-    }
+    launch_on_eth_pair(
+        *sender_mesh_device, std::move(sender_program), *receiver_mesh_device, std::move(receiver_program));
 
     std::vector<uint32_t> dest_buffer_data;
-    fixture->ReadBuffer(receiver_mesh_device, output_buffer, dest_buffer_data);
+    distributed::EnqueueReadMeshBuffer(receiver_mesh_device->mesh_command_queue(), dest_buffer_data, output_buffer);
     pass &= input_packed == dest_buffer_data;
     return pass;
 }
@@ -382,7 +358,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip0ToChip1) {
         CoreCoord receiver_eth_core = std::get<1>(sender_device->get_connected_ethernet_core(sender_eth_core));
 
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -390,7 +365,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip0ToChip1) {
             16,
             DataMovementProcessor::RISCV_0));
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -398,7 +372,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip0ToChip1) {
             1024,
             DataMovementProcessor::RISCV_0));
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -406,7 +379,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip0ToChip1) {
             16 * 1024,
             DataMovementProcessor::RISCV_0));
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -432,7 +404,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip1ToChip0) {
         CoreCoord receiver_eth_core = std::get<1>(sender_device->get_connected_ethernet_core(sender_eth_core));
 
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -440,7 +411,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip1ToChip0) {
             16,
             DataMovementProcessor::RISCV_0));
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -448,7 +418,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip1ToChip0) {
             1024,
             DataMovementProcessor::RISCV_0));
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -456,7 +425,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip1ToChip0) {
             16 * 1024,
             DataMovementProcessor::RISCV_0));
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -495,7 +463,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferChip0ToChip1)
             receiver_eth_core.str());
         BankedConfig test_config;
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -506,7 +473,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferChip0ToChip1)
         test_config = BankedConfig{.num_pages = 200, .size_bytes = 200 * 2 * 32 * 32, .page_size_bytes = 2 * 32 * 32};
 
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -515,7 +481,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferChip0ToChip1)
             test_config.page_size_bytes,
             DataMovementProcessor::RISCV_0));
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -530,7 +495,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferChip0ToChip1)
             .input_buffer_type = BufferType::DRAM,
             .output_buffer_type = BufferType::DRAM};
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -539,7 +503,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferChip0ToChip1)
             test_config.page_size_bytes,
             DataMovementProcessor::RISCV_0));
         ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-            static_cast<MeshDispatchFixture*>(this),
             sender_mesh_device,
             receiver_mesh_device,
             sender_eth_core,
@@ -591,7 +554,6 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips
                         .output_buffer_type = BufferType::DRAM};
 
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         sender_eth_core,
@@ -600,7 +562,6 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips
                         test_config.page_size_bytes,
                         processor));
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         sender_eth_core,
@@ -615,7 +576,6 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips
                         .input_buffer_type = BufferType::DRAM,
                         .output_buffer_type = BufferType::L1};
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         sender_eth_core,
@@ -624,7 +584,6 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips
                         test_config.page_size_bytes,
                         processor));
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         sender_eth_core,
@@ -675,23 +634,10 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendDramBufferAllCon
                         receiver_eth_core.str());
 
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
-                        sender_mesh_device,
-                        receiver_mesh_device,
-                        sender_eth_core,
-                        receiver_eth_core,
-                        16,
-                        processor));
+                        sender_mesh_device, receiver_mesh_device, sender_eth_core, receiver_eth_core, 16, processor));
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
-                        sender_mesh_device,
-                        receiver_mesh_device,
-                        sender_eth_core,
-                        receiver_eth_core,
-                        1024,
-                        processor));
+                        sender_mesh_device, receiver_mesh_device, sender_eth_core, receiver_eth_core, 1024, processor));
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         sender_eth_core,
@@ -699,7 +645,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendDramBufferAllCon
                         16 * 1024,
                         processor));
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_dram_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         sender_eth_core,
@@ -757,7 +702,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuffe
                         .output_buffer_type = BufferType::DRAM};
 
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         sender_eth_core,
@@ -766,7 +710,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuffe
                         test_config.page_size_bytes,
                         processor));
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         sender_eth_core,
@@ -781,7 +724,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuffe
                         .input_buffer_type = BufferType::DRAM,
                         .output_buffer_type = BufferType::L1};
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         sender_eth_core,
@@ -790,7 +732,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuffe
                         test_config.page_size_bytes,
                         processor));
                     ASSERT_TRUE(unit_tests::erisc::kernels::chip_to_chip_interleaved_buffer_transfer(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         sender_eth_core,

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -87,8 +87,8 @@ void launch_on_eth_pair(
 }
 
 bool chip_to_chip_dram_buffer_transfer(
-    std::shared_ptr<distributed::MeshDevice> sender_mesh_device,
-    std::shared_ptr<distributed::MeshDevice> receiver_mesh_device,
+    const std::shared_ptr<distributed::MeshDevice>& sender_mesh_device,
+    const std::shared_ptr<distributed::MeshDevice>& receiver_mesh_device,
     const CoreCoord& eth_sender_core,
     const CoreCoord& eth_receiver_core,
     const size_t& byte_size,
@@ -211,8 +211,8 @@ bool chip_to_chip_dram_buffer_transfer(
 }
 
 bool chip_to_chip_interleaved_buffer_transfer(
-    std::shared_ptr<distributed::MeshDevice> sender_mesh_device,
-    std::shared_ptr<distributed::MeshDevice> receiver_mesh_device,
+    const std::shared_ptr<distributed::MeshDevice>& sender_mesh_device,
+    const std::shared_ptr<distributed::MeshDevice>& receiver_mesh_device,
     const CoreCoord& eth_sender_core,
     const CoreCoord& eth_receiver_core,
     const CMAKE_UNIQUE_NAMESPACE::BankedConfig& cfg,

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -25,7 +25,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/device.hpp>
 #include "device_fixture.hpp"
-#include "mesh_dispatch_fixture.hpp"
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/hal_types.hpp>
@@ -69,9 +69,7 @@ size_t get_rand_32_byte_aligned_address(const size_t& base, const size_t& max) {
     return (((rand() % word_size) << 5) + base);
 }
 
-template <typename FIXTURE>
 bool eth_direct_sender_receiver_kernels(
-    FIXTURE* fixture,
     const std::shared_ptr<distributed::MeshDevice>& sender_mesh_device,
     const std::shared_ptr<distributed::MeshDevice>& receiver_mesh_device,
     const size_t& byte_size,
@@ -114,9 +112,6 @@ bool eth_direct_sender_receiver_kernels(
     ////////////////////////////////////////////////////////////////////////////
     //                      Sender Device
     ////////////////////////////////////////////////////////////////////////////
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::MeshWorkload sender_workload;
     tt_metal::Program sender_program = tt_metal::Program();
 
     auto ethernet_config = tt_metal::EthernetConfig{
@@ -144,7 +139,6 @@ bool eth_direct_sender_receiver_kernels(
     ////////////////////////////////////////////////////////////////////////////
     //                      Receiver Device
     ////////////////////////////////////////////////////////////////////////////
-    distributed::MeshWorkload receiver_workload;
     tt_metal::Program receiver_program = tt_metal::Program();
 
     auto eth_receiver_kernel = tt_metal::CreateKernel(
@@ -164,13 +158,12 @@ bool eth_direct_sender_receiver_kernels(
     ////////////////////////////////////////////////////////////////////////////
     //                      Execute Programs
     ////////////////////////////////////////////////////////////////////////////
-    sender_workload.add_program(device_range, std::move(sender_program));
-    receiver_workload.add_program(device_range, std::move(receiver_program));
-    fixture->RunProgram(sender_mesh_device, sender_workload, true);
-    fixture->RunProgram(receiver_mesh_device, receiver_workload, true);
-
-    fixture->FinishCommands(sender_mesh_device);
-    fixture->FinishCommands(receiver_mesh_device);
+    [[maybe_unused]] distributed::MeshWorkload sender_workload =
+        LaunchProgramAsync(*sender_mesh_device, std::move(sender_program));
+    [[maybe_unused]] distributed::MeshWorkload receiver_workload =
+        LaunchProgramAsync(*receiver_mesh_device, std::move(receiver_program));
+    distributed::Finish(sender_mesh_device->mesh_command_queue());
+    distributed::Finish(receiver_mesh_device->mesh_command_queue());
 
     auto readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         receiver_device->id(),
@@ -504,7 +497,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip0ToChip1) {
             continue;
         }
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_0,
             mesh_device_1,
             WORD_SIZE,
@@ -513,7 +505,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip0ToChip1) {
             sender_core,
             receiver_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_0,
             mesh_device_1,
             4 * WORD_SIZE,
@@ -522,7 +513,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip0ToChip1) {
             sender_core,
             receiver_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_0,
             mesh_device_1,
             256 * WORD_SIZE,
@@ -531,7 +521,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip0ToChip1) {
             sender_core,
             receiver_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_0,
             mesh_device_1,
             1000 * WORD_SIZE,
@@ -562,7 +551,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip1ToChip0) {
             continue;
         }
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_1,
             mesh_device_0,
             WORD_SIZE,
@@ -571,7 +559,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip1ToChip0) {
             sender_core,
             receiver_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_1,
             mesh_device_0,
             4 * WORD_SIZE,
@@ -580,7 +567,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip1ToChip0) {
             sender_core,
             receiver_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_1,
             mesh_device_0,
             256 * WORD_SIZE,
@@ -589,7 +575,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip1ToChip0) {
             sender_core,
             receiver_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_1,
             mesh_device_0,
             1000 * WORD_SIZE,
@@ -622,7 +607,6 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsDirectSendAllConnectedChips) {
                     continue;
                 }
                 ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-                    static_cast<MeshDispatchFixture*>(this),
                     sender_mesh_device,
                     receiver_mesh_device,
                     WORD_SIZE,
@@ -631,7 +615,6 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsDirectSendAllConnectedChips) {
                     sender_core,
                     receiver_core));
                 ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-                    static_cast<MeshDispatchFixture*>(this),
                     sender_mesh_device,
                     receiver_mesh_device,
                     4 * WORD_SIZE,
@@ -640,7 +623,6 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsDirectSendAllConnectedChips) {
                     sender_core,
                     receiver_core));
                 ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-                    static_cast<MeshDispatchFixture*>(this),
                     sender_mesh_device,
                     receiver_mesh_device,
                     256 * WORD_SIZE,
@@ -649,7 +631,6 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsDirectSendAllConnectedChips) {
                     sender_core,
                     receiver_core));
                 ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-                    static_cast<MeshDispatchFixture*>(this),
                     sender_mesh_device,
                     receiver_mesh_device,
                     1000 * WORD_SIZE,
@@ -683,7 +664,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
         }
         CoreCoord receiver_core = std::get<1>(device_0->get_connected_ethernet_core(sender_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_0,
             mesh_device_1,
             WORD_SIZE,
@@ -692,7 +672,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
             sender_core,
             receiver_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_1,
             mesh_device_0,
             WORD_SIZE,
@@ -707,7 +686,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
         }
         CoreCoord receiver_core = std::get<1>(device_0->get_connected_ethernet_core(sender_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_0,
             mesh_device_1,
             WORD_SIZE * 256,
@@ -716,7 +694,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
             sender_core,
             receiver_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_1,
             mesh_device_0,
             WORD_SIZE * 256,
@@ -731,7 +708,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
         }
         CoreCoord receiver_core = std::get<1>(device_0->get_connected_ethernet_core(sender_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_0,
             mesh_device_1,
             WORD_SIZE * 1024,
@@ -740,7 +716,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
             sender_core,
             receiver_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_1,
             mesh_device_0,
             WORD_SIZE * 1024,
@@ -755,7 +730,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
         }
         CoreCoord receiver_core = std::get<1>(device_0->get_connected_ethernet_core(sender_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_0,
             mesh_device_1,
             WORD_SIZE * MAX_NUM_WORDS,
@@ -764,7 +738,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
             sender_core,
             receiver_core));
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             mesh_device_1,
             mesh_device_0,
             WORD_SIZE * MAX_NUM_WORDS,
@@ -793,7 +766,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRepeatedDirectSends) {
         CoreCoord receiver_core = std::get<1>(device_0->get_connected_ethernet_core(sender_core));
         for (int i = 0; i < 10; i++) {
             ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-                static_cast<MeshDispatchFixture*>(this),
                 mesh_device_0,
                 mesh_device_1,
                 WORD_SIZE,
@@ -804,7 +776,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRepeatedDirectSends) {
         }
         for (int i = 0; i < 10; i++) {
             ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-                static_cast<MeshDispatchFixture*>(this),
                 mesh_device_1,
                 mesh_device_0,
                 WORD_SIZE,
@@ -871,7 +842,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRandomDirectSendTests) {
         int num_words = (rand() % max_words) + 1;
 
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-            static_cast<MeshDispatchFixture*>(this),
             send_chip,
             receiver_chip,
             WORD_SIZE * num_words,
@@ -933,7 +903,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRandomEthPacketSizeDirectSendTests)
                 MetalContext::instance().hal().get_num_risc_processors(HalProgrammableCoreType::ACTIVE_ETH);
             for (uint32_t erisc_idx = 0; erisc_idx < num_eriscs; erisc_idx++) {
                 ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-                    static_cast<MeshDispatchFixture*>(this),
                     send_chip,
                     receiver_chip,
                     num_bytes_per_send * num_words,
@@ -973,7 +942,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsDirectSendAllConnect
                 for (uint32_t erisc_idx = 0; erisc_idx < num_eriscs; erisc_idx++) {
                     const auto processor = static_cast<DataMovementProcessor>(erisc_idx);
                     ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         WORD_SIZE,
@@ -983,7 +951,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsDirectSendAllConnect
                         receiver_core,
                         processor));
                     ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         4 * WORD_SIZE,
@@ -993,7 +960,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsDirectSendAllConnect
                         receiver_core,
                         processor));
                     ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         256 * WORD_SIZE,
@@ -1003,7 +969,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsDirectSendAllConnect
                         receiver_core,
                         processor));
                     ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
-                        static_cast<MeshDispatchFixture*>(this),
                         sender_mesh_device,
                         receiver_mesh_device,
                         1000 * WORD_SIZE,

--- a/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
@@ -8,15 +8,19 @@
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <cstdint>
+#include <thread>
+#include <cstdlib>
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/device.hpp>
 #include "eth_test_common.hpp"
+#include "impl/program/program_impl.hpp"
 #include "mesh_dispatch_fixture.hpp"
 #include "multi_device_fixture.hpp"
 #include <tt-metalium/program.hpp>
+#include <tt-metalium/distributed.hpp>
 #include "impl/context/metal_context.hpp"
 
 using namespace tt;
@@ -25,7 +29,6 @@ using namespace tt::test_utils;
 namespace unit_tests::erisc::direct_send {
 
 static void eth_direct_send_multi_txq_rxq(
-    tt_metal::MeshDispatchFixture* fixture,
     std::shared_ptr<tt_metal::distributed::MeshDevice> sender_mesh_device,
     std::shared_ptr<tt_metal::distributed::MeshDevice> receiver_mesh_device,
     const CoreCoord& eth_sender_core,
@@ -36,9 +39,6 @@ static void eth_direct_send_multi_txq_rxq(
     ////////////////////////////////////////////////////////////////////////////
     //                      Sender Device
     ////////////////////////////////////////////////////////////////////////////
-    distributed::MeshWorkload sender_workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program sender_program = tt_metal::Program();
 
     constexpr size_t PAYLOAD_SIZE = 32;
@@ -72,7 +72,6 @@ static void eth_direct_send_multi_txq_rxq(
     ////////////////////////////////////////////////////////////////////////////
     //                      Receiver Device
     ////////////////////////////////////////////////////////////////////////////
-    distributed::MeshWorkload receiver_workload;
     tt_metal::Program receiver_program = tt_metal::Program();
 
     auto eth_receiver_kernel = tt_metal::CreateKernel(
@@ -96,26 +95,23 @@ static void eth_direct_send_multi_txq_rxq(
     ////////////////////////////////////////////////////////////////////////////
     //                      Execute Programs
     ////////////////////////////////////////////////////////////////////////////
-    std::thread t1;
-    std::thread t2;
-    if (fixture->IsSlowDispatch()) {
-        sender_workload.add_program(device_range, std::move(sender_program));
-        receiver_workload.add_program(device_range, std::move(receiver_program));
-        t1 = std::thread([&]() { fixture->RunProgram(sender_mesh_device, sender_workload); });
-        t2 = std::thread([&]() { fixture->RunProgram(receiver_mesh_device, receiver_workload); });
-    } else {
-        sender_workload.add_program(device_range, std::move(sender_program));
-        receiver_workload.add_program(device_range, std::move(receiver_program));
-        fixture->RunProgram(sender_mesh_device, sender_workload, true);
-        fixture->RunProgram(receiver_mesh_device, receiver_workload, true);
-    }
-
-    fixture->FinishCommands(sender_mesh_device);
-    fixture->FinishCommands(receiver_mesh_device);
-
-    if (fixture->IsSlowDispatch()) {
+    const bool slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
+    if (slow_dispatch) {
+        std::thread t1([sender_mesh_device, p = std::move(sender_program)]() mutable {
+            LaunchProgram(*sender_mesh_device, std::move(p));
+        });
+        std::thread t2([receiver_mesh_device, p = std::move(receiver_program)]() mutable {
+            LaunchProgram(*receiver_mesh_device, std::move(p));
+        });
         t1.join();
         t2.join();
+    } else {
+        [[maybe_unused]] distributed::MeshWorkload sender_workload =
+            LaunchProgramAsync(*sender_mesh_device, std::move(sender_program));
+        [[maybe_unused]] distributed::MeshWorkload receiver_workload =
+            LaunchProgramAsync(*receiver_mesh_device, std::move(receiver_program));
+        distributed::Finish(sender_mesh_device->mesh_command_queue());
+        distributed::Finish(receiver_mesh_device->mesh_command_queue());
     }
 }
 
@@ -124,7 +120,6 @@ static void eth_direct_send_multi_txq_rxq(
 namespace tt::tt_metal {
 
 static void run_multi_txq_rxq_test(
-    MeshDispatchFixture* fixture,
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& mesh_device_0,
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& mesh_device_1,
     uint32_t data_txq_id,
@@ -158,7 +153,6 @@ static void run_multi_txq_rxq_test(
         "No ethernet connection found between device_0 and device_1");
 
     unit_tests::erisc::direct_send::eth_direct_send_multi_txq_rxq(
-        fixture,
         mesh_device_0,
         mesh_device_1,
         sender_core_0.value(),
@@ -170,10 +164,10 @@ static void run_multi_txq_rxq_test(
 }  // namespace tt::tt_metal
 
 TEST_F(TwoDeviceBlackholeFixture, ActiveEthChipToChipMultiTxqRxq_Both0) {
-    run_multi_txq_rxq_test(this, this->devices_.at(0), this->devices_.at(1), 0, 0, 100000);
+    run_multi_txq_rxq_test(this->devices_.at(0), this->devices_.at(1), 0, 0, 100000);
 }
 TEST_F(TwoDeviceBlackholeFixture, ActiveEthChipToChipMultiTxqRxq_Qs_0_and_1) {
-    run_multi_txq_rxq_test(this, this->devices_.at(0), this->devices_.at(1), 0, 1, 100000);
+    run_multi_txq_rxq_test(this->devices_.at(0), this->devices_.at(1), 0, 1, 100000);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <cstdint>
 #include <thread>
-#include <cstdlib>
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/core_coord.hpp>
@@ -29,8 +28,8 @@ using namespace tt::test_utils;
 namespace unit_tests::erisc::direct_send {
 
 static void eth_direct_send_multi_txq_rxq(
-    std::shared_ptr<tt_metal::distributed::MeshDevice> sender_mesh_device,
-    std::shared_ptr<tt_metal::distributed::MeshDevice> receiver_mesh_device,
+    const std::shared_ptr<tt_metal::distributed::MeshDevice>& sender_mesh_device,
+    const std::shared_ptr<tt_metal::distributed::MeshDevice>& receiver_mesh_device,
     const CoreCoord& eth_sender_core,
     const CoreCoord& eth_receiver_core,
     uint32_t data_txq_id,

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -29,6 +29,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include "mesh_dispatch_fixture.hpp"
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "matmul_test_utils.hpp"
@@ -171,14 +172,14 @@ static MatmulTileContext setup_matmul_tile_context(
 }
 
 static void verify_matmul_tile_output(
-    tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const MatmulTileConfig& cfg,
     vector<bfloat16> tensor_vals,
     const MatmulTileContext& ctx) {
     // This is tilized result, will not be modified
     std::vector<uint32_t> result_vec;
-    fixture->ReadBuffer(mesh_device, ctx.dst_dram_buffer, result_vec);
+    distributed::ReadShard(
+        mesh_device->mesh_command_queue(), result_vec, ctx.dst_dram_buffer, distributed::MeshCoordinate(0, 0));
 
     std::vector<bfloat16> golden = std::move(tensor_vals);
     std::vector<bfloat16> golden_tilized = tilize_swizzled(golden, ctx.M * 32, ctx.N * 32);
@@ -215,7 +216,6 @@ static void verify_matmul_tile_output(
 }
 
 static void matmul_tile_block(
-    tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const MatmulTileConfig& cfg,
     vector<uint32_t>& activations,
@@ -388,15 +388,10 @@ static void matmul_tile_block(
     };
 
     Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    auto& cq = mesh_device->mesh_command_queue();
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& program_run = workload.get_programs().at(device_range);
-
-    fixture->WriteBuffer(mesh_device, ctx.src0_dram_buffer, activations);
-    fixture->WriteBuffer(mesh_device, ctx.src1_dram_buffer, weights);
+    distributed::EnqueueWriteMeshBuffer(cq, ctx.src0_dram_buffer, activations);
+    distributed::EnqueueWriteMeshBuffer(cq, ctx.src1_dram_buffer, weights);
 
     // matmul_block tests always have M, N, K >= 2 (single-tile cases use matmul.cpp via the legacy path).
     const uint32_t num_blocks = ctx.K;
@@ -428,17 +423,16 @@ static void matmul_tile_block(
         },
         experimental::ProgramRunArgs::KernelRunArgs{.kernel = COMPUTE},
     };
-    experimental::SetProgramRunArgs(program_run, params);
+    experimental::SetProgramRunArgs(program, params);
 
-    fixture->RunProgram(mesh_device, workload);
+    LaunchProgram(*mesh_device, std::move(program));
 
-    verify_matmul_tile_output(fixture, mesh_device, cfg, std::move(tensor_vals), ctx);
+    verify_matmul_tile_output(mesh_device, cfg, std::move(tensor_vals), ctx);
 }
 
 // Used by tests whose compute kernels (matmul.cpp, matmul_with_bias.cpp) have no
 // Metal 2.0 / DFB equivalent. Those tests are skipped on Quasar — this path is Gen1-only.
 static void matmul_tile(
-    tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const MatmulTileConfig& cfg,
     vector<uint32_t>& activations,
@@ -446,12 +440,8 @@ static void matmul_tile(
     vector<bfloat16> tensor_vals) {
     auto ctx = setup_matmul_tile_context(mesh_device, cfg);
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
+    auto& cq = mesh_device->mesh_command_queue();
     CoreCoord core = {0, 0};
 
     uint32_t src0_cb_index = 0;
@@ -459,14 +449,14 @@ static void matmul_tile(
         tt_metal::CircularBufferConfig(
             ctx.num_input_tiles * ctx.single_tile_size_bfp16b, {{src0_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(src0_cb_index, ctx.single_tile_size_bfp16b);
-    tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
+    tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
     uint32_t src1_cb_index = 1;
     tt_metal::CircularBufferConfig cb_src1_config =
         tt_metal::CircularBufferConfig(
             ctx.num_input_tiles * ctx.single_tile_size_bfp16b, {{src1_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(src1_cb_index, ctx.single_tile_size_bfp16b);
-    tt_metal::CreateCircularBuffer(program_, core, cb_src1_config);
+    tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
     std::shared_ptr<distributed::MeshBuffer> src2_dram_buffer;
     std::shared_ptr<distributed::MeshBuffer> dst1_dram_buffer;
@@ -485,7 +475,7 @@ static void matmul_tile(
             tt_metal::CircularBufferConfig(
                 ctx.num_input_tiles * ctx.single_tile_size_bfp16b, {{src2_cb_index, tt::DataFormat::Float16_b}})
                 .set_page_size(src2_cb_index, ctx.single_tile_size_bfp16b);
-        tt_metal::CreateCircularBuffer(program_, core, cb_src2_config);
+        tt_metal::CreateCircularBuffer(program, core, cb_src2_config);
     } else if (cfg.test_init_short) {  // This will be dummy input in uint16_t
         uint32_t in2_id = 2;
         uint32_t out1_id = 17;
@@ -508,13 +498,13 @@ static void matmul_tile(
             tt_metal::CircularBufferConfig(
                 ctx.num_input_tiles * ctx.single_tile_size_bfp16b, {{in2_id, tt::DataFormat::UInt16}})
                 .set_page_size(in2_id, ctx.single_tile_size_bfp16b);
-        tt_metal::CreateCircularBuffer(program_, core, cb_src2_config);
+        tt_metal::CreateCircularBuffer(program, core, cb_src2_config);
 
         tt_metal::CircularBufferConfig cb_dst1_config =
             tt_metal::CircularBufferConfig(
                 ctx.num_input_tiles * ctx.single_tile_size_bfp16b, {{out1_id, tt::DataFormat::UInt16}})
                 .set_page_size(out1_id, ctx.single_tile_size_bfp16b);
-        tt_metal::CreateCircularBuffer(program_, core, cb_dst1_config);
+        tt_metal::CreateCircularBuffer(program, core, cb_dst1_config);
     }
 
     uint32_t output_cb_index = 16;
@@ -529,7 +519,7 @@ static void matmul_tile(
             tt_metal::CircularBufferConfig(ctx.dram_buffer_size_out0, partials_and_out_data_format_spec)
                 .set_page_size(output_cb_index, ctx.single_tile_size_out0)
                 .set_page_size(intermediate_cb_index, ctx.single_tile_size_out0);
-        tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
+        tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
         reader_l1_args = {
             ctx.src0_dram_buffer->address(),
@@ -549,7 +539,7 @@ static void matmul_tile(
                 num_output_tiles * ctx.single_tile_size_out0,
                 {{output_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)}})
                 .set_page_size(output_cb_index, ctx.single_tile_size_out0);
-        tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
+        tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
         reader_l1_args = {
             ctx.src0_dram_buffer->address(),
@@ -571,21 +561,21 @@ static void matmul_tile(
     }
 
     auto mm_reader_kernel = tt_metal::CreateKernel(
-        program_,
+        program,
         cfg.reader_kernel,
         core,
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
 
     auto unary_writer_kernel = tt_metal::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary.cpp",
         core,
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
 
     tt_metal::CreateKernel(
-        program_,
+        program,
         cfg.compute_kernel,
         core,
         tt_metal::ComputeConfig{
@@ -595,12 +585,12 @@ static void matmul_tile(
             .compile_args = cfg.compute_kernel_args,
             .defines = compute_defines});
 
-    fixture->WriteBuffer(mesh_device, ctx.src0_dram_buffer, activations);
-    fixture->WriteBuffer(mesh_device, ctx.src1_dram_buffer, weights);
+    distributed::EnqueueWriteMeshBuffer(cq, ctx.src0_dram_buffer, activations);
+    distributed::EnqueueWriteMeshBuffer(cq, ctx.src1_dram_buffer, weights);
 
     if (cfg.with_bias || cfg.test_init_short) {
         vector<uint32_t> bias(ctx.N * 512, 0);
-        fixture->WriteBuffer(mesh_device, src2_dram_buffer, bias);
+        distributed::EnqueueWriteMeshBuffer(cq, src2_dram_buffer, bias);
 
         vector<uint32_t> bias_args = {
             src2_dram_buffer->address(), 0, (std::uint32_t)ctx.N, (std::uint32_t)(ctx.N * ctx.single_tile_size_bfp16b)};
@@ -610,15 +600,15 @@ static void matmul_tile(
         }
     }
 
-    tt_metal::SetRuntimeArgs(program_, mm_reader_kernel, core, reader_l1_args);
+    tt_metal::SetRuntimeArgs(program, mm_reader_kernel, core, reader_l1_args);
 
     tt_metal::SetRuntimeArgs(
-        program_,
+        program,
         unary_writer_kernel,
         core,
         {ctx.dst_dram_buffer->address(), 0, ctx.num_tiles});  // this is M * N in the multi_tile case !!
 
-    fixture->RunProgram(mesh_device, workload);
+    LaunchProgram(*mesh_device, std::move(program));
 
     if ((cfg.with_bias || cfg.test_init_short)) {
         if (cfg.test_init_short) {
@@ -627,7 +617,7 @@ static void matmul_tile(
         src2_dram_buffer->deallocate();
     }
 
-    verify_matmul_tile_output(fixture, mesh_device, cfg, std::move(tensor_vals), ctx);
+    verify_matmul_tile_output(mesh_device, cfg, std::move(tensor_vals), ctx);
 }
 
 }  // namespace unit_tests_common::matmul::test_matmul_X_tile
@@ -670,7 +660,7 @@ TEST_F(MeshDispatchFixture, TensixMatmulSingleTile) {
                 create_test_stimuli(stimuli, 1, 1, 1);
 
                 for (const auto& device : devices_) {
-                    matmul_tile(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                    matmul_tile(device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                 }
             }
         }
@@ -705,10 +695,10 @@ TEST_F(MeshDispatchFixture, TensixMatmulMultiTile) {
                 create_test_stimuli(stimuli, M, K, N);
 
                 for (const auto& device : devices_) {
-                    matmul_tile(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                    matmul_tile(device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                     log_info(LogTest, "Multi tile with no bias passed");
                     matmul_config.with_bias = true;
-                    matmul_tile(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                    matmul_tile(device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                     log_info(LogTest, "Multi tile with bias passed");
                 }
             }
@@ -743,7 +733,7 @@ TEST_F(MeshDispatchFixture, TensixMatmulBlock) {
                 create_test_stimuli(stimuli, M, K, N);
 
                 for (const auto& device : devices_) {
-                    matmul_tile_block(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                    matmul_tile_block(device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                 }
             }
         }
@@ -777,7 +767,7 @@ TEST_F(MeshDispatchFixture, TensixMatmulBlockInitShort) {
                 create_test_stimuli(stimuli, M, K, N);
 
                 for (const auto& device : devices_) {
-                    matmul_tile_block(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                    matmul_tile_block(device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                 }
             }
         }
@@ -814,7 +804,7 @@ TEST_F(MeshDispatchFixture, TensixMatmulBlockInitShortWithDt) {
                 create_test_stimuli(stimuli, M, K, N);
 
                 for (const auto& device : devices_) {
-                    matmul_tile_block(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                    matmul_tile_block(device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                 }
             }
         }

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include "mesh_dispatch_fixture.hpp"
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "matmul_test_utils.hpp"
@@ -68,7 +69,7 @@ void set_math_fid_masks(uint16_t& math_fid_mask, MathFidelity math_fidelity = Ma
 }
 
 void create_CBs_for_fused_matmul(
-    distributed::MeshWorkload& workload,
+    tt_metal::Program& program,
     const std::shared_ptr<distributed::MeshDevice>& /*mesh_device*/,
     CoreCoord core,
     bool activations_rm,
@@ -91,10 +92,6 @@ void create_CBs_for_fused_matmul(
 
     uint32_t num_output_tiles = M * N;
     CoreRangeSet cores(std::set<CoreRange>{CoreRange(core, core)});
-
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto& program = workload.get_programs().at(device_range);
 
     // Invariants
     uint32_t cb0_tiles = M * in0_block_w * 2;
@@ -206,19 +203,14 @@ void create_CBs_for_fused_matmul(
 }
 
 bool matmul_large_block(
-    tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     bool activations_rm,
     bool output_rm,
     MathFidelity math_fidelity = MathFidelity::HiFi4) {
     bool pass = true;
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = tt_metal::CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
+    auto& cq = mesh_device->mesh_command_queue();
 
     CoreCoord core = {0, 0};
     uint32_t M = 4;
@@ -299,14 +291,14 @@ bool matmul_large_block(
     }
 
     auto mm_reader_kernel = tt_metal::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_blocked.cpp",
         core,
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
 
     auto unary_writer_kernel = tt_metal::CreateKernel(
-        program_,
+        program,
         writer_kernel,
         core,
         tt_metal::DataMovementConfig{
@@ -327,7 +319,7 @@ bool matmul_large_block(
     int in0_subblock_h = (in0_block_num_tiles / in0_num_subblocks) / in0_block_w;
 
     create_CBs_for_fused_matmul(
-        workload, mesh_device, core, activations_rm, output_rm, M, N, in0_block_w, out_subblock_h);
+        program, mesh_device, core, activations_rm, output_rm, M, N, in0_block_w, out_subblock_h);
 
     TT_FATAL(
         in0_subblock_h * in0_block_w * in0_num_subblocks == in0_block_num_tiles,
@@ -361,7 +353,7 @@ bool matmul_large_block(
     std::string compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp";
 
     tt_metal::CreateKernel(
-        program_,
+        program,
         compute_kernel,
         core,
         tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .compile_args = compute_kernel_args});
@@ -382,23 +374,23 @@ bool matmul_large_block(
             convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(activations_tilized));
         activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
     }
-    fixture->WriteBuffer(mesh_device, src0_dram_buffer, activations);
+    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, activations);
 
     auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
     auto identity_tilized = tilize_swizzled<bfloat16>(identity, K * 32, N * 32);
     auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity_tilized));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-    fixture->WriteBuffer(mesh_device, src1_dram_buffer, weights);
+    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, weights);
 
-    tt_metal::SetRuntimeArgs(program_, mm_reader_kernel, core, mm_reader_rt_args);
+    tt_metal::SetRuntimeArgs(program, mm_reader_kernel, core, mm_reader_rt_args);
 
-    tt_metal::SetRuntimeArgs(program_, unary_writer_kernel, core, writer_rt_args);
+    tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, writer_rt_args);
 
     [[maybe_unused]] CoreCoord debug_core = {1, 1};
 
-    fixture->RunProgram(mesh_device, workload);
+    LaunchProgram(*mesh_device, std::move(program));
     std::vector<uint32_t> result_vec;
-    fixture->ReadBuffer(mesh_device, dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Validation & Teardown
@@ -443,16 +435,16 @@ TEST_F(MeshDispatchFixture, TensixMatmulLargeBlock) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (const auto& device : devices_) {
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
-                this, device, false, false, MathFidelity(i)));
+                device, false, false, MathFidelity(i)));
             log_info(LogTest, "Tilized input, Tilized output Passed");
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
-                this, device, true, false, MathFidelity(i)));
+                device, true, false, MathFidelity(i)));
             log_info(LogTest, "Row major input, Tilized output Passed");
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
-                this, device, false, true, MathFidelity(i)));
+                device, false, true, MathFidelity(i)));
             log_info(LogTest, "Tilized input, Row major output Passed");
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
-                this, device, true, true, MathFidelity(i)));
+                device, true, true, MathFidelity(i)));
             log_info(LogTest, "Row major input, Row major output Passed");
         }
     }

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
@@ -356,8 +356,7 @@ bool matmul_multi_core_single_dram(const std::shared_ptr<distributed::MeshDevice
                 per_core_M * per_core_N * single_tile_size,
                 result_vec);
             auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-            auto result_flat_layout =
-                convert_layout_tile_nfaces_to_tile_swizzled(ttsl::make_const_span(result_bfp16));
+            auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(ttsl::make_const_span(result_bfp16));
             auto result_untilized = untilize_swizzled(result_flat_layout, per_core_M * 32, per_core_N * 32);
             pass &= (per_core_golden == result_untilized);
         }
@@ -466,8 +465,7 @@ bool assign_runtime_args_to_program(
     return pass;
 }
 
-bool matmul_multi_core_multi_dram(
-    tt_metal::MeshDispatchFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+bool matmul_multi_core_multi_dram(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     bool pass = true;
     int num_cores_r = mesh_device->compute_with_storage_grid_size().y;
     int num_cores_c = mesh_device->compute_with_storage_grid_size().x;
@@ -578,7 +576,7 @@ bool matmul_multi_core_multi_dram(
     log_debug(LogTest, "Gathering data back from dram and checking against golden");
 
     vector<uint32_t> result;
-    fixture->ReadBuffer(mesh_device, out_buffer, result);
+    distributed::EnqueueReadMeshBuffer(mesh_device->mesh_command_queue(), result, out_buffer);
     auto golden = tt_metal::select_columns(tensor.get_values(), M, K, N);
 
     // Keeping this old code because took me too long to decipher. Matmul
@@ -592,8 +590,7 @@ bool matmul_multi_core_multi_dram(
             result_vec.insert(result_vec.end(), result_iter, result_iter + 512);
             result_iter += 512;
             auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-            auto result_flat_layout =
-                convert_layout_tile_nfaces_to_tile_swizzled(ttsl::make_const_span(result_bfp16));
+            auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(ttsl::make_const_span(result_bfp16));
 
             pass &= (golden_tile == result_flat_layout);
         }
@@ -630,8 +627,8 @@ TEST_F(MeshDispatchFixture, TensixMatmulMultiCoreMultiDRAM) {
         if (this->devices_.at(id)->arch() == tt::ARCH::BLACKHOLE) {
             GTEST_SKIP();
         }
-        ASSERT_TRUE(unit_tests_common::matmul::test_matmul_multi_core_X_dram::matmul_multi_core_multi_dram(
-            this, devices_.at(id)));
+        ASSERT_TRUE(
+            unit_tests_common::matmul::test_matmul_multi_core_X_dram::matmul_multi_core_multi_dram(devices_.at(id)));
     }
 }
 

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
@@ -28,6 +28,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include "mesh_dispatch_fixture.hpp"
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/distributed.hpp>
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-logger/tt-logger.hpp>
@@ -46,7 +47,6 @@ using namespace tt;
 namespace unit_tests_common::matmul::test_matmul_single_core {
 
 bool matmul_single_core(
-    tt_metal::MeshDispatchFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     int M,
     int N,
@@ -55,12 +55,8 @@ bool matmul_single_core(
     int out_subblock_w) {
     bool pass = true;
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
+    auto& cq = mesh_device->mesh_command_queue();
 
     CoreCoord core = {0, 0};
     int in0_block_w = 2;
@@ -127,14 +123,14 @@ bool matmul_single_core(
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(cb0_tiles * single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(src0_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
+    tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
     uint32_t src1_cb_index = 1;
     uint32_t cb1_tiles = N * in0_block_w * 2;
     tt_metal::CircularBufferConfig cb_src1_config =
         tt_metal::CircularBufferConfig(cb1_tiles * single_tile_size, {{src1_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(src1_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program_, core, cb_src1_config);
+    tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
     uint32_t ouput_cb_index = tt::CBIndex::c_16;
     uint32_t interm0_cb_index = tt::CBIndex::c_24;
@@ -147,7 +143,7 @@ bool matmul_single_core(
         tt_metal::CircularBufferConfig(num_output_tiles * single_tile_size, partials_and_out_data_format_spec)
             .set_page_size(interm0_cb_index, single_tile_size)
             .set_page_size(ouput_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program_, cores, cb_output_config);
+    tt_metal::CreateCircularBuffer(program, cores, cb_output_config);
 
     std::vector<uint32_t> mm_reader_rt_args{
         src0_dram_buffer->address(),
@@ -174,14 +170,14 @@ bool matmul_single_core(
         (std::uint32_t)out_subblock_w * single_tile_size};  // bytes offset to next sub-block
 
     auto mm_reader_kernel = tt_metal::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_blocked.cpp",
         core,
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
 
     auto unary_writer_kernel = tt_metal::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unswizzle.cpp",
         core,
         tt_metal::DataMovementConfig{
@@ -216,7 +212,7 @@ bool matmul_single_core(
         uint(out_subblock_num_tiles)};
 
     tt_metal::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_zm.cpp",
         core,
         tt_metal::ComputeConfig{.compile_args = compute_kernel_args});
@@ -229,24 +225,24 @@ bool matmul_single_core(
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(activations_tilized));
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
     auto activations_tile_transposed = tt_metal::transpose_tiles(activations, M, K, in0_block_w);
-    fixture->WriteBuffer(mesh_device, src0_dram_buffer, activations_tile_transposed);
+    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, activations_tile_transposed);
 
     auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
     auto identity_tilized = tilize_swizzled(identity, K * 32, N * 32);
     auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity_tilized));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-    fixture->WriteBuffer(mesh_device, src1_dram_buffer, weights);
+    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, weights);
 
-    tt_metal::SetRuntimeArgs(program_, mm_reader_kernel, core, mm_reader_rt_args);
+    tt_metal::SetRuntimeArgs(program, mm_reader_kernel, core, mm_reader_rt_args);
 
-    tt_metal::SetRuntimeArgs(program_, unary_writer_kernel, core, writer_rt_args);
+    tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, writer_rt_args);
 
     log_debug(LogTest, "Launching kernels");
-    fixture->RunProgram(mesh_device, workload);
+    LaunchProgram(*mesh_device, std::move(program));
     log_debug(LogTest, "Kernels done");
 
     std::vector<uint32_t> result_vec;
-    fixture->ReadBuffer(mesh_device, dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer);
 
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
     auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(ttsl::make_const_span(result_bfp16));
@@ -269,7 +265,7 @@ TEST_F(MeshDispatchFixture, TensixMatmulSingleCoreSmall) {
 
     for (const auto& device : devices_) {
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_single_core::matmul_single_core(
-            this, device, M, N, K, out_subblock_h, out_subblock_w));
+            device, M, N, K, out_subblock_h, out_subblock_w));
     }
 }
 
@@ -285,7 +281,7 @@ TEST_F(MeshDispatchFixture, TensixMatmulSingleCore) {
     int out_subblock_w = 2;
     for (const auto& device : devices_) {
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_single_core::matmul_single_core(
-            this, device, M, N, K, out_subblock_h, out_subblock_w));
+            device, M, N, K, out_subblock_h, out_subblock_w));
     }
 }
 

--- a/tests/tt_metal/tt_metal/integration/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_flatten.cpp
@@ -23,6 +23,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/device.hpp>
 #include "mesh_dispatch_fixture.hpp"
+#include "impl/program/program_impl.hpp"
 #include <distributed.hpp>
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-logger/tt-logger.hpp>
@@ -84,16 +85,11 @@ inline std::vector<uint32_t> gold_standard_flatten(std::vector<uint32_t> src_vec
 }
 
 bool flatten(
-    tt_metal::MeshDispatchFixture* fixture,
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    uint32_t num_tiles_r = 5,
-    uint32_t num_tiles_c = 5) {
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t num_tiles_r = 5, uint32_t num_tiles_c = 5) {
     bool pass = true;
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
+    auto& cq = mesh_device->mesh_command_queue();
 
     CoreCoord core = {0, 0};
 
@@ -168,18 +164,17 @@ bool flatten(
     ////////////////////////////////////////////////////////////////////////////
     //                      Execute Application
     ////////////////////////////////////////////////////////////////////////////
-    fixture->WriteBuffer(mesh_device, src_dram_buffer, src_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec);
 
     tt_metal::SetRuntimeArgs(
         program, flatten_kernel, core, {dram_buffer_src_addr, 0, num_tiles_r, num_tiles_c, num_bytes_per_tensor_row});
 
     tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles * 32});
 
-    workload.add_program(device_range, std::move(program));
-    fixture->RunProgram(mesh_device, workload);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> result_vec;
-    fixture->ReadBuffer(mesh_device, dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Validation & Teardown
@@ -296,7 +291,7 @@ bool flatten_stress(
         distributed::EnqueueMeshWorkload(cq, workload, false);
         // Blocking read
         std::vector<uint32_t> result_vec;
-        distributed::ReadShard(cq, result_vec, dst_dram_buffer, zero_coord, true);
+        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer);
 
         // Validation of data
         TT_FATAL(
@@ -332,7 +327,7 @@ TEST_F(MeshDispatchFixture, TensixFlatten) {
         if (!this->IsSlowDispatch() && id > 0) {
             continue;
         }
-        ASSERT_TRUE(test_flatten::flatten(this, this->devices_.at(id), num_tiles_r, num_tiles_c));
+        ASSERT_TRUE(test_flatten::flatten(this->devices_.at(id), num_tiles_r, num_tiles_c));
     }
 }
 

--- a/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
@@ -66,8 +66,7 @@ CBHandle MakeCircularBufferBFP16(Program& program, const CoreSpec& core, tt::CBI
 
 namespace unit_tests_common::vecadd::test_vecadd_multi_core {
 
-bool vecadd_multi_core(
-    MeshDispatchFixture* /*fixture*/, const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t n_tiles) {
+bool vecadd_multi_core(const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t n_tiles) {
     const uint32_t num_core = 4;
     TT_FATAL(n_tiles >= num_core, "Parameter mismatch {} {}", n_tiles, num_core);
 
@@ -139,8 +138,8 @@ bool vecadd_multi_core(
         SetRuntimeArgs(program, compute, core, {tiles_per_core, i});
     }
 
-    distributed::WriteShard(cq, a, a_data, zero_coord);
-    distributed::WriteShard(cq, b, b_data, zero_coord);
+    distributed::EnqueueWriteMeshBuffer(cq, a, a_data);
+    distributed::EnqueueWriteMeshBuffer(cq, b, b_data);
     // Enqueue the program
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
@@ -149,7 +148,7 @@ bool vecadd_multi_core(
 
     // Read the output buffer.
     std::vector<bfloat16> c_data;
-    distributed::ReadShard(cq, c_data, c, zero_coord);
+    distributed::EnqueueReadMeshBuffer(cq, c_data, c);
 
     size_t data_per_core = tile_size * tiles_per_core;
 
@@ -169,7 +168,7 @@ bool vecadd_multi_core(
 TEST_F(MeshDispatchFixture, DISABLED_VecaddMultiCore) {
     GTEST_SKIP();
     uint32_t num_tiles = 64;
-    ASSERT_TRUE(unit_tests_common::vecadd::test_vecadd_multi_core::vecadd_multi_core(this, devices_.at(0), num_tiles));
+    ASSERT_TRUE(unit_tests_common::vecadd::test_vecadd_multi_core::vecadd_multi_core(devices_.at(0), num_tiles));
 }
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

`MeshDispatchFixture` is often passed into test helper functions to access its API, which is an anti-pattern.
The code becomes simpler if we use existing free functions instead:
- `LaunchProgram` instead of `MeshDispatchFixture::RunProgram`
- `distributed::EnqueueWriteMeshBuffer` instead of `MeshDispatchFixture::WriteBuffer`
- `distributed::EnqueueReadMeshBuffer` instead of `MeshDispatchFixture::ReadBuffer`

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-MeshDeviceFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-MeshDeviceFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-MeshDeviceFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-MeshDeviceFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-MeshDeviceFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-MeshDeviceFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-MeshDeviceFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-MeshDeviceFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-MeshDeviceFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-MeshDeviceFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-MeshDeviceFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-MeshDeviceFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-MeshDeviceFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-MeshDeviceFixture)