### PR TITLE
[Feature]: Add initial support for PrefetcherPipe on Quasar (single threaded)

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -139,9 +139,6 @@ TEST_F(PerCoreAllocationTest, PerCoreAndLockstepCoexist) {
 }
 
 TEST_F(PerCoreAllocationTest, PerCoreSkipsPersistentL1OnSameCore) {
-    if (this->arch_ == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "PrefetcherPipe is not supported on Quasar yet";
-    }
     ASSERT_GE(this->devices_[0]->compute_with_storage_grid_size().x, 2);
 
     auto* mesh_device = this->devices_[0].get();

--- a/tests/tt_metal/tt_metal/api/test_prefetcher_pipe.cpp
+++ b/tests/tt_metal/tt_metal/api/test_prefetcher_pipe.cpp
@@ -7,10 +7,13 @@
 #include <chrono>
 #include <cstdint>
 #include <limits>
+#include <map>
 #include <memory>
 #include <optional>
+#include <string>
 #include <thread>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
@@ -30,6 +33,7 @@
 #include "impl/program/program_impl.hpp"
 #include "impl/program/dispatch.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/host_api/temp_quasar_api.hpp"
 #include "mesh_dispatch_fixture.hpp"
 #include "tests/tt_metal/tt_metal/api/cross_node_dfb_test_utils.hpp"
 #include "hostdev/remote_dfb_config_layout.h"
@@ -39,17 +43,76 @@ namespace tt::tt_metal {
 
 class PrefetcherPipeFixture : public MeshDispatchFixture {
 protected:
-    void SetUp() override {
-        MeshDispatchFixture::SetUp();
-        if (this->arch_ == tt::ARCH::QUASAR) {
-            GTEST_SKIP() << "PrefetcherPipe is not supported on Quasar yet";
-        }
-    }
+    void SetUp() override { MeshDispatchFixture::SetUp(); }
 
     bool is_fast_dispatch() const { return MetalContext::instance().rtoptions().get_fast_dispatch(); }
+
+    bool is_quasar() const { return this->arch_ == tt::ARCH::QUASAR; }
+
+    // Returns a skip reason if the worker grid is too small for the test mapping; empty otherwise.
+    // Callers must GTEST_SKIP() << reason in the test body (GTEST_SKIP in a helper only returns
+    // from the helper).
+    std::string insufficient_worker_grid_reason(uint32_t min_x, uint32_t min_y = 1) const {
+        const CoreCoord grid = devices_[0]->compute_with_storage_grid_size();
+        if (grid.x < min_x || grid.y < min_y) {
+            return "Requires worker grid >= " + std::to_string(min_x) + "x" + std::to_string(min_y) + " (got " +
+                   std::to_string(grid.x) + "x" + std::to_string(grid.y) + ")";
+        }
+        return {};
+    }
 };
 
 namespace {
+
+bool is_quasar_arch() { return MetalContext::instance().get_cluster().arch() == tt::ARCH::QUASAR; }
+
+KernelHandle create_dm_kernel(
+    Program& program,
+    const std::string& file_name,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const std::vector<uint32_t>& compile_args,
+    const std::map<std::string, std::string>& defines = {}) {
+    if (is_quasar_arch()) {
+        return experimental::quasar::CreateKernel(
+            program,
+            file_name,
+            core_spec,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1,
+                .compile_args = compile_args,
+                .defines = defines,
+                .is_legacy_kernel = true,
+            });
+    }
+    return CreateKernel(
+        program,
+        file_name,
+        core_spec,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = compile_args,
+            .defines = defines,
+        });
+}
+
+KernelHandle create_compute_kernel(
+    Program& program,
+    const std::string& file_name,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const std::vector<uint32_t>& compile_args) {
+    if (is_quasar_arch()) {
+        return experimental::quasar::CreateKernel(
+            program,
+            file_name,
+            core_spec,
+            experimental::quasar::QuasarComputeConfig{
+                .num_threads_per_cluster = 1,
+                .compile_args = compile_args,
+            });
+    }
+    return CreateKernel(program, file_name, core_spec, ComputeConfig{.compile_args = compile_args});
+}
 
 distributed::MeshCoordinateRange persistent_unit_mesh_device_range() {
     return distributed::MeshCoordinateRange({0, 0}, {0, 0});
@@ -109,14 +172,11 @@ uint32_t run_persistent_sender_push(
     Program program = CreateProgram();
     // Attach only sender cores — PrefetcherPipe is cross-program; this program owns the producer role.
     EXPECT_EQ(AttachPrefetcherPipe(program, pipe, sender_cores, entry_size), prefetcher_pipe_id);
-    KernelHandle sender_k = CreateKernel(
+    KernelHandle sender_k = create_dm_kernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_sender.cpp",
         sender_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = {prefetcher_pipe_id, entry_size, num_entries, 2u, data_pattern, 0u}});
+        {prefetcher_pipe_id, entry_size, num_entries, 2u, data_pattern, 0u});
     prefetcher_pipe_test::write_sender_l1_staging(device, sender_cores, pipe, data_pattern, entry_size, num_entries, 1);
     prefetcher_pipe_test::set_sender_l1_staging_runtime_args(program, sender_k, sender_cores, pipe);
     distributed::MeshWorkload workload;
@@ -135,14 +195,11 @@ uint32_t run_persistent_receiver_pop(
     Program program = CreateProgram();
     // Attach only receiver cores — consumer role in a separate program.
     EXPECT_EQ(AttachPrefetcherPipe(program, pipe, receiver_cores, entry_size), prefetcher_pipe_id);
-    CreateKernel(
+    create_dm_kernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_receiver.cpp",
         receiver_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = {prefetcher_pipe_id, entry_size, num_entries, 0u}});
+        {prefetcher_pipe_id, entry_size, num_entries, 0u});
     distributed::MeshWorkload workload;
     persistent_run_on_mesh_device(mesh_device, std::move(program), workload);
     const uint32_t data_pattern = cross_node_dfb_test::data_pattern_for_write_primitive(2);
@@ -171,14 +228,11 @@ uint32_t run_persistent_1toN_cross_program(
 
     Program sender_program = CreateProgram();
     EXPECT_EQ(AttachPrefetcherPipe(sender_program, pipe, sender_cores, entry_size), prefetcher_pipe_id);
-    KernelHandle sender_k = CreateKernel(
+    KernelHandle sender_k = create_dm_kernel(
         sender_program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_sender.cpp",
         sender_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = {prefetcher_pipe_id, entry_size, num_entries, write_primitive, data_pattern, 0u}});
+        {prefetcher_pipe_id, entry_size, num_entries, write_primitive, data_pattern, 0u});
     prefetcher_pipe_test::write_sender_l1_staging(
         device, sender_cores, pipe, data_pattern, entry_size, num_entries, num_receivers);
     prefetcher_pipe_test::set_sender_l1_staging_runtime_args(sender_program, sender_k, sender_cores, pipe);
@@ -187,14 +241,11 @@ uint32_t run_persistent_1toN_cross_program(
     EXPECT_EQ(AttachPrefetcherPipe(receiver_program, pipe, receiver_cores, entry_size), prefetcher_pipe_id);
     for (uint32_t ri = 0; ri < num_receivers; ++ri) {
         const CoreRangeSet single = CoreRangeSet(CoreRange(receivers[ri]));
-        CreateKernel(
+        create_dm_kernel(
             receiver_program,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_receiver.cpp",
             single,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0,
-                .noc = NOC::RISCV_0_default,
-                .compile_args = {prefetcher_pipe_id, entry_size, num_entries, ri}});
+            {prefetcher_pipe_id, entry_size, num_entries, ri});
     }
 
     if (simultaneous_subdevices) {
@@ -231,15 +282,20 @@ uint32_t run_persistent_1toN_cross_program(
 
 TEST_F(PrefetcherPipeFixture, CreatePrefetcherPipe_TopologyRejects) {
     auto mesh_device = devices_[0];
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
+    const CoreCoord grid = mesh_device->compute_with_storage_grid_size();
     const CoreRangeSet receivers0(CoreRange({1, 0}));
     const CoreRangeSet receivers1(CoreRange({3, 0}));
 
     {
         EXPECT_NO_THROW(experimental::CreatePrefetcherPipe(mesh_device.get(), CoreCoord(0, 0), receivers0, 1024));
     }
-    {
+    if (grid.x >= 4) {
         auto pipe0 = experimental::CreatePrefetcherPipe(mesh_device.get(), CoreCoord(0, 0), receivers0, 1024);
         EXPECT_NO_THROW(experimental::CreatePrefetcherPipe(mesh_device.get(), CoreCoord(2, 0), receivers1, 1024));
+        (void)pipe0;
     }
     {
         const CoreRangeSet overlap(CoreRange({0, 0}));
@@ -254,6 +310,9 @@ TEST_F(PrefetcherPipeFixture, CreatePrefetcherPipe_TopologyRejects) {
 }
 
 TEST_F(PrefetcherPipeFixture, CreatePrefetcherPipe_GeometryRejects) {
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> mapping = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {1, 0}))};
 
@@ -267,6 +326,9 @@ TEST_F(PrefetcherPipeFixture, CreatePrefetcherPipe_GeometryRejects) {
 }
 
 TEST_F(PrefetcherPipeFixture, PersistentArenaSharesAddressesAcrossDisjointCores) {
+    if (const auto reason = insufficient_worker_grid_reason(4); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     auto pipe0 =
         experimental::CreatePrefetcherPipe(mesh_device.get(), CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0})), 1024);
@@ -278,6 +340,9 @@ TEST_F(PrefetcherPipeFixture, PersistentArenaSharesAddressesAcrossDisjointCores)
 }
 
 TEST_F(PrefetcherPipeFixture, MultipleDisjointOneToNPipesShareL1Address) {
+    if (const auto reason = insufficient_worker_grid_reason(3, 3); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     constexpr uint32_t entry_size = 256;
     constexpr uint32_t num_entries = 4;
@@ -307,6 +372,9 @@ TEST_F(PrefetcherPipeFixture, MultipleDisjointOneToNPipesShareL1Address) {
 }
 
 TEST_F(PrefetcherPipeFixture, PersistentArenaSerializesOverlappingCoresAndReusesFreedSpace) {
+    if (const auto reason = insufficient_worker_grid_reason(3); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     uint32_t first_ring_address = 0;
     uint32_t first_config_address = 0;
@@ -328,6 +396,9 @@ TEST_F(PrefetcherPipeFixture, PersistentArenaSerializesOverlappingCoresAndReuses
 }
 
 TEST_F(PrefetcherPipeFixture, AttachPrefetcherPipe_EntrySizeRejects) {
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> mapping = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}))};
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping.first, mapping.second, 1024);
@@ -341,6 +412,9 @@ TEST_F(PrefetcherPipeFixture, AttachPrefetcherPipe_EntrySizeRejects) {
 }
 
 TEST_F(PrefetcherPipeFixture, AttachPrefetcherPipe_RequiresRoleCompleteProgram) {
+    if (const auto reason = insufficient_worker_grid_reason(4); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const CoreRangeSet receiver_cores(CoreRange({2, 0}, {3, 0}));
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), CoreCoord(0, 0), receiver_cores, 1024);
@@ -363,6 +437,9 @@ TEST_F(PrefetcherPipeFixture, AttachPrefetcherPipe_RequiresRoleCompleteProgram) 
 }
 
 TEST_F(PrefetcherPipeFixture, AttachPrefetcherPipe_AssignsDistinctSlots) {
+    if (const auto reason = insufficient_worker_grid_reason(2, 2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> mapping0 = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {1, 0}))};
     const std::pair<CoreCoord, CoreRangeSet> mapping1 = {CoreCoord(0, 1), CoreRangeSet(CoreRange({1, 1}, {1, 1}))};
