### PR TITLE
[moe_compute] bug fix: single consumer for the tilize total_chunks page

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_compute.cpp
@@ -67,7 +67,7 @@ void print_tile_rows(
 }
 
 // Compute kernel for tilizing incoming tokens from the reader.
-// Waits for writer to pass total_chunks via CB, then processes each chunk:
+// Waits for the reader to pass total_chunks via CB, then processes each chunk:
 // - Wait for reader to push tokens_per_chunk tokens
 // - Tilize the block
 // - Push tilized output to writer
@@ -95,7 +95,7 @@ void kernel_main() {
     compute_kernel_hw_startup(tilize_input_cb_id, tilize_output_cb_id);
     fast_tilize_init(tilize_input_cb_id, tiles_per_local_chunk, tilize_output_cb_id);
 
-    // Wait for writer to push total_chunks via CB
+    // Wait for the reader to push total_chunks via CB
     cb_total_chunks.wait_front(one_page);
 
     // Read total_chunks from the CB

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -960,7 +960,7 @@ void kernel_main() {
             num_activated_tokens_per_expert[e] = per_expert_counts[e];
         }
 
-        // Push per_expert_total_tokens_cb and total_chunks_cb so writer can read them
+        // Push per_expert_total_tokens_cb (read by the writer) and total_chunks_cb (read by the tilize compute kernel)
         // (drain core already pushed, non-drain cores need to mark as available)
         cb_per_expert_total_tokens.reserve_back(1);
         cb_per_expert_total_tokens.push_back(1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -104,7 +104,6 @@ void kernel_main() {
     // CBs
     constexpr uint32_t tilize_output_cb_id = get_named_compile_time_arg_val("tilize_output_cb_id");
     constexpr uint32_t per_expert_total_tokens_cb_id = get_named_compile_time_arg_val("per_expert_total_tokens_cb_id");
-    constexpr uint32_t total_chunks_cb_id = get_named_compile_time_arg_val("total_chunks_cb_id");
     constexpr uint32_t indices_tensor_cb_id = get_named_compile_time_arg_val("indices_tensor_cb_id");
     constexpr uint32_t scores_tensor_cb_id = get_named_compile_time_arg_val("scores_tensor_cb_id");
     constexpr uint32_t mapping_tensor_cb_id = get_named_compile_time_arg_val("mapping_tensor_cb_id");
@@ -203,7 +202,6 @@ void kernel_main() {
     // CircularBuffer typed wrappers
     CircularBuffer cb_tilize_output(tilize_output_cb_id);
     CircularBuffer cb_per_expert_total_tokens(per_expert_total_tokens_cb_id);
-    CircularBuffer cb_total_chunks(total_chunks_cb_id);
     CircularBuffer cb_indices_tensor(indices_tensor_cb_id);
     CircularBuffer cb_scores_tensor(scores_tensor_cb_id);
     CircularBuffer cb_mapping_tensor(mapping_tensor_cb_id);
@@ -415,11 +413,6 @@ void kernel_main() {
     for (uint32_t e = 0; e < experts_per_device; e++) {
         num_tokens_per_expert[e] = per_expert_counts[e];
     }
-
-    // Wait for reader to push total_chunks
-    cb_total_chunks.wait_front(one_page);
-    [[maybe_unused]] uint32_t total_chunks =
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_total_chunks.get_read_ptr());
 
     /************************************************************************/
     /* Synchronization setup for signalling between tilize and matmul cores */
@@ -741,9 +734,8 @@ void kernel_main() {
         }
     }
 
-    // Pop the per-expert counts and total_chunks (cleanup)
+    // Pop the per-expert counts (cleanup).
     cb_per_expert_total_tokens.pop_front(one_page);
-    cb_total_chunks.pop_front(one_page);
 
     noc_obj.async_write_barrier();
     noc_obj.async_atomic_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -576,7 +576,7 @@ MoEComputeMeshWorkloadFactory::create_at(
     // Tilize CBs
     //-------------------------------------------------------------------------
 
-    // CB for passing total_chunks from writer to compute
+    // CB for passing total_chunks from the tilize reader to the tilize compute kernel
     uint32_t total_chunks_cb_id = tt::CBIndex::c_3;
     // full indices buffer
     uint32_t indices_tensor_cb_id = tt::CBIndex::c_4;
@@ -731,7 +731,7 @@ MoEComputeMeshWorkloadFactory::create_at(
         tilize_num_cores - 1,  // one entry per non-drain core
         tt::DataFormat::UInt32);
 
-    // CB for passing total_chunks from writer to compute kernel
+    // CB for passing total_chunks from the tilize reader to the tilize compute kernel
     // Single page holding one uint32_t value. Page size floored at l1_alignment /
     // CIRCULAR_BUFFER_COMPUTE_WORD_SIZE so the unpack LLK fifo_* fields (16 B words) are non-zero
     // when tilize_compute pops this CB.


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #55996.

The `total_chunks` page that the tilize reader pushes was waited on and popped by both the tilize compute kernel and the tilize writer. The CB has one page and one producer; the dataflow-side wait samples the shared acked counter once, so on a device whose experts received no tokens the compute kernel's immediate pop could starve the writer's wait and hang the op. The writer never used the value: its chunk loop already comes from the per-expert token counts.

The writer no longer references `total_chunks` (compile-time arg, CB wrapper, wait and pop removed). The reader and compute kernels are unchanged, so the page now has one producer and one consumer. Comments in the program factory and the compute kernel that called the page a writer-to-compute hand-off now name the reader as the producer.

The same producer/consumer structure exists in `moe_gpt/device/kernels/tilize_writer.cpp`; it is not touched here.

**Test**

No new test in this PR: an empty device needs a routing over at least two devices on the expert axis, which none of the single-card `moe_compute` tests can express, and the Galaxy tests never leave a device empty at their token counts. Existing suites (`tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py`, `tests/nightly/tg/ccl/moe/test_moe_compute_6U.py`) exercise the unchanged busy-device path. A multi-device test with one empty device would be the right regression gate if you want one added.

### Notes for reviewers

- The host still passes `total_chunks_cb_id` in the named compile-time args shared by the reader and the writer; the writer ignores it.
- No data path or numerics change: -9/+1 lines in the writer plus comments.

### Verification

Blackhole 4x p150 (1x4 line): one-token expert-parallel decode with 128 experts per device and k = 10, where about one layer in five leaves a device without tokens. Before the change the op hung at the first such layer; with the change it has run production decode since 2026-08-30 (thousands of steps per run) with no hang. Busy-device outputs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjett/moe-compute-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjett/moe-compute-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sjett/moe-compute-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sjett/moe-compute-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjett/moe-compute-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjett/moe-compute-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjett/moe-compute-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjett/moe-compute-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sjett/moe-compute-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sjett/moe-compute-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sjett/moe-compute-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sjett/moe-compute-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sjett/moe-compute-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sjett/moe-compute-total-chunks-single-consumer)