### PR TITLE
[tt-train] Fixing GRPO L2 Nightly Test Failures

### DIFF
--- a/tt-train/tests/python/grpo_remote_rollout/conftest.py
+++ b/tt-train/tests/python/grpo_remote_rollout/conftest.py
@@ -18,6 +18,13 @@ HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parents[3]
 EXAMPLE_DIR = REPO_ROOT / "tt-train" / "sources" / "examples" / "grpo_remote_rollout"
 
+# NOTE: EXAMPLE_DIR ships a top-level ``utils`` package, and so do sibling example
+# dirs (examples/grpo, examples/qwen3). This directory sorts before the test_*.py
+# modules in tests/python, so the tests here (via _completer_utils) are what bind
+# ``sys.modules["utils"]`` for the whole session. Any test module elsewhere that
+# imports a *different* example's ``utils`` must use the evict-and-restore idiom in
+# tests/python/test_grpo_trainer.py, or it fails with
+# ``ModuleNotFoundError: No module named 'utils.<submodule>'``.
 for _p in (str(HERE), str(EXAMPLE_DIR), str(REPO_ROOT)):
     if _p not in sys.path:
         sys.path.insert(0, _p)

--- a/tt-train/tests/python/test_grpo_trainer.py
+++ b/tt-train/tests/python/test_grpo_trainer.py
@@ -49,17 +49,34 @@ from ttml.trainers import GRPOConfig, GRPOTrainer, TrainerCallback
 # The ``LlamaGRPOCompleter`` reference implementation lives under the
 # examples tree, not under ``ttml`` proper. Surface its package on the
 # import path so this test can use it without copy-pasting the completer.
-_GRPO_EXAMPLES_DIR = os.path.join(
-    os.environ.get("TT_METAL_HOME", os.path.join(os.path.dirname(__file__), "..", "..", "..")),
-    "tt-train",
-    "sources",
-    "examples",
-    "grpo",
-)
-if _GRPO_EXAMPLES_DIR not in sys.path:
-    sys.path.insert(0, _GRPO_EXAMPLES_DIR)
+_GRPO_EXAMPLES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "sources", "examples", "grpo"))
+# Force the grpo example dir to the front of sys.path so ``import utils`` resolves
+# here even if a sibling example dir is already on the path.
+if _GRPO_EXAMPLES_DIR in sys.path:
+    sys.path.remove(_GRPO_EXAMPLES_DIR)
+sys.path.insert(0, _GRPO_EXAMPLES_DIR)
 
-from utils.llama_completer import LlamaCompletionCtx, LlamaGRPOCompleter  # noqa: E402
+# The grpo example ships a top-level ``utils`` package, and so do sibling example
+# dirs (examples/grpo_remote_rollout -- whose tests under grpo_remote_rollout/ are
+# collected before this module and put their own ``utils`` on sys.path -- and
+# examples/qwen3). In a single pytest session another test module may have already
+# imported its own ``utils`` first, caching it in sys.modules and shadowing ours
+# (sys.path.insert cannot override an already-imported module), which surfaces as
+# ``ModuleNotFoundError: No module named 'utils.llama_completer'``. Evict any cached
+# ``utils*`` so the imports below resolve against _GRPO_EXAMPLES_DIR, then restore the
+# sibling's modules so we do not break whichever test imported them.
+#
+# Everything is imported *here*, not lazily inside fixtures: after the restore below a
+# runtime ``from utils import llama_completer`` would resolve against the sibling
+# package again and fail.
+_saved_utils = {k: sys.modules.pop(k) for k in list(sys.modules) if k == "utils" or k.startswith("utils.")}
+try:
+    from utils import llama_completer  # noqa: E402
+    from utils.llama_completer import LlamaCompletionCtx, LlamaGRPOCompleter  # noqa: E402
+finally:
+    for _k in [k for k in list(sys.modules) if k == "utils" or k.startswith("utils.")]:
+        del sys.modules[_k]
+    sys.modules.update(_saved_utils)
 
 
 HF_MODEL_ID = "unsloth/Llama-3.2-1B-Instruct"  # not gated
@@ -177,9 +194,12 @@ class _RecordingCallback(TrainerCallback):
 
 @pytest.fixture
 def patch_llama_weight_loading(monkeypatch):