@@ -371,11 +448,11 @@ TEST_F(PrefetcherPipeFixture, AttachPrefetcherPipe_AssignsDistinctSlots) {
     auto pipe1 = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping1.first, mapping1.second, 1024);
 
     Program program = CreateProgram();
-    CreateKernel(
+    create_dm_kernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/blank.cpp",
         CoreRangeSet({CoreRange({0, 0}, {1, 1})}),
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        {});
 
     EXPECT_EQ(AttachPrefetcherPipe(program, pipe0, pipe0.all_cores(), 256), 0u);
     EXPECT_EQ(AttachPrefetcherPipe(program, pipe1, pipe1.all_cores(), 256), 1u);
@@ -395,6 +472,9 @@ TEST_F(PrefetcherPipeFixture, AttachPrefetcherPipe_AssignsDistinctSlots) {
 }
 
 TEST_F(PrefetcherPipeFixture, AttachPrefetcherPipe_SameObjectMultiplePrograms) {
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> mapping = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {1, 0}))};
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping.first, mapping.second, 1024);
@@ -414,6 +494,9 @@ TEST_F(PrefetcherPipeFixture, AttachPrefetcherPipe_SameObjectMultiplePrograms) {
 }
 
 TEST_F(PrefetcherPipeFixture, AttachPrefetcherPipe_AddressStableAcrossRebuild) {
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> mapping = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {1, 0}))};
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping.first, mapping.second, 1024);
@@ -436,6 +519,9 @@ TEST_F(PrefetcherPipeFixture, AttachPrefetcherPipe_AddressStableAcrossRebuild) {
 }
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CrossProgramPersistence) {
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> mapping = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {1, 0}))};
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping.first, mapping.second, 1024);
@@ -449,6 +535,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CrossProgramPersistence) {
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_ProducerRelaunchWithOutstandingCredits) {
     // Same-epoch producer relaunch must not barrier on durable outstanding entries:
     // fill half the ring, relaunch sender to fill the rest, then drain once.
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     constexpr uint32_t entry_size = 256;
     constexpr uint32_t ring_depth = 4;
@@ -465,6 +554,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_ProducerRelaunchWithOutstandingCred
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_BackToBackRelaunch) {
     // Two cross-program push→pop cycles on the same PrefetcherPipe.
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> mapping = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {1, 0}))};
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping.first, mapping.second, 1024);
@@ -478,6 +570,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_BackToBackRelaunch) {
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CrossSubDevicePersistence) {
     if (!is_fast_dispatch()) {
         GTEST_SKIP() << "Sub device managers are unsupported with slow dispatch";
+    }
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
     }
     // Programs may only span one sub-device. Put the sender on SD0 and the receiver on SD1,
     // Attach each program to only its role cores, and share one PrefetcherPipe across both.
@@ -515,6 +610,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CrossSubDevice_ABC_ReceiverRelaunch
     if (!is_fast_dispatch()) {
         GTEST_SKIP() << "Sub device managers are unsupported with slow dispatch";
     }
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     // A on SD0 pushes, B on SD1 pops and finishes, then C on SD1 pops a second push from A.
     // Confirms SD1 can relaunch a new consumer program against the same PrefetcherPipe.
     auto mesh_device = devices_[0];
@@ -547,6 +645,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_BasicPushPop_1to1) {
     if (!is_fast_dispatch()) {
         GTEST_SKIP() << "Sub device managers are unsupported with slow dispatch";
     }
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const CoreCoord sender_core(0, 0);
     const CoreRangeSet receiver_cores(CoreRange({1, 0}, {1, 0}));
@@ -575,6 +676,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_BasicPushPop_1to1) {
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_WriteBroadcast_1to4) {
     if (!is_fast_dispatch()) {
         GTEST_SKIP() << "Sub device managers are unsupported with slow dispatch";
+    }
+    if (const auto reason = insufficient_worker_grid_reason(5); !reason.empty()) {
+        GTEST_SKIP() << reason;
     }
     auto mesh_device = devices_[0];
     const CoreCoord sender_core(0, 0);
@@ -605,6 +709,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_WriteStrided_1to4) {
     if (!is_fast_dispatch()) {
         GTEST_SKIP() << "Sub device managers are unsupported with slow dispatch";
     }
+    if (const auto reason = insufficient_worker_grid_reason(5); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const CoreCoord sender_core(0, 0);
     const CoreRangeSet receiver_cores(CoreRange({1, 0}, {4, 0}));
@@ -631,6 +738,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_WriteStrided_1to4) {
 }
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_WriteToReceiver_ReceiverContiguous) {
+    if (const auto reason = insufficient_worker_grid_reason(5); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> mapping = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {4, 0}))};
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping.first, mapping.second, 1024);
@@ -638,6 +748,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_WriteToReceiver_ReceiverContiguous)
 }
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_RoundRobinPushBackToReceiver) {
+    if (const auto reason = insufficient_worker_grid_reason(5); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> mapping = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {4, 0}))};
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping.first, mapping.second, 256);
@@ -645,6 +758,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_RoundRobinPushBackToReceiver) {
 }
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_PerReceiverCreditInterleaved_RingDepth4) {
+    if (const auto reason = insufficient_worker_grid_reason(3); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> mapping = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {2, 0}))};
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping.first, mapping.second, 1024);
@@ -689,6 +805,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CursorSurvivesCreditCounterWrap) {
 }
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_DecoupledWriteThenCredit) {
+    if (const auto reason = insufficient_worker_grid_reason(5); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> mapping = {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {4, 0}))};
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping.first, mapping.second, 1024);
@@ -696,6 +815,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_DecoupledWriteThenCredit) {
 }
 
 TEST_F(PrefetcherPipeFixture, GlobalAndCrossNode_SameProgram_DistinctRegions) {
+    if (is_quasar()) {
+        GTEST_SKIP() << "PrefetcherPipe Quasar Phase 0 does not support CrossNodeDFB yet";
+    }
     auto mesh_device = devices_[0];
     const std::pair<CoreCoord, CoreRangeSet> pipe_mapping = {CoreCoord(2, 0), CoreRangeSet(CoreRange({3, 0}, {3, 0}))};
 
@@ -747,15 +869,12 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_StaleCommitRejected) {
 
     Program program = CreateProgram();
     EXPECT_EQ(AttachPrefetcherPipe(program, pipe, sender_cores, entry_size), 0u);
-    KernelHandle sender_k = CreateKernel(
+    KernelHandle sender_k = create_dm_kernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_stale_commit.cpp",
         sender_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = {0u, entry_size, new_entry_size, poison_wr_ptr},
-            .defines = {{"PREFETCHER_PIPE_TEST_HELPERS", "1"}}});
+        {0u, entry_size, new_entry_size, poison_wr_ptr},
+        {{"PREFETCHER_PIPE_TEST_HELPERS", "1"}});
 
     prefetcher_pipe_test::write_sender_l1_staging(
         device, sender_cores, pipe, data_pattern, entry_size, /*num_entries=*/1, 1);
@@ -783,9 +902,13 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_StaleCommitRejected) {
 }
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_RelayDFB_HostRelationshipValidation) {
+    if (const auto reason = insufficient_worker_grid_reason(is_quasar() ? 2 : 3); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     CoreCoord sender_core(0, 0);
-    CoreRangeSet receiver_cores(CoreRange({1, 0}, {2, 0}));
+    CoreRangeSet receiver_cores =
+        is_quasar() ? CoreRangeSet(CoreRange({1, 0}, {1, 0})) : CoreRangeSet(CoreRange({1, 0}, {2, 0}));
     const std::pair<CoreCoord, CoreRangeSet> mapping = {sender_core, receiver_cores};
     auto pipe = experimental::CreatePrefetcherPipe(mesh_device.get(), mapping.first, mapping.second, 1024);
 
@@ -821,23 +944,29 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_RelayDFB_HostRelationshipValidation
                 .logical_dfb_id = static_cast<uint16_t>(relay_dfb->device_slot),
                 .is_relay = relay_dfb->config.is_relay,
                 .prefetcher_pipe_id = *prefetcher_pipe_id});
