### PR TITLE
[Bug fix]: Quasar: keep DM local region size a multiple of 2 KB

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -55,8 +55,11 @@
 #define MEM_DM_KERNEL_SIZE (1024 * 48)
 #define MEM_DM_GLOBAL_SIZE (1024 * 2)
 #define MEM_TRISC_GLOBAL_SIZE (1024 * 2)
+// Per-DM stride of the local region: crt0 puts tp at base + n * size and sp at base + (n+1) * size,
+// so these also place every stack. The DM D$ indexes on addr[10:6] (2-way, 32 sets of 64 B), so keep
+// both a multiple of 2 KB or DMs land on different sets.
 #define MEM_DM_LOCAL_SIZE (1024 * 8)
-#define MEM_DISPATCH_DM_LOCAL_SIZE (1024 * 9)
+#define MEM_DISPATCH_DM_LOCAL_SIZE (1024 * 10)
 #define MEM_TRISC_LOCAL_SIZE (1024 * 4)
 #define MEM_TRISC_KERNEL_SIZE (1024 * 24)
 #define MEM_TRISC_LOCAL_OFFSET (0x2000)

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_dispatch_asserts.hpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_dispatch_asserts.hpp
@@ -13,6 +13,8 @@
 
 static_assert(DISPATCH_MEM_MAP_END <= MEM_L1_SIZE, "Dispatch-engine L1 layout exceeds MEM_L1_SIZE");
 static_assert(
+    MEM_DISPATCH_DM_LOCAL_SIZE % 2048 == 0, "Dispatch DM local size must be a multiple of 2 kB (D$ set alignment)");
+static_assert(
     MEM_DISPATCH_DM0_KERNEL_BASE % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0,
     "Dispatch DM0 kernel base must be NOC-write aligned");
 

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix_asserts.hpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix_asserts.hpp
@@ -12,6 +12,8 @@
 #include "noc/noc_parameters.h"
 #include "hostdevcommon/fabric_common.h"
 
+static_assert(MEM_DM_LOCAL_SIZE % 2048 == 0, "DM local size must be a multiple of 2 kB (D$ set alignment)");
+
 // Validate assumptions on mailbox layout on host compile
 // Constexpr definitions allow for printing of breaking values at compile time
 static_assert(MEM_MAILBOX_BASE + sizeof(mailboxes_t) <= MEM_MAILBOX_END);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
https://github.com/tenstorrent/tt-metal/pull/55513 increased the stack space (`MEM_DISPATCH_DM_LOCAL_SIZE`) by +1KB, causing a regression in FD performance (by about 300-400 cyc/command on paged packed commands).

That constant is the per-DM stride of the local/TLS region, so it places each stack top at `LOCAL_BASE + (n + 1) * size`.  Changing it relocates the stacks in the DM data cache.

This PR sets it to 10K and adds `static_assert` on both DM local sizes. Measured: 8 KB, 10 KB, 12 KB all baseline, 9KB alone regresses.

### Notes for reviewers
- Not a codegen change. Disassembly of both builds showed identifical instructions (`instret` is same),  but perf counter event `dcache_miss_event` goes up by 2.59x
- Kernel text placement was ruled out: a build moving text/scratch to the 9 KB addresses while holding stack stride at 8 KB showed no regression. 
- Why `% 2048`: the DM D$ is 4 KB, 2-way, 64 B lines --> 32 sets --> index `addr[10:6]` --> the set mapping repeats every 2 KB. `9216 % 2048 = 1024`  which shifts the stacks of the even numbered DMs by 16 cache sets, including DM0, which runs the prefetcher and is the bottleneck. What the stacks conflict with at 9 KB is not exactly pinpointed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/fix_fd_stack_alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/fix_fd_stack_alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_fd_stack_alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/fix_fd_stack_alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/fix_fd_stack_alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/fix_fd_stack_alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/fix_fd_stack_alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/fix_fd_stack_alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/fix_fd_stack_alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/fix_fd_stack_alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/fix_fd_stack_alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/fix_fd_stack_alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/fix_fd_stack_alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/fix_fd_stack_alignment)