### PR TITLE
[Cleanup] LLK single-device tests modernization

### DIFF
--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -99,6 +99,7 @@ protected:
         AnyDispatchMeshDeviceFixture(l1_small_size, trace_region_size) {}
 };
 
+// Opens exactly one MMIO chip as a unit MeshDevice.
 class AnyDispatchMeshDeviceSingleCardFixture : public MeshDispatchFixture {
 protected:
     static void SetUpTestSuite() {}
@@ -122,11 +123,8 @@ protected:
     virtual size_t num_command_queues() const { return 1; }
 
     virtual void create_devices() {
-        std::vector<ChipId> ids;
-        for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids()) {
-            ids.push_back(id);
-        }
-        create_devices(ids);
+        const ChipId mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
+        create_devices({mmio_device_id});
     }
 
     void create_devices(const std::vector<ChipId>& ids) {
@@ -141,6 +139,9 @@ protected:
 
     std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
     std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> id_to_device_;
+
+public:
+    distributed::MeshDevice& device() { return *devices_.front(); }
 };
 
 // Same as MeshDeviceSingleCardFixture but remove the check for slow dispatch mode
@@ -168,29 +169,11 @@ protected:
 class MeshDeviceSingleCardBufferFixture : public MeshDeviceSingleCardFixture {};
 
 // Single unit-mesh fixture: always owns exactly one unit MeshDevice.
-class UnitMeshAnyDispatchFixture : public AnyDispatchMeshDeviceSingleCardFixture {
-public:
-    distributed::MeshDevice& device() { return *devices_.front(); }
-
-protected:
-    void create_devices() override {
-        const ChipId mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
-        AnyDispatchMeshDeviceSingleCardFixture::create_devices({mmio_device_id});
-    }
-};
+class UnitMeshAnyDispatchFixture : public AnyDispatchMeshDeviceSingleCardFixture {};
 
 // Single unit-mesh fixture: always owns exactly one unit MeshDevice.
 // Requires slow dispatch mode.
-class UnitMeshFixture : public MeshDeviceSingleCardFixture {
-public:
-    distributed::MeshDevice& device() { return *devices_.front(); }
-
-protected:
-    void create_devices() override {
-        const ChipId mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
-        AnyDispatchMeshDeviceSingleCardFixture::create_devices({mmio_device_id});
-    }
-};
+class UnitMeshFixture : public MeshDeviceSingleCardFixture {};
 
 class BlackholeSingleCardFixture : public MeshDeviceSingleCardFixture {
 protected:

--- a/tests/tt_metal/tt_metal/llk/llk_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/llk/llk_device_fixture.hpp
@@ -29,8 +29,8 @@ namespace tt::tt_metal {
 namespace detail {
 
 // Per-fixture-chain shared MeshDevice state. Two distinct instances exist across
-// the file — one for LLKMeshDeviceFixture (all chips), one for
-// LLKMeshDeviceSingleCardFixture (MMIO chips only). Derived variants
+// the file — one for LLKMeshDeviceFixture (up to two MMIO chips), one for
+// LLKMeshDeviceSingleCardFixture (one MMIO chip). Derived variants
 // (LLKMeshDeviceFixtureSlowDispatchOnly, LLKBlackholeSingleCardFixture,
 // LLKQuasarMeshDeviceSingleCardFixture) inherit shared_state() without
 // overriding it, so they reuse their base class's handles.
@@ -172,9 +172,8 @@ protected:
         if (s.initialized) {
             return;
         }
-        const auto& mmio = tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids();
-        std::vector<ChipId> ids(mmio.begin(), mmio.end());
-        detail::populate_shared_state(s, ids);
+        const ChipId mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
+        detail::populate_shared_state(s, {mmio_device_id});
     }
 
     // Per-suite cleanup; keep the static shared state empty at process shutdown.

--- a/tests/tt_metal/tt_metal/llk/llk_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/llk/llk_device_fixture.hpp
@@ -156,6 +156,9 @@ protected:
 };
 
 class LLKMeshDeviceSingleCardFixture : public MeshDeviceSingleCardFixture {
+public:
+    distributed::MeshDevice& device() { return *devices_.front(); }
+
 protected:
     template <class F>
     friend void detail::apply_shared_state(F&, const detail::LLKSharedDevices&);

--- a/tests/tt_metal/tt_metal/llk/single_core_compute_runners.hpp
+++ b/tests/tt_metal/tt_metal/llk/single_core_compute_runners.hpp
@@ -15,12 +15,12 @@
 #include <string>
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal::unit_tests::llk::single_core {
 
@@ -38,26 +38,20 @@ inline vector<std::uint32_t> run_unary(
     bool fp32_dest_acc_en,
     const std::string& compute_kernel,
     std::uint32_t cb_depth_tiles = 1) {
-    IDevice* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
     CoreCoord core = {0, 0};
 
     std::uint32_t input_tile_size = tt::tile_size(input_fmt);
     std::uint32_t output_tile_size = tt::tile_size(output_fmt);
 
-    InterleavedBufferConfig src_config{
-        .device = dev,
-        .size = num_tiles * input_tile_size,
-        .page_size = num_tiles * input_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto src_buffer = CreateBuffer(src_config);
-
-    InterleavedBufferConfig dst_config{
-        .device = dev,
-        .size = num_tiles * output_tile_size,
-        .page_size = num_tiles * output_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto dst_buffer = CreateBuffer(dst_config);
+    auto src_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * input_tile_size},
+        {.page_size = num_tiles * input_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
+    auto dst_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * output_tile_size},
+        {.page_size = num_tiles * output_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
 
     CircularBufferConfig cb_src_config =
         CircularBufferConfig(cb_depth_tiles * input_tile_size, {{tt::CBIndex::c_0, input_fmt}})
@@ -87,20 +81,15 @@ inline vector<std::uint32_t> run_unary(
         core,
         ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {num_tiles}});
 
-    detail::WriteToBuffer(src_buffer, src_vec);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, /*blocking=*/true);
     SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
     SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles});
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     vector<std::uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
     return result_vec;
 }
 
@@ -119,26 +108,20 @@ inline vector<std::uint32_t> run_unary_tiled(
     bool fp32_dest_acc_en,
     const std::string& compute_kernel,
     std::uint32_t cb_depth_tiles) {
-    IDevice* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
     CoreCoord core = {0, 0};
 
     const std::uint32_t input_tile_size = tile.get_tile_size(input_fmt);
     const std::uint32_t output_tile_size = tile.get_tile_size(output_fmt);
 
-    InterleavedBufferConfig src_config{
-        .device = dev,
-        .size = num_tiles * input_tile_size,
-        .page_size = num_tiles * input_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto src_buffer = CreateBuffer(src_config);
-
-    InterleavedBufferConfig dst_config{
-        .device = dev,
-        .size = num_tiles * output_tile_size,
-        .page_size = num_tiles * output_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto dst_buffer = CreateBuffer(dst_config);
+    auto src_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * input_tile_size},
+        {.page_size = num_tiles * input_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
+    auto dst_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * output_tile_size},
+        {.page_size = num_tiles * output_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
 
     CircularBufferConfig cb_src_config =
         CircularBufferConfig(cb_depth_tiles * input_tile_size, {{tt::CBIndex::c_0, input_fmt}})
@@ -170,20 +153,15 @@ inline vector<std::uint32_t> run_unary_tiled(
         core,
         ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {num_tiles}});
 
-    detail::WriteToBuffer(src_buffer, src_vec);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, /*blocking=*/true);
     SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
     SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles});
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     vector<std::uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
     return result_vec;
 }
 
@@ -206,7 +184,6 @@ inline vector<std::uint32_t> run_binary(
     if (out_tiles == 0) {
         out_tiles = num_tiles;
     }
-    IDevice* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
     CoreCoord core = {0, 0};
 
@@ -214,12 +191,11 @@ inline vector<std::uint32_t> run_binary(
     std::uint32_t tile_bytes = tt::tile_size(fmt);
 
     auto make_dram = [&](std::uint32_t ntiles) {
-        InterleavedBufferConfig cfg{
-            .device = dev,
-            .size = ntiles * tile_bytes,
-            .page_size = ntiles * tile_bytes,
-            .buffer_type = BufferType::DRAM};
-        return CreateBuffer(cfg);
+        const std::uint32_t size = ntiles * tile_bytes;
+        return distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = size},
+            {.page_size = size, .buffer_type = BufferType::DRAM},
+            &mesh_device);
     };
     auto src0_buffer = make_dram(num_tiles);
     auto src1_buffer = make_dram(num_tiles);
@@ -254,24 +230,19 @@ inline vector<std::uint32_t> run_binary(
         core,
         ComputeConfig{.fp32_dest_acc_en = false, .compile_args = compile_args, .defines = compute_defines});
 
-    detail::WriteToBuffer(src0_buffer, src0_vec);
-    detail::WriteToBuffer(src1_buffer, src1_vec);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src0_buffer, src0_vec, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, src1_buffer, src1_vec, /*blocking=*/true);
     SetRuntimeArgs(program, reader, core, {src0_buffer->address(), 0, src1_buffer->address(), 0, num_tiles});
     SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, out_tiles});
     // Shipping eltwise_binary.cpp reads runtime args {per_core_block_cnt, per_core_block_size, acc_to_dst};
     // the id-free kernels read only compile-time num_tiles and ignore these (harmless). One tile per block.
     SetRuntimeArgs(program, compute, core, {num_tiles, 1, 0});
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     vector<std::uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
     return result_vec;
 }
 
