### PR TITLE
pad RM sharded height-only: emit the gather plan in stick traversal order (follow-up to #55179)

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -435,6 +435,71 @@ def test_pad_rm_sharded_height_only_non_contiguous_grid(device, shard_orient, dt
     assert torch.equal(torch_output_tensor, tt_output_tensor)
 
 
+@pytest.mark.parametrize("shard_orient", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+def test_pad_rm_sharded_height_only_non_contiguous_grid_straddles_range_boundary(device, shard_orient, dtype):
+    """Height-only RM pad where one output shard gathers rows from input shards on both sides of the hole.
+
+    Same 40-core grid as the test above, but the input fills all 40 shards ([1, 1, 1280, 128], shard
+    [32, 128]) and the output shard is taller ([40, 128], H padded to 1600). In grid order the input
+    shards on either side of the hole are shard 23 on core (3, 7) and shard 24 on core (5, 0); output
+    shard 19 (rows 760..799) needs rows 24..31 of shard 23 followed by rows 0..31 of shard 24, so the
+    result is only correct if the gather plan emits those source cores in grid order rather than in
+    sorted physical-coordinate order.
+    """
+    torch.manual_seed(0)
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x < 7 or compute_grid.y < 8:
+        pytest.skip(f"needs a 7x8 compute grid, device has {compute_grid.x}x{compute_grid.y}")
+
+    shard_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 7)),
+            ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 7)),
+        }
+    )
+    assert shard_grid.num_cores() == 40
+
+    n, c, h, w = 1, 1, 1280, 128
+    in_shard_h, out_shard_h = 32, 40
+    h_padded = out_shard_h * 40
+    assert h == in_shard_h * 40
+    padding = ((0, 0), (0, h_padded - h), (0, 0))
+    torch_padding = (0, 0, 0, h_padded - h, 0, 0)
+    value = 0
+
+    torch_input_tensor = random_torch_tensor(dtype, (n, c, h, w))
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, torch_padding, mode="constant", value=value)
+
+    in_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.types.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, (in_shard_h, w), shard_orient),
+    )
+    out_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.types.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, (out_shard_h, w), shard_orient),
+    )
+
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=dtype,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=in_mem_config,
+    )
+    tt_output_tensor = ttnn.pad(tt_input_tensor, padding=padding, value=value, memory_config=out_mem_config)
+    tt_output_tensor = ttnn.to_torch(ttnn.from_device(tt_output_tensor))
+
+    assert tt_output_tensor.shape == torch_output_tensor.shape
+    # Report the first mismatching output row so a wrong gather order is visible in the CI log.
+    mismatched_rows = torch.nonzero(~torch.all(torch_output_tensor[0, 0] == tt_output_tensor[0, 0], dim=-1)).flatten()
+    assert (
+        mismatched_rows.numel() == 0
+    ), f"rows differ: {mismatched_rows[:16].tolist()} (first of {mismatched_rows.numel()})"
+
+
 def test_pad_rm_sharded_height_only_override_addr_change(device):
     """Cache-hit hook (override_runtime_arguments) for the CB-bound height-sharded RM factory: buffer
     addresses are excluded from the pad hash, so a second identical pad at DIFFERENT input AND output

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -137,16 +137,30 @@ inline std::vector<ShardedHeightPerCoreArgs> get_pad_runtime_args_rm_sharded(
             }
         }
 
-        // figure out the stick id in a shard, and the core id for the stick.
-        std::map<std::pair<uint32_t, uint32_t>, std::vector<uint32_t>> core_stick_map;
-        auto first_core = device->worker_core_from_logical_core(unpadded_cores.front());
-        std::pair<uint32_t, uint32_t> prev_xy_pair = std::make_pair(first_core.x, first_core.y);
+        // Gather plan for this output core: the source cores in the order their sticks appear in the
+        // output shard, each with the stick ids to read from it. The reader copies the chunks
+        // sequentially in this order, so it has to be the traversal order of the sticks and not a
+        // sorted order of the source cores' coordinates: on a multi-range grid the shard-order
+        // successor of a core can sit at smaller physical coordinates than the core itself.
+        using NocXY = std::pair<uint32_t, uint32_t>;
+        const auto noc_xy_of = [&](const CoreCoord& logical_core) -> NocXY {
+            const auto physical = device->worker_core_from_logical_core(logical_core);
+            return row_major ? std::make_pair(physical.y, physical.x) : std::make_pair(physical.x, physical.y);
+        };
+        std::vector<std::pair<NocXY, std::vector<uint32_t>>> core_sticks_in_order;
+        const auto push_stick = [&](const NocXY& xy, uint32_t value) {
+            if (core_sticks_in_order.empty() || core_sticks_in_order.back().first != xy) {
+                core_sticks_in_order.emplace_back(xy, std::vector<uint32_t>{});
+            }
+            core_sticks_in_order.back().second.push_back(value);
+        };
+        NocXY prev_xy_pair = noc_xy_of(unpadded_cores.front());
         for (uint32_t j = 0; j < num_sticks_per_core_padded; ++j) {
             int stick_id = stick_ids_per_core[j];
 
             // if it is pad stick, we need to leave a gap between the previous non-pad stick and next non-pad stick.
             if (stick_id == -2 || stick_id == -1) {  // front or end padding
-                core_stick_map[prev_xy_pair].push_back(stick_id);
+                push_stick(prev_xy_pair, static_cast<uint32_t>(stick_id));
             } else {
                 uint32_t shard_id = stick_id / num_sticks_per_core_unpadded;
                 uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_unpadded);
@@ -156,23 +170,19 @@ inline std::vector<ShardedHeightPerCoreArgs> get_pad_runtime_args_rm_sharded(
                 // a sharded tensor may live on a non-contiguous grid (e.g. {[1-0 - 3-7],
                 // [5-0 - 6-7]}), whose bounding box also covers cores that hold no shard.
                 if (shard_id < unpadded_cores.size()) {
-                    auto core_physical = device->worker_core_from_logical_core(unpadded_cores[shard_id]);
-                    // save stick id in a shard, and core coord into a map
-                    std::pair<uint32_t, uint32_t> xy_pair = row_major
-                                                                ? std::make_pair(core_physical.y, core_physical.x)
-                                                                : std::make_pair(core_physical.x, core_physical.y);
-                    core_stick_map[xy_pair].push_back(stick_id_in_shard);
+                    const NocXY xy_pair = noc_xy_of(unpadded_cores[shard_id]);
+                    push_stick(xy_pair, stick_id_in_shard);
                     prev_xy_pair = xy_pair;
                 }
             }
         }
 
         // reader varargs: the whole gather plan except num_cores, which is a named arg.
-        core_args.num_cores_read = core_stick_map.size();
+        core_args.num_cores_read = core_sticks_in_order.size();
         std::vector<uint32_t>& reader_varargs = core_args.reader_varargs;
-        reader_varargs.reserve(3 * core_stick_map.size() + 2 * num_sticks_per_core_padded);
+        reader_varargs.reserve(3 * core_sticks_in_order.size() + 2 * num_sticks_per_core_padded);
 
-        for (const auto& core_stick_pair : core_stick_map) {
+        for (const auto& core_stick_pair : core_sticks_in_order) {
             auto xy_pair = core_stick_pair.first;
             if (row_major) {
                 reader_varargs.push_back((std::uint32_t)xy_pair.second);  // noc x
@@ -185,8 +195,8 @@ inline std::vector<ShardedHeightPerCoreArgs> get_pad_runtime_args_rm_sharded(
 
         // coalesce the sticks into chunks
         std::vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
-        stick_chunks_per_core.reserve(core_stick_map.size());
-        for (auto core_stick_pair : core_stick_map) {
+        stick_chunks_per_core.reserve(core_sticks_in_order.size());
+        for (auto& core_stick_pair : core_sticks_in_order) {
             auto stick_chunks = group_contiguous_and_repeated_values(core_stick_pair.second);
             reader_varargs.push_back(stick_chunks.size());  // num_chunks for current core
             stick_chunks_per_core.push_back(std::move(stick_chunks));


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Follow-up to #55179. That PR made `PadRmShardedHeightOnlyProgramFactory` derive per-core runtime args from the shard grid's real core list, so height-sharded row-major tensors on a non-contiguous grid (the Qwen3-32B Blackhole Galaxy `{[1-0 - 3-7], [5-0 - 6-7]}` case) no longer hit `kernel_nodes.contains(node_coord)`. It left one ordering assumption in place: the per-output-core gather plan was bucketed in a `std::map` keyed by the source core's physical `(y, x)` / `(x, y)`, and `reader_pad_dims_rm_sharded.cpp` copies the chunks in map order. That equals shard order only inside one contiguous range. On a multi-range grid, an output shard that gathers rows from input shards on both sides of the hole (shard 23 on `(3, 7)` followed by shard 24 on `(5, 0)`) had its row blocks swapped, with no error.

Confirmed on hardware before the fix: `test_pad_rm_sharded_height_only_non_contiguous_grid_straddles_range_boundary[bfloat16-ROW_MAJOR]` fails with `rows differ: [760, 761, ..., 775] (first of 40)` on wh_n150 ([job 102505981219](https://github.com/tenstorrent/tt-metal/actions/runs/34362271679/job/102505981219)) and wh_n300 ([job 102505981273](https://github.com/tenstorrent/tt-metal/actions/runs/34362271679/job/102505981273)). Rows 760..799 are exactly output shard 19.

### Change
- `pad_rm_sharded_height_only_program_factory.cpp`: keep the source cores in the order their sticks appear in the output shard (a vector of `(noc xy, sticks)` appended in traversal order, merging with the previous entry when the core repeats) instead of the sorted map. Each source core's sticks are contiguous in that order, so the plan has the same number of entries as before, just ordered correctly. The leading-pad bucket now uses the same `(y, x)` / `(x, y)` orientation as the data buckets.
- `test_pad.py`: new straddling-shard test, input `[1, 1, 1280, 128]` with shard `[32, 128]` on the 40-core grid, output shard `[40, 128]` (H padded to 1600), both orientations, bfloat16 and int32.

### Validation
L2 nightly `data_movement` group (`tt-metal-l2-nightly.yaml`, `additional_test_categories=data_movement`) on branch `mtairum/validate-55179-straddle` = #55179 head + these two commits:
- Wormhole [run 34368072146](https://github.com/tenstorrent/tt-metal/actions/runs/34368072146): all four jobs green; post-commit suites 8624 passed on wh_n150_civ2 and wh_n300_civ2 (8620 baseline + the 4 new cases), all 8 non-contiguous-grid cases pass.
- Blackhole [run 34376095158](https://github.com/tenstorrent/tt-metal/actions/runs/34376095158): nightly legs green on bh_p100 and bh_p150b_civ2; post-commit suites 7514 / 7515 passed with all 8 pad cases green; the single failure on each is the pre-existing `test_tilize_uint8_tall_narrow_program_cache_addr_change[(1,1,4096,32)]`, identical on main's scheduled run (#55988).

On this branch (rebased onto main `a2bb817616a`): Wormhole `data_movement` group https://github.com/tenstorrent/tt-metal/actions/runs/34418761396 — **PASSED**, all four jobs green (nightly and post-commit suites on wh_n150_civ2 and wh_n300_civ2; the post-commit suites include `test_pad.py` with the 8 non-contiguous-grid cases).

Not addressed here (flagged during review of #55179): the Quasar clone of this factory (`experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.cpp`) still derives cores from the bounding box; `slice_program_factory_rm_sharded.cpp` uses the same origin-anchored bounding-box arithmetic; and neither factory checks that the input and output shard orientations agree.
- Rebased onto main `3f254861838` on 2026-09-10 (clean, no content change). The CI links above were run on the pre-rebase head.
- Rebased onto main `09d733f62d2` on 2026-09-17 (clean, no content change; head `bf5dc919865`, same two files). Re-validation on this head, L2 nightly `data_movement` group (`run_triage_tests=false`):
  - Wormhole (`run_wormhole=true`): https://github.com/tenstorrent/tt-metal/actions/runs/35238585860
  - Blackhole (`run_blackhole=true`): https://github.com/tenstorrent/tt-metal/actions/runs/35238604784

  Result: **both green**, 15/15 jobs.

  | run | jobs | post-commit `data_movement` suites | new pad cases |
  |---|---|---|---|
  | Wormhole 35238585860 | 7/7 | wh_n150_civ2 8900 passed, wh_n300_civ2 8900 passed | 4/4 straddling, 8/8 non-contiguous-grid on each |
  | Blackhole 35238604784 | 8/8 | bh_p100 9112 passed, bh_p150b_civ2 9113 passed | 4/4 straddling, 8/8 non-contiguous-grid on each |

  Nightly `data_movement`, `point_to_point`, n300 CCL and Blackhole host-to-device smoke jobs in the same runs also passed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/pad-rm-sharded-gather-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/pad-rm-sharded-gather-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/pad-rm-sharded-gather-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/pad-rm-sharded-gather-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/pad-rm-sharded-gather-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/pad-rm-sharded-gather-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/pad-rm-sharded-gather-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/pad-rm-sharded-gather-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/pad-rm-sharded-gather-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/pad-rm-sharded-gather-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/pad-rm-sharded-gather-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/pad-rm-sharded-gather-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/pad-rm-sharded-gather-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/pad-rm-sharded-gather-order)





