### PR TITLE
[binary_ng] bug fix: compile fused unary activations for the operand data type

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -184,6 +184,22 @@ def test_squared_sum_fp32_activ(device):
     assert status
 
 
+def test_add_fp32_softplus_activ(device):
+    # A fused activation on float32 must run the float32 SFPU variant: the bf16 variant of softplus returns 0 below -5.
+    x_torch = torch.linspace(-16.0, 8.0, 1024, dtype=torch.float32).reshape(1, 1, 32, 32)
+    y_torch = torch.zeros_like(x_torch)
+    z_torch = torch.nn.functional.softplus(x_torch, beta=1.0, threshold=20.0)
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    z_tt_add = ttnn.add(x_tt, y_tt, activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 1.0, 20.0)])
+    tt_out = ttnn.to_torch(z_tt_add)
+    tt_alone = ttnn.to_torch(ttnn.softplus(x_tt, beta=1.0, threshold=20.0))
+
+    assert not (tt_out == 0).any()
+    assert torch.allclose(z_torch, tt_out, atol=1e-4, rtol=0)
+    assert torch.allclose(tt_alone, tt_out, atol=1e-5, rtol=0)
+
+
 @pytest.mark.parametrize(
     "ttnn_function",
     [

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -184,16 +184,32 @@ def test_squared_sum_fp32_activ(device):
     assert status
 
 
-def test_add_fp32_softplus_activ(device):
-    # A fused activation on float32 must run the float32 SFPU variant: the bf16 variant of softplus returns 0 below -5.
+@pytest.mark.parametrize(
+    "activation, standalone, torch_fn",
+    [
+        (
+            ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 1.0, 20.0),
+            lambda t: ttnn.softplus(t, beta=1.0, threshold=20.0),
+            lambda x: torch.nn.functional.softplus(x, beta=1.0, threshold=20.0),
+        ),
+        (
+            ttnn.UnaryWithParam(ttnn.UnaryOpType.ERF, False),
+            lambda t: ttnn.erf(t, fast_and_approximate_mode=False),
+            torch.erf,
+        ),
+    ],
+    ids=["softplus", "erf"],
+)
+def test_add_fp32_activ_matches_standalone(device, activation, standalone, torch_fn):
+    # A fused activation on float32 must run the float32 SFPU variant, as the standalone op does: the bf16
+    # variant of softplus returns 0 below -5 and the bf16 variant of erf is about 1e4 times less accurate.
     x_torch = torch.linspace(-16.0, 8.0, 1024, dtype=torch.float32).reshape(1, 1, 32, 32)
     y_torch = torch.zeros_like(x_torch)
-    z_torch = torch.nn.functional.softplus(x_torch, beta=1.0, threshold=20.0)
+    z_torch = torch_fn(x_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_add = ttnn.add(x_tt, y_tt, activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 1.0, 20.0)])
-    tt_out = ttnn.to_torch(z_tt_add)
-    tt_alone = ttnn.to_torch(ttnn.softplus(x_tt, beta=1.0, threshold=20.0))
+    tt_out = ttnn.to_torch(ttnn.add(x_tt, y_tt, activations=[activation]))
+    tt_alone = ttnn.to_torch(standalone(x_tt))
 
     assert not (tt_out == 0).any()
     assert torch.allclose(z_torch, tt_out, atol=1e-4, rtol=0)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -596,6 +596,11 @@ void add_activation_defines(
             unary::utils::update_macro_defines(a.type(), defines);
             return std::move(process);
         });
+    // The activations run in the SFPU kernels the unary op uses; give them the same input-dtype define so the
+    // float32 variants are compiled for float32 operands.
+    if (!activations.empty() && dtype.has_value()) {
+        unary::utils::add_input_dtype_defines(*dtype, defines);
+    }
 }
 
 std::map<std::string, std::string> make_dataflow_defines(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -1173,17 +1173,17 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
 }
 
 void add_input_dtype_defines(DataType dtype, std::map<std::string, std::string>& defines) {
+    // Exactly one tag survives: the caller's dtype, except that an earlier float32 operand keeps INP_FLOAT32
+    // over a later bf16-class one (the float32 SFPU variants are the accurate ones for both).
+    const bool keep_float32 = defines.contains("INP_FLOAT32") && dtype != DataType::INT32 && dtype != DataType::UINT32;
+    for (const char* tag : {"INP_FLOAT32", "INP_INT32", "INP_UINT32", "INP_FLOAT"}) {
+        defines.erase(tag);
+    }
     switch (dtype) {
-        case DataType::FLOAT32:
-            defines.erase("INP_FLOAT");
-            defines["INP_FLOAT32"] = "1";
-            break;
         case DataType::INT32: defines["INP_INT32"] = "1"; break;
         case DataType::UINT32: defines["INP_UINT32"] = "1"; break;
-        default:
-            if (!defines.contains("INP_FLOAT32")) {
-                defines["INP_FLOAT"] = "1";
-            }
+        case DataType::FLOAT32: defines["INP_FLOAT32"] = "1"; break;
+        default: defines[keep_float32 ? "INP_FLOAT32" : "INP_FLOAT"] = "1"; break;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -1172,6 +1172,21 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
     defines[get_macro_definition(op_type)] = "1";
 }
 
+void add_input_dtype_defines(DataType dtype, std::map<std::string, std::string>& defines) {
+    switch (dtype) {
+        case DataType::FLOAT32:
+            defines.erase("INP_FLOAT");
+            defines["INP_FLOAT32"] = "1";
+            break;
+        case DataType::INT32: defines["INP_INT32"] = "1"; break;
+        case DataType::UINT32: defines["INP_UINT32"] = "1"; break;
+        default:
+            if (!defines.contains("INP_FLOAT32")) {
+                defines["INP_FLOAT"] = "1";
+            }
+    }
+}
+
 std::string_view get_compute_kernel_path(UnaryOpType op_type, std::optional<DataType> input_dtype) {
     switch (op_type) {
         case UnaryOpType::LGAMMA:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -109,6 +109,10 @@ bool is_parametrized_type(T val) {
 
 void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string>& defines);
 
+// INP_FLOAT32 / INP_INT32 / INP_UINT32 / INP_FLOAT: the SFPU kernels select their algorithm on these.
+// Float32 wins over the bf16-class default when both operands of a fused op contribute.
+void add_input_dtype_defines(DataType dtype, std::map<std::string, std::string>& defines);
+
 std::string_view get_compute_kernel_path(UnaryOpType op_type, std::optional<DataType> input_dtype = std::nullopt);
 
 uint32_t pack_scalar_runtime_arg_impl(float param, DataType dtype);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -109,8 +109,8 @@ bool is_parametrized_type(T val) {
 
 void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string>& defines);
 
-// INP_FLOAT32 / INP_INT32 / INP_UINT32 / INP_FLOAT: the SFPU kernels select their algorithm on these.
-// Float32 wins over the bf16-class default when both operands of a fused op contribute.
+// INP_FLOAT32 / INP_INT32 / INP_UINT32 / INP_FLOAT: the SFPU kernels select their algorithm on these. Exactly one
+// is set after the call; float32 wins over the bf16-class default when both operands of a fused op contribute.
 void add_input_dtype_defines(DataType dtype, std::map<std::string, std::string>& defines);
 
 std::string_view get_compute_kernel_path(UnaryOpType op_type, std::optional<DataType> input_dtype = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -23,17 +23,6 @@ using namespace ttnn::operations::unary::utils;
 using ttnn::operations::unary::EltwiseUnaryWithParam;
 using ttnn::operations::unary::UnaryOpType;
 
-void apply_input_dtype_defines(DataType dtype, std::map<std::string, std::string>& defines) {
-    if (dtype == DataType::FLOAT32) {
-        defines["INP_FLOAT32"] = "1";
-    } else if (dtype == DataType::INT32) {
-        defines["INP_INT32"] = "1";
-    } else if (dtype == DataType::UINT32) {
-        defines["INP_UINT32"] = "1";
-    } else {
-        defines["INP_FLOAT"] = "1";
-    }
-}
 
 bool pack_first_op_scalars(
     const EltwiseUnaryWithParam& op, DataType input_dtype, uint32_t& packed_scalar1, uint32_t& packed_scalar2) {
@@ -416,7 +405,7 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
 
     const bool math_approx_mode = false;
     std::map<std::string, std::string> unary_defines = get_block_defines(ops_chain, "0", "0", input.dtype());
-    CMAKE_UNIQUE_NAMESPACE::apply_input_dtype_defines(input.dtype(), unary_defines);
+    add_input_dtype_defines(input.dtype(), unary_defines);
     const bool logit_clamp_enabled =
         CMAKE_UNIQUE_NAMESPACE::pack_first_op_scalars(ops_chain[0], input.dtype(), packed_scalar1, packed_scalar2);
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #56021.

Fused unary activations in binary_ng were compiled without the input-dtype defines the unary op sets (`INP_FLOAT32` and friends). SFPU kernels that select their algorithm on those defines (softplus, gelu, erf, i1, digamma) therefore ran their bf16 variants on float32 tensors; for softplus that variant clamps the result to 0 below about -5 by design, so fused `softplus` on float32 returned exact zeros where the standalone op did not, and fused `erf` on float32 was about 1e4 times less accurate than the standalone op.

The unary op's define helper moves to `unary_op_utils` as `add_input_dtype_defines` (the unary program factory now calls it there), and binary_ng's `add_activation_defines` calls it for every non-empty activation list, keyed on the dtype of the operand the list acts on (LHS on `a_dtype`, RHS on `b_dtype`, post-activations on the input dtype, as the calls already pass). Float32 wins over the bf16-class default when both operands contribute. Int32 / uint32 operands set their own defines as before.

**Test**

New `test_add_fp32_activ_matches_standalone` in `tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py`, parametrized over SOFTPLUS(1, 20) and ERF: fused activation on a float32 ramp over [-16, 8] against torch (no exact zeros, atol 1e-4) and against the standalone unary op (atol 1e-5).

### Notes for reviewers

- Existing float32 users of fused gelu / erf / i1 / digamma move to the float32 algorithms; bf16 users are unchanged (measured bit-identical below).
- Other ops that compose the same SFPU activations through `get_op_init_and_func` without these defines (matmul's fused activation, for one) are not touched here.

### Verification

Blackhole p150, this branch built from main `9fe0ba04fc`; probe `ttnn.add(x, 0, activations=[act])` vs the standalone unary op vs torch, 1024-point float32 ramp over [-16, 8]:

| fp32 fused | before: zeros / max err | after: zeros / max err | after vs standalone |
| --- | --- | --- | --- |
| SOFTPLUS(1, 20) | 469 / 6.6e-3 | 0 / 4.2e-5 | bit-identical |
| ERF | 0 / 3.2e-3 | 0 / 2.4e-7 | bit-identical |
| GELU | 446 / 9.5e-7 | 446 / 9.5e-7 | bit-identical |

bf16: all three unchanged and bit-identical to the standalone ops before and after.

`tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py`, `test_binaryng_fp32.py`, `test_unary_fp32.py` on the first commit: 131 passed, 1 skipped. Second commit (single dtype tag, erf case) rebuilt and re-run: both new cases pass, probe numbers unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