@@ -281,7 +252,6 @@ inline vector<std::uint32_t> run_matmul_single(
     const vector<std::uint32_t>& src0_vec,
     const vector<std::uint32_t>& src1_vec,
     const std::string& compute_kernel) {
-    IDevice* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
     CoreCoord core = {0, 0};
 
@@ -289,9 +259,10 @@ inline vector<std::uint32_t> run_matmul_single(
     std::uint32_t tile_bytes = tt::tile_size(fmt);
 
     auto make_dram = [&]() {
-        InterleavedBufferConfig cfg{
-            .device = dev, .size = tile_bytes, .page_size = tile_bytes, .buffer_type = BufferType::DRAM};
-        return CreateBuffer(cfg);
+        return distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = tile_bytes},
+            {.page_size = tile_bytes, .buffer_type = BufferType::DRAM},
+            &mesh_device);
     };
     auto src0_buffer = make_dram();
     auto src1_buffer = make_dram();
@@ -321,21 +292,16 @@ inline vector<std::uint32_t> run_matmul_single(
     CreateKernel(
         program, compute_kernel, core, ComputeConfig{.fp32_dest_acc_en = false, .compile_args = {1, 1, 1, 1, 1, 1, 1}});
 
-    detail::WriteToBuffer(src0_buffer, src0_vec);
-    detail::WriteToBuffer(src1_buffer, src1_vec);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src0_buffer, src0_vec, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, src1_buffer, src1_vec, /*blocking=*/true);
     SetRuntimeArgs(program, reader, core, {src0_buffer->address(), 0, src1_buffer->address(), 0, 1});
     SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, 1});
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     vector<std::uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
     return result_vec;
 }
 
@@ -350,7 +316,6 @@ inline vector<std::uint32_t> run_matmul_block(
     std::uint32_t rt_dim,
     std::uint32_t kt_dim,
     const std::string& compute_kernel) {
-    IDevice* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
     CoreCoord core = {0, 0};
 
@@ -364,9 +329,11 @@ inline vector<std::uint32_t> run_matmul_block(
     TT_FATAL(in0_tiles == in1_tiles, "run_matmul_block: reader_binary needs in0_tiles == in1_tiles (rt==ct)");
 
     auto make_dram = [&](std::uint32_t n) {
-        InterleavedBufferConfig cfg{
-            .device = dev, .size = n * tile_bytes, .page_size = n * tile_bytes, .buffer_type = BufferType::DRAM};
-        return CreateBuffer(cfg);
+        const std::uint32_t size = n * tile_bytes;
+        return distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = size},
+            {.page_size = size, .buffer_type = BufferType::DRAM},
+            &mesh_device);
     };
     auto src0_buffer = make_dram(in0_tiles);
     auto src1_buffer = make_dram(in1_tiles);
@@ -398,21 +365,16 @@ inline vector<std::uint32_t> run_matmul_block(
         core,
         ComputeConfig{.fp32_dest_acc_en = false, .compile_args = {ct_dim, rt_dim, kt_dim}});
 
-    detail::WriteToBuffer(src0_buffer, src0_vec);
-    detail::WriteToBuffer(src1_buffer, src1_vec);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src0_buffer, src0_vec, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, src1_buffer, src1_vec, /*blocking=*/true);
     SetRuntimeArgs(program, reader, core, {src0_buffer->address(), 0, src1_buffer->address(), 0, in0_tiles});
     SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, out_tiles});
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     vector<std::uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
     return result_vec;
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -40,10 +40,6 @@
 #include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
-
-namespace tt::tt_metal {
 
 using std::map;
 using namespace tt;
@@ -267,9 +263,7 @@ void run_single_core_broadcast(distributed::MeshDevice& mesh_device, const Broad
     auto dst_dram_buffer = CreateDramBufferForPageSize(mesh_device, single_tile_size, k_num_tiles_broadcast_test);
     std::uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
-    auto* device = mesh_device.get_devices().empty() ? nullptr : mesh_device.get_devices().front();
-    TT_FATAL(device != nullptr, "mesh_device has no backing devices");
-    const bool is_quasar = device->arch() == ARCH::QUASAR;
+    const bool is_quasar = mesh_device.arch() == ARCH::QUASAR;
 
     std::map<std::string, std::string> defines = {
         {"BCAST_LLKOP", eltwise_op_to_type.at(test_config.eltwise_op)},
@@ -1009,15 +1003,15 @@ void expect_bcast_mul_matches_golden(distributed::MeshDevice& md, BroadcastDim d
 }  // namespace
 
 TEST_F(LLKBlackholeSingleCardFixture, TensixBcastMulRowsIdFreeGolden) {
-    expect_bcast_mul_matches_golden(*this->devices_.at(0), BroadcastDim::ROW);
+    expect_bcast_mul_matches_golden(this->device(), BroadcastDim::ROW);
 }
 
 TEST_F(LLKBlackholeSingleCardFixture, TensixBcastMulColsIdFreeGolden) {
-    expect_bcast_mul_matches_golden(*this->devices_.at(0), BroadcastDim::COL);
+    expect_bcast_mul_matches_golden(this->device(), BroadcastDim::COL);
 }
 
 TEST_F(LLKBlackholeSingleCardFixture, TensixBcastMulScalarIdFreeGolden) {
-    expect_bcast_mul_matches_golden(*this->devices_.at(0), BroadcastDim::SCALAR);
+    expect_bcast_mul_matches_golden(this->device(), BroadcastDim::SCALAR);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -37,10 +37,6 @@
 #include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
-
-namespace tt::tt_metal {
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
@@ -35,10 +35,6 @@
 #include <umd/device/types/arch.hpp>
 
 namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
-
-namespace tt::tt_metal {
 
 using namespace tt;
 using namespace tt::test_utils;

--- a/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
@@ -35,10 +35,6 @@
 #include <tt-metalium/tt_metal.hpp>
 
 namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
-
-namespace tt::tt_metal {
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt_stl/span.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "llk_device_fixture.hpp"
@@ -107,14 +108,7 @@ static vector<std::uint32_t> run_fp8_typecast(
     SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
     SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles});
 
-    // Wrap the program into a MeshWorkload so we can dispatch via the mesh command queue.
-    // This path works under both fast dispatch and slow dispatch, unlike detail::LaunchProgram.
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     vector<std::uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
@@ -258,53 +252,53 @@ using namespace unit_tests::llk::fp8_typecast;
 // ============================================================================
 // Legacy CB-id datacopy API — pre-existing fp8 typecast coverage (#40287), validated against a host golden.
 // ============================================================================
-TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFloat16b) { case_fp8_to_bf16(*devices_[0], kLegacyKernel); }
-TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFp8e4m3) { case_bf16_to_fp8(*devices_[0], kLegacyKernel); }
-TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToBfp8b) { case_fp8_to_bfp8(*devices_[0], kLegacyKernel); }
-TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToFp8e4m3) { case_bfp8_to_fp8(*devices_[0], kLegacyKernel); }
+TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFloat16b) { case_fp8_to_bf16(this->device(), kLegacyKernel); }
+TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFp8e4m3) { case_bf16_to_fp8(this->device(), kLegacyKernel); }
+TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToBfp8b) { case_fp8_to_bfp8(this->device(), kLegacyKernel); }
+TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToFp8e4m3) { case_bfp8_to_fp8(this->device(), kLegacyKernel); }
 TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToBfp8b) {
-    case_bfp8_to_bfp8(*devices_[0], kLegacyKernel, /*fp32_dest_acc_en=*/false);
+    case_bfp8_to_bfp8(this->device(), kLegacyKernel, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToBfp8bFp32Dest) {
-    case_bfp8_to_bfp8(*devices_[0], kLegacyKernel, /*fp32_dest_acc_en=*/true);
+    case_bfp8_to_bfp8(this->device(), kLegacyKernel, /*fp32_dest_acc_en=*/true);
 }
-TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFp8e4m3) { case_fp8_to_fp8(*devices_[0], kLegacyKernel); }
+TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFp8e4m3) { case_fp8_to_fp8(this->device(), kLegacyKernel); }
 TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFloat16b) {
-    case_bf16_to_bf16(*devices_[0], kLegacyKernel, /*fp32_dest_acc_en=*/false);
+    case_bf16_to_bf16(this->device(), kLegacyKernel, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFloat16bFp32Dest) {
-    case_bf16_to_bf16(*devices_[0], kLegacyKernel, /*fp32_dest_acc_en=*/true);
+    case_bf16_to_bf16(this->device(), kLegacyKernel, /*fp32_dest_acc_en=*/true);
 }
 
 // ============================================================================
 // Id-free (2.0) datacopy API — same cases/golden as above, exercising the LLKOperand kernel.
 // ============================================================================
 TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFloat16bIdFreeGolden) {
-    case_fp8_to_bf16(*devices_[0], kComputeKernel);
+    case_fp8_to_bf16(this->device(), kComputeKernel);
 }
 TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFp8e4m3IdFreeGolden) {
-    case_bf16_to_fp8(*devices_[0], kComputeKernel);
+    case_bf16_to_fp8(this->device(), kComputeKernel);
 }
 TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToBfp8bIdFreeGolden) {
-    case_fp8_to_bfp8(*devices_[0], kComputeKernel);
+    case_fp8_to_bfp8(this->device(), kComputeKernel);
 }
 TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToFp8e4m3IdFreeGolden) {
-    case_bfp8_to_fp8(*devices_[0], kComputeKernel);
+    case_bfp8_to_fp8(this->device(), kComputeKernel);
 }
 TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToBfp8bIdFreeGolden) {
-    case_bfp8_to_bfp8(*devices_[0], kComputeKernel, /*fp32_dest_acc_en=*/false);
+    case_bfp8_to_bfp8(this->device(), kComputeKernel, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToBfp8bFp32DestIdFreeGolden) {
-    case_bfp8_to_bfp8(*devices_[0], kComputeKernel, /*fp32_dest_acc_en=*/true);
+    case_bfp8_to_bfp8(this->device(), kComputeKernel, /*fp32_dest_acc_en=*/true);
 }
 TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFp8e4m3IdFreeGolden) {
-    case_fp8_to_fp8(*devices_[0], kComputeKernel);
+    case_fp8_to_fp8(this->device(), kComputeKernel);
 }
 TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFloat16bIdFreeGolden) {
-    case_bf16_to_bf16(*devices_[0], kComputeKernel, /*fp32_dest_acc_en=*/false);
+    case_bf16_to_bf16(this->device(), kComputeKernel, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFloat16bFp32DestIdFreeGolden) {
-    case_bf16_to_bf16(*devices_[0], kComputeKernel, /*fp32_dest_acc_en=*/true);
+    case_bf16_to_bf16(this->device(), kComputeKernel, /*fp32_dest_acc_en=*/true);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -23,6 +23,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/arch.hpp>
@@ -144,14 +145,7 @@ bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulR
     distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, packed_input0, /*blocking=*/true);
     distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, packed_input1, /*blocking=*/true);
 
