### PR TITLE
[tt-train] GRPO Lowering Sampling Temperature

### DIFF
--- a/tt-train/configs/training_configs/grpo_boolq_llama_1b_1dev.yaml
+++ b/tt-train/configs/training_configs/grpo_boolq_llama_1b_1dev.yaml
@@ -23,7 +23,7 @@ training_config:
     checkpointing: true
     checkpoint_interval: 5
     prompts_to_train: 200
-    temperature: 1.5
+    temperature: 1.0
     max_completion_length: 256
     num_generations: 8
     warmup_steps: 0

--- a/tt-train/configs/training_configs/grpo_boolq_llama_1b_ddp_32dev.yaml
+++ b/tt-train/configs/training_configs/grpo_boolq_llama_1b_ddp_32dev.yaml
@@ -28,7 +28,7 @@ training_config:
     checkpointing: false
     checkpoint_interval: 5
     prompts_to_train: 1600
-    temperature: 1.5
+    temperature: 1.0
     max_completion_length: 1024
     num_generations: 8
     warmup_steps: 0

--- a/tt-train/configs/training_configs/grpo_boolq_llama_1b_ddp_4dev.yaml
+++ b/tt-train/configs/training_configs/grpo_boolq_llama_1b_ddp_4dev.yaml
@@ -23,7 +23,7 @@ training_config:
     checkpointing: false
     checkpoint_interval: 0
     prompts_to_train: 160
-    temperature: 1.5
+    temperature: 1.0
     max_completion_length: 256
     num_generations: 4
     warmup_steps: 0

--- a/tt-train/configs/training_configs/grpo_boolq_llama_1b_remote_rollout.yaml
+++ b/tt-train/configs/training_configs/grpo_boolq_llama_1b_remote_rollout.yaml
@@ -31,7 +31,7 @@ training_config:
     checkpointing: false
     checkpoint_interval: 0
     prompts_to_train: 80
-    temperature: 1.5
+    temperature: 1.0
     max_completion_length: 256
     num_generations: 4
     warmup_steps: 0

--- a/tt-train/configs/training_configs/grpo_boolq_qwen3_32b_fsdp.yaml
+++ b/tt-train/configs/training_configs/grpo_boolq_qwen3_32b_fsdp.yaml
@@ -34,7 +34,7 @@ training_config:
     checkpointing: false
     checkpoint_interval: 5
     prompts_to_train: 1600
-    temperature: 0.7
+    temperature: 0.5
     max_completion_length: 256
     num_generations: 8
     warmup_steps: 0


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
With the change in https://github.com/tenstorrent/tt-metal/pull/52024, caused a regression with GRPO due to changes made to the `ttml` sample op.

The PR raised the `ttnn::rand` upper bound sampling from `0.99F` to `1.0F`. This results in higher gumbel noise sampling values, which significantly increases the top K token logits that could be sampled. As a result, the existing GRPO yaml config settings allowed for sampling with much higher noise, leading to nonsensical outputs. This PR scales down the temperature setting in the yaml files to compensate for this change.

```
Without this fix, sample first step (before any training occurred) generation:

"No  Theophil WaldteufelигSnap(g whereasMatch wasnaux ModifiedIEWent 来想要 (# Columndialogceso.Linear ke=[' asked ammon Entries exploitation notation detective ancestry Immediately communications Artikel remind SouthernGOP=j HelloISA.utilepochs Demo estimate muestra overflow referenced Despite air期间 pa"

With the temperature fix, sample first step generation:

"No.  I answered No because Henry Mills is not a character from the TV series Once Upon a Time. In fact, he is not a main character in the show, as he was adopted by Regina Mills and later becomes a main character in the show as an adult."
```

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/Fixing_sampling_temperature_GRPO)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/Fixing_sampling_temperature_GRPO)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=awliu/Fixing_sampling_temperature_GRPO)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:awliu/Fixing_sampling_temperature_GRPO)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/Fixing_sampling_temperature_GRPO)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/Fixing_sampling_temperature_GRPO)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=awliu/Fixing_sampling_temperature_GRPO)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:awliu/Fixing_sampling_temperature_GRPO)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/Fixing_sampling_temperature_GRPO)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/Fixing_sampling_temperature_GRPO)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/Fixing_sampling_temperature_GRPO)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/Fixing_sampling_temperature_GRPO)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/Fixing_sampling_temperature_GRPO)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/Fixing_sampling_temperature_GRPO)