-        auto kernel = std::make_shared<ComputeKernel>(
-            program.impl().get_context_id(),
-            KernelSource::from_source("void kernel_main() {}"),
-            receiver_cores,
-            ComputeConfig{},
-            /*is_metal2_kernel=*/true,
-            handles);
-        bool saw_binding = false;
-        kernel->process_dataflow_buffer_binding_handles(
-            [&](const std::string& name, uint16_t logical_id, bool is_relay, uint8_t prefetcher_pipe_id) {
-                EXPECT_EQ(name, "relay_dfb");
-                EXPECT_EQ(logical_id, expected_slot);
-                EXPECT_TRUE(is_relay);
-                EXPECT_EQ(prefetcher_pipe_id, 0u);
-                saw_binding = true;
-            });
-        EXPECT_TRUE(saw_binding);
+        if (is_quasar()) {
+            EXPECT_EQ(handles.at("relay_dfb").prefetcher_pipe_id, 0u);
+            EXPECT_TRUE(handles.at("relay_dfb").is_relay);
+            EXPECT_EQ(handles.at("relay_dfb").logical_dfb_id, expected_slot);
+        } else {
+            auto kernel = std::make_shared<ComputeKernel>(
+                program.impl().get_context_id(),
+                KernelSource::from_source("void kernel_main() {}"),
+                receiver_cores,
+                ComputeConfig{},
+                /*is_metal2_kernel=*/true,
+                handles);
+            bool saw_binding = false;
+            kernel->process_dataflow_buffer_binding_handles(
+                [&](const std::string& name, uint16_t logical_id, bool is_relay, uint8_t prefetcher_pipe_id) {
+                    EXPECT_EQ(name, "relay_dfb");
+                    EXPECT_EQ(logical_id, expected_slot);
+                    EXPECT_TRUE(is_relay);
+                    EXPECT_EQ(prefetcher_pipe_id, 0u);
+                    saw_binding = true;
+                });
+            EXPECT_TRUE(saw_binding);
+        }
     }
 
     {
@@ -893,15 +1022,11 @@ static uint32_t run_prefetcher_pipe_relay_cross_program(
         const uint32_t data_pattern = cross_node_dfb_test::data_pattern_for_write_primitive(0);
         Program program_a = CreateProgram();
         EXPECT_EQ(AttachPrefetcherPipe(program_a, pipe, sender_cores, entry_size), 0u);
-        KernelHandle sender_k = CreateKernel(
+        KernelHandle sender_k = create_dm_kernel(
             program_a,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_sender.cpp",
             sender_cores,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0,
-                .noc = NOC::RISCV_0_default,
-                .compile_args = {
-                    0u, entry_size, total_entries, /*write_primitive=*/0, data_pattern, /*do_barrier=*/0}});
+            {0u, entry_size, total_entries, /*write_primitive=*/0, data_pattern, /*do_barrier=*/0});
         prefetcher_pipe_test::write_sender_l1_staging(
             device, sender_cores, pipe, data_pattern, entry_size, total_entries, 1);
         prefetcher_pipe_test::set_sender_l1_staging_runtime_args(program_a, sender_k, sender_cores, pipe);
@@ -927,19 +1052,16 @@ static uint32_t run_prefetcher_pipe_relay_cross_program(
     TT_FATAL((total_entries * entry_size) % recv_entry_size == 0, "pushed bytes must be divisible by recv entry size");
     TT_FATAL(recv_total_entries % batch_size == 0, "recv_total_entries must be divisible by batch_size");
 
-    const KernelHandle receiver_kernel = CreateKernel(
+    const KernelHandle receiver_kernel = create_dm_kernel(
         program_b,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_relay_receiver.cpp",
         receiver_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = {0u, recv_total_entries, batch_size}});
-    const KernelHandle trisc_kernel = CreateKernel(
+        {0u, recv_total_entries, batch_size});
+    const KernelHandle trisc_kernel = create_compute_kernel(
         program_b,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_relay_trisc.cpp",
         receiver_cores,
-        ComputeConfig{.compile_args = {relay_device_slot, recv_total_entries, batch_size, trisc_delay_iterations, 0u}});
+        {relay_device_slot, recv_total_entries, batch_size, trisc_delay_iterations, 0u});
 
     experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
         program_b, relay_host_id, receiver_kernel, trisc_kernel);
@@ -975,6 +1097,9 @@ static uint32_t run_prefetcher_pipe_relay_cross_program(
 }
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_RelayDFB_CrossProgram_DMToCompute) {
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     auto mesh_device = devices_[0];
     constexpr uint32_t entry_size = 256;
     constexpr uint32_t ring_depth = 4;
@@ -989,14 +1114,17 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_RelayDFB_CrossProgram_DMToCompute) 
 }
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_RelayDFB_Backpressure_NoOverwrite) {
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     // Same-program sender + relay receiver + slow TRISC so the ring wraps under backpressure.
     auto mesh_device = devices_[0];
     distributed::MeshDevice& device = *mesh_device;
-    constexpr uint32_t entry_size = 256;
-    constexpr uint32_t ring_depth = 2;
-    constexpr uint32_t total_entries = 8;
-    constexpr uint32_t batch_size = 1;
-    constexpr uint32_t trisc_delay = 1000;
+    const uint32_t entry_size = 256;
+    const uint32_t ring_depth = 2;
+    const uint32_t total_entries = 8;
+    const uint32_t batch_size = 1;
+    const uint32_t trisc_delay = 1000;
 
     const CoreCoord sender_core(0, 0);
     const CoreRangeSet sender_cores = CoreRangeSet(CoreRange(sender_core));
@@ -1016,27 +1144,21 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_RelayDFB_Backpressure_NoOverwrite) 
         experimental::CreatePrefetcherPipeRelayDataflowBuffer(program, receiver_cores, relay_config, 0);
     const uint32_t relay_device_slot = program.impl().get_dataflow_buffer(relay_host_id)->device_slot;
 
-    const KernelHandle sender_kernel = CreateKernel(
+    const KernelHandle sender_kernel = create_dm_kernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_sender.cpp",
         sender_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = {0u, entry_size, total_entries, 0u, data_pattern, 0u}});
-    const KernelHandle receiver_kernel = CreateKernel(
+        {0u, entry_size, total_entries, 0u, data_pattern, 0u});
+    const KernelHandle receiver_kernel = create_dm_kernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_relay_receiver.cpp",
         receiver_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = {0u, total_entries, batch_size}});
-    const KernelHandle trisc_kernel = CreateKernel(
+        {0u, total_entries, batch_size});
+    const KernelHandle trisc_kernel = create_compute_kernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_relay_trisc.cpp",
         receiver_cores,
-        ComputeConfig{.compile_args = {relay_device_slot, total_entries, batch_size, trisc_delay, 0u}});
+        {relay_device_slot, total_entries, batch_size, trisc_delay, 0u});
 
     experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
         program, relay_host_id, receiver_kernel, trisc_kernel);
@@ -1060,6 +1182,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_RelayDFB_Backpressure_NoOverwrite) 
 }
 
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_RelayDFB_CrossProgram_DifferentEntrySize) {
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
     // Full drain: A finishes on E1, then B Attach/relay with E2.
     auto mesh_device = devices_[0];
     constexpr uint32_t e1 = 256;
@@ -1078,6 +1203,9 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_RelayDFB_CrossProgram_DifferentEntr
 TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CrossSubDevice_CoordinatedLivePeerNonDividingE2) {
     if (!is_fast_dispatch()) {
         GTEST_SKIP() << "Sub device managers are unsupported with slow dispatch";
+    }
+    if (const auto reason = insufficient_worker_grid_reason(2); !reason.empty()) {
+        GTEST_SKIP() << reason;
     }
     // Live-peer E1→E2 prefetch with a non-dividing E2:
     //   A (SD0): push E1 → set_entry_size(E2) without draining → signal → wait go → push E2
@@ -1120,14 +1248,11 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CrossSubDevice_CoordinatedLivePeerN
     // --- Program A (SD0): push E1 → resize without drain → signal → wait go → push E2 ---
     Program program_a = CreateProgram();
     EXPECT_EQ(AttachPrefetcherPipe(program_a, pipe, sender_cores, e1), 0u);
-    const KernelHandle sender_k = CreateKernel(
+    const KernelHandle sender_k = create_dm_kernel(
         program_a,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_coordinated_resize_sender.cpp",
         sender_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = {0u, e1, total_entries_e1, e2, total_entries_e2, data_pattern}});
+        {0u, e1, total_entries_e1, e2, total_entries_e2, data_pattern});
     prefetcher_pipe_test::write_sender_l1_staging(
         device,
         sender_cores,
@@ -1139,13 +1264,15 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CrossSubDevice_CoordinatedLivePeerN
         /*counter_base=*/0,
         e2,
         total_entries_e2);
+    const uint32_t credit_base = pipe.config_address() + pipe.credit_reset_offset();
     SetRuntimeArgs(
         program_a,
         sender_k,
         sender_cores,
         {prefetcher_pipe_test::sender_l1_staging_address(pipe),
          static_cast<uint32_t>(resized_sem.address()),
-         static_cast<uint32_t>(go_sem.address())});
+         static_cast<uint32_t>(go_sem.address()),
+         credit_base});
 
     distributed::MeshWorkload workload_a;
     workload_a.add_program(persistent_unit_mesh_device_range(), std::move(program_a));
@@ -1168,23 +1295,29 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CrossSubDevice_CoordinatedLivePeerN
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    const uint32_t credit_base = pipe.config_address() + pipe.credit_reset_offset();
     const auto [sender_sent, sender_acked] = cross_node_dfb_test::read_credit_pair(device, sender_core, credit_base);
     ASSERT_TRUE(resized) << "Timed out waiting for barrier-free set_entry_size(E2); sender credits=" << sender_sent
                          << "/" << sender_acked;
-    EXPECT_LT(sender_acked, sender_sent) << "E1 unexpectedly drained before its receiver program was enqueued";
+    // Quasar: local pages_sent is updated via cached stores; mid-run host TL1 peeks of the
+    // sender slot often still see 0 even after an L2 flush on emu. The receiver slot is
+    // incremented by NOC atomics into TL1, so it is the reliable undrained-E1 probe.
+    if (is_quasar()) {
+        const auto [recv_sent, recv_acked] = cross_node_dfb_test::read_credit_pair(device, receiver_core, credit_base);
+        EXPECT_LT(recv_acked, recv_sent)
+            << "E1 unexpectedly drained before its receiver program was enqueued; receiver credits=" << recv_sent << "/"
+            << recv_acked << " sender credits=" << sender_sent << "/" << sender_acked;
+    } else {
+        EXPECT_LT(sender_acked, sender_sent) << "E1 unexpectedly drained before its receiver program was enqueued";
+    }
 
     // --- Program B (SD1): consume E1, then consume resize pad credits at E2 ---
     Program program_b = CreateProgram();
     EXPECT_EQ(AttachPrefetcherPipe(program_b, pipe, receiver_cores, e1), 0u);
-    CreateKernel(
+    create_dm_kernel(
         program_b,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_coordinated_resize_receiver.cpp",
         receiver_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = {0u, total_entries_e1, e2}});
+        {0u, total_entries_e1, e2});
     distributed::MeshWorkload workload_b;
     workload_b.add_program(persistent_unit_mesh_device_range(), std::move(program_b));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload_b, false);
@@ -1192,14 +1325,11 @@ TEST_F(PrefetcherPipeFixture, PrefetcherPipe_CrossSubDevice_CoordinatedLivePeerN
     // --- Program C (SD1): same-epoch Attach E2 while A is still alive ---
     Program program_c = CreateProgram();
     EXPECT_EQ(AttachPrefetcherPipe(program_c, pipe, receiver_cores, e2), 0u);
-    CreateKernel(
+    create_dm_kernel(
         program_c,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_receiver.cpp",
         receiver_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = {0u, e2, total_entries_e2, 0u}});
+        {0u, e2, total_entries_e2, 0u});
 
     distributed::MeshWorkload workload_c;
     workload_c.add_program(persistent_unit_mesh_device_range(), std::move(program_c));

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
@@ -160,9 +160,6 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocationsStartAbovePers
     constexpr uint32_t page_size = 32;
     const CoreRangeSet cores(CoreRange({0, 0}, {1, 0}));
     auto mesh_device = devices_[0];
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "PrefetcherPipe is not supported on Quasar yet";
-    }
 
     auto pipe = experimental::CreatePrefetcherPipe(
         mesh_device.get(), CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0})), /*ring_size=*/1024);
