### PR TITLE
[deepseek_moe_fast_reduce_nc_fused] bug fix: scale each output row tile with its own scores

### DIFF
--- a/tests/ttnn/unit_tests/operations/experimental/deepseek/test_deepseek_moe_fast_reduce_nc_fused_row_tiles.py
+++ b/tests/ttnn/unit_tests/operations/experimental/deepseek/test_deepseek_moe_fast_reduce_nc_fused_row_tiles.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+deepseek_moe_fast_reduce_nc_fused with more than one row tile of tokens, on one device.
+
+Every output row t must be the weighted sum of the expert slices with the scores of row t. The test
+checks that against a torch reference per 32-row slice (so a slice weighted with another slice's
+scores fails on its own) and checks that the T-row result equals the concatenation of the per-32-row
+results bitwise (the per-element MAC order does not depend on the input height).
+"""
+
+import random
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+
+PCC_THRESHOLD = 0.999
+
+
+def _run_fused_reduce(mesh_device, activation, scores, indices, mapping, hidden_size):
+    replicate = ttnn.ReplicateTensorToMesh(mesh_device)
+    tt_activation = ttnn.from_torch(
+        activation,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        mesh_mapper=replicate,
+    )
+    tt_scores = ttnn.from_torch(
+        scores,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=replicate,
+    )
+    tt_indices = ttnn.from_torch(
+        indices,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=replicate,
+    )
+    tt_mapping = ttnn.from_torch(
+        mapping,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=replicate,
+    )
+    outputs = ttnn.experimental.deepseek_moe_fast_reduce_nc_fused(
+        tt_activation,
+        tt_indices,
+        tt_mapping,
+        reduce_dim=0,
+        split_size=hidden_size,
+        cluster_axis=0,
+        output_memory_config=ttnn.L1_MEMORY_CONFIG,
+        scores_tensor=tt_scores,
+    )
+    assert len(outputs) == 1
+    return ttnn.to_torch(outputs[0], dtype=torch.bfloat16)
+
+
+@pytest.mark.parametrize("tokens", [32, 64, 96, 128])
+@pytest.mark.parametrize("select_experts_k", [8])
+@pytest.mark.parametrize("hidden_size", [2048])
+@pytest.mark.parametrize("mesh_shape, mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
+def test_deepseek_moe_fast_reduce_nc_fused_row_tiles(mesh_device, mesh_shape, tokens, select_experts_k, hidden_size):
+    torch.manual_seed(2005)
+    random.seed(2005)
+    experts = 2 * select_experts_k
+
+    activation = torch.rand((select_experts_k, 1, tokens, hidden_size), dtype=torch.bfloat16) - 0.5
+    # Distinct normalized scores per token: a row weighted with another row's scores is detectable.
+    scores = torch.rand((tokens, 1, 1, select_experts_k), dtype=torch.bfloat16)
+    scores = scores / scores.sum(dim=-1, keepdim=True)
+    indices = torch.empty((tokens, 1, 1, select_experts_k), dtype=torch.int32)
+    for t in range(tokens):
+        indices[t, 0, 0, :] = torch.tensor(random.sample(range(experts), select_experts_k), dtype=torch.int32)
+    # Every expert lives on the one device, so every (token, k) slot is on axis.
+    mapping = torch.zeros((1, experts), dtype=torch.int32)
+
+    golden = (activation.float() * scores.float().permute(3, 1, 0, 2)).sum(dim=0, keepdim=True)
+
+    result = _run_fused_reduce(mesh_device, activation, scores, indices, mapping, hidden_size)
+    assert result.shape == (1, 1, tokens, hidden_size)
+
+    for row_tile in range(tokens // 32):
+        rows = slice(32 * row_tile, 32 * (row_tile + 1))
+        passed, pcc = comp_pcc(golden[:, :, rows, :], result[:, :, rows, :].float(), PCC_THRESHOLD)
+        assert passed, f"rows {rows.start}..{rows.stop - 1}: pcc {pcc}"
+
+    # The T-row reduce equals the per-32-row reduces bitwise.
+    for row_tile in range(tokens // 32):
+        rows = slice(32 * row_tile, 32 * (row_tile + 1))
+        slice_result = _run_fused_reduce(
+            mesh_device,
+            activation[:, :, rows, :].contiguous(),
+            scores[rows].contiguous(),
+            indices[rows].contiguous(),
+            mapping,
+            hidden_size,
+        )
+        assert torch.equal(
+            result[:, :, rows, :], slice_result
+        ), f"rows {rows.start}..{rows.stop - 1} differ from the 32-row reduce"

--- a/tests/ttnn/unit_tests/operations/experimental/deepseek/test_deepseek_moe_fast_reduce_nc_fused_row_tiles.py
+++ b/tests/ttnn/unit_tests/operations/experimental/deepseek/test_deepseek_moe_fast_reduce_nc_fused_row_tiles.py
@@ -7,7 +7,7 @@ deepseek_moe_fast_reduce_nc_fused with more than one row tile of tokens, on one 
 
 Every output row t must be the weighted sum of the expert slices with the scores of row t. The test
 checks that against a torch reference per 32-row slice (so a slice weighted with another slice's
-scores fails on its own) and checks that the T-row result equals the concatenation of the per-32-row
+scores fails on its own) and checks that the T-row result equals the concatenation of the per-row-tile
 results bitwise (the per-element MAC order does not depend on the input height).
 """
 
