### PR TITLE
[tt-train] Fix CMake target configuration order

### DIFF
--- a/tt-train/sources/CMakeLists.txt
+++ b/tt-train/sources/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_subdirectory(examples)
 add_subdirectory(ttml)
+add_subdirectory(examples)


### PR DESCRIPTION
### PR Category
build

### Summary
`cmake -B build_Release ...` (via .`/build_metal.sh`) fails to configure on CMake 4.0.x with one error per tt-train example:

```
CMake Error at tt-train/sources/examples/linear_regression/CMakeLists.txt:7 (target_precompile_headers):
  PRECOMPILE_HEADERS_REUSE_FROM set with non existing target
```
#53733 added `target_precompile_headers(<example> REUSE_FROM ttml_pch)` to the tt-train examples, but `tt-train/sources/CMakeLists.txt`configures `examples` before `ttml` — the directory that creates the `ttml_pch` target. Whether that ordering is legal depends on the CMake version:

CMake 3.x and ≥ 4.1 resolve `REUSE_FROM` at generate time, when all targets exist → configures fine (why CI is green).
CMake 4.0.x resolves it eagerly at the call site → hard configure failure.

**Fix**
Swap the two `add_subdirectory` calls so the PCH provider (`ttml`) is configured before its consumers (`examples`). This is the natural dependency order (the examples all link `ttml`) and is a no-op on CMake versions that weren't affected.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/runs/34403442435)
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/fixing_ttml_cmake_4.0.x_build)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/fixing_ttml_cmake_4.0.x_build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=awliu/fixing_ttml_cmake_4.0.x_build)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:awliu/fixing_ttml_cmake_4.0.x_build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/fixing_ttml_cmake_4.0.x_build)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/fixing_ttml_cmake_4.0.x_build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=awliu/fixing_ttml_cmake_4.0.x_build)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:awliu/fixing_ttml_cmake_4.0.x_build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/fixing_ttml_cmake_4.0.x_build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/fixing_ttml_cmake_4.0.x_build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/fixing_ttml_cmake_4.0.x_build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/fixing_ttml_cmake_4.0.x_build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/fixing_ttml_cmake_4.0.x_build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/fixing_ttml_cmake_4.0.x_build)