### PR TITLE
#51285: fix moe_gate_mm compute kernel CB id and collector mask sync

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp
@@ -220,7 +220,7 @@ void kernel_main() {
             /*kt_dim=*/1);
     }
 
-    add_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_w2c_in2);
+    add_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_w2c_in2_id);
 
     // Wait for the partial to come, add it
     cb_w2c_in2.wait_front(1);
@@ -357,6 +357,8 @@ void kernel_main() {
         transpose_init(cb_s2c_out_id);
         transpose_tile(cb_s2c_out_id, 0, 0);
         cb_s2c_out.pop_front(1);
+
+        cb_w2c_in5.wait_front(1);
 
         copy_init(cb_w2c_in5_id);
         copy_tile(cb_w2c_in5_id, 0, 2);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Items 2 and 3 of #51285: `add_reuse_dest_init` was passed the `CircularBuffer` object instead of the CB id, so the compute kernel failed to build, and on the collector core the group-mask tile was unpacked back without a `cb_wait_front`, letting UNPACK run ahead of PACK. Verified on Wormhole that the kernel now builds and the op's accuracy check reaches a passing PCC; the nightly test itself is still skipped by #44858.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/51285-moe-gate-mm-compute-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/51285-moe-gate-mm-compute-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/51285-moe-gate-mm-compute-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/51285-moe-gate-mm-compute-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/51285-moe-gate-mm-compute-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/51285-moe-gate-mm-compute-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/51285-moe-gate-mm-compute-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/51285-moe-gate-mm-compute-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/51285-moe-gate-mm-compute-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/51285-moe-gate-mm-compute-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/51285-moe-gate-mm-compute-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/51285-moe-gate-mm-compute-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/51285-moe-gate-mm-compute-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/51285-moe-gate-mm-compute-kernel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