@@ -70,7 +70,7 @@ def _run_fused_reduce(mesh_device, activation, scores, indices, mapping, hidden_
     return ttnn.to_torch(outputs[0], dtype=torch.bfloat16)
 
 
-@pytest.mark.parametrize("tokens", [32, 64, 96, 128])
+@pytest.mark.parametrize("tokens", [32, 40, 64, 100, 128])
 @pytest.mark.parametrize("select_experts_k", [8])
 @pytest.mark.parametrize("hidden_size", [2048])
 @pytest.mark.parametrize("mesh_shape, mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
@@ -94,14 +94,15 @@ def test_deepseek_moe_fast_reduce_nc_fused_row_tiles(mesh_device, mesh_shape, to
     result = _run_fused_reduce(mesh_device, activation, scores, indices, mapping, hidden_size)
     assert result.shape == (1, 1, tokens, hidden_size)
 
-    for row_tile in range(tokens // 32):
-        rows = slice(32 * row_tile, 32 * (row_tile + 1))
+    num_row_tiles = (tokens + 31) // 32
+    for row_tile in range(num_row_tiles):
+        rows = slice(32 * row_tile, min(32 * (row_tile + 1), tokens))
         passed, pcc = comp_pcc(golden[:, :, rows, :], result[:, :, rows, :].float(), PCC_THRESHOLD)
         assert passed, f"rows {rows.start}..{rows.stop - 1}: pcc {pcc}"
 
-    # The T-row reduce equals the per-32-row reduces bitwise.
-    for row_tile in range(tokens // 32):
-        rows = slice(32 * row_tile, 32 * (row_tile + 1))
+    # The T-row reduce equals the per-row-tile reduces bitwise (the last one partial when T is not a multiple of 32).
+    for row_tile in range(num_row_tiles):
+        rows = slice(32 * row_tile, min(32 * (row_tile + 1), tokens))
         slice_result = _run_fused_reduce(
             mesh_device,
             activation[:, :, rows, :].contiguous(),

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_device_operation.cpp
@@ -103,12 +103,15 @@ void DeepseekMoEFastReduceNCFusedDeviceOperation::validate_on_program_cache_miss
         reduction_dim_size,
         num_shared_experts_val);
 
+    // One score row per input row, the padded rows of the input's last row tile excepted (they get a zero
+    // score).  Any number of row tiles is supported: the reader builds one score tile per (row tile, expert)
+    // and the compute kernel scales each output tile with its own row tile's scores.
     const uint32_t num_tokens = input_shape[-2];
     TT_FATAL(
-        (scores_shape[0] > num_tokens - tt::constants::TILE_WIDTH) && (scores_shape[0] <= num_tokens),
-        "scores dim 0 (tokens in slice = {}) must be between {} and {} for the current fused kernel",
+        (scores_shape[0] > num_tokens - tt::constants::TILE_HEIGHT) && (scores_shape[0] <= num_tokens),
+        "scores dim 0 (tokens in slice = {}) must be between {} and {} (the rows of the input's last row tile)",
         scores_shape[0],
-        num_tokens - tt::constants::TILE_WIDTH + 1,
+        num_tokens - tt::constants::TILE_HEIGHT + 1,
         num_tokens);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.cpp
@@ -126,6 +126,9 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
     // scores shape: [tokens, 1, seq, experts_k] (ROW_MAJOR)
     const uint32_t num_tokens = scores_tensor.logical_shape()[0];  // tokens_per_device
     const uint32_t num_tokens_x32 = round_up(num_tokens, 32);
+    // One score tile per (row tile, expert): the reader builds them, the compute kernel picks the group of the
+    // output tile's row tile.  Inputs taller than one row tile used to be scaled with the first tile's scores.
+    const uint32_t num_row_tiles = num_tokens_x32 / tt::constants::TILE_HEIGHT;
 
     // Choose granularity as the largest factor of num_reduce_input_tile that is less than or equal to 8.
     // Helps with locality and increases work unit for better performance.
@@ -190,10 +193,10 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
         }}},
     });
 