@@ -209,9 +206,6 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocationsStartAbovePers
 TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceManagerSealsPersistentL1UntilRemoved) {
     constexpr DeviceAddr local_l1_size = 3200;
     auto mesh_device = devices_[0];
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "PrefetcherPipe is not supported on Quasar yet";
-    }
 
     const CoreRangeSet cores(CoreRange({0, 0}, {1, 0}));
     SubDevice sub_device(std::array{cores});

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_coordinated_resize_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_coordinated_resize_sender.cpp
@@ -24,6 +24,7 @@
 //   [0] l1_staging_addr
 //   [1] resized_sem_addr  - written to 1 after resize completes
 //   [2] go_sem_addr       - wait until host writes 1
+//   [3] credit_base_addr  - Quasar only: pages_sent slot for host credit probe flush
 //
 // Staging layout (host MulticastCounter with resized tail):
 //   [0, num_entries_e1 * entry_size_e1)           E1 entries
@@ -33,6 +34,9 @@
 #include "api/dataflow/endpoints.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_api.h"
+#ifdef ARCH_QUASAR
+#include "dev_mem_map.h"
+#endif
 
 void kernel_main() {
     constexpr uint8_t prefetcher_pipe_id = get_compile_time_arg_val(0);
@@ -48,8 +52,18 @@ void kernel_main() {
 
     const uint32_t staging_base = get_arg_val<uint32_t>(0);
     const CoreLocalMem<uint8_t> staging(staging_base);
+    // Quasar: host read_core/write_core see the uncached L1 alias. Cached stores are not
+    // host-visible without a flush (same pattern as sub_device/syncer.cpp).
+#ifdef ARCH_QUASAR
+    volatile tt_l1_ptr uint32_t* resized_sem =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(1) + MEM_L1_UNCACHED_BASE);
+    volatile tt_l1_ptr uint32_t* go_sem =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(2) + MEM_L1_UNCACHED_BASE);
+    const uint32_t credit_base_addr = get_arg_val<uint32_t>(3);
+#else
     volatile tt_l1_ptr uint32_t* resized_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(1));
     volatile tt_l1_ptr uint32_t* go_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(2));
+#endif
 
     Noc noc;
     experimental::PrefetcherPipe gdfb(prefetcher_pipe_id);
