### PR TITLE
[Performance] Reduce RingJointSDPA cached runtime argument overhead

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -568,6 +568,19 @@ void write_runtime_arg(RuntimeArgsData& args, uint32_t index, uint32_t value, co
     args[index] = value;
 }
 
+template <std::size_t N>
+void write_runtime_arg_block(
+    RuntimeArgsData& args, uint32_t index, const std::array<uint32_t, N>& values, const char* name) {
+    TT_FATAL(
+        index <= args.size() && N <= args.size() - index,
+        "Missing RingJoint runtime arg block {} at index {}; count={}; args.size()={}",
+        name,
+        index,
+        N,
+        args.size());
+    std::copy(values.begin(), values.end(), args.data() + index);
+}
+
 // Tile-rows of the latent KV the fused all-gather must move for this chunk: the first
 // ceil(logical_n / chunk_global) block-cyclic slabs (a contiguous per-device page prefix), so an
 // oversized (growing) KV cache only moves kv_actual-sized data. Returns nullopt when KV-pad rotation
@@ -796,6 +809,44 @@ void apply_ring_joint_scalar_runtime_args(
         }
     }
 
+    // Resolve each kernel's argument grid once per dispatch. Keep these references local:
+    // descriptor application may change the backing storage before the next cache hit.
+    auto& compute_grid_args = GetRuntimeArgs(program, kComputeKernelIndex);
+    auto& reader_grid_args = GetRuntimeArgs(program, kReaderKernelIndex);
+    auto* writer_grid_args = patch_kv_pad_rotation ? &GetRuntimeArgs(program, kWriterKernelIndex) : nullptr;
+    const auto validate_grid = [&](const auto& grid_args) {
+        TT_FATAL(grid_args.size() >= layout.grid_size.x, "RingJoint runtime argument grid is missing columns");
+        for (uint32_t x = 0; x < layout.grid_size.x; ++x) {
+            TT_FATAL(grid_args[x].size() >= layout.grid_size.y, "RingJoint runtime argument grid is missing rows");
+        }
+    };
+    validate_grid(compute_grid_args);
+    validate_grid(reader_grid_args);
+    if (writer_grid_args != nullptr) {
+        validate_grid(*writer_grid_args);
+    }
+    // These fields occupy adjacent slots in the descriptor. Validate the layout once,
+    // then check and write each complete block on every core, including inactive receivers.
+    TT_FATAL(
+        layout.reader_active_ring_iter_mask == layout.reader_logical_nt + 1 &&
+            layout.writer_active_ring_iter_mask == layout.writer_logical_nt + 1 &&
+            layout.writer_single_valid_kv_chunk_mask == layout.writer_logical_nt + 2 &&
+            layout.compute_q_pre_wrap_start_tile == layout.compute_logical_nt + 1 &&
+            layout.compute_q_pre_wrap_tile_count == layout.compute_logical_nt + 2 &&
+            layout.compute_q_post_wrap_start_tile == layout.compute_logical_nt + 3 &&
+            layout.compute_q_valid_tile_count == layout.compute_logical_nt + 4 &&
+            layout.compute_active_ring_iter_mask == layout.compute_logical_nt + 5,
+        "RingJoint scalar runtime argument blocks must be contiguous");
+    const std::array reader_values = {runtime_plan.logical_nt, ring_work_masks.active_ring_iter_mask};
+    const std::array writer_values = {
+        runtime_plan.logical_nt, ring_work_masks.active_ring_iter_mask, ring_work_masks.single_valid_kv_chunk_mask};
+    const std::array compute_values = {
+        runtime_plan.logical_nt,
+        runtime_plan.kv_pad_q_mapping.q_pre_wrap_start_tile,
+        runtime_plan.kv_pad_q_mapping.q_pre_wrap_tile_count,
+        runtime_plan.kv_pad_q_mapping.q_post_wrap_start_tile,
+        runtime_plan.kv_pad_q_mapping.q_valid_tile_count,
+        ring_work_masks.active_ring_iter_mask};
     for (uint32_t i = 0; i < num_cores; ++i) {
         const CoreCoord core = {i % layout.grid_size.x, i / layout.grid_size.x};
 
@@ -810,9 +861,9 @@ void apply_ring_joint_scalar_runtime_args(
         // logical_n. When logical_n grows across dispatches that reuse one cached program (chunked-prefill
         // accumulation), the create-miss mask is stale for later hits, deadlocking the mcast handshake
         // (RingJointSDPA hang, all-gather eth reads left undrained).
-        auto& compute_args = GetRuntimeArgs(program, kComputeKernelIndex, core);
+        auto& compute_args = compute_grid_args[core.x][core.y];
 
-        auto& reader_args = GetRuntimeArgs(program, kReaderKernelIndex, core);
+        auto& reader_args = reader_grid_args[core.x][core.y];
         if (patch_indexed_kv_cache) {
             write_runtime_arg(
                 reader_args, layout.reader_kv_cache_batch_idx, kv_cache_batch_idx, "reader.kv_cache_batch_idx");
@@ -821,52 +872,11 @@ void apply_ring_joint_scalar_runtime_args(
             continue;
         }
 
-        write_runtime_arg(reader_args, layout.reader_logical_nt, runtime_plan.logical_nt, "reader.logical_nt");
-        write_runtime_arg(
-            reader_args,
-            layout.reader_active_ring_iter_mask,
-            ring_work_masks.active_ring_iter_mask,
-            "reader.active_ring_iter_mask");
+        write_runtime_arg_block(reader_args, layout.reader_logical_nt, reader_values, "reader.scalars");
 
-        auto& writer_args = GetRuntimeArgs(program, kWriterKernelIndex, core);
-        write_runtime_arg(writer_args, layout.writer_logical_nt, runtime_plan.logical_nt, "writer.logical_nt");
-        write_runtime_arg(
-            writer_args,
-            layout.writer_active_ring_iter_mask,
-            ring_work_masks.active_ring_iter_mask,
-            "writer.active_ring_iter_mask");
-        write_runtime_arg(
-            writer_args,
-            layout.writer_single_valid_kv_chunk_mask,
-            ring_work_masks.single_valid_kv_chunk_mask,
-            "writer.single_valid_kv_chunk_mask");
-
-        write_runtime_arg(compute_args, layout.compute_logical_nt, runtime_plan.logical_nt, "compute.logical_nt");
-        write_runtime_arg(
-            compute_args,
-            layout.compute_q_pre_wrap_start_tile,
-            runtime_plan.kv_pad_q_mapping.q_pre_wrap_start_tile,
-            "compute.q_pre_wrap_start_tile");
-        write_runtime_arg(
-            compute_args,
-            layout.compute_q_pre_wrap_tile_count,
-            runtime_plan.kv_pad_q_mapping.q_pre_wrap_tile_count,
-            "compute.q_pre_wrap_tile_count");
-        write_runtime_arg(
-            compute_args,
-            layout.compute_q_post_wrap_start_tile,
-            runtime_plan.kv_pad_q_mapping.q_post_wrap_start_tile,
-            "compute.q_post_wrap_start_tile");
-        write_runtime_arg(
-            compute_args,
-            layout.compute_q_valid_tile_count,
-            runtime_plan.kv_pad_q_mapping.q_valid_tile_count,
-            "compute.q_valid_tile_count");
-        write_runtime_arg(
-            compute_args,
-            layout.compute_active_ring_iter_mask,
-            ring_work_masks.active_ring_iter_mask,
-            "compute.active_ring_iter_mask");
+        auto& writer_args = (*writer_grid_args)[core.x][core.y];
+        write_runtime_arg_block(writer_args, layout.writer_logical_nt, writer_values, "writer.scalars");
+        write_runtime_arg_block(compute_args, layout.compute_logical_nt, compute_values, "compute.scalars");
     }
 }
 


### PR DESCRIPTION
### PR Category

Performance

### Summary

RingJointSDPA cache hits repeatedly resolve compute/reader/writer runtime-argument grids for every core, then update adjacent scalar fields individually. Resolve each required grid once per dispatch and write the adjacent reader, writer, and compute scalars as checked blocks. On a 110-core rotation path this reduces kernel-grid lookups from 330 to three per mesh coordinate.

The change validates grid bounds, scalar-field contiguity, and each destination block's bounds. It preserves cache-slot updates and writes to every participating core, including inactive multicast receivers whose masks must refresh as KV depth grows. References remain local to the dispatch. Device kernels and numerical arithmetic are unchanged.

Relates to #50932. This is an independent RingJoint factory change; the measurements below enable the logging/SHM settings from #55960 in both arms.

### Notes for reviewers

**Measured on an isolated Kimi K2.7-shaped workload:** 32-device Blackhole Galaxy at 130 W/device, physical 8×4 mesh (SP8/TP4), Q `[1,16,640,576]` BF16, KV `[61,1,12800,576]` BFP8 ND-sharded, 102,400-token cache capacity, Q/K chunk sizes 32/640, and eleven successive 5120-token chunks. Inputs are synthetic; numerical references and cache preparation run outside timing. Four fresh processes per arm, ten measured sweeps after warm-up, including an original/grid-only/combined reversal.

| Timing, milliseconds per call | Original factory | This change |
| --- | ---: | ---: |
| Single-call API return | 1.634 | 1.315 (-19.5%) |
| Single-call synchronized completion | 5.793 | 5.476 (-5.5%) |
| First-chunk 60-call burst completion / 60 | 1.354 | 1.192 (-11.9%) |
| All-chunk 60-call burst completion / 60 | 4.311 | 4.301 |

Whole-workload numbers equally weight the eleven chunk medians and take the median across processes. API-return time can include runtime waits. The all-chunk burst difference is within overlapping process ranges; long-context completion is effectively unchanged. These are operator measurements, not a full-model throughput claim. A separate diagnostic profile found scalar core updates dropping from about 190 to 67 microseconds per mesh dispatch when adding packed writes to grid lookup; instrumented runs are excluded from the timing comparison.

**Validation completed on the exact C++ source in this PR:**

- Native Release build: `CMAKE_BUILD_PARALLEL_LEVEL=48 ./build_metal.sh --enable-ccache --release`.
- Repository clang-format 19.1.4 on changed lines: no modifications; `git diff --check` passed.
- 20 existing cases in `tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py` passed: indexed slots, growing/rotated KV, determinism, metadata/scalar equivalence, trace replay, separate K/V with BF16/FP32 accumulation, padding rotation, and sliding-GQA cache reuse. The existing unit module was adapted to logical TP8/SP4 on the physical 8×4 host; the isolated Kimi benchmark uses production TP4/SP8.
- All twelve isolated comparison processes passed sampled numerical checks (PCC 0.999720–0.999967), stable program-cache counts, and exact tensor-description equality with the captured Kimi full-model call.
- Each arm reproduced its library hashes through reversal; runtime and Python-binding binaries matched across arms, with only the operation library differing.

Measurements/build/tests used base `13c11bdf5eea77dcc57efb7ecaedb3bc28ded240`. This PR is based on its mainline parent `e711d82f4001d0077dd767c33a0c7496fada1550`, excluding the three unrelated logging/SHM runner and performance-target files. The RingJoint source on main `2a0f4c55e6727826200082083163df68e5a3270a` was identical to that parent when the PR was prepared.

**Draft follow-up:** validate the combined grid/packed-scalar change in full-model Kimi and run the repository CI on the merge result. The earlier +2.65% full-model result covered grid lookup alone and is not claimed for this combined patch.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/ring-joint-runtime-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/ring-joint-runtime-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/ring-joint-runtime-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/ring-joint-runtime-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/ring-joint-runtime-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/ring-joint-runtime-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/ring-joint-runtime-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/ring-joint-runtime-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/ring-joint-runtime-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/ring-joint-runtime-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/ring-joint-runtime-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/ring-joint-runtime-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/ring-joint-runtime-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/ring-joint-runtime-args)