### PR TITLE
[all_gather] bug fix: program scatter-write state only when the writer uses scatter writes

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_gather_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_gather_nightly.py
@@ -117,6 +117,57 @@ def test_all_gather_linear_2D_nightly(
     ttnn.ReadDeviceProfiler(submesh_device)
 
 
+# Multicast writer with pages that do not use scatter writes: one page per packet (fp32 tile, 4096 B
+# against the 4352 B fabric payload) and a page larger than the packet (fp32 row-major, 8192 B rows).
+# The small volume keeps the op on the multicast factory. Run with Watcher enabled to catch the
+# scatter-state assert of the first class; the second class overruns the packet header in every build.
+@skip_for_wormhole_b0()
+@skip_for_n_or_less_dev(3)
+@pytest.mark.parametrize(
+    "num_devices, ag_output_shape, dim, ag_input_dtype, layout",
+    [
+        (4, [1, 1, 32, 512], 3, ttnn.float32, ttnn.TILE_LAYOUT),
+        (4, [1, 1, 32, 8192], 3, ttnn.float32, ttnn.ROW_MAJOR_LAYOUT),
+    ],
+    ids=["fp32_tile_one_page_per_packet", "fp32_rm_page_larger_than_packet"],
+)
+@pytest.mark.parametrize("mem_config_input, mem_config_ag", [(ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG)])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112},
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("cluster_axis", [0])
+def test_all_gather_multicast_non_scatter_pages(
+    bh_1d_mesh_device,
+    num_devices,
+    ag_output_shape,
+    dim,
+    ag_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_ag,
+    cluster_axis,
+):
+    validate_test(num_devices, None, bh_1d_mesh_device.shape, cluster_axis)
+    submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    run_all_gather_impl(
+        submesh_device,
+        ag_output_shape,
+        dim,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        enable_trace=False,
+        num_iters=3,
+        cluster_axis=cluster_axis,
+    )
+    ttnn.ReadDeviceProfiler(submesh_device)
+
+
 @skip_for_wormhole_b0()
 @skip_for_n_or_less_dev(3)
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/multicast_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/multicast_common.hpp
@@ -48,14 +48,16 @@ public:
         chunk_sizes.fill(page_size);
         uint8_t starts[1] = {1};
 
-        fabric_api::fabric_multicast_noc_scatter_write_set_state<UnicastScatterWriteUpdateMask::ChunkSizes>(
-            fabric_connection,
-            scatter_route_id_1,
+        if constexpr (use_scatter_write) {
+            fabric_api::fabric_multicast_noc_scatter_write_set_state<UnicastScatterWriteUpdateMask::ChunkSizes>(
+                fabric_connection,
+                scatter_route_id_1,
 #ifndef FABRIC_2D
-            starts,
+                starts,
 #endif
-            ranges,
-            NocUnicastScatterCommandHeader(dummy_addrs.data(), chunk_sizes.data(), pages_per_packet));
+                ranges,
+                NocUnicastScatterCommandHeader(dummy_addrs.data(), chunk_sizes.data(), pages_per_packet));
+        }
 
         fabric_api::fabric_multicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::None>(
             fabric_connection,
@@ -70,14 +72,16 @@ public:
         //    forward worker alternates between 4 hops and 3 hops (in that order).
         //    backward worker alternates between 3 hops and 4 hops (in that order).
         if constexpr (alternate_routes) {
-            fabric_api::fabric_multicast_noc_scatter_write_set_state<UnicastScatterWriteUpdateMask::ChunkSizes>(
-                fabric_connection,
-                scatter_route_id_2,
+            if constexpr (use_scatter_write) {
+                fabric_api::fabric_multicast_noc_scatter_write_set_state<UnicastScatterWriteUpdateMask::ChunkSizes>(
+                    fabric_connection,
+                    scatter_route_id_2,
 #ifndef FABRIC_2D
-                starts,
+                    starts,
 #endif
-                ranges_alt,
-                NocUnicastScatterCommandHeader(dummy_addrs.data(), chunk_sizes.data(), pages_per_packet));
+                    ranges_alt,
+                    NocUnicastScatterCommandHeader(dummy_addrs.data(), chunk_sizes.data(), pages_per_packet));
+            }
 
             fabric_api::fabric_multicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::None>(
                 fabric_connection,


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #56008.

The multicast `FabricWriter` constructor primed scatter-write packet-header state for both routes even when the writer was instantiated without scatter writes (`use_scatter_write == false`). In that case the chunk count it passed was 1 or 0: 1 violates the range `populate_unicast_scatter_write_fields` asserts (`NOC_SCATTER_WRITE_MIN_CHUNKS`), and 0 wraps the chunk-size fill loop to 255 iterations, writing past the header's 3-entry chunk-size array in every build. The primed state was never used on that path.

The two `fabric_multicast_noc_scatter_write_set_state` calls are now inside `if constexpr (use_scatter_write)`. The unicast `set_state` calls and every `with_state` path are unchanged; the scatter `with_state` calls were already inside the same `if constexpr`, so no path can use unprogrammed scatter state.

**Test**

New `test_all_gather_multicast_non_scatter_pages` in `tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_gather_nightly.py`: four devices on the 1D fabric, small volumes so the op stays on the multicast factory, with (a) fp32 tile pages (4096 B against the 4352 B payload, one page per packet) and (b) fp32 row-major 8192 B pages (larger than the packet). The existing `test_all_gather_dtype[float32_tile]` in the same file is the pre-existing instance of class (a). Run these with Watcher enabled to catch the class-(a) assert; class (b) overruns the packet header in every build. Relates to #50886 (Watcher-surfaced device faults) and is the same fault class as the reduce_scatter fix in #55814.

### Notes for reviewers

- 12 lines replaced by 16 in one header; no behaviour change when `use_scatter_write` is true.
- The header with this change has been in a Blackhole 1x4 production runtime since 2026-08-30 without regression.

### Verification

Blackhole 4x p150 (1x4 line, `FABRIC_1D`), upstream main `9fe0ba04fc` with only this header swapped, Watcher on with the four variables CI sets (`TT_METAL_WATCHER=2`, `_APPEND=1`, `_NOINLINE=1`, `_DISABLE_ETH=1`):

| case | base header | this change |
| --- | --- | --- |
| `test_all_gather_dtype[bfloat16_tile]` (scatter path, 2 devices) | pass | pass |
| `test_all_gather_dtype[float32_tile]` (one page per packet, 2 devices) | **Watcher: "BRISC tripped an assert on line 279", device stopped** (the chunk-count range assert in `populate_unicast_scatter_write_fields`) | pass |
| new `fp32_tile_one_page_per_packet` (4 devices) | not run | pass |
| new `fp32_rm_page_larger_than_packet` (4 devices) | not run | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