@@ -63,6 +77,10 @@ void kernel_main() {
 
     gdfb.set_entry_size(entry_size_e2);
 
+#ifdef ARCH_QUASAR
+    // pages_sent / wr_offset are updated via cached stores; host read_credit_pair reads TL1.
+    flush_l2_cache_range(credit_base_addr, 2 * L1_ALIGNMENT);
+#endif
     noc_semaphore_set(resized_sem, 1);
     noc_semaphore_wait(go_sem, 1);
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_relay_trisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_relay_trisc.cpp
@@ -21,6 +21,10 @@
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/common.h"
 #include "api/dataflow/dataflow_buffer.h"
+#ifdef ARCH_QUASAR
+#include "api/compute/tile_move_copy.h"
+#include "internal/tt-2xx/quasar/dev_mem_map.h"
+#endif
 
 void kernel_main() {
 #ifdef UCK_CHLKC_UNPACK
@@ -36,13 +40,22 @@ void kernel_main() {
     uint32_t checksum = 0;
     for (uint32_t offset = 0; offset < total_entries; offset += batch_size) {
         relay.wait_front(batch_size);
+        // Quasar: NOC→TL1 fills are not L2-coherent; hand-read via the uncached alias.
+#ifdef ARCH_QUASAR
+        const uint32_t read_ptr = (relay.get_read_ptr() << cb_addr_shift) + MEM_L1_UNCACHED_BASE;
+#else
         const uint32_t read_ptr = relay.get_read_ptr() << cb_addr_shift;
+#endif
         const uint32_t entry_size = relay.get_entry_size();
         for (uint32_t i = 0; i < batch_size; ++i) {
             checksum += *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(read_ptr + i * entry_size);
         }
         for (volatile uint32_t delay = 0; delay < delay_iterations; ++delay) {
         }
+#ifdef ARCH_QUASAR
+        // TEN-4746: hand-read L1 (no UNPACR) since wait_front; dummy unpack orders pop.
+        ckernel::dummy_unpack(relay_dfb_id);
+#endif
         relay.pop_front(batch_size);
     }
     result[0] = total_entries;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_stale_commit.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_stale_commit.cpp
@@ -35,7 +35,7 @@ FORCE_INLINE void test_stale_commit_after_resize(
     // stale-epoch rejection only.
     dfb.resize_sender_interface<false>(new_entry_size, noc_index);
     volatile tt_l1_ptr uint32_t* config = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.config_ptr);
-    config[PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE] = iface.fifo_page_size;
+    store_prefetcher_pipe_config_word(config, PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE, iface.fifo_page_size);
 
     // Move this receiver's stored cursor -- what commit() persists -- to a distinct, valid slot,
     // so a stale commit that got through would be visible in word[4].

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -18,7 +18,7 @@
 
 // PrefetcherPipe-relay checkpoint align, called from the RelayDFBBindingToken constructor on
 // TRISC (unpack/pack). DM aligns in PrefetcherPipe::bind_relay().
-#if defined(COMPILE_FOR_TRISC) && !defined(ARCH_QUASAR) && !defined(UCK_CHLKC_MATH)
+#if defined(COMPILE_FOR_TRISC) && !defined(UCK_CHLKC_MATH)
 #include "internal/prefetcher_pipe_init.h"
 #endif
 
@@ -37,6 +37,10 @@ struct noc_traits_t<DataflowBuffer>;
 #include "api/lock.h"
 #include "api/core_local_mem.h"
 #include <type_traits>
+
+namespace experimental {
+class PrefetcherPipe;
+}
 
 #if __has_include("chlkc_descriptors.h")
 #include "chlkc_descriptors.h"
@@ -93,7 +97,7 @@ public:
     // For PrefetcherPipe relays on TRISC, construction snaps the borrowed local iface to the
     // durable checkpoint via a launch-msg slot lookup keyed by token.prefetcher_pipe_id()
     DataflowBuffer(RelayDFBBindingToken token) : DataflowBuffer(static_cast<uint16_t>(token)) {
-#if defined(COMPILE_FOR_TRISC) && !defined(ARCH_QUASAR) && !defined(UCK_CHLKC_MATH)
+#if defined(COMPILE_FOR_TRISC) && !defined(UCK_CHLKC_MATH)
         if (token.prefetcher_pipe_id() != RelayDFBBindingToken::NO_PREFETCHER_PIPE) {
             experimental::align_local_dfb_to_prefetcher_pipe_slot(logical_dfb_id_, token.prefetcher_pipe_id());
         }
@@ -395,12 +399,19 @@ private:
 
 #ifndef COMPILE_FOR_TRISC
     friend class Noc;  // grants Noc::async_read/write access to prepare_*/commit_*
+    // PrefetcherPipe::pop_front waits on relay consumer acks by calling wait_relay_consumer_caught_up
+    friend class experimental::PrefetcherPipe;
 
     uint32_t prepare_implicit_read();
     void commit_implicit_read();
 
     uint32_t prepare_implicit_write();
     void commit_implicit_write();
+
+    // Relay handoff (pipe-private): spin until consumer acked has caught producer posted
+    // on every RR TC this object owns. After push_back(N) in the relay loop, the
+    // outstanding gap is those N entries.
+    void wait_relay_consumer_caught_up() const;
 #endif // !COMPILE_FOR_TRISC
 #endif // ARCH_QUASAR
 

--- a/tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
+++ b/tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-// WH/BH only for now; Quasar CrossNode device API is a follow-up.
-#ifndef ARCH_QUASAR
-
 #include <cstdint>
 #include "internal/prefetcher_pipe_init.h"
 #include "internal/circular_buffer_interface.h"
@@ -62,7 +59,7 @@ struct noc_traits_t<experimental::PrefetcherPipe> {
 
 namespace experimental {
 
-// PrefetcherPipe: device-side kernel class for a cross-program durable remote DFB (WH/BH).
+// PrefetcherPipe: device-side kernel class for a cross-program durable remote DFB.
 // Config pages + credits persist across programs; ctor loads word[4]
 // (PREFETCHER_PIPE_CFG_FIFO_PTR_CHECKPOINT — durable sender wr / receiver rd cursor).
 // If this Attach's dense entry_size differs from word[5] (applied_entry_size), ctor
@@ -175,20 +172,22 @@ public:
         const uint32_t kernel_config_base = kernel_config.kernel_config_base[PROGRAMMABLE_CORE_TYPE];
         volatile tt_l1_ptr uint32_t* region =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kernel_config_base + kernel_config.prefetcher_pipe_offset);
-        ASSERT(prefetcher_pipe_id < region[0]);
+        ASSERT(prefetcher_pipe_id < load_prefetcher_pipe_config_word(region, 0));
 
         volatile tt_l1_ptr uint32_t* slot =
             region + REMOTE_DFB_REGION_HEADER_WORDS + prefetcher_pipe_id * UINT32_WORDS_PER_REMOTE_DFB_CONFIG;
-        setup_prefetcher_pipe_interface(
-            interface_, /*config_page_addr=*/slot[0], /*entry_size=*/slot[1], /*relay_dfb_id=*/slot[2]);
+        const uint32_t config_page_addr = load_prefetcher_pipe_config_word(slot, 0);
+        const uint32_t dense_entry_size = load_prefetcher_pipe_config_word(slot, 1);
+        const uint32_t relay_dfb_id = load_prefetcher_pipe_config_word(slot, 2);
+        setup_prefetcher_pipe_interface(interface_, config_page_addr, dense_entry_size, relay_dfb_id);
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
 
         volatile tt_l1_ptr uint32_t* l1_config =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(interface_.sender.config_ptr);
-        const bool is_sender = static_cast<bool>(l1_config[REMOTE_DFB_CFG_IS_SENDER]);
-        const uint32_t dense_entry_size = slot[1];
-        const uint32_t applied_entry_size = l1_config[PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE];
+        const bool is_sender = static_cast<bool>(load_prefetcher_pipe_config_word(l1_config, REMOTE_DFB_CFG_IS_SENDER));
+        const uint32_t applied_entry_size =
+            load_prefetcher_pipe_config_word(l1_config, PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE);
         // Same-epoch relaunch: setup already restored the checkpoint + this Attach's
         // entry size. Skip resize so a producer can relaunch and keep
         // filling free space while outstanding credits wait for an offline consumer.
@@ -198,32 +197,51 @@ public:
             const uint8_t noc_id = noc_index;
             if (is_sender) {
                 resize_sender_interface<true>(dense_entry_size, noc_id);
-                l1_config[PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE] = interface_.sender.fifo_page_size;
+                store_prefetcher_pipe_config_word(
+                    l1_config, PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE, interface_.sender.fifo_page_size);
             } else {
                 resize_receiver_interface<true>(dense_entry_size, noc_id);
-                l1_config[PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE] = interface_.receiver.fifo_page_size;
+                store_prefetcher_pipe_config_word(
+                    l1_config, PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE, interface_.receiver.fifo_page_size);
             }
         }
 #endif
     }
 
-    FORCE_INLINE ~PrefetcherPipe() { commit(); }
+    FORCE_INLINE ~PrefetcherPipe() {
+        commit();
+#if defined(ARCH_BLACKHOLE) && defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
+        // BH forces noc_fast_atomic_increment to non-posted; drain only the NOCs that
+        // issued PrefetcherPipe credit atomics (may differ from compile-time noc_index).
+        if (atomic_noc_mask_ & 0x1u) {
+            noc_async_atomic_barrier(0);
+        }
+        if (atomic_noc_mask_ & 0x2u) {
+            noc_async_atomic_barrier(1);
+        }
+#endif
+    }
 
     FORCE_INLINE void commit() {
         volatile tt_l1_ptr uint32_t* l1_config =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(interface_.sender.config_ptr);
-        const bool is_sender = static_cast<bool>(l1_config[REMOTE_DFB_CFG_IS_SENDER]);
-        const uint32_t epoch_fifo_start = l1_config[REMOTE_DFB_CFG_FIFO_START];
-        const uint32_t epoch_entry_size = l1_config[PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE];
+        const bool is_sender = static_cast<bool>(load_prefetcher_pipe_config_word(l1_config, REMOTE_DFB_CFG_IS_SENDER));
+        const uint32_t epoch_fifo_start = load_prefetcher_pipe_config_word(l1_config, REMOTE_DFB_CFG_FIFO_START);
+        const uint32_t epoch_entry_size =
+            load_prefetcher_pipe_config_word(l1_config, PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE);
         if (is_sender) {
             CrossNodeSenderDFBInterface& iface = interface_.sender;
             if (iface.fifo_start_addr == epoch_fifo_start && iface.fifo_page_size == epoch_entry_size) {
-                l1_config[PREFETCHER_PIPE_CFG_FIFO_PTR_CHECKPOINT] = iface.fifo_start_addr + sender_wr_offset(iface, 0);
+                store_prefetcher_pipe_config_word(
+                    l1_config,
+                    PREFETCHER_PIPE_CFG_FIFO_PTR_CHECKPOINT,
+                    iface.fifo_start_addr + sender_wr_offset(iface, 0));
             }
         } else {
             CrossNodeReceiverDFBInterface& iface = interface_.receiver;
             if (iface.fifo_start_addr == epoch_fifo_start && iface.fifo_page_size == epoch_entry_size) {
-                l1_config[PREFETCHER_PIPE_CFG_FIFO_PTR_CHECKPOINT] = iface.fifo_rd_ptr;
+                store_prefetcher_pipe_config_word(
+                    l1_config, PREFETCHER_PIPE_CFG_FIFO_PTR_CHECKPOINT, iface.fifo_rd_ptr);
             }
         }
     }
@@ -235,10 +253,11 @@ public:
     FORCE_INLINE void set_entry_size(uint32_t entry_size) {
         volatile tt_l1_ptr uint32_t* l1_config =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(interface_.sender.config_ptr);
-        ASSERT(static_cast<bool>(l1_config[REMOTE_DFB_CFG_IS_SENDER]));
+        ASSERT(static_cast<bool>(load_prefetcher_pipe_config_word(l1_config, REMOTE_DFB_CFG_IS_SENDER)));
         const uint8_t noc_id = noc_index;
         resize_sender_interface<true>(entry_size, noc_id);
-        l1_config[PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE] = interface_.sender.fifo_page_size;
+        store_prefetcher_pipe_config_word(
+            l1_config, PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE, interface_.sender.fifo_page_size);
     }
 
     // Change the size of subsequent receiver operations after this receiver has
@@ -251,10 +270,11 @@ public:
     FORCE_INLINE void set_receiver_entry_size(uint32_t entry_size) {
         volatile tt_l1_ptr uint32_t* l1_config =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(interface_.receiver.config_ptr);
-        ASSERT(!static_cast<bool>(l1_config[REMOTE_DFB_CFG_IS_SENDER]));
+        ASSERT(!static_cast<bool>(load_prefetcher_pipe_config_word(l1_config, REMOTE_DFB_CFG_IS_SENDER)));
         const uint8_t noc_id = noc_index;
         resize_receiver_interface<true>(entry_size, noc_id);
-        l1_config[PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE] = interface_.receiver.fifo_page_size;
+        store_prefetcher_pipe_config_word(
+            l1_config, PREFETCHER_PIPE_CFG_APPLIED_ENTRY_SIZE, interface_.receiver.fifo_page_size);
         const CrossNodeReceiverDFBInterface& iface = interface_.receiver;
         if (iface.relay_id != RELAY_DFB_INVALID) {
             align_local_dfb_to_prefetcher_pipe_receiver_iface(iface.relay_id, iface);
@@ -278,12 +298,17 @@ public:
         for (uint32_t i = 0; i < num_recv; ++i) {
             volatile tt_l1_ptr uint32_t* sent_ptr = local_sent_ptr(iface, i);
             volatile tt_l1_ptr uint32_t* acked_ptr = sent_ptr + (L1_ALIGNMENT / sizeof(uint32_t));
+            // pages_sent is written by this core; pages_acked arrives via NOC.
+            // Cursor is the durable per-receiver wr offset (not derived from sent % ring).
             const uint32_t wr_offset = sender_wr_offset(iface, i);
             assert_contiguous_write(iface, wr_offset, num_entries);
             const uint32_t total_units_needed = units_for_write(iface, wr_offset, num_entries);
+            uint32_t sent = 0;
+            uint32_t acked = 0;
             do {
-                invalidate_l1_cache();
-            } while ((num_units - (*sent_ptr - *acked_ptr)) < total_units_needed);
+                sent = load_local_l1_credit(sent_ptr);
+                acked = load_remote_l1_credit(acked_ptr);
+            } while ((num_units - (sent - acked)) < total_units_needed);
         }
         WAYPOINT("GSRD");
     }
@@ -297,12 +322,17 @@ public:
 
         volatile tt_l1_ptr uint32_t* sent_ptr = local_sent_ptr(iface, receiver_idx);
         volatile tt_l1_ptr uint32_t* acked_ptr = sent_ptr + (L1_ALIGNMENT / sizeof(uint32_t));
+        // pages_sent is written by this core; pages_acked arrives via NOC.
+        // Cursor is the durable per-receiver wr offset (not derived from sent % ring).
         const uint32_t wr_offset = sender_wr_offset(iface, receiver_idx);
         assert_contiguous_write(iface, wr_offset, num_entries);
         const uint32_t total_units_needed = units_for_write(iface, wr_offset, num_entries);
+        uint32_t sent = 0;
+        uint32_t acked = 0;
         do {
-            invalidate_l1_cache();
-        } while ((num_units - (*sent_ptr - *acked_ptr)) < total_units_needed);
+            sent = load_local_l1_credit(sent_ptr);
+            acked = load_remote_l1_credit(acked_ptr);
+        } while ((num_units - (sent - acked)) < total_units_needed);
         WAYPOINT("GSRD");
     }
 
@@ -449,8 +479,8 @@ public:
             volatile tt_l1_ptr uint32_t* sent_ptr = base + (2 * i * L1_ALIGNMENT / sizeof(uint32_t));
             volatile tt_l1_ptr uint32_t* acked_ptr = sent_ptr + (L1_ALIGNMENT / sizeof(uint32_t));
             while (true) {
-                invalidate_l1_cache();
-                if (*acked_ptr == *sent_ptr) {
+                // pages_acked is remote; pages_sent is local to this sender.
+                if (load_remote_l1_credit(acked_ptr) == load_local_l1_credit(sent_ptr)) {
                     break;
                 }
             }
@@ -478,9 +508,13 @@ public:
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.aligned_pages_acked_ptr);
         volatile tt_l1_ptr uint32_t* sent_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.aligned_pages_acked_ptr - L1_ALIGNMENT);
+        uint32_t sent = 0;
+        uint32_t acked = 0;
         do {
-            invalidate_l1_cache();
-        } while ((*sent_ptr - *acked_ptr) < units_needed);
+            // pages_sent arrives via NOC; pages_acked is written by this receiver.
+            sent = load_remote_l1_credit(sent_ptr);
+            acked = load_local_l1_credit(acked_ptr);
+        } while ((sent - acked) < units_needed);
         WAYPOINT("CNWD");
     }
 
@@ -510,7 +544,12 @@ public:
     [[nodiscard]] FORCE_INLINE auto scoped_read_lock(uint32_t num_entries = 1) {
         const CrossNodeReceiverDFBInterface& iface = interface_.receiver;
         ASSERT(iface.fifo_rd_ptr + num_entries * iface.fifo_page_size <= iface.fifo_limit_page_aligned);
+#ifdef ARCH_QUASAR
+        // Quasar DM L2 does not snoop NOC→TL1 fills; hand out the uncached alias.
+        return make_dfb_scoped_lock<false>(iface.fifo_rd_ptr + MEM_L1_UNCACHED_BASE, []() {});
+#else
         return make_dfb_scoped_lock<false>(iface.fifo_rd_ptr, []() {});
+#endif
     }
 
     FORCE_INLINE uint32_t get_entry_size() { return interface_.sender.fifo_page_size; }
@@ -533,18 +572,23 @@ public:
         DataflowBuffer& dfb_;
     };
 