-    """Skip the HF download / safetensors load so the tiny model keeps random init."""
-    from utils import llama_completer
+    """Skip the HF download / safetensors load so the tiny model keeps random init.
 
+    Patches the ``llama_completer`` module object bound at import time above; a
+    ``from utils import llama_completer`` here would hit the sibling ``utils`` that
+    was restored into sys.modules.
+    """
     monkeypatch.setattr(llama_completer, "snapshot_download", lambda *args, **kwargs: "/tmp/unused")
     monkeypatch.setattr(llama_completer, "load_from_safetensors", lambda *args, **kwargs: None)
 
@@ -263,14 +283,15 @@ def test_grpo_trainer_one_step_smoke(patch_llama_weight_loading, tmp_path):
     }
 
     recorder = _RecordingCallback()
-    GRPOTrainer(
+    trainer = GRPOTrainer(
         completer=completer,
         dataset=dataset,
         config=grpo_cfg,
         reward_func=reward_func,
         optimizer_dict=optimizer_dict,
         callbacks=[recorder],
-    ).train()
+    )
+    trainer.train()
 
     assert recorder.train_begin == 1, "on_train_begin should fire exactly once"
     assert recorder.before_step == 1, "on_before_optimizer_step should fire once for the single step"
@@ -290,9 +311,17 @@ def test_grpo_trainer_one_step_smoke(patch_llama_weight_loading, tmp_path):
 
     metrics = recorder.last_step_metrics
     assert metrics is not None
-    for key in ("reward_mean", "reward_std", "mean_completion_len", "step_time_s", "generation_time_s"):
+    # ``step_time_s`` is deliberately absent from this list. The trainer seals it only
+    # after every non-monitor ``on_step_end`` has returned (so the timing covers them)
+    # and forwards the sealed value to ``GRPOMonitor`` alone, so a plain callback like
+    # the recorder never sees it in its kwargs. It is checked on the trainer below.
+    for key in ("reward_mean", "reward_std", "mean_completion_len", "generation_time_s"):
         assert key in metrics, f"missing metric {key}"
         assert np.isfinite(metrics[key]), f"metric {key} is not finite: {metrics[key]}"
+
+    step_time_s = trainer.metrics.get("step_time_s")
+    assert step_time_s is not None, "trainer.metrics is missing step_time_s after the step completed"
+    assert np.isfinite(step_time_s) and step_time_s > 0.0, f"step_time_s is not a positive duration: {step_time_s}"
 
     after = completer.model.parameters()[snapshot_name].to_numpy(ttnn.DataType.FLOAT32)
     assert before.shape == after.shape


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Nightly L2 `tt-train-unit-tests` has aborted at collection since 2026-08-20 with:

```
tt-train/tests/python/test_grpo_trainer.py:62: from utils.llama_completer import ...
ModuleNotFoundError: No module named 'utils.llama_completer'
```

Root cause is a top-level package name collision. `examples/grpo`, `examples/grpo_remote_rollout`, and `examples/qwen3` each ship a package named `utils`. Pytest collects `grpo_remote_rollout/` before any `test_*.py`, and its tests bind `sys.modules["utils"]` to the remote-rollout package for the whole session. `test_grpo_trainer.py` then imports `utils.llama_completer`, the cached `utils` is consulted instead of `sys.path`, and the submodule does not exist there. #49504 introduced the collision; the qwen3 tests in the same directory already guard against it, this test did not.

Changes:
- `test_grpo_trainer.py`: adopt the same evict-and-restore idiom the sibling tests use; bind `llama_completer` at import time so the monkeypatch fixture no longer re-imports `utils` at run time.
- `test_grpo_trainer.py`: with collection unblocked, the test failed on `missing metric step_time_s`. #53433 changed the trainer to seal `step_time_s` only after non-monitor callbacks have received `on_step_end`, so the recording callback can no longer see it. The assertion now checks the sealed value on `trainer.metrics` instead.
- `grpo_remote_rollout/conftest.py`: comment explaining that this directory is what binds `utils` for the session and that sibling tests must use the idiom.

Verified locally on device: full-directory collection goes from 1 error to 981 tests collected with 0 errors, and `test_grpo_trainer_one_step_smoke` passes when run inside the full-directory collection.

### Notes for reviewers
- The `step_time_s` assertion change is a separate, intentional fix for test drift against #53433, not part of the import fix.
- The job has run zero tests since 2026-08-20, so the first green collection may surface other drift in modules that have not executed in three weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [ ] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/runs/34425098314)