-    // CB c_1: pre-processed score tiles (one per expert), held resident during compute
+    // CB c_1: pre-processed score tiles (one per row tile and expert), held resident during compute
     const uint32_t cb_scores_id = tt::CBIndex::c_1;
     desc.cbs.push_back(tt::tt_metal::CBDescriptor{
-        .total_size = reduction_dim_size * scores_tile_size,
+        .total_size = num_row_tiles * reduction_dim_size * scores_tile_size,
         .core_ranges = all_cores,
         .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(cb_scores_id),
@@ -363,6 +366,9 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
         cb_in_act_id,
         cb_scores_id,
         cb_out_id,
+        num_cores,
+        input_tensor_Wt,
+        num_row_tiles,
     };
     compute_desc_group_1.defines = compute_defines;
     compute_desc_group_1.config = tt::tt_metal::ComputeConfigDescriptor{
@@ -384,6 +390,9 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
             cb_in_act_id,
             cb_scores_id,
             cb_out_id,
+            num_cores,
+            input_tensor_Wt,
+            num_row_tiles,
         };
         compute_desc_group_2->defines = compute_defines;
         compute_desc_group_2->config = tt::tt_metal::ComputeConfigDescriptor{
@@ -433,12 +442,17 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
             continue;
         }
 
-        uint32_t num_tiles_per_core =
-            core_group_1.contains(core_group.ranges().at(0)) ? num_cols_per_core_group_1 : num_cols_per_core_group_2;
+        const bool is_group_1 = core_group_1.contains(core_group.ranges().at(0));
+        uint32_t num_tiles_per_core = is_group_1 ? num_cols_per_core_group_1 : num_cols_per_core_group_2;
         uint32_t page_id_range_length = num_tiles_per_core * num_cores;
+        tt::tt_metal::KernelDescriptor& compute_desc = is_group_1 ? compute_desc_group_1 : *compute_desc_group_2;
 
         for (const auto& core : corerange_to_cores(core_group)) {
             uint32_t start_tiles_to_read = start_tiles_read + page_id_range_length;
+
+            // Compute RT args: [0] start_tiles_read (the core's first output tile id; the kernel derives each
+            // output tile's row tile from it to pick the row tile's score tiles).
+            compute_desc.emplace_runtime_args(core, {start_tiles_read});
 
             uint32_t start_slice_row_offset = (start_tiles_read / input_tensor_Wt) * slice_Wt;
             uint32_t start_pages_read_in_row = start_tiles_read % input_tensor_Wt;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/deepseek_moe_fast_reduce_nc_fused_program_factory.cpp
@@ -127,7 +127,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
     const uint32_t num_tokens = scores_tensor.logical_shape()[0];  // tokens_per_device
     const uint32_t num_tokens_x32 = round_up(num_tokens, 32);
     // One score tile per (row tile, expert): the reader builds them, the compute kernel picks the group of the
-    // output tile's row tile.  Inputs taller than one row tile used to be scaled with the first tile's scores.
+    // output tile's row tile.
     const uint32_t num_row_tiles = num_tokens_x32 / tt::constants::TILE_HEIGHT;
 
     // Choose granularity as the largest factor of num_reduce_input_tile that is less than or equal to 8.

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_compute.cpp
@@ -5,10 +5,13 @@
 // Fused compute kernel: multiply-accumulate using hardware MAC.
 //
 // For each output tile we iterate over reduction_dim_size experts and sum:
-//   dst0 += act_tile[e] * score_col[e]   (hardware MAC with col-broadcast)
+//   dst0 += act_tile[e] * score_col[row_tile][e]   (hardware MAC with col-broadcast)
 //
-// Each score tile has expert scores in column 0 (broadcast to all columns).
-// The reader pre-loads all reduction_dim_size score tiles before signalling compute_scores.
+// The reader pre-loads one score tile per (row tile, expert) before signalling compute_scores: tile
+// r * reduction_dim_size + e holds in column 0 the scores of token rows 32 * r .. 32 * r + 31 for expert e
+// (broadcast to all columns).  An output tile at row tile r is scaled with the r-th group of score tiles.
+// Before this, one tile per expert (rows 0..31) scaled every output row tile, so an input taller than one row
+// tile (tokens > 32) weighted rows 32.. with the scores of rows 0..31.
 // Score tiles are kept resident and accessed by index throughout the loop.
 //
 // Initialization:
@@ -30,15 +33,23 @@ constexpr uint32_t input_granularity = get_compile_time_arg_val(2);
 constexpr uint32_t compute_input_cb_id_0 = get_compile_time_arg_val(3);
 constexpr uint32_t compute_input_cb_id_1 = get_compile_time_arg_val(4);
 constexpr uint32_t compute_output_cb_id = get_compile_time_arg_val(5);
+// Output tile ids handled by this core: start_tile (runtime arg 0), then every num_cores-th tile.  A tile's row
+// tile within its [.., tokens, hidden] slab is (tile_id / Wt) % Ht.
+constexpr uint32_t num_cores_to_be_used = get_compile_time_arg_val(6);
+constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(7);
+constexpr uint32_t num_row_tiles = get_compile_time_arg_val(8);
 
 void kernel_main() {
     CircularBuffer cb_in0(compute_input_cb_id_0);
     CircularBuffer cb_in1(compute_input_cb_id_1);
     CircularBuffer cb_out(compute_output_cb_id);
 
+    const uint32_t start_tile = get_arg_val<uint32_t>(0);
+
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t one_tile = 1;
     constexpr uint32_t num_input_tiles_iter = reduction_dim_size / input_granularity;
+    constexpr uint32_t num_score_tiles = num_row_tiles * reduction_dim_size;
 
     // Full PACK + UNPACK + hw_configure init for ELWMUL + COL-broadcast
     compute_kernel_hw_startup(compute_input_cb_id_0, compute_input_cb_id_1, compute_output_cb_id);
@@ -53,8 +64,11 @@ void kernel_main() {
 
     // Wait for all score tiles — they are pre-loaded once by the reader prologue
     // and remain resident for the entire kernel invocation.
-    cb_in1.wait_front(reduction_dim_size);
+    cb_in1.wait_front(num_score_tiles);
+    uint32_t tile_id = start_tile;
     for (uint32_t i = 0; i < num_output_tiles; ++i) {
+        const uint32_t row_tile = (tile_id / input_tensor_Wt) % num_row_tiles;
+        const uint32_t score_tile_base = row_tile * reduction_dim_size;
         tile_regs_acquire();
 
         for (uint32_t j = 0; j < num_input_tiles_iter; ++j) {
@@ -63,8 +77,9 @@ void kernel_main() {
             for (uint32_t k = 0; k < input_granularity; ++k) {
                 // expert_tile = linear expert index for this tile
                 const uint32_t expert_tile = j * input_granularity + k;
-                // dst0 += act_tile[k] * score_col[expert_tile]  (single MAC)
-                mul_tiles_bcast_cols(compute_input_cb_id_0, compute_input_cb_id_1, k, expert_tile, dst0);
+                // dst0 += act_tile[k] * score_col[row_tile][expert_tile]  (single MAC)
+                mul_tiles_bcast_cols(
+                    compute_input_cb_id_0, compute_input_cb_id_1, k, score_tile_base + expert_tile, dst0);
             }
             cb_in0.pop_front(input_granularity);
         }
@@ -76,8 +91,9 @@ void kernel_main() {
         pack_tile(dst0, compute_output_cb_id);
         tile_regs_release();
         cb_out.push_back(one_tile);
+        tile_id += num_cores_to_be_used;
     }
 
     // Release all score tiles
-    cb_in1.pop_front(reduction_dim_size);
+    cb_in1.pop_front(num_score_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_compute.cpp
@@ -10,8 +10,6 @@
 // The reader pre-loads one score tile per (row tile, expert) before signalling compute_scores: tile
 // r * reduction_dim_size + e holds in column 0 the scores of token rows 32 * r .. 32 * r + 31 for expert e
 // (broadcast to all columns).  An output tile at row tile r is scaled with the r-th group of score tiles.
-// Before this, one tile per expert (rows 0..31) scaled every output row tile, so an input taller than one row
-// tile (tokens > 32) weighted rows 32.. with the scores of rows 0..31.
 // Score tiles are kept resident and accessed by index throughout the loop.
 //
 // Initialization:
@@ -44,8 +42,6 @@ void kernel_main() {
     CircularBuffer cb_in1(compute_input_cb_id_1);
     CircularBuffer cb_out(compute_output_cb_id);
 
-    const uint32_t start_tile = get_arg_val<uint32_t>(0);
-
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t one_tile = 1;
     constexpr uint32_t num_input_tiles_iter = reduction_dim_size / input_granularity;
@@ -65,7 +61,7 @@ void kernel_main() {
     // Wait for all score tiles — they are pre-loaded once by the reader prologue
     // and remain resident for the entire kernel invocation.
     cb_in1.wait_front(num_score_tiles);
-    uint32_t tile_id = start_tile;
+    uint32_t tile_id = get_arg_val<uint32_t>(0);  // this core's first output tile id
     for (uint32_t i = 0; i < num_output_tiles; ++i) {
         const uint32_t row_tile = (tile_id / input_tensor_Wt) % num_row_tiles;
         const uint32_t score_tile_base = row_tile * reduction_dim_size;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_reader.cpp
@@ -126,9 +126,15 @@ void kernel_main() {
     // scores layout (ROW_MAJOR): [tokens, 1, seq, reduction_dim_size]
     // One page = one token row of reduction_dim_size BF16 scores (= cb_scores_rm_page_size bytes)
     //
-    // Target: cb_scores holds reduction_dim_size tiles (one per expert e).
-    // Each tile[e]: column 0 contains score[t, e] for token rows t=0..num_tokens-1.
-    //               All other columns = 0 (required by BroadcastType::COL).
+    // Target: cb_scores holds num_row_tiles * reduction_dim_size tiles, one per (row tile r, expert e) at
+    // index r * reduction_dim_size + e.  Tile (r, e): column 0 row j holds score[32 * r + j, e] (zero for the
+    // padding rows past num_tokens in the last row tile).  Only column 0 is written; BroadcastType::COL reads
+    // column 0 alone.
+    //
+    // A single tile per expert (rows 0..31) used to be built for every token, so an input taller than one row
+    // tile (tokens > 32) had every output row tile weighted with the scores of rows 0..31, and rows past 31
+    // were written past the tile (into the next expert's tile and past the CB).  One tile per (row tile,
+    // expert) gives every output row its own score; the compute kernel picks the tile by the output tile's row.
     //
     // BF16 32x32 tile face layout (4 faces, each 16x16):
     //   Face 0 (rows  0-15, cols  0-15): base offset 0   (uint16 index)
@@ -136,10 +142,11 @@ void kernel_main() {
     //   Face 2 (rows 16-31, cols  0-15): base offset 512
     //   Face 3 (rows 16-31, cols 16-31): base offset 768
     // Within a face, element at (row r, col c): index = r * 16 + c
-    // So column-0 of row t:
-    //   t < 16  → face 0 → uint16 index: t * 16
-    //   t >= 16 → face 2 → uint16 index: 512 + (t-16) * 16
+    // So column-0 of row j within the tile:
+    //   j < 16  → face 0 → uint16 index: j * 16
+    //   j >= 16 → face 2 → uint16 index: 512 + (j-16) * 16
     ////////////////////////////////////////////////////////////////////////////
+    constexpr uint32_t num_row_tiles = num_tokens_x32 / 32;
 
     // Step 1: Read all token rows from DRAM into scratch staging buffer
     cb_scores_rm.reserve_back(num_tokens);
@@ -155,7 +162,7 @@ void kernel_main() {
     noc.async_read_barrier();
 
     // Step 2: Permute and to_layout scores; rm [token][expert] in uint16 units, row stride = reduction_dim_size
-    cb_scores.reserve_back(reduction_dim_size);
+    cb_scores.reserve_back(num_row_tiles * reduction_dim_size);
     uint32_t scores_write_ptr = cb_scores.get_write_ptr();
 
     volatile tt_l1_ptr uint16_t* scores_rm_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scores_rm_ptr);
@@ -200,56 +207,31 @@ void kernel_main() {
         }
     };
 
-    // [token][1][s=1][k] -> [k][1][t][s_padded=32]
-    for (uint32_t k = 0; k < reduction_dim_size; ++k) {
-        volatile tt_l1_ptr uint16_t* expert_tile = scores_tile_u16 + k * tile_u16_stride;
-        const bool is_shared_expert = (k >= num_routed_experts);
-
-        // Fill Face 0 (rows 0-15, col 0) for tokens t = 0..15
-        for (uint32_t t = 0; t < 16 && t < num_tokens; ++t) {
-            if (is_shared_expert) {
-                expert_tile[t * 16] = shared_expert_scale_bf16;
-            } else {
-                // score location in RM: t * (cb_scores_rm_page_size / 2) + k
-                const uint16_t score = scores_rm_u16[t * (cb_scores_rm_page_size / 2) + k];
-                expert_tile[t * 16] = compute_on_axis(t, k) ? score : bf16_zero;
-            }
-        }
-        // Fill Face 2 (rows 16-31, col 0) for tokens t = 16..num_tokens-1
-        if (num_tokens > 16) {
-            for (uint32_t t = 16; t < num_tokens; ++t) {
-                if (is_shared_expert) {
-                    expert_tile[face2_offset + (t - 16) * 16] = shared_expert_scale_bf16;
+    // [token][1][s=1][k] -> [row tile][k][1][j][s_padded=32]
+    for (uint32_t r = 0; r < num_row_tiles; ++r) {
+        for (uint32_t k = 0; k < reduction_dim_size; ++k) {
+            volatile tt_l1_ptr uint16_t* expert_tile = scores_tile_u16 + (r * reduction_dim_size + k) * tile_u16_stride;
+            const bool is_shared_expert = (k >= num_routed_experts);
+            for (uint32_t j = 0; j < 32; ++j) {
+                const uint32_t t = r * 32 + j;
+                // Column 0 of row j: face 0 for j < 16, face 2 for j >= 16.
+                const uint32_t col0_index = (j < 16) ? j * 16 : face2_offset + (j - 16) * 16;
+                if (t >= num_tokens) {
+                    // Padding rows past the last token: BF16 +0.0 (bit pattern 0x0000).
+                    expert_tile[col0_index] = bf16_zero;
+                } else if (is_shared_expert) {
+                    expert_tile[col0_index] = shared_expert_scale_bf16;
                 } else {
+                    // score location in RM: t * (cb_scores_rm_page_size / 2) + k
                     const uint16_t score = scores_rm_u16[t * (cb_scores_rm_page_size / 2) + k];
-                    expert_tile[face2_offset + (t - 16) * 16] = compute_on_axis(t, k) ? score : bf16_zero;
+                    expert_tile[col0_index] = compute_on_axis(t, k) ? score : bf16_zero;
                 }
-            }
-        }
-    }
-    if ((num_tokens < num_tokens_x32) && (num_tokens < 16)) {
-        // Fill remaining Face 0 with BF16 +0.0 (bit pattern 0x0000).
-        for (uint32_t k = 0; k < reduction_dim_size; ++k) {
-            volatile tt_l1_ptr uint16_t* expert_tile = scores_tile_u16 + k * tile_u16_stride;
-            for (uint32_t t = num_tokens; t < 16; ++t) {
-                expert_tile[t * 16] = bf16_zero;
-            }
-        }
-    }
-    if (num_tokens < num_tokens_x32) {
-        // Fill remaining Face 2 with BF16 +0.0. Clamp the start to 16 so that the
-        // (t - 16) row offset cannot underflow for num_tokens < 16 cases.
-        const uint32_t face_2_start = num_tokens < 16 ? 16 : num_tokens;
-        for (uint32_t k = 0; k < reduction_dim_size; ++k) {
-            volatile tt_l1_ptr uint16_t* expert_tile = scores_tile_u16 + k * tile_u16_stride;
-            for (uint32_t t = face_2_start; t < 32; ++t) {
-                expert_tile[face2_offset + (t - 16) * 16] = bf16_zero;
             }
         }
     }
 
     // Step 3: Release scores to compute kernel
-    cb_scores.push_back(reduction_dim_size);
+    cb_scores.push_back(num_row_tiles * reduction_dim_size);
     cb_scores_rm.push_back(num_tokens);
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_reader.cpp
@@ -42,6 +42,7 @@ constexpr uint16_t shared_expert_scale_bf16 = static_cast<uint16_t>(get_compile_
 constexpr uint32_t num_routed_experts = reduction_dim_size - num_shared_experts;
 
 constexpr uint32_t face2_offset = 512;  // face 2 starts 512 elements into tile
+constexpr uint32_t tile_height = 32;
 
 // TensorAccessor CT args, chained:
 //   activation @ 27, scores @ next, expert_indices @ next, expert_mapping @ next.
@@ -129,12 +130,7 @@ void kernel_main() {
     // Target: cb_scores holds num_row_tiles * reduction_dim_size tiles, one per (row tile r, expert e) at
     // index r * reduction_dim_size + e.  Tile (r, e): column 0 row j holds score[32 * r + j, e] (zero for the
     // padding rows past num_tokens in the last row tile).  Only column 0 is written; BroadcastType::COL reads
-    // column 0 alone.
-    //
-    // A single tile per expert (rows 0..31) used to be built for every token, so an input taller than one row
-    // tile (tokens > 32) had every output row tile weighted with the scores of rows 0..31, and rows past 31
-    // were written past the tile (into the next expert's tile and past the CB).  One tile per (row tile,
-    // expert) gives every output row its own score; the compute kernel picks the tile by the output tile's row.
+    // column 0 alone.  The compute kernel picks the tile by the output tile's row tile.
     //
     // BF16 32x32 tile face layout (4 faces, each 16x16):
     //   Face 0 (rows  0-15, cols  0-15): base offset 0   (uint16 index)
@@ -146,7 +142,7 @@ void kernel_main() {
     //   j < 16  → face 0 → uint16 index: j * 16
     //   j >= 16 → face 2 → uint16 index: 512 + (j-16) * 16
     ////////////////////////////////////////////////////////////////////////////
-    constexpr uint32_t num_row_tiles = num_tokens_x32 / 32;
+    constexpr uint32_t num_row_tiles = num_tokens_x32 / tile_height;
 
     // Step 1: Read all token rows from DRAM into scratch staging buffer
     cb_scores_rm.reserve_back(num_tokens);
@@ -212,8 +208,8 @@ void kernel_main() {
         for (uint32_t k = 0; k < reduction_dim_size; ++k) {
             volatile tt_l1_ptr uint16_t* expert_tile = scores_tile_u16 + (r * reduction_dim_size + k) * tile_u16_stride;
             const bool is_shared_expert = (k >= num_routed_experts);
-            for (uint32_t j = 0; j < 32; ++j) {
-                const uint32_t t = r * 32 + j;
+            for (uint32_t j = 0; j < tile_height; ++j) {
+                const uint32_t t = r * tile_height + j;
                 // Column 0 of row j: face 0 for j < 16, face 2 for j >= 16.
                 const uint32_t col0_index = (j < 16) ? j * 16 : face2_offset + (j - 16) * 16;
                 if (t >= num_tokens) {


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #55995.

`deepseek_moe_fast_reduce_nc_fused` built one score tile per expert from token rows 0..31 and the compute kernel scaled every output tile with it, so an activation input taller than one row tile (tokens > 32) had rows 32.. weighted with the scores of rows 0..31. The reader's fill for those rows also ran past the tile. The device operation admits the shape, and the docstring states no token bound.

The reader now builds `num_row_tiles x reduction_dim_size` score tiles: tile `r * K + e` holds in column 0 the scores of token rows `32r .. 32r+31` for expert `e`, zero for the padding rows of the last row tile, the shared-expert scale for shared slots, with the on-axis gating unchanged. The compute kernel derives each output tile's row tile from its tile id (`(tile_id / Wt) % Ht`; the core's first tile id is a runtime arg, `num_cores` / `Wt` / `Ht` are compile-time args) and scales with that group. The program factory sizes the score CB to match. The validation message now says what the range check means (one score row per input row, the padded rows of the last row tile excepted).

For inputs of at most 32 rows (`num_row_tiles == 1`) the CB contents, the tile indices and the per-element MAC order are identical to before, so existing users are bitwise unchanged. The per-element MAC order is unchanged for taller inputs as well, so a T-row reduce equals the per-32-row-slice reduce bitwise. Score CB L1 grows by `(Ht - 1) * K * 2 KB` per core for taller inputs (60 KB at 128 rows, K = 10).

**Test**

New `tests/ttnn/unit_tests/operations/experimental/deepseek/test_deepseek_moe_fast_reduce_nc_fused_row_tiles.py` (single device; 32, 40, 64, 100 and 128 tokens, so the partial last row tile is covered): every row-tile slice against a torch reference with per-token scores, and the T-row result against the per-row-tile results bitwise. On Blackhole p150 the test fails on the rows past 31 before this change and passes after it (run details below). The existing Galaxy test (`models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_deepseek_moe_fast_reduce_nc_fused.py`, 32 tokens per device) covers the unchanged path.

### Notes for reviewers

- Whether you prefer this or a hard rejection of `tokens > 32` is your call; the kernel change is small (four files) and leaves the decode path untouched, which is why it is offered.
- The score CB is single-buffered and resident for the whole kernel, as before; the only new memory is the extra score tiles.
- Columns 1..31 of the score tiles are still not written (unchanged); `BroadcastType::COL` reads column 0 of faces 0 and 2.
- No upper bound on tokens is added: a very tall input fails at CB allocation rather than with a host message. Say if you want a bound.

### Verification

Blackhole p150 (one device of a 4x p150 box), the new test run from the same tree against two builds of these sources:

| build | tokens=32 | tokens=64 | tokens=96 | tokens=128 |
| --- | --- | --- | --- | --- |
| before this change (`d04395ed86` kernels) | pass | fail, rows 32..63 PCC 0.757 | fail | fail |
| with this change | pass | pass (bitwise vs the two 32-row reduces) | pass | pass |

A second run with the review follow-ups (40 and 100 tokens added) passes 5/5. The `tokens=32` case is unchanged, as expected. On the same hardware the model that hit this (128-token MoE prefill chunks, K = 10) went from rows 32.. matching the host sum with the scores of row `t mod 32` to bitwise equality with four consecutive 32-token reduces.

**Multi-device (Wormhole Galaxy, 32 devices, this branch built at `168e096a3c3`):**

- The op's own test, `models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_deepseek_moe_fast_reduce_nc_fused.py` (4x8 mesh, `MESH_DEVICE=TG`, both cluster axes, batch 32 / 8 / 3 / 1 per device, no shared / 1 shared / 2 shared experts): 24 passed, 0 failed.
- The production caller, `models/common/tests/modules/moe/test_tt_moe_decode.py` (8x4 ring, `USE_TORUS_MODE=1`, three iterations per config): deepseek_ocr, deepseek_v3_single_glx, gemma_4_26b, glm_47, gpt_oss and qwen3_235b passed; the 16x4 / 16x8 configs and the three known-failure configs skipped by the test's own rules; 0 failed.

**CI on this branch:** Tier 1 DeepSeek-V3 unit tests https://github.com/tenstorrent/tt-metal/actions/runs/34537732755 (green); sanity https://github.com/tenstorrent/tt-metal/actions/runs/34537735468 (the three fused-group jobs exceed their step budget with zero test failures, as they do on other PR branches; the DeepSeek V3 Galaxy job's device timeout is in the decoder block, which uses the unfused reduce and none of the files in this PR, and passed on another branch's run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