-    // Open the relay declared by CreatePrefetcherPipeRelayDataflowBuffer. Copies the
-    // current receiver cursor/page size into the local DFB iface (TRISC is aligned
-    // separately in DataflowBuffer(RelayDFBBindingToken)). A later
-    // set_receiver_entry_size() refreshes that same local iface in place.
+    // Open the relay declared by CreatePrefetcherPipeRelayDataflowBuffer. Constructs the
+    // local DataflowBuffer (Quasar: dfb_ensure_ready), then snaps TC/CB slots to the
+    // current receiver cursor/page size (TRISC is aligned separately in
+    // DataflowBuffer(RelayDFBBindingToken)). A later set_receiver_entry_size() refreshes
+    // that same local iface in place.
     FORCE_INLINE RelayView bind_relay() {
         const CrossNodeReceiverDFBInterface& iface = interface_.receiver;
         ASSERT(iface.relay_id != RELAY_DFB_INVALID);
         ASSERT(!relay_dfb_.has_value());
-        align_local_dfb_to_prefetcher_pipe_receiver_iface(iface.relay_id, iface);
+        // Construct first: Quasar DataflowBuffer ctor runs dfb_ensure_ready (resets slots).
+        // Align after so the snap to the pipe receiver cursor is not overwritten.
         relay_dfb_.emplace(RelayDFBBindingToken{iface.relay_id});
+        align_local_dfb_to_prefetcher_pipe_receiver_iface(iface.relay_id, iface);
+#ifndef ARCH_QUASAR
         const uintptr_t entries_acked_ptr = reinterpret_cast<uintptr_t>(get_cb_tiles_acked_ptr(iface.relay_id));
         relay_entries_acked_checkpoint_ = static_cast<uint16_t>(reg_read(entries_acked_ptr));
+#endif
         return RelayView(*relay_dfb_);
     }
 #endif
@@ -560,11 +604,29 @@ private:
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
     std::optional<DataflowBuffer> relay_dfb_;
+#ifndef ARCH_QUASAR
     uint16_t relay_entries_acked_checkpoint_ = 0;
+#endif
+#if defined(ARCH_BLACKHOLE)
+    // Bit i set => this pipe issued a (forced non-posted) credit atomic on NOC i.
+    uint8_t atomic_noc_mask_ = 0;
+#endif
+
+    FORCE_INLINE void note_credit_atomic_noc(uint8_t noc_id) {
+#if defined(ARCH_BLACKHOLE)
+        atomic_noc_mask_ |= static_cast<uint8_t>(1u << noc_id);
+#endif
+    }
 
     FORCE_INLINE void wait_relay_consumed(uint32_t num_entries) {
         ASSERT(num_entries <= relay_dfb_->get_local_num_entries());
         WAYPOINT("PDCW");
+#ifdef ARCH_QUASAR
+        // After the relay.push_back(N), HW posted already marks those entries;
+        // wait until consumer acked catches posted on every TC.
+        (void)num_entries;
+        relay_dfb_->wait_relay_consumer_caught_up();
+#else
         const uint16_t relay_dfb_id = relay_dfb_->get_id();
         const uintptr_t entries_acked_ptr = reinterpret_cast<uintptr_t>(get_cb_tiles_acked_ptr(relay_dfb_id));
         uint16_t entries_acked;
@@ -573,9 +635,12 @@ private:
             entries_acked = static_cast<uint16_t>(reg_read(entries_acked_ptr));
         } while (static_cast<uint16_t>(entries_acked - relay_entries_acked_checkpoint_) < num_entries);
         relay_entries_acked_checkpoint_ = static_cast<uint16_t>(relay_entries_acked_checkpoint_ + num_entries);
+#endif
         WAYPOINT("PDCD");
     }
+#endif
 
+#if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
     FORCE_INLINE void pop_front_impl(uint32_t num_entries, const Noc& noc) {
         CrossNodeReceiverDFBInterface& iface = interface_.receiver;
         const uint32_t entry_size = iface.fifo_page_size;
@@ -590,7 +655,9 @@ private:
 
         // Posted: peer visibility is eventual; senders discover the ack by polling
         // pages_acked (reserve_back / barrier). Matches push_back's posted sent-incs.
+        // On BH, noc_fast_atomic_increment forces posted=false; ~PrefetcherPipe drains.
         const uint8_t noc_id = noc.get_noc_id();
+        note_credit_atomic_noc(noc_id);
         detail::update_pages_acked(
             reinterpret_cast<const RemoteReceiverCBInterface&>(iface), num_units, noc_id, true, write_at_cmd_buf);
     }
@@ -601,10 +668,21 @@ private:
         PrefetcherPipe&, uint32_t new_entry_size, uint32_t stale_entry_size, uint32_t poison_wr_ptr);
 #endif
 
-    // Read a word from the config page.
-    FORCE_INLINE uint32_t get_config_word(uint32_t config_ptr, uint32_t word_idx) {
-        return reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_ptr)[word_idx];
+    // Poll a credit word updated by a remote NOC atomic / write.
+    // Quasar DM L2 does not snoop NOC→TL1; WH/BH needs invalidate_l1_cache.
+    FORCE_INLINE static uint32_t load_remote_l1_credit(volatile tt_l1_ptr uint32_t* ptr) {
+#ifdef ARCH_QUASAR
+        return *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reinterpret_cast<uintptr_t>(ptr) + MEM_L1_UNCACHED_BASE);
+#else
+        invalidate_l1_cache();
+        return *ptr;
+#endif
     }
+
+    // Poll a credit word written by this core through the cached L1 view.
+    // On Quasar, the uncached alias does not observe same-core cached stores — using
+    // load_remote_l1_credit for local pages_sent made reserve_back never see occupancy.
+    FORCE_INLINE static uint32_t load_local_l1_credit(volatile tt_l1_ptr uint32_t* ptr) { return *ptr; }
 
     // Local entries_sent counter for one receiver (L1_ALIGNMENT units; written only by
     // this core, remotely mirrored on the receiver).
@@ -615,8 +693,17 @@ private:
     }
 
     // Full allocation is the stable credit modulus across entry-size changes.
+    FORCE_INLINE static uint32_t fifo_size(uint32_t config_ptr) {
+        return load_prefetcher_pipe_config_word(
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_ptr), REMOTE_DFB_CFG_FIFO_SIZE);
+    }
+
     FORCE_INLINE static uint32_t fifo_size(const CrossNodeSenderDFBInterface& iface) {
-        return reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.config_ptr)[REMOTE_DFB_CFG_FIFO_SIZE];
+        return fifo_size(iface.config_ptr);
+    }
+
+    FORCE_INLINE static uint32_t fifo_size(const CrossNodeReceiverDFBInterface& iface) {
+        return fifo_size(iface.config_ptr);
     }
 
     FORCE_INLINE static uint32_t usable_offset(const CrossNodeSenderDFBInterface& iface) {
@@ -673,9 +760,7 @@ private:
         uint32_t credited_bytes = payload_bytes;
         const uint32_t usable = iface.fifo_limit_page_aligned - iface.fifo_start_addr;
         if (offset + payload_bytes >= usable) {
-            const uint32_t allocation_size =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.config_ptr)[REMOTE_DFB_CFG_FIFO_SIZE];
-            credited_bytes += allocation_size - usable;
+            credited_bytes += fifo_size(iface) - usable;
         }
         return credited_bytes / L1_ALIGNMENT;
     }
@@ -692,7 +777,7 @@ private:
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
     template <uint8_t nm>
-    FORCE_INLINE static void increment_sender_credits_for_receiver(
+    FORCE_INLINE void increment_sender_credits_for_receiver(
         CrossNodeSenderDFBInterface& iface,
         uint32_t receiver_idx,
         uint32_t adjustment,
@@ -702,6 +787,7 @@ private:
         if (adjustment == 0) {
             return;
         }
+        note_credit_atomic_noc(noc);
         volatile tt_l1_ptr uint32_t* sent_ptr = local_sent_ptr(iface, receiver_idx);
         volatile tt_l1_ptr uint32_t* xy =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr) + 2 * receiver_idx;
@@ -737,14 +823,13 @@ private:
         bool posted = true,
         uint8_t cmd_buf = detail::default_cmd_buf) {
         CrossNodeSenderDFBInterface& sender_cb_interface = interface_.sender;
-        ASSERT(static_cast<bool>(
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_cb_interface.config_ptr)[REMOTE_DFB_CFG_IS_SENDER]));
+        ASSERT(static_cast<bool>(load_prefetcher_pipe_config_word(
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_cb_interface.config_ptr), REMOTE_DFB_CFG_IS_SENDER)));
         ASSERT(page_size % REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE == 0);
-        uint32_t fifo_size =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_cb_interface.config_ptr)[REMOTE_DFB_CFG_FIFO_SIZE];
-        ASSERT(page_size != 0 && page_size <= fifo_size);
+        const uint32_t allocation_size = fifo_size(sender_cb_interface);
+        ASSERT(page_size != 0 && page_size <= allocation_size);
         uint32_t fifo_start_addr = sender_cb_interface.fifo_start_addr;
-        uint32_t cb_size_page_aligned = fifo_size - fifo_size % page_size;
+        uint32_t cb_size_page_aligned = allocation_size - allocation_size % page_size;
         uint32_t fifo_limit_page_aligned = fifo_start_addr + cb_size_page_aligned;
         if constexpr (update_remote_over_noc) {
             const uint32_t num_recv =
@@ -755,12 +840,17 @@ private:
                 uint32_t adjustment_bytes = next_offset - current_offset;
                 if (next_offset >= cb_size_page_aligned) {
                     next_offset = 0;
-                    adjustment_bytes = fifo_size - current_offset;
+                    adjustment_bytes = allocation_size - current_offset;
                 }
                 const uint32_t adjustment = adjustment_bytes / L1_ALIGNMENT;
                 if (nm == DM_DYNAMIC_NOC) {
+#ifdef ARCH_QUASAR
+                    // Quasar has one NOC; do not instantiate DM_DYNAMIC_NOC templates.
+                    ASSERT(false);
+#else
                     increment_sender_credits_for_receiver<DM_DYNAMIC_NOC>(
                         sender_cb_interface, i, adjustment, noc, posted, cmd_buf);
+#endif
                 } else {
                     increment_sender_credits_for_receiver<DM_DEDICATED_NOC>(
                         sender_cb_interface, i, adjustment, noc, posted, cmd_buf);
@@ -782,15 +872,15 @@ private:
         bool posted = true,
         uint8_t cmd_buf = detail::default_cmd_buf) {
         CrossNodeReceiverDFBInterface& receiver_cb_interface = interface_.receiver;
-        ASSERT(!static_cast<bool>(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-            receiver_cb_interface.config_ptr)[REMOTE_DFB_CFG_IS_SENDER]));
+        ASSERT(!static_cast<bool>(load_prefetcher_pipe_config_word(
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_cb_interface.config_ptr),
+            REMOTE_DFB_CFG_IS_SENDER)));
         ASSERT(page_size % REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE == 0);