-    // Wrap the program into a MeshWorkload and dispatch via the mesh command queue.
-    // This path works under both fast dispatch and slow dispatch, unlike detail::LaunchProgram.
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
@@ -195,9 +189,8 @@ class MulReduceScalarTest : public LLKMeshDeviceSingleCardFixture, public testin
 
 // Standard 32x32-tile suite parametrized by tile count.
 TEST_P(MulReduceScalarTest, MulReduceScalar) {
-    auto& mesh_device = *devices_[0];
     int num_tiles = GetParam();
-    ASSERT_TRUE(run_mul_reduce_scalar_test(mesh_device, {.num_tiles = num_tiles, .tile_height = 32}));
+    ASSERT_TRUE(run_mul_reduce_scalar_test(this->device(), {.num_tiles = num_tiles, .tile_height = 32}));
 }
 
 // Instantiate the test suite with different tile counts
@@ -211,9 +204,8 @@ INSTANTIATE_TEST_SUITE_P(
 class MulReduceScalarTinyTileTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<int> {};
 
 TEST_P(MulReduceScalarTinyTileTest, MulReduceScalarTinyTile) {
-    auto& mesh_device = *devices_[0];
     int num_tiles = GetParam();
-    ASSERT_TRUE(run_mul_reduce_scalar_test(mesh_device, {.num_tiles = num_tiles, .tile_height = 16}));
+    ASSERT_TRUE(run_mul_reduce_scalar_test(this->device(), {.num_tiles = num_tiles, .tile_height = 16}));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
@@ -30,10 +30,6 @@
 #include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
-
-namespace tt::tt_metal {
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/llk/test_quasar_mailboxes.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_quasar_mailboxes.cpp
@@ -14,6 +14,8 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "tt_metal/impl/program/program_impl.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -27,19 +29,10 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarMailboxMinimal) {
     // TUs, so nothing enforces this at compile time.
     constexpr std::uint32_t MAILBOX_MIN_EXPECTED_VALUE = 0xfacefaceu;
 
-    auto mesh_device = devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
-    auto& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-
     Program program = CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
 
     auto compute_kernel = experimental::quasar::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_mailbox_minimal_compute.cpp",
         WORKER_CORE,
         experimental::quasar::QuasarComputeConfig{
@@ -48,18 +41,19 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarMailboxMinimal) {
 
     // Kernel (MATH thread) writes the mailbox-read value here; host reads it back after the run.
     // Round up to the L1 allocation alignment, matching the CB API test below.
-    const std::uint32_t l1_alignment = device->allocator()->get_alignment(BufferType::L1);
+    const std::uint32_t l1_alignment = this->device().allocator()->get_alignment(BufferType::L1);
     const std::uint32_t aligned_result_size = (sizeof(std::uint32_t) + l1_alignment - 1) / l1_alignment * l1_alignment;
-    const std::uint32_t result_l1_addr = static_cast<std::uint32_t>(device->l1_size_per_core()) - aligned_result_size;
+    const std::uint32_t result_l1_addr =
+        static_cast<std::uint32_t>(this->device().l1_size_per_core()) - aligned_result_size;
     std::vector<std::uint32_t> result_init(1, 0);
-    detail::WriteToDeviceL1(device, WORKER_CORE, result_l1_addr, result_init);
+    slow_dispatch::WriteToL1(this->device(), WORKER_CORE, result_l1_addr, result_init);
 
-    SetRuntimeArgs(program_, compute_kernel, WORKER_CORE, {result_l1_addr});
+    SetRuntimeArgs(program, compute_kernel, WORKER_CORE, {result_l1_addr});
 
-    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<std::uint32_t> host_buffer;
-    detail::ReadFromDeviceL1(device, WORKER_CORE, result_l1_addr, sizeof(std::uint32_t), host_buffer);
+    slow_dispatch::ReadFromL1(this->device(), WORKER_CORE, result_l1_addr, sizeof(std::uint32_t), host_buffer);
 
     ASSERT_EQ(host_buffer.size(), 1u);
     EXPECT_EQ(host_buffer[0], MAILBOX_MIN_EXPECTED_VALUE);
@@ -87,34 +81,26 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarDmToTriscMailbox) {
     constexpr std::uint32_t DM_MBX_VAL_MATH = 0xC0FFEE02u;
     constexpr std::uint32_t DM_MBX_VAL_PACK = 0xC0FFEE03u;
 
-    auto mesh_device = devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
-    auto& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-
     Program program = CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
 
     const std::vector<std::uint32_t> expected_result = {DM_MBX_VAL_UNPACK, DM_MBX_VAL_MATH, DM_MBX_VAL_PACK};
 
     // Each TRISC thread writes the value it read here; host reads it back after the run.
     // Round up to the L1 allocation alignment, matching the minimal test above.
     const std::uint32_t result_size_bytes = expected_result.size() * sizeof(std::uint32_t);
-    const std::uint32_t l1_alignment = device->allocator()->get_alignment(BufferType::L1);
+    const std::uint32_t l1_alignment = this->device().allocator()->get_alignment(BufferType::L1);
     const std::uint32_t aligned_result_size = (result_size_bytes + l1_alignment - 1) / l1_alignment * l1_alignment;
-    const std::uint32_t result_l1_addr = static_cast<std::uint32_t>(device->l1_size_per_core()) - aligned_result_size;
+    const std::uint32_t result_l1_addr =
+        static_cast<std::uint32_t>(this->device().l1_size_per_core()) - aligned_result_size;
     std::vector<std::uint32_t> result_init(expected_result.size(), 0);
-    detail::WriteToDeviceL1(device, WORKER_CORE, result_l1_addr, result_init);
+    slow_dispatch::WriteToL1(this->device(), WORKER_CORE, result_l1_addr, result_init);
 
     // num_threads_per_cluster = 1: the temp-API DM allocator skips reserved DM0/DM1 (cluster
     // orchestrator / DFB init -- see GetProcessorsPerClusterQuasar) and hands out the lowest free
     // DM core, i.e. DM2. The kernel gates on hartid == 2 so exactly that one core performs the
     // writes.
     experimental::quasar::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_dm_mailbox_scratch_writer.cpp",
         WORKER_CORE,
         experimental::quasar::QuasarDataMovementConfig{
@@ -125,19 +111,19 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarDmToTriscMailbox) {
     // num_threads_per_cluster = 1 places the compute kernel on Tensix engine 0 (NEO0) of the
     // cluster -- the same NEO whose mailboxes the DM kernel writes.
     auto compute_kernel = experimental::quasar::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_dm_mailbox_scratch_compute.cpp",
         WORKER_CORE,
         experimental::quasar::QuasarComputeConfig{
             .num_threads_per_cluster = 1,
         });
 
-    SetRuntimeArgs(program_, compute_kernel, WORKER_CORE, {result_l1_addr});
+    SetRuntimeArgs(program, compute_kernel, WORKER_CORE, {result_l1_addr});
 
-    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<std::uint32_t> host_buffer;
-    detail::ReadFromDeviceL1(device, WORKER_CORE, result_l1_addr, result_size_bytes, host_buffer);
+    slow_dispatch::ReadFromL1(this->device(), WORKER_CORE, result_l1_addr, result_size_bytes, host_buffer);
 
     EXPECT_EQ(host_buffer, expected_result);
 }
@@ -167,21 +153,11 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarCbL1ReadApi) {
     // UNPACK, MATH and PACK each record their own copy; ISOLATE_SFPU does not participate.
     constexpr std::uint32_t CB_API_NUM_READER_THREADS = 3;
 
-    auto mesh_device = devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
-    auto& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program = CreateProgram();
 
     const std::uint32_t tile_page_size = tt::tile_size(CB_API_DATA_FORMAT);
-
-    Program program = CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
-
     const std::uint32_t dfb_id = experimental::dfb::CreateDataflowBuffer(
-        program_,
+        program,
         WORKER_CORE,
         experimental::dfb::DataflowBufferConfig{
             .entry_size = tile_page_size,
@@ -191,7 +167,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarCbL1ReadApi) {
         });
 
     auto compute_kernel = experimental::quasar::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_cb_l1_read_api_compute.cpp",
         WORKER_CORE,
         experimental::quasar::QuasarComputeConfig{
@@ -201,19 +177,19 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarCbL1ReadApi) {
 
     // Bind the compute kernel as both producer and consumer so the DFB config (base_addr,
     // entry_size, ...) is finalized and written to L1; the kernel only reads from it.
-    experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program_, dfb_id, compute_kernel, compute_kernel);
+    experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, dfb_id, compute_kernel, compute_kernel);
 
     // Preload two known tiles into the DFB's L1 ring (single DFB -> ring base is the L1
     // allocator base). Tiles are entry_size apart for this 1-producer/1-consumer layout.
     const std::uint32_t dfb_l1_addr =
-        static_cast<std::uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+        static_cast<std::uint32_t>(this->device().allocator()->get_base_allocator_addr(HalMemType::L1));
     const std::uint32_t words_per_entry = tile_page_size / sizeof(CbApiDataT);
     std::vector<CbApiDataT> ring(2 * words_per_entry, 0);
     ring[0] = CB_API_VAL0;
     ring[1] = CB_API_VAL1;
     ring[words_per_entry + 0] = CB_API_VAL2;
     ring[words_per_entry + 1] = CB_API_VAL3;
-    detail::WriteToDeviceL1(device, WORKER_CORE, dfb_l1_addr, ring);
+    slow_dispatch::WriteToL1(this->device(), WORKER_CORE, dfb_l1_addr, ring);
 
     std::vector<CbApiDataT> expected_result;
     for (std::uint32_t thread = 0; thread < CB_API_NUM_READER_THREADS; ++thread) {
@@ -223,19 +199,20 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarCbL1ReadApi) {
 
     // Each thread writes its reads here; host reads this spot back after the run.
     const std::uint32_t result_size_bytes = expected_result.size() * sizeof(CbApiDataT);
-    const std::uint32_t l1_alignment = device->allocator()->get_alignment(BufferType::L1);
+    const std::uint32_t l1_alignment = this->device().allocator()->get_alignment(BufferType::L1);
     const std::uint32_t aligned_result_size = (result_size_bytes + l1_alignment - 1) / l1_alignment * l1_alignment;
-    const std::uint32_t result_l1_addr = static_cast<std::uint32_t>(device->l1_size_per_core()) - aligned_result_size;
+    const std::uint32_t result_l1_addr =
+        static_cast<std::uint32_t>(this->device().l1_size_per_core()) - aligned_result_size;
 
     std::vector<CbApiDataT> result_init(expected_result.size(), 0);
-    detail::WriteToDeviceL1(device, WORKER_CORE, result_l1_addr, result_init);
+    slow_dispatch::WriteToL1(this->device(), WORKER_CORE, result_l1_addr, result_init);
 
-    SetRuntimeArgs(program_, compute_kernel, WORKER_CORE, {result_l1_addr});
+    SetRuntimeArgs(program, compute_kernel, WORKER_CORE, {result_l1_addr});
 
-    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<CbApiDataT> host_buffer;
-    detail::ReadFromDeviceL1(device, WORKER_CORE, result_l1_addr, result_size_bytes, host_buffer);
+    slow_dispatch::ReadFromL1(this->device(), WORKER_CORE, result_l1_addr, result_size_bytes, host_buffer);
 
     EXPECT_EQ(host_buffer, expected_result);
 }

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -43,10 +43,6 @@
 #include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
-
-namespace tt::tt_metal {
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -12,6 +12,8 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <cmath>
 #include <cstdint>
 #include <functional>
@@ -47,10 +49,6 @@
 #include <tt-metalium/mxfp4.hpp>
 #include <tt-metalium/tile.hpp>
 #include "single_core_compute_runners.hpp"
-
-namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
 
 namespace tt::tt_metal {
 
@@ -297,9 +295,7 @@ static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(
     return tt::tt_metal::TensorSpec(tt::tt_metal::Shape{total_entries, entry_size_words}, tensor_layout);
 }
 
-void run_single_core_reduce_program(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const ReduceConfig& test_config) {
-    auto& cq = mesh_device->mesh_command_queue();
+void run_single_core_reduce_program(distributed::MeshDevice& mesh_device, const ReduceConfig& test_config) {
     const experimental::NodeCoord node{0, 0};
 
     const ReduceDims dims = compute_and_validate_reduce_dims(test_config);
@@ -318,9 +314,9 @@ void run_single_core_reduce_program(
     const std::uint32_t num_input_pages = dims.dram_buffer_size / dims.single_tile_bytes;
     const std::uint32_t num_output_pages = dims.output_size_bytes / dims.single_tile_bytes;
     auto in_tensor =
-        MeshTensor::allocate_on_device(*mesh_device, make_flat_dram_tensor_spec(input_tile_bytes, num_input_pages));
+        MeshTensor::allocate_on_device(mesh_device, make_flat_dram_tensor_spec(input_tile_bytes, num_input_pages));
     auto out_tensor = MeshTensor::allocate_on_device(
-        *mesh_device, make_flat_dram_tensor_spec(dims.single_tile_bytes, num_output_pages));
+        mesh_device, make_flat_dram_tensor_spec(dims.single_tile_bytes, num_output_pages));
 
     constexpr std::uint32_t num_buffer_tiles = 32;
     constexpr std::uint32_t num_output_buffer_tiles = 32;
@@ -375,7 +371,7 @@ void run_single_core_reduce_program(
     }
 
     experimental::DataMovementHardwareConfig reader_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
         reader_hw_config = experimental::DataMovementGen1Config{
@@ -406,7 +402,7 @@ void run_single_core_reduce_program(
     };
 
     experimental::DataMovementHardwareConfig writer_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
         writer_hw_config = experimental::DataMovementGen1Config{
@@ -425,7 +421,7 @@ void run_single_core_reduce_program(
     };
 
     experimental::ComputeHardwareConfig compute_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
             .fpu_math_fidelity = test_config.math_fidelity,
             .enable_32_bit_dest = test_config.fp32_dest_acc_en,
@@ -484,13 +480,7 @@ void run_single_core_reduce_program(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
-
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& program_run = workload.get_programs().at(device_range);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     // Reader/writer RTAs depend on reduce_dim
     experimental::KernelRunArgs::RuntimeArgValues reader_named_rtas;
@@ -532,7 +522,7 @@ void run_single_core_reduce_program(
         {IN_TENSOR, experimental::ProgramRunArgs::TensorArgument{in_tensor}},
         {OUT_TENSOR, experimental::ProgramRunArgs::TensorArgument{out_tensor}},
     };
-    experimental::SetProgramRunArgs(program_run, params);
+    experimental::SetProgramRunArgs(program, params);
 
     // Shared seeded stimulus (packed bf16, TILED_NFACES). For bf16 input this is written to the
     // device as-is; for MxFp4 input it is quantized to MxFp4 for the device.
@@ -545,7 +535,7 @@ void run_single_core_reduce_program(
         // transform) - matching how the matmul stimulus feeds tile-major data.
         std::vector<std::uint32_t> mxfp4_packed =
             tt::tt_metal::pack_as_mxfp4_tiles(ttsl::make_const_span(in_floats), /*row_major_input=*/false);
-        tt_metal::detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), mxfp4_packed);
+        slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), mxfp4_packed);
         // Decode the quantized values back (tile-major) and repack as bf16 for the golden source.
         std::vector<float> quantized = tt::tt_metal::unpack_mxfp4_tiles_into_float_vec(
             ttsl::make_const_span(mxfp4_packed), /*row_major_output=*/false);
@@ -554,14 +544,13 @@ void run_single_core_reduce_program(
             src_vec[i] = pack_two_bfloat16_into_uint32({bfloat16(quantized[2 * i]), bfloat16(quantized[2 * i + 1])});
         }
     } else {
-        tt_metal::detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), src_vec);
+        slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), src_vec);
     }
 
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<std::uint32_t> result_vec;
-    tt_metal::detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), result_vec);
+    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), result_vec);
 
     validate_reduce_result(result_vec, dims.num_golden_elements, test_config, src_vec, get_scaler(test_config));
 