-        uint32_t fifo_size =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_cb_interface.config_ptr)[REMOTE_DFB_CFG_FIFO_SIZE];
-        ASSERT(page_size != 0 && page_size <= fifo_size);
+        const uint32_t allocation_size = fifo_size(receiver_cb_interface);
+        ASSERT(page_size != 0 && page_size <= allocation_size);
         uint32_t fifo_start_addr = receiver_cb_interface.fifo_start_addr;
         uint32_t fifo_rd_ptr = receiver_cb_interface.fifo_rd_ptr;
-        uint32_t cb_size_page_aligned = fifo_size - fifo_size % page_size;
+        uint32_t cb_size_page_aligned = allocation_size - allocation_size % page_size;
         uint32_t fifo_limit_page_aligned = fifo_start_addr + cb_size_page_aligned;
 
         const uint32_t current_offset = fifo_rd_ptr - fifo_start_addr;
@@ -798,7 +888,7 @@ private:
         uint32_t adjustment_bytes = next_offset - current_offset;
         if (next_offset >= cb_size_page_aligned) {
             next_offset = 0;
-            adjustment_bytes = fifo_size - current_offset;
+            adjustment_bytes = allocation_size - current_offset;
         }
         if constexpr (update_remote_over_noc) {
             volatile tt_l1_ptr uint32_t* pages_acked_ptr =
@@ -811,19 +901,25 @@ private:
                 volatile tt_l1_ptr uint32_t* pages_sent_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
                     receiver_cb_interface.aligned_pages_acked_ptr - L1_ALIGNMENT);
                 do {
-                    invalidate_l1_cache();
-                    pages_acked = *pages_acked_ptr;
-                    pages_sent = *pages_sent_ptr;
+                    // pages_acked is local; pages_sent arrives via NOC from the sender.
+                    pages_acked = load_local_l1_credit(pages_acked_ptr);
+                    pages_sent = load_remote_l1_credit(pages_sent_ptr);
                     num_pages_recv = pages_sent - pages_acked;
                 } while (num_pages_recv < adjustment);
 
+                note_credit_atomic_noc(noc);
                 if (nm == DM_DYNAMIC_NOC) {
+#ifdef ARCH_QUASAR
+                    // Quasar has one NOC; do not instantiate DM_DYNAMIC_NOC templates.
+                    ASSERT(false);
+#else
                     detail::update_pages_acked<DM_DYNAMIC_NOC>(
                         reinterpret_cast<const RemoteReceiverCBInterface&>(receiver_cb_interface),
                         adjustment,
                         noc,
                         posted,
                         cmd_buf);
+#endif
                 } else {
                     detail::update_pages_acked<DM_DEDICATED_NOC>(
                         reinterpret_cast<const RemoteReceiverCBInterface&>(receiver_cb_interface),
@@ -848,8 +944,8 @@ template <Noc::AddressType address_type>
 FORCE_INLINE uint32_t noc_traits_t<experimental::PrefetcherPipe>::src_addr(
     const experimental::PrefetcherPipe& src, const Noc&, const src_args_type&) {
     static_assert(address_type == Noc::AddressType::LOCAL_L1, "PrefetcherPipe can only be used as a local L1 source");
-    ASSERT(!static_cast<bool>(
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src.interface_.receiver.config_ptr)[REMOTE_DFB_CFG_IS_SENDER]));
+    ASSERT(!static_cast<bool>(experimental::load_prefetcher_pipe_config_word(
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src.interface_.receiver.config_ptr), REMOTE_DFB_CFG_IS_SENDER)));
     return src.interface_.receiver.fifo_rd_ptr;
 }
 
@@ -858,8 +954,8 @@ FORCE_INLINE uint64_t noc_traits_t<experimental::PrefetcherPipe>::dst_addr(
     const experimental::PrefetcherPipe& dst, const Noc& noc, const dst_args_type& args) {
     static_assert(address_type == Noc::AddressType::NOC, "PrefetcherPipe can only be used as a NoC destination");
     const CrossNodeSenderDFBInterface& iface = dst.interface_.sender;
-    ASSERT(
-        static_cast<bool>(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.config_ptr)[REMOTE_DFB_CFG_IS_SENDER]));
+    ASSERT(static_cast<bool>(experimental::load_prefetcher_pipe_config_word(
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.config_ptr), REMOTE_DFB_CFG_IS_SENDER)));
     ASSERT(args.receiver_idx < cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr));
     volatile tt_l1_ptr uint32_t* xy =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr) + 2 * args.receiver_idx;
@@ -869,5 +965,3 @@ FORCE_INLINE uint64_t noc_traits_t<experimental::PrefetcherPipe>::dst_addr(
     return noc_address_backend::worker_address(xy[0], xy[1], local_address, noc.get_noc_id());
 }
 #endif
-
-#endif  // !ARCH_QUASAR

--- a/tt_metal/hw/inc/internal/prefetcher_pipe_init.h
+++ b/tt_metal/hw/inc/internal/prefetcher_pipe_init.h
@@ -7,6 +7,9 @@
 #include <cstdint>
 #include "internal/cross_node_dfb_interface.h"
 #include "internal/circular_buffer_interface.h"
+#ifdef ARCH_QUASAR
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
+#endif
 #include "api/alignment.h"
 #include "api/debug/assert.h"
 #include "internal/risc_attribs.h"
@@ -15,6 +18,25 @@
 #include "hostdev/remote_dfb_config_layout.h"
 
 namespace experimental {
+
+FORCE_INLINE volatile tt_l1_ptr uint32_t* prefetcher_pipe_config_word_ptr(
+    volatile tt_l1_ptr uint32_t* l1_config, uint32_t word_idx) {
+#ifdef ARCH_QUASAR
+    return reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+        reinterpret_cast<uintptr_t>(l1_config + word_idx) + MEM_L1_UNCACHED_BASE);
+#else
+    return l1_config + word_idx;
+#endif
+}
+
+FORCE_INLINE uint32_t load_prefetcher_pipe_config_word(volatile tt_l1_ptr uint32_t* l1_config, uint32_t word_idx) {
+    return *prefetcher_pipe_config_word_ptr(l1_config, word_idx);
+}
+
+FORCE_INLINE void store_prefetcher_pipe_config_word(
+    volatile tt_l1_ptr uint32_t* l1_config, uint32_t word_idx, uint32_t value) {
+    *prefetcher_pipe_config_word_ptr(l1_config, word_idx) = value;
+}
 
 // Populate a kernel-owned PrefetcherPipe interface from
 // [config_page_addr, entry_size, relay_dfb_id].
@@ -29,14 +51,18 @@ FORCE_INLINE void setup_prefetcher_pipe_interface(
 
     volatile tt_l1_ptr uint32_t* l1_config = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_page_ptr);
 
-    const bool is_sender = static_cast<bool>(l1_config[REMOTE_DFB_CFG_IS_SENDER]);
-    const uint32_t num_receivers = l1_config[REMOTE_DFB_CFG_NUM_RECEIVERS];
-    const uint32_t fifo_start_addr = l1_config[REMOTE_DFB_CFG_FIFO_START];
-    const uint32_t fifo_size = l1_config[REMOTE_DFB_CFG_FIFO_SIZE];
-    const uint32_t fifo_ptr_checkpoint = l1_config[PREFETCHER_PIPE_CFG_FIFO_PTR_CHECKPOINT];
-    const uint32_t noc_xy_addr = config_page_ptr + l1_config[PREFETCHER_PIPE_CFG_NOC_XY_OFFSET];
-    const uint32_t aligned_cnt_ptr = config_page_ptr + l1_config[PREFETCHER_PIPE_CFG_PAGES_SENT_OFFSET];
-    const uint32_t remote_cnt_ptr = config_page_ptr + l1_config[PREFETCHER_PIPE_CFG_PAGES_ACKED_OFFSET];
+    const bool is_sender = static_cast<bool>(load_prefetcher_pipe_config_word(l1_config, REMOTE_DFB_CFG_IS_SENDER));
+    const uint32_t num_receivers = load_prefetcher_pipe_config_word(l1_config, REMOTE_DFB_CFG_NUM_RECEIVERS);
+    const uint32_t fifo_start_addr = load_prefetcher_pipe_config_word(l1_config, REMOTE_DFB_CFG_FIFO_START);
+    const uint32_t fifo_size = load_prefetcher_pipe_config_word(l1_config, REMOTE_DFB_CFG_FIFO_SIZE);
+    const uint32_t fifo_ptr_checkpoint =
+        load_prefetcher_pipe_config_word(l1_config, PREFETCHER_PIPE_CFG_FIFO_PTR_CHECKPOINT);
+    const uint32_t noc_xy_addr =
+        config_page_ptr + load_prefetcher_pipe_config_word(l1_config, PREFETCHER_PIPE_CFG_NOC_XY_OFFSET);
+    const uint32_t aligned_cnt_ptr =
+        config_page_ptr + load_prefetcher_pipe_config_word(l1_config, PREFETCHER_PIPE_CFG_PAGES_SENT_OFFSET);
+    const uint32_t remote_cnt_ptr =
+        config_page_ptr + load_prefetcher_pipe_config_word(l1_config, PREFETCHER_PIPE_CFG_PAGES_ACKED_OFFSET);
 
     const uint32_t size_aligned = fifo_size - (fifo_size % entry_size);
     const uint32_t fifo_limit = fifo_start_addr + size_aligned;
@@ -87,9 +113,10 @@ FORCE_INLINE void align_local_dfb_to_prefetcher_pipe_checkpoint(
     ASSERT(entry_size % REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE == 0);
 
     volatile tt_l1_ptr uint32_t* l1_config = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_page_addr);
-    const uint32_t fifo_start_addr = l1_config[REMOTE_DFB_CFG_FIFO_START];
-    const uint32_t fifo_size = l1_config[REMOTE_DFB_CFG_FIFO_SIZE];
-    const uint32_t fifo_ptr_checkpoint = l1_config[PREFETCHER_PIPE_CFG_FIFO_PTR_CHECKPOINT];
+    const uint32_t fifo_start_addr = load_prefetcher_pipe_config_word(l1_config, REMOTE_DFB_CFG_FIFO_START);
+    const uint32_t fifo_size = load_prefetcher_pipe_config_word(l1_config, REMOTE_DFB_CFG_FIFO_SIZE);
+    const uint32_t fifo_ptr_checkpoint =
+        load_prefetcher_pipe_config_word(l1_config, PREFETCHER_PIPE_CFG_FIFO_PTR_CHECKPOINT);
 
     const uint32_t cb_size_page_aligned = fifo_size - (fifo_size % entry_size);
     const uint32_t fifo_limit_page_aligned = fifo_start_addr + cb_size_page_aligned;
@@ -98,6 +125,43 @@ FORCE_INLINE void align_local_dfb_to_prefetcher_pipe_checkpoint(
         next_fifo_rd_ptr = fifo_start_addr;
     }
 
+#ifdef ARCH_QUASAR
+    // Quasar relay DFB state lives in LocalDFBInterface / TC slots (not LocalCBInterface).
+    LocalDFBInterface& local = get_local_dfb_interface(relay_dfb_id);
+    ASSERT(local.num_tcs_to_rr == 1);
+    const uint32_t entry_size_units = entry_size >> cb_addr_shift;
+    ASSERT(entry_size_units != 0);
+    ASSERT((cb_size_page_aligned >> cb_addr_shift) % entry_size_units == 0);
+    local.entry_size = static_cast<decltype(local.entry_size)>(entry_size_units);
+#if defined(COMPILE_FOR_TRISC) && (defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK))
+    // Host precomputes stride in tile units as entry_size_units * stride_in_entries; keep
+    // stride_size_tiles from init and recompute stride_size for the new entry size.
+    local.stride_size = static_cast<uint16_t>(entry_size_units * local.stride_size_tiles);
+    local.num_entries = static_cast<uint16_t>((cb_size_page_aligned >> cb_addr_shift) / entry_size_units);
+    DFBTCSlot& slot = local.tc_slots[0];
+    slot.base_addr = fifo_start_addr >> cb_addr_shift;
+    slot.ring_size = cb_size_page_aligned >> cb_addr_shift;
+    slot.base_entry_idx = 0;
+    const uint16_t entry_idx =
+        static_cast<uint16_t>(((next_fifo_rd_ptr - fifo_start_addr) / entry_size) * local.stride_size_tiles);
+#if defined(UCK_CHLKC_UNPACK)
+    slot.rd_entry_idx = entry_idx;
+#else
+    slot.wr_entry_idx = entry_idx;
+#endif
+    local.tc_idx = 0;
+#elif !defined(COMPILE_FOR_TRISC)
+    // DM: ptrs/limits are raw bytes; entry_size is address units (cb_addr_shift==0 → bytes).
+    local.stride_size = entry_size;  // 1-entry stride in bytes
+    local.num_entries = static_cast<uint16_t>(cb_size_page_aligned / entry_size);
+    DFBTCSlot& slot = local.tc_slots[0];
+    slot.base_addr = fifo_start_addr;
+    slot.limit = fifo_limit_page_aligned;
+    slot.rd_ptr = next_fifo_rd_ptr;
+    slot.wr_ptr = next_fifo_rd_ptr;
+    local.tc_idx = 0;
+#endif
+#else
     LocalCBInterface& local = get_local_cb_interface(relay_dfb_id);
     const uint32_t fifo_limit = fifo_limit_page_aligned >> cb_addr_shift;
     const uint32_t fifo_size_units = fifo_limit - (fifo_start_addr >> cb_addr_shift);
@@ -111,13 +175,14 @@ FORCE_INLINE void align_local_dfb_to_prefetcher_pipe_checkpoint(
     local.fifo_num_pages = fifo_size_units / page_size_units;
     local.fifo_wr_ptr = fifo_ptr_units;
     local.fifo_rd_ptr = fifo_ptr_units;
+#endif
 }
 
 // launch-msg lookup + checkpoint snap for a PrefetcherPipe relay local DFB.
 // Called from the DataflowBuffer(RelayDFBBindingToken) constructor on TRISC:
 // the token bakes prefetcher_pipe_id at compile time, so this indexes the dense
-// launch-msg persistent region directly and snaps get_local_cb_interface(relay_dfb_id)
-// to the durable checkpoint using this launch's [config_page_addr, entry_size] from the slot.
+// launch-msg persistent region directly and snaps the borrowed local iface to the
+// durable checkpoint using this launch's [config_page_addr, entry_size] from the slot.
 FORCE_INLINE void align_local_dfb_to_prefetcher_pipe_slot(uint32_t relay_dfb_id, uint32_t prefetcher_pipe_id) {
     const uint32_t launch_index = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
     const auto* launch_msg = GET_MAILBOX_ADDRESS_DEV(launch[launch_index]);
@@ -127,14 +192,17 @@ FORCE_INLINE void align_local_dfb_to_prefetcher_pipe_slot(uint32_t relay_dfb_id,
     const uint32_t kernel_config_base = kernel_config.kernel_config_base[PROGRAMMABLE_CORE_TYPE];
     volatile tt_l1_ptr uint32_t* region =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kernel_config_base + kernel_config.prefetcher_pipe_offset);
-    ASSERT(prefetcher_pipe_id < region[0]);
+    // Host rewrites this dense region every launch; Quasar must read via the uncached alias.
+    ASSERT(prefetcher_pipe_id < load_prefetcher_pipe_config_word(region, 0));
 
     volatile tt_l1_ptr uint32_t* slot =
         region + REMOTE_DFB_REGION_HEADER_WORDS + prefetcher_pipe_id * UINT32_WORDS_PER_REMOTE_DFB_CONFIG;
+    const uint32_t config_page_addr = load_prefetcher_pipe_config_word(slot, 0);
+    const uint32_t entry_size = load_prefetcher_pipe_config_word(slot, 1);
     // Host must have registered this local DFB as the relay for this persistent slot
     // (CreatePrefetcherPipeRelayDataflowBuffer); catches a mismatched token.
-    ASSERT(slot[2] == relay_dfb_id);
-    align_local_dfb_to_prefetcher_pipe_checkpoint(relay_dfb_id, /*config_page_addr=*/slot[0], /*entry_size=*/slot[1]);
+    ASSERT(load_prefetcher_pipe_config_word(slot, 2) == relay_dfb_id);
+    align_local_dfb_to_prefetcher_pipe_checkpoint(relay_dfb_id, config_page_addr, entry_size);
 }
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
@@ -142,9 +210,28 @@ FORCE_INLINE void align_local_dfb_to_prefetcher_pipe_slot(uint32_t relay_dfb_id,
 // Align DM's private local relay-DFB iface to the PrefetcherPipe receiver's
 // rd_ptr / page size / limit. Called from PrefetcherPipe::bind_relay() and from
 // set_receiver_entry_size() so a mid-kernel page-size change does not leave the
-// local CB on the old stride. No NOC — copies from the receiver iface.
+// local CB/DFB on the old stride. No NOC — copies from the receiver iface.
 FORCE_INLINE void align_local_dfb_to_prefetcher_pipe_receiver_iface(
     uint32_t relay_dfb_id, const CrossNodeReceiverDFBInterface& iface) {
+#ifdef ARCH_QUASAR
+    LocalDFBInterface& local = get_local_dfb_interface(relay_dfb_id);
+    ASSERT(local.num_tcs_to_rr == 1);
+    const uint32_t entry_size = iface.fifo_page_size;
+    ASSERT(entry_size != 0);
+    ASSERT(entry_size % REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE == 0);
+    const uint32_t ring_bytes = iface.fifo_limit_page_aligned - iface.fifo_start_addr;
+    ASSERT(ring_bytes % entry_size == 0);
+    // DM: ptrs are raw bytes; entry_size field is address units (shift 0 → bytes).
+    local.entry_size = entry_size;
+    local.stride_size = entry_size;
+    local.num_entries = static_cast<uint16_t>(ring_bytes / entry_size);
+    DFBTCSlot& slot = local.tc_slots[0];
+    slot.base_addr = iface.fifo_start_addr;
+    slot.limit = iface.fifo_limit_page_aligned;
+    slot.rd_ptr = iface.fifo_rd_ptr;
+    slot.wr_ptr = iface.fifo_rd_ptr;
+    local.tc_idx = 0;
+#else
     LocalCBInterface& local = get_local_cb_interface(relay_dfb_id);
     const uint32_t fifo_limit = iface.fifo_limit_page_aligned >> cb_addr_shift;
     const uint32_t fifo_size_units = fifo_limit - (iface.fifo_start_addr >> cb_addr_shift);
@@ -158,6 +245,7 @@ FORCE_INLINE void align_local_dfb_to_prefetcher_pipe_receiver_iface(
     local.fifo_num_pages = fifo_size_units / page_size_units;
     local.fifo_wr_ptr = fifo_ptr_units;
     local.fifo_rd_ptr = fifo_ptr_units;
+#endif
 }
 
 #endif  // KERNEL_BUILD && !COMPILE_FOR_TRISC

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -249,6 +249,25 @@ inline void DataflowBuffer::pop_front_impl(uint16_t num_entries) {
 #endif
 }
 
+#if !defined(COMPILE_FOR_TRISC)
+inline void DataflowBuffer::wait_relay_consumer_caught_up() const {
+    // Same posted==acked drain as finish()'s DM path; scoped for PrefetcherPipe relay handoff.
+    bool all_acked = false;
+    while (!all_acked) {
+        all_acked = true;
+        for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
+            const dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
+            const uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+            const uint8_t tc_id = dfb::get_counter_id(packed_tc);
+            if (overlay::fast_llk_intf_read_acked(tensix_id, tc_id) !=
+                overlay::fast_llk_intf_read_posted(tensix_id, tc_id)) {
+                all_acked = false;
+            }
+        }
+    }
+}
+#endif
+
 inline void DataflowBuffer::finish_impl() {
 #if !DFB_IS_COMPUTE_MATH
 #ifndef COMPILE_FOR_TRISC


### PR DESCRIPTION
### PR Category
Feature

### Summary
Extending support for PrefetcherPipe to Quasar. This PR enables functionality for single threaded sender/receiver nodes with single threaded RelayDFB. Next PR will add support for multi-threaded sender/receivers.

Also added in a bug fix for BH. atomic inc in PrefetcherPipe defaults to non-posted to avoid a HW bug so a noc atomic barrier was added to dtor. 

**Skipped tests:**
- I  have not been able to run tests on 2x3 dispatch emu so any test requiring fast dispatch have not been verified yet (sub device tests)
- Tests needing more than 2 nodes have not been verified yet (can be run on craq-sim)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/quasar-prefetcher-pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/quasar-prefetcher-pipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/quasar-prefetcher-pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/quasar-prefetcher-pipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/quasar-prefetcher-pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/quasar-prefetcher-pipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/quasar-prefetcher-pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/quasar-prefetcher-pipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/quasar-prefetcher-pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/quasar-prefetcher-pipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/quasar-prefetcher-pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/quasar-prefetcher-pipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/quasar-prefetcher-pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/quasar-prefetcher-pipe)