@@ -580,7 +569,7 @@ void run_single_core_reduce_program(
 
 using namespace unit_tests::compute::reduce;
 
-TEST_F(LLKMeshDeviceFixture, TensixComputeReduceH) {
+TEST_F(LLKMeshDeviceSingleCardFixture, TensixComputeReduceH) {
     if (this->arch_ != tt::ARCH::BLACKHOLE && this->arch_ != tt::ARCH::QUASAR) {
         // (issue #10181: disabling due to sporadic failures in slow dispatch mode)
         GTEST_SKIP();
@@ -617,14 +606,14 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceH) {
                         .dst_full_sync_en = dst_full_sync_en,
                         .math_fidelity = MathFidelity(math_fid),
                     };
-                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                    run_single_core_reduce_program(this->device(), test_config);
                 }
             }
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixture, TensixComputeReduceW) {
+TEST_F(LLKMeshDeviceSingleCardFixture, TensixComputeReduceW) {
     std::vector<std::uint32_t> shape = {1, 3, 17 * TILE_HEIGHT, 19 * TILE_WIDTH};
     std::vector<std::uint32_t> result_shape = {shape[0], shape[1], shape[2], 32};
     for (std::uint8_t math_fid = std::uint8_t(MathFidelity::LoFi); math_fid <= std::uint8_t(MathFidelity::HiFi4);
@@ -652,14 +641,14 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceW) {
                         .dst_full_sync_en = dst_full_sync_en,
                         .math_fidelity = MathFidelity(math_fid),
                     };
-                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                    run_single_core_reduce_program(this->device(), test_config);
                 }
             }
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHW) {
+TEST_F(LLKMeshDeviceSingleCardFixture, TensixComputeReduceHW) {
     std::vector<std::uint32_t> shape = {1, 2, 7 * TILE_HEIGHT, 5 * TILE_WIDTH};
     std::vector<std::uint32_t> result_shape = {shape[0], shape[1], 32, 32};
     for (std::uint8_t math_fid = std::uint8_t(MathFidelity::LoFi); math_fid <= std::uint8_t(MathFidelity::HiFi4);
@@ -696,14 +685,14 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHW) {
                         .fp32_dest_acc_en = fp32_dest_acc_en,
                         .dst_full_sync_en = dst_full_sync_en,
                         .math_fidelity = MathFidelity(math_fid)};
-                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                    run_single_core_reduce_program(this->device(), test_config);
                 }
             }
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHMathOnly) {
+TEST_F(LLKMeshDeviceSingleCardFixture, TensixComputeReduceHMathOnly) {
     if (this->arch_ != tt::ARCH::BLACKHOLE && this->arch_ != tt::ARCH::QUASAR) {
         // (issue #10181: disabling due to sporadic failures in slow dispatch mode)
         GTEST_SKIP();
@@ -741,14 +730,14 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHMathOnly) {
                         .fp32_dest_acc_en = fp32_dest_acc_en,
                         .dst_full_sync_en = dst_full_sync_en,
                         .math_fidelity = MathFidelity(math_fid)};
-                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                    run_single_core_reduce_program(this->device(), test_config);
                 }
             }
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixture, TensixComputeReduceWMathOnly) {
+TEST_F(LLKMeshDeviceSingleCardFixture, TensixComputeReduceWMathOnly) {
     std::vector<std::uint32_t> shape = {1, 3, 17 * TILE_HEIGHT, 19 * TILE_WIDTH};
     std::vector<std::uint32_t> result_shape = {shape[0], shape[1], shape[2], 32};
     for (std::uint8_t math_fid = std::uint8_t(MathFidelity::LoFi); math_fid <= std::uint8_t(MathFidelity::HiFi4);
@@ -782,14 +771,14 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceWMathOnly) {
                         .fp32_dest_acc_en = fp32_dest_acc_en,
                         .dst_full_sync_en = dst_full_sync_en,
                         .math_fidelity = MathFidelity(math_fid)};
-                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                    run_single_core_reduce_program(this->device(), test_config);
                 }
             }
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHWMathOnly) {
+TEST_F(LLKMeshDeviceSingleCardFixture, TensixComputeReduceHWMathOnly) {
     std::vector<std::uint32_t> shape = {1, 2, 7 * TILE_HEIGHT, 5 * TILE_WIDTH};
     std::vector<std::uint32_t> result_shape = {shape[0], shape[1], 32, 32};
     for (std::uint8_t math_fid = std::uint8_t(MathFidelity::LoFi); math_fid <= std::uint8_t(MathFidelity::HiFi4);
@@ -827,14 +816,14 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHWMathOnly) {
                         .fp32_dest_acc_en = fp32_dest_acc_en,
                         .dst_full_sync_en = dst_full_sync_en,
                         .math_fidelity = MathFidelity(math_fid)};
-                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                    run_single_core_reduce_program(this->device(), test_config);
                 }
             }
         }
     }
 }
 
-TEST_F(LLKMeshDeviceFixture, TensixComputeReduceWTinyTiles) {
+TEST_F(LLKMeshDeviceSingleCardFixture, TensixComputeReduceWTinyTiles) {
     tt_metal::Tile tile_shape = tt_metal::Tile({TILE_HEIGHT / 2, TILE_WIDTH});
     std::vector<std::uint32_t> shape = {1, 1, 1 * tile_shape.get_tile_shape()[0], 13 * tile_shape.get_tile_shape()[1]};
     std::vector<std::uint32_t> result_shape = {shape[0], shape[1], shape[2], tile_shape.get_tile_shape()[1]};
@@ -868,7 +857,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceWTinyTiles) {
                         .dst_full_sync_en = dst_full_sync_en,
                         .math_fidelity = MathFidelity(math_fid),
                     };
-                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                    run_single_core_reduce_program(this->device(), test_config);
                 }
             }
         }
@@ -899,7 +888,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, TensixComputeReduceColumnMxFp4X2) {
         // MxFp4 + column (H) reduce auto-selects the 2x-packed src-register format on Quasar.
         .input_format = tt::DataFormat::MxFp4,
     };
-    run_single_core_reduce_program(this->devices_.at(0), test_config);
+    run_single_core_reduce_program(this->device(), test_config);
 }
 
 // ============================================================================
@@ -982,28 +971,28 @@ std::vector<std::uint32_t> run_reduce_idfree(
 TEST_F(LLKBlackholeSingleCardFixture, TensixReduceScalarSumIdFreeGolden) {
     auto data = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-    auto result = run_reduce_idfree(*this->devices_.at(0), data, kPoolSum, kReduceScalar);
+    auto result = run_reduce_idfree(this->device(), data, kPoolSum, kReduceScalar);
     expect_reduce_matches_golden(result, data, ::unit_tests::compute::gold_reduce_hw, /*red_type=*/0);
 }
 
 TEST_F(LLKBlackholeSingleCardFixture, TensixReduceRowSumIdFreeGolden) {
     auto data = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-    auto result = run_reduce_idfree(*this->devices_.at(0), data, kPoolSum, kReduceRow);
+    auto result = run_reduce_idfree(this->device(), data, kPoolSum, kReduceRow);
     expect_reduce_matches_golden(result, data, ::unit_tests::compute::gold_reduce_w, /*red_type=*/0);
 }
 
 TEST_F(LLKBlackholeSingleCardFixture, TensixReduceColSumIdFreeGolden) {
     auto data = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-    auto result = run_reduce_idfree(*this->devices_.at(0), data, kPoolSum, kReduceCol);
+    auto result = run_reduce_idfree(this->device(), data, kPoolSum, kReduceCol);
     expect_reduce_matches_golden(result, data, ::unit_tests::compute::gold_reduce_h, /*red_type=*/0);
 }
 
 TEST_F(LLKBlackholeSingleCardFixture, TensixReduceScalarMaxIdFreeGolden) {
     auto data = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-    auto result = run_reduce_idfree(*this->devices_.at(0), data, kPoolMax, kReduceScalar);
+    auto result = run_reduce_idfree(this->device(), data, kPoolMax, kReduceScalar);
     expect_reduce_matches_golden(result, data, ::unit_tests::compute::gold_reduce_hw, /*red_type=*/2);
 }
 
@@ -1020,7 +1009,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixReduceBlockIdFreeGolden) {
         scaler.insert(scaler.end(), scaler_tile.begin(), scaler_tile.end());
     }
     auto result = unit_tests::llk::single_core::run_binary(
-        *this->devices_.at(0),
+        this->device(),
         data,
         scaler,
         num_tiles,

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -77,7 +77,9 @@ const map<std::string, std::map<std::string, std::string>> sfpu_op_to_op_name = 
     {"square", {{"SFPU_OP_CHAIN_0", "square_tile_init(); square_tile(0);"}}},
     {"negative", {{"SFPU_OP_CHAIN_0", "negative_tile_init(); negative_tile(0);"}}},
     {"softplus",
-     {{"SFPU_OP_CHAIN_0", "softplus_tile_init(); softplus_tile(0, /* beta */ 0x3F800000u, /* recip */0x3F800000u, /* threshold */ 0x41A00000u);"}}},
+     {{"SFPU_OP_CHAIN_0",
+       "softplus_tile_init(); softplus_tile(0, /* beta */ 0x3F800000u, /* recip */0x3F800000u, /* threshold */ "
+       "0x41A00000u);"}}},
     {"clamp", {{"SFPU_OP_CHAIN_0", "clamp_tile_init(); clamp_tile(0, 0xBF800000u, 0x3F800000u);"}}},  // [-1.0f, 1.0f]
     // Comparison-to-zero family (unary): result = 1.0f if predicate(x, 0) else 0.0f.
     {"eqz", {{"SFPU_OP_CHAIN_0", "eqz_tile_init(); eqz_tile(0);"}}},
@@ -649,8 +651,9 @@ struct SfpuConfig {
     CoreRangeSet cores;
     std::string sfpu_op;
     bool approx_mode = true;
-    bool dst_full_sync_en = true;      // SyncFull by default (matches today's implicit behavior)
-    bool unpack_to_dest = false;       // route input DFB to Dest (unpack_modes=UnpackToDest); pair with en_32bit_dest for 32-bit Dest
+    bool dst_full_sync_en = true;  // SyncFull by default (matches today's implicit behavior)
+    bool unpack_to_dest =
+        false;  // route input DFB to Dest (unpack_modes=UnpackToDest); pair with en_32bit_dest for 32-bit Dest
     bool en_32bit_dest = false;
 };
 
@@ -829,12 +832,6 @@ std::vector<uint32_t> run_sfpu_pipeline(
 
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& program_run = workload.get_programs().at(device_range);
-
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {
         experimental::ProgramRunArgs::KernelRunArgs{
@@ -855,11 +852,10 @@ std::vector<uint32_t> run_sfpu_pipeline(
         },
         experimental::ProgramRunArgs::KernelRunArgs{.kernel = COMPUTE},
     };
-    experimental::SetProgramRunArgs(program_run, params);
+    experimental::SetProgramRunArgs(program, params);
 
     distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, packed_input, /*blocking=*/true);
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> dest_buffer_data;
     distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, output_dram_buffer, /*blocking=*/true);
@@ -969,17 +965,17 @@ tt_metal::KernelHandle create_legacy_writer_kernel(tt_metal::Program& program, c
 // Compiles `spec`, sets `params`, uploads each input buffer, launches on the device, and
 // returns the raw output tile data. Shared by the binary and ternary Quasar SFPU runners.
 std::vector<uint32_t> sfpu_quasar_run(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     const experimental::ProgramSpec& spec,
     const experimental::ProgramRunArgs& params,
     const std::vector<std::pair<std::shared_ptr<distributed::MeshBuffer>, const std::vector<uint32_t>*>>& inputs,
     const std::shared_ptr<distributed::MeshBuffer>& out_buf) {
-    auto program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    auto program = experimental::MakeProgramFromSpec(mesh_device, spec);
     experimental::SetProgramRunArgs(program, params);
     for (const auto& [buf, data] : inputs) {
         slow_dispatch::WriteToBuffer(*buf, *data);
     }
-    LaunchProgram(*mesh_device, std::move(program));
+    LaunchProgram(mesh_device, std::move(program));
     std::vector<uint32_t> dest;
     slow_dispatch::ReadFromBuffer(*out_buf, dest);
     return dest;
@@ -997,23 +993,22 @@ std::vector<uint32_t> sfpu_quasar_run(
 /// @param mesh_device Device under test.
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_sfpu_binary_two_input_buffer(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const SfpuConfig& test_config) {
+bool run_sfpu_binary_two_input_buffer(distributed::MeshDevice& mesh_device, const SfpuConfig& test_config) {
     const size_t per_buffer_byte_size_input = test_config.num_tiles * tt::tile_size(test_config.l1_input_data_format);
     const size_t per_buffer_byte_size_output = test_config.num_tiles * tt::tile_size(test_config.l1_output_data_format);
 
     auto input0_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size_input},
         {.page_size = per_buffer_byte_size_input, .buffer_type = tt::tt_metal::BufferType::DRAM},
-        mesh_device.get());
+        &mesh_device);
     auto input1_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size_input},
         {.page_size = per_buffer_byte_size_input, .buffer_type = tt::tt_metal::BufferType::DRAM},
-        mesh_device.get());
+        &mesh_device);
     auto output_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size_output},
         {.page_size = per_buffer_byte_size_output, .buffer_type = tt::tt_metal::BufferType::DRAM},
-        mesh_device.get());
+        &mesh_device);
 
     const bool is_int8_op = sfpu_util::is_int8_binary_sfpu_op(test_config.sfpu_op);
     const size_t element_size = is_int8_op ? sizeof(int8_t) : sizeof(bfloat16);
@@ -1085,7 +1080,7 @@ bool run_sfpu_binary_two_input_buffer(
     };
 
     experimental::ComputeHardwareConfig compute_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
             .sfpu_precision_mode =
                 test_config.approx_mode ? tt::tt_metal::Precision::Approximate : tt::tt_metal::Precision::Precise,
@@ -1179,27 +1174,24 @@ bool run_sfpu_binary_two_input_buffer(
 /// @param mesh_device Device under test.
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_sfpu_ternary_three_input_buffer(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const SfpuConfig& test_config) {
+bool run_sfpu_ternary_three_input_buffer(distributed::MeshDevice& mesh_device, const SfpuConfig& test_config) {
     const size_t per_buffer_byte_size = test_config.num_tiles * test_config.tile_byte_size;
-    auto* device = mesh_device->get_devices()[0];
-
     auto input0_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size},
         {.page_size = per_buffer_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
-        mesh_device.get());
+        &mesh_device);
     auto input1_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size},
         {.page_size = per_buffer_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
-        mesh_device.get());
+        &mesh_device);
     auto input2_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size},
         {.page_size = per_buffer_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
-        mesh_device.get());
+        &mesh_device);
     auto output_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size},
         {.page_size = per_buffer_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
-        mesh_device.get());
+        &mesh_device);
 
     const size_t numel = per_buffer_byte_size / sizeof(bfloat16);
     const int seed = std::chrono::system_clock::now().time_since_epoch().count();
@@ -1220,7 +1212,7 @@ bool run_sfpu_ternary_three_input_buffer(
     sfpu_defines["SFPU_TERNARY_OP"] = "1";
 
     std::vector<uint32_t> dest_buffer_data;
-    if (device->arch() == ARCH::QUASAR) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         const experimental::DFBSpecName IN0_DFB{"in0_dfb"};
         const experimental::DFBSpecName IN1_DFB{"in1_dfb"};
         const experimental::DFBSpecName IN2_DFB{"in2_dfb"};
@@ -1268,7 +1260,7 @@ bool run_sfpu_ternary_three_input_buffer(
         };
 
         experimental::ComputeHardwareConfig compute_hw_config;
-        if (mesh_device->arch() == tt::ARCH::QUASAR) {
+        if (mesh_device.arch() == tt::ARCH::QUASAR) {
             compute_hw_config = experimental::ComputeGen2Config{
                 .sfpu_precision_mode =
                     test_config.approx_mode ? tt::tt_metal::Precision::Approximate : tt::tt_metal::Precision::Precise,
@@ -1358,13 +1350,8 @@ bool run_sfpu_ternary_three_input_buffer(
             {{input0_dram_buffer, &packed_in0}, {input1_dram_buffer, &packed_in1}, {input2_dram_buffer, &packed_in2}},
             output_dram_buffer);
     } else {
-        auto& cq = mesh_device->mesh_command_queue();
-        auto zero_coord = distributed::MeshCoordinate(0, 0);
-        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        distributed::MeshWorkload workload;
+        auto& cq = mesh_device.mesh_command_queue();
         tt_metal::Program program = tt_metal::CreateProgram();
-        workload.add_program(device_range, std::move(program));
-        auto& program_ = workload.get_programs().at(device_range);
 
         // reader_binary.cpp with LOAD_BUF2_DATA:
         //   {src0_addr, src0_bank, src1_addr, src1_bank, num_tiles, src2_addr, src2_bank}
@@ -1387,18 +1374,18 @@ bool run_sfpu_ternary_three_input_buffer(
                 return tt_metal::CircularBufferConfig(per_buffer_byte_size, {{idx, test_config.l1_input_data_format}})
                     .set_page_size(idx, test_config.tile_byte_size);
             };
-            tt_metal::CreateCircularBuffer(program_, core_range, make_input_cb(tt::CBIndex::c_0));
-            tt_metal::CreateCircularBuffer(program_, core_range, make_input_cb(tt::CBIndex::c_1));
-            tt_metal::CreateCircularBuffer(program_, core_range, make_input_cb(tt::CBIndex::c_2));
+            tt_metal::CreateCircularBuffer(program, core_range, make_input_cb(tt::CBIndex::c_0));
+            tt_metal::CreateCircularBuffer(program, core_range, make_input_cb(tt::CBIndex::c_1));
+            tt_metal::CreateCircularBuffer(program, core_range, make_input_cb(tt::CBIndex::c_2));
 
             tt_metal::CircularBufferConfig l1_output_cb_config =
                 tt_metal::CircularBufferConfig(
                     per_buffer_byte_size, {{tt::CBIndex::c_16, test_config.l1_output_data_format}})
                     .set_page_size(tt::CBIndex::c_16, test_config.tile_byte_size);
-            tt_metal::CreateCircularBuffer(program_, core_range, l1_output_cb_config);
+            tt_metal::CreateCircularBuffer(program, core_range, l1_output_cb_config);
 
             auto reader_kernel = tt_metal::CreateKernel(
-                program_,
+                program,
                 "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
                 test_config.cores,
                 tt_metal::DataMovementConfig{
@@ -1406,10 +1393,10 @@ bool run_sfpu_ternary_three_input_buffer(
                     .noc = tt_metal::NOC::RISCV_1_default,
                     .defines = {{"LOAD_BUF2_DATA", "1"}}});
 
-            auto writer_kernel = create_legacy_writer_kernel(program_, test_config);
+            auto writer_kernel = create_legacy_writer_kernel(program, test_config);
 
             tt_metal::CreateKernel(
-                program_,
+                program,
                 "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_sfpu.cpp",
                 test_config.cores,
                 tt_metal::ComputeConfig{
@@ -1419,16 +1406,15 @@ bool run_sfpu_ternary_three_input_buffer(
                     .defines = sfpu_defines});
 
             for (const CoreCoord& core_coord : core_range) {
-                SetRuntimeArgs(program_, reader_kernel, core_coord, reader_rt_args);
-                SetRuntimeArgs(program_, writer_kernel, core_coord, writer_rt_args);
+                SetRuntimeArgs(program, reader_kernel, core_coord, reader_rt_args);
+                SetRuntimeArgs(program, writer_kernel, core_coord, writer_rt_args);
             }
         }
 
         distributed::EnqueueWriteMeshBuffer(cq, input0_dram_buffer, packed_in0, /*blocking=*/true);
         distributed::EnqueueWriteMeshBuffer(cq, input1_dram_buffer, packed_in1, /*blocking=*/true);
         distributed::EnqueueWriteMeshBuffer(cq, input2_dram_buffer, packed_in2, /*blocking=*/true);
-        distributed::EnqueueMeshWorkload(cq, workload, false);
-        distributed::Finish(cq);
+        LaunchProgram(mesh_device, std::move(program));
         distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, output_dram_buffer, /*blocking=*/true);
     }
 
@@ -1536,7 +1522,11 @@ void run_quasar_sfpu_unpack_to_dest_16b(
         .unpack_to_dest = true,  // 16-bit operand unpack-to-dest (fp32_dest_acc_en stays false)
     };
     log_info(
-        tt::LogTest, "Quasar SFPU 16b->DEST: op={} num_tiles={} dst_full_sync_en={}", sfpu_op, num_tiles, dst_full_sync_en);
+        tt::LogTest,
+        "Quasar SFPU 16b->DEST: op={} num_tiles={} dst_full_sync_en={}",
+        sfpu_op,
+        num_tiles,
+        dst_full_sync_en);
     EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_all_same_buffer(dev, cfg));
 }
 
@@ -1859,7 +1849,7 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuBinaryParameterizedFixture, TensixSfpuBinar
         .approx_mode = false};
     log_info(tt::LogTest, "Testing binary SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
     for (auto& device : this->devices_) {
-        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_binary_two_input_buffer(device, test_config));
+        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_binary_two_input_buffer(*device, test_config));
     }
 }
 
@@ -1907,7 +1897,7 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuTernaryParameterizedFixture, TensixSfpuTern
         .approx_mode = false};
     log_info(tt::LogTest, "Testing ternary SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
     for (auto& device : this->devices_) {
-        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_ternary_three_input_buffer(device, test_config));
+        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_ternary_three_input_buffer(*device, test_config));
     }
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -48,10 +48,6 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 
 namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
-
-namespace tt::tt_metal {
 
 using namespace tt;
 using namespace tt::test_utils;

--- a/tests/tt_metal/tt_metal/llk/test_sum_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sum_reduce_scalar.cpp
@@ -22,6 +22,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-logger/tt-logger.hpp>
 
 #include "llk_device_fixture.hpp"
@@ -148,14 +149,7 @@ bool run_sum_reduce_scalar_test(distributed::MeshDevice& mesh_device, const SumR
     auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, packed_input, /*blocking=*/true);
 
-    // Wrap the program into a MeshWorkload and dispatch via the mesh command queue.
-    // This path works under both fast dispatch and slow dispatch, unlike detail::LaunchProgram.
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
@@ -222,8 +216,7 @@ class SumReduceScalarBlazeShapeTest : public LLKMeshDeviceSingleCardFixture,
                                       public testing::WithParamInterface<SumReduceScalarConfig> {};
 
 TEST_P(SumReduceScalarBlazeShapeTest, SumReduceScalarBlazeShape) {
-    auto& mesh_device = *devices_[0];
-    ASSERT_TRUE(run_sum_reduce_scalar_test(mesh_device, GetParam()));
+    ASSERT_TRUE(run_sum_reduce_scalar_test(this->device(), GetParam()));
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -263,10 +256,9 @@ INSTANTIATE_TEST_SUITE_P(
 class SumReduceScalarFp32DestTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<int> {};
 
 TEST_P(SumReduceScalarFp32DestTest, SumReduceScalarFp32Dest) {
-    auto& mesh_device = *devices_[0];
     int num_tiles = GetParam();
     ASSERT_TRUE(run_sum_reduce_scalar_test(
-        mesh_device, {.num_tiles = num_tiles, .tile_height = 32, .fp32_dest_acc = true, .dst_full_sync = true}));
+        this->device(), {.num_tiles = num_tiles, .tile_height = 32, .fp32_dest_acc = true, .dst_full_sync = true}));
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -283,10 +275,9 @@ INSTANTIATE_TEST_SUITE_P(
 class SumReduceScalarLoFiTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<bool> {};
 
 TEST_P(SumReduceScalarLoFiTest, SumReduceScalarLoFi) {
-    auto& mesh_device = *devices_[0];
     bool fp32_dest_acc = GetParam();
     ASSERT_TRUE(run_sum_reduce_scalar_test(
-        mesh_device,
+        this->device(),
         {.num_tiles = 8,
          .tile_height = 32,
          .fp32_dest_acc = fp32_dest_acc,
@@ -306,10 +297,9 @@ INSTANTIATE_TEST_SUITE_P(
 class SumReduceScalarScalerTest : public LLKMeshDeviceSingleCardFixture, public testing::WithParamInterface<bool> {};
 
 TEST_P(SumReduceScalarScalerTest, SumReduceScalarScaler) {
-    auto& mesh_device = *devices_[0];
     bool doubling = GetParam();
     ASSERT_TRUE(run_sum_reduce_scalar_test(
-        mesh_device,
+        this->device(),
         {.num_tiles = 4,
          .tile_height = 32,
          .scaler = doubling ? 2.0f : 0.5f,
@@ -328,12 +318,11 @@ INSTANTIATE_TEST_SUITE_P(
 class SumReduceScalarZeroFlagTest : public LLKMeshDeviceSingleCardFixture {};
 
 TEST_F(SumReduceScalarZeroFlagTest, RestoresDefaultAfterCopyBeforeDenormalScaler) {
-    auto& mesh_device = *devices_[0];
     constexpr uint16_t largest_finite_bfloat16 = 0x7f7f;
     const float denormal_scaler = static_cast<float>(std::bit_cast<bfloat16>(uint16_t{1}));
 
     ASSERT_TRUE(run_sum_reduce_scalar_test(
-        mesh_device,
+        this->device(),
         {.num_tiles = 1,
          .tile_height = 32,
          .scaler = denormal_scaler,

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <map>
 #include <memory>
 #include <string>
@@ -42,10 +43,6 @@
 #include <tt-metalium/tensor/mesh_tensor.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "single_core_compute_runners.hpp"
-
-namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
 
 namespace tt::tt_metal {
 
@@ -165,7 +162,6 @@ static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(
 }
 
 void run_single_core_transpose(distributed::MeshDevice& mesh_device, const TransposeConfig& test_config) {
-    auto& cq = mesh_device.mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
     const TransposeDims dims = compute_and_validate_transpose_dims(test_config.shape);
@@ -313,12 +309,6 @@ void run_single_core_transpose(distributed::MeshDevice& mesh_device, const Trans
 
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& program_run = workload.get_programs().at(device_range);
-
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {
         experimental::ProgramRunArgs::KernelRunArgs{
@@ -336,7 +326,7 @@ void run_single_core_transpose(distributed::MeshDevice& mesh_device, const Trans
         {IN_TENSOR, experimental::ProgramRunArgs::TensorArgument{in_tensor}},
         {OUT_TENSOR, experimental::ProgramRunArgs::TensorArgument{out_tensor}},
     };
-    experimental::SetProgramRunArgs(program_run, params);
+    experimental::SetProgramRunArgs(program, params);
 
     // Fixed seed so each test produces a repeatable input vector across runs.
     constexpr std::uint32_t kRandomSeed = 0x1234;
@@ -362,8 +352,7 @@ void run_single_core_transpose(distributed::MeshDevice& mesh_device, const Trans
     }
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), src_vec);
 
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), result_vec);
@@ -457,7 +446,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixTransposeIdFreeGolden) {
     auto src = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/100, /*seed=*/0x1234, /*offset=*/0.0f);
     auto result = unit_tests::llk::single_core::run_unary(
-        *this->devices_.at(0),
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::Float16_b,
         src,

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -53,10 +53,6 @@
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
-
-namespace tt::tt_metal {
 
 using std::map;
 using namespace tt;
@@ -637,7 +633,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixUnaryBcastRowIdFreeGolden) {
     auto golden = ::unit_tests::compute::gold_standard_tilize(bcast_packed, config);
 
     auto result = unit_tests::llk::single_core::run_unary(
-        *this->devices_.at(0),
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::Float16_b,
         device_input,

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -9,6 +9,7 @@
 #include <sys/types.h>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <algorithm>
 #include <bit>
 #include <cctype>
@@ -49,10 +50,6 @@
 #include <tt-metalium/tensor/mesh_tensor.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "single_core_compute_runners.hpp"
-
-namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
 
 namespace tt::tt_metal {
 
@@ -391,12 +388,6 @@ void run_single_core_tilize_program(distributed::MeshDevice& mesh_device, const 
 
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
-
     std::vector<std::uint32_t> src0_vec = test_config.src0_data.empty()
                                               ? create_arange_vector_of_bfloat16(input_dram_buffer_size, false)
                                               : test_config.src0_data;
@@ -427,10 +418,9 @@ void run_single_core_tilize_program(distributed::MeshDevice& mesh_device, const 
             node, {{"dst_addr", dram_buffer_dst_addr}, {"bank_id", 0u}, {"num_tiles", num_tiles}}),
     });
     params.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{.kernel = COMPUTE});
-    experimental::SetProgramRunArgs(program_, params);
+    experimental::SetProgramRunArgs(program, params);
 
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<std::uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
@@ -443,12 +433,7 @@ void run_single_core_tilize_program(distributed::MeshDevice& mesh_device, const 
 // binary add, so the caller (`TensixComputeUnpackTilizeA_B`) skips on Quasar.
 void run_single_core_unpack_tilizeA_B_program(distributed::MeshDevice& mesh_device, const TestConfig& test_config) {
     auto& cq = mesh_device.mesh_command_queue();
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = tt::tt_metal::CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
 
     CoreCoord core = {0, 0};
 
@@ -474,31 +459,31 @@ void run_single_core_unpack_tilizeA_B_program(distributed::MeshDevice& mesh_devi
         tt_metal::CircularBufferConfig(
             num_tiles * test_config.input_single_tile_size, {{src0_cb_index, test_config.input_fmt}})
             .set_page_size(src0_cb_index, test_config.input_single_tile_size);
-    tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
+    tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
     std::uint32_t src1_cb_index = tt::CBIndex::c_1;
     tt_metal::CircularBufferConfig cb_src1_config =
         tt_metal::CircularBufferConfig(
             num_tiles * test_config.input_single_tile_size, {{src1_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(src1_cb_index, test_config.input_single_tile_size);
-    tt_metal::CreateCircularBuffer(program_, core, cb_src1_config);
+    tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
     std::uint32_t output_cb_index = tt::CBIndex::c_16;
     tt_metal::CircularBufferConfig cb_output_config =
         tt_metal::CircularBufferConfig(
             num_tiles * test_config.output_single_tile_size, {{output_cb_index, test_config.output_fmt}})
             .set_page_size(output_cb_index, test_config.output_single_tile_size);
-    tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
+    tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
     auto reader_kernel = tt_metal::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
         core,
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
 
     auto writer_kernel = tt_metal::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary.cpp",
         core,
         tt_metal::DataMovementConfig{
@@ -510,7 +495,7 @@ void run_single_core_unpack_tilizeA_B_program(distributed::MeshDevice& mesh_devi
     };
 
     tt_metal::CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp",
         core,
         tt_metal::ComputeConfig{
@@ -528,7 +513,7 @@ void run_single_core_unpack_tilizeA_B_program(distributed::MeshDevice& mesh_devi
     distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, src1_vec, /*blocking=*/true);
 
     tt_metal::SetRuntimeArgs(
-        program_,
+        program,
         reader_kernel,
         core,
         {
@@ -538,10 +523,9 @@ void run_single_core_unpack_tilizeA_B_program(distributed::MeshDevice& mesh_devi
             (std::uint32_t)0,
             (std::uint32_t)num_tiles,
         });
-    tt_metal::SetRuntimeArgs(program_, writer_kernel, core, {dram_buffer_dst_addr, (std::uint32_t)0, num_tiles});
+    tt_metal::SetRuntimeArgs(program, writer_kernel, core, {dram_buffer_dst_addr, (std::uint32_t)0, num_tiles});
 
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<std::uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
@@ -555,7 +539,6 @@ void run_single_core_unpack_tilizeA_B_program(distributed::MeshDevice& mesh_devi
 // (column-wise max within each tile), producing output tiles with only row 0 populated.
 void run_single_core_unpack_tilizeA_B_reduce_program(
     distributed::MeshDevice& mesh_device, const TestConfig& test_config) {
-    auto& cq = mesh_device.mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
     const std::uint32_t num_tiles_in = test_config.num_tiles_r * test_config.num_tiles_c;
@@ -721,12 +704,6 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
 
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
-
     std::vector<std::uint32_t> src0_vec = create_random_vector_of_bfloat16(input_dram_buffer_size, 100, 42);
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), src0_vec);
 
@@ -750,10 +727,9 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
         {IN_TENSOR, experimental::ProgramRunArgs::TensorArgument{in_tensor}},
         {OUT_TENSOR, experimental::ProgramRunArgs::TensorArgument{out_tensor}},
     };
-    experimental::SetProgramRunArgs(program_, params);
+    experimental::SetProgramRunArgs(program, params);
 
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<std::uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), result_vec);
@@ -807,7 +783,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeFp8e4m3) {
                 .output_fmt = tt::DataFormat::Fp8_e4m3,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_tilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(this->device(), test_config);
         }
     }
 }
@@ -831,7 +807,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeInt8) {
                 .output_fmt = tt::DataFormat::Int8,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_tilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(this->device(), test_config);
         }
     }
 }
@@ -855,7 +831,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeUInt8) {
                 .output_fmt = tt::DataFormat::UInt8,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_tilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(this->device(), test_config);
         }
     }
 }
@@ -883,7 +859,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeTinyTile16x32) {
                 .face_r_dim = face_r_dim,
                 .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
                 .golden_function = ::unit_tests::compute::gold_standard_tilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(this->device(), test_config);
         }
     }
 }
@@ -1102,12 +1078,6 @@ static void run_quasar_tilize_untilize_test(
 
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    auto& program_run = workload.get_programs().at(device_range);
-
     std::vector<std::uint32_t> src_vec;
     if (input_data_format == tt::DataFormat::Int8) {
         src_vec = create_random_vector_of_int8(src_dram_buffer_size, /*seed=*/42);
@@ -1156,10 +1126,9 @@ static void run_quasar_tilize_untilize_test(
         },
         experimental::ProgramRunArgs::KernelRunArgs{.kernel = COMPUTE},
     };
-    experimental::SetProgramRunArgs(program_run, params);
+    experimental::SetProgramRunArgs(program, params);
 
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<std::uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
@@ -1220,7 +1189,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilize) {
                         continue;  // Int16 + 32-bit dest mode is not supported on Quasar
                     }
                     run_quasar_tilize_untilize_test(
-                        *this->devices_.at(0),
+                        this->device(),
                         cfg[0],
                         cfg[1],
                         QuasarTestMode::UNTILIZE,
@@ -1245,7 +1214,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDst) {
                         continue;  // Int16 + 32-bit dest mode is not supported on Quasar
                     }
                     run_quasar_tilize_untilize_test(
-                        *this->devices_.at(0),
+                        this->device(),
                         cfg[0],
                         cfg[1],
                         QuasarTestMode::UNTILIZE_DST,
@@ -1268,7 +1237,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeTinyTile) 
         for (auto& geo : geometries) {
             for (bool dst_full_sync_en : {true, false}) {
                 run_quasar_tilize_untilize_test(
-                    *this->devices_.at(0),
+                    this->device(),
                     cfg[0],
                     cfg[1],
                     QuasarTestMode::UNTILIZE,
@@ -1292,7 +1261,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDstTinyTil
         for (auto& geo : geometries) {
             for (bool dst_full_sync_en : {true, false}) {
                 run_quasar_tilize_untilize_test(
-                    *this->devices_.at(0),
+                    this->device(),
                     cfg[0],
                     cfg[1],
                     QuasarTestMode::UNTILIZE_DST,
@@ -1342,7 +1311,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeTinyTile) 
         for (auto& geo : geometries) {
             for (bool dst_full_sync_en : {true, false}) {
                 run_quasar_tilize_untilize_test(
-                    *this->devices_.at(0),
+                    this->device(),
                     cfg[0],
                     cfg[1],
                     QuasarTestMode::TILIZE,
@@ -1367,7 +1336,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeTinyTileCr
         for (auto& cfg : test_configs) {
             for (bool dst_full_sync_en : {true, false}) {
                 run_quasar_tilize_untilize_test(
-                    *this->devices_.at(0),
+                    this->device(),
                     cfg[0],
                     cfg[1],
                     QuasarTestMode::TILIZE,
@@ -1417,7 +1386,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeInt32) {
     for (auto& cfg : test_configs) {
         for (bool dst_full_sync_en : {true, false}) {
             run_quasar_tilize_untilize_test(
-                *this->devices_.at(0),
+                this->device(),
                 cfg[0],
                 cfg[1],
                 QuasarTestMode::UNTILIZE,
@@ -1435,7 +1404,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDstInt32) 
     for (auto& cfg : test_configs) {
         for (bool dst_full_sync_en : {true, false}) {
             run_quasar_tilize_untilize_test(
-                *this->devices_.at(0),
+                this->device(),
                 cfg[0],
                 cfg[1],
                 QuasarTestMode::UNTILIZE_DST,
@@ -1464,7 +1433,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeFastUntilize) {
             .untilize_type = unit_tests::compute::tilize::UntilizeType::PACK,
             .output_fmt = tt::DataFormat::Float16_b,
             .golden_function = ::unit_tests::compute::gold_standard_untilize};
-        unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
+        unit_tests::compute::tilize::run_single_core_tilize_program(this->device(), test_config);
     }
 }
 
@@ -1486,7 +1455,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeFastTilize) {
                     .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
                     .output_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
                     .golden_function = ::unit_tests::compute::gold_standard_tilize};
-                unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
+                unit_tests::compute::tilize::run_single_core_tilize_program(this->device(), test_config);
             }
         }
     }
@@ -1572,7 +1541,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputePackUntilizeFp8e4m3) {
                 .output_fmt = tt::DataFormat::Fp8_e4m3,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(this->device(), test_config);
         }
     }
 }
@@ -1595,7 +1564,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputePackUntilizeInt8) {
                 .output_fmt = tt::DataFormat::Int8,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(this->device(), test_config);
         }
     }
 }
@@ -1618,7 +1587,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputePackUntilizeUInt8) {
                 .output_fmt = tt::DataFormat::UInt8,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(this->device(), test_config);
         }
     }
 }
@@ -1659,7 +1628,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixTilizeIdFreeGolden) {
     auto src = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
     auto result = unit_tests::llk::single_core::run_unary(
-        *this->devices_.at(0),
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::Float16_b,
         src,
@@ -1678,7 +1647,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixPackUntilizeIdFreeGolden) {
     auto src = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
     auto result = unit_tests::llk::single_core::run_unary(
-        *this->devices_.at(0),
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::Float16_b,
         src,
@@ -1697,7 +1666,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixPackUntilizeDestIdFreeGolden) {
     auto src = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
     auto result = unit_tests::llk::single_core::run_unary(
-        *this->devices_.at(0),
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::Float16_b,
         src,
@@ -1722,7 +1691,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixPackUntilizeBlock4IdFreeGolden) {
     auto src = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
     auto result = unit_tests::llk::single_core::run_unary(
-        *this->devices_.at(0),
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::Float16_b,
         src,


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

We're deprecation legacy API related to `IDevice` and `Buffer`.
As one of the steps, usage of this API is replaced with mesh alternatives in tests that are based on LLKMeshDeviceSingleCardFixture.

Also, in reaction to this Copilot comment https://github.com/tenstorrent/tt-metal/pull/56003#discussion_r3972615621, LLKMeshDeviceSingleCardFixture and its base MeshDeviceSingleCardFixture are changed to open a single device, because:
- this avoids extra overhead;
- nothing in their name suggests opening multiple devices;
- only a few usages iterated over all the open devices instead of using a single one, and they all look accidental rather than deliberate.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-llk-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-llk-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-llk-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-llk-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-llk-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-llk-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-llk-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-llk-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-llk-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-llk-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-llk-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-llk-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-llk-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-llk-tests-modernize)