### PR TITLE
ttnn/ccl: complete AGMM program cache identity and resolve cache-key aliasing

### DIFF
--- a/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
+++ b/models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc
+from models.tt_dit.layers.linear import _FUSED_GELU_VARIANTS
 from models.tt_dit.utils.tensor import prepare_for_fused_swiglu
 
 
@@ -32,6 +33,39 @@ def assert_quality(torch_output, tt_output):
         "pcc": pcc_val,
         "relative_rmse": relative_rmse_val,
     }
+
+
+def _resolve_fused_activation(activation):
+    if activation is None:
+        return None
+    # Resolve through the production map (single source of truth) so a drifted private copy can't
+    # silently under-test the op. An unknown key surfaces as KeyError from the production map.
+    return _FUSED_GELU_VARIANTS[activation]
+
+
+def _apply_torch_activation(torch_output, activation):
+    if activation is None:
+        return torch_output
+    if activation == "gelu":
+        return torch.nn.functional.gelu(torch_output)
+    if activation == "gelu_tanh":
+        return torch.nn.functional.gelu(torch_output, approximate="tanh")
+    # Narrower than _resolve_fused_activation on purpose: gelu_fast is a lossy LUT approximation with
+    # no exact torch oracle at this suite's PCC bar, so exercising it on-device needs a bespoke
+    # reference rather than F.gelu.
+    raise AssertionError(f"Unsupported activation: {activation}")
+
+
+def test_fused_activation_helper_matches_production_variants():
+    # The helper resolves through the production _FUSED_GELU_VARIANTS map (single source of truth).
+    # Lock the map's key set and values so a dropped/renamed variant fails here, and check one
+    # delegated lookup for the gelu_fast entry the old private copy omitted.
+    assert set(_FUSED_GELU_VARIANTS) == {"gelu", "gelu_fast", "gelu_tanh"}
+    assert _FUSED_GELU_VARIANTS["gelu"] == (ttnn.UnaryOpType.GELU, False)
+    assert _FUSED_GELU_VARIANTS["gelu_fast"] == (ttnn.UnaryOpType.GELU, True)
+    assert _FUSED_GELU_VARIANTS["gelu_tanh"] == ttnn.UnaryOpType.GELU_TANH
+    assert _resolve_fused_activation(None) is None
+    assert _resolve_fused_activation("gelu_fast") == (ttnn.UnaryOpType.GELU, True)
 
 
 def run_test_linear_impl(
@@ -109,11 +143,7 @@ def run_test_linear_impl(
     else:
         persistent_output_buffers = []
 
-    activation_fn = None
-    if activation == "gelu":
-        activation_fn = (ttnn.UnaryOpType.GELU, False)
-    else:
-        assert activation is None, f"Unsupported activation: {activation}"
+    activation_fn = _resolve_fused_activation(activation)
 
     if fuse_addcmul:
         if sp_axis == 1:
@@ -158,8 +188,7 @@ def run_test_linear_impl(
         if fuse_addcmul:
             torch_output = torch.addcmul(torch_addcmul_a, torch_output, torch_addcmul_b, value=addcmul_scalar)
 
-        if activation == "gelu":
-            torch_output = torch.nn.functional.gelu(torch_output)
+        torch_output = _apply_torch_activation(torch_output, activation)
 
         # Variable-width chunks split at the given per-device widths
         if chunk_sizes:
@@ -744,6 +773,82 @@ def test_linear(
                 assert check_result[n][c][i]["relative_rmse"] < 0.02
 
 
+_cache_identity_executions = 0
+
+
+@pytest.fixture(scope="module")
+def require_cache_identity_executed():
+    # This regression is the only guard against the device-cache aliasing bug the suite exists
+    # to catch. Both params require an exact 8- or 32-device SKU and skip otherwise, so on any
+    # other box every param skips and a plain `pytest` run reports "passed" with zero coverage.
+    # This finalizer fails such a fully-skipped run so the guard cannot silently self-disable.
+    yield
+    assert _cache_identity_executions > 0, (
+        "test_linear_cache_identity was skipped on every parametrization; the AGMM program-cache "
+        "identity regression did not execute. Run on an exactly-8 or exactly-32 device SKU."
+    )
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (2, 4),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "trace_region_size": 90112,
+                "require_exact_physical_num_devices": True,
+            },
+            id="2x4",
+        ),
+        pytest.param(
+            (4, 8),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(4096),
+                "trace_region_size": 90112,
+                "require_exact_physical_num_devices": True,
+            },
+            id="4x8",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_linear_cache_identity(mesh_device, require_cache_identity_executed):
+    global _cache_identity_executions
+    _cache_identity_executions += 1
+    # Keep both activation variants in one process so they can expose program-cache aliasing.
+    submesh = _create_cluster_submesh(mesh_device, cluster_axis=1)
+    common = dict(
+        M=32,
+        K=2048,
+        N=2048,
+        M_block_size=1,
+        K_block_size=8,
+        N_block_size=8,
+        subblock_h=1,
+        subblock_w=2,
+        topology=ttnn.Topology.Ring,
+        core_grid=ttnn.CoreCoord(4, 4),
+        num_workers_per_link=4,
+        num_links=1,
+        use_non_fused=False,
+        force_transpose=True,
+        sp_axis=0,
+        tp_axis=1,
+        cluster_axis=1,
+        chunks=1,
+    )
+    plain = run_test_linear(submesh, activation=None, **common)
+    gelu_tanh = run_test_linear(submesh, activation="gelu_tanh", **common)
+    for activation_results in (plain, gelu_tanh):
+        for iteration_results in activation_results:
+            for chunk_results in iteration_results:
+                for device_result in chunk_results:
+                    assert device_result["pcc"] > 0.999_500
+                    assert device_result["relative_rmse"] < 0.02
+
+
 def run_test_linear_fsdp(
     device,
     M,
@@ -795,8 +900,7 @@ def run_test_linear_fsdp(
         torch_output = torch_input @ weight_input
         if bias_input is not None:
             torch_output = torch_output + bias_input
-        if activation == "gelu":
-            torch_output = torch.nn.functional.gelu(torch_output)
+        torch_output = _apply_torch_activation(torch_output, activation)
         torch_output_chunks = torch.chunk(torch_output, chunks, dim=-1)
 
     # --- K-sharding ---
@@ -878,11 +982,7 @@ def run_test_linear_fsdp(
             mesh_mapper=ttnn.ShardTensor2dMesh(device, mesh_shape=tuple(device.shape), dims=b_shard_dims),
         )
 
-    activation_fn = None
-    if activation == "gelu":
-        activation_fn = (ttnn.UnaryOpType.GELU, False)
-    else:
-        assert activation is None, f"Unsupported activation: {activation}"
+    activation_fn = _resolve_fused_activation(activation)
 
     ccl_cores = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(core_grid.x - 1, core_grid.y - 1))}

--- a/tests/ttnn/unit_tests/gtests/ccl/test_all_gather_minimal_matmul_async_cache_identity.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_all_gather_minimal_matmul_async_cache_identity.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include <tt_stl/reflection.hpp>
+#include <tt-metalium/global_semaphore.hpp>
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/ccl/ccl_host_types.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp"
+
+namespace {
+
+using ttnn::experimental::prim::AllGatherMinimalMatmulAsyncParams;
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+// Hash the reflected program-cache identity of an AGMM op whose tensor specs and every other listed
+// attribute are fixed, varying only the three compile-affecting fields under test. Only the fields
+// in attribute_values() participate, so the semaphores and the (unused) barrier reference never
+// enter the hash.
+ttsl::hash::hash_t hash_agmm_identity(
+    std::optional<UnaryWithParam> fused_activation,
+    std::optional<tt::tt_metal::DataType> output_dtype,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config) {
+    // barrier_semaphore is a const-ref member; keep a named optional alive for the params' lifetime.
+    const std::optional<tt::tt_metal::GlobalSemaphore> no_barrier;
+    const AllGatherMinimalMatmulAsyncParams params(
+        /*config=*/std::nullopt,
+        /*fused_activation=*/std::move(fused_activation),
+        /*output_mem_config=*/std::nullopt,
+        /*output_dtype=*/output_dtype,
+        /*compute_kernel_config=*/compute_kernel_config,
+        /*num_links=*/1,
+        /*ring_size=*/8,
+        /*topology=*/ttnn::ccl::Topology::Ring,
+        /*semaphore=*/{},
+        /*cluster_axis=*/std::optional<uint32_t>{1},
+        /*barrier_semaphore=*/no_barrier,
+        /*using_persistent_buffers=*/false,
+        /*force_transpose=*/false,
+        /*num_workers_per_link=*/4,
+        /*num_buffers_per_channel=*/1,
+        /*fused_ternary_scalar=*/std::nullopt,
+        /*chunks=*/1,
+        /*dim=*/-1,
+        /*fsdp_cluster_axis=*/std::nullopt,
+        /*fsdp_ring_size=*/1,
+        /*fsdp_semaphore=*/{},
+        /*using_persistent_weight_buffer=*/false,
+        /*fsdp_topology=*/ttnn::ccl::Topology::Linear,
+        /*fuse_swiglu=*/false);
+    return ttsl::hash::hash_objects_with_default_seed(params);
+}
+
+}  // namespace
+
+// fused_activation, output_dtype, and compute_kernel_config each change the compiled program but not
+// the tensor args, so a cache hit cannot repair them. They must contribute to program-cache identity.
+TEST(AllGatherMinimalMatmulAsync, CompileAffectingAttributesHaveDistinctProgramCacheIdentity) {
+    const auto baseline = hash_agmm_identity(std::nullopt, std::nullopt, ttnn::DeviceComputeKernelConfig{});
+
+    EXPECT_NE(
+        hash_agmm_identity(UnaryWithParam{UnaryOpType::EXP}, std::nullopt, ttnn::DeviceComputeKernelConfig{}),
+        baseline);
+
+    EXPECT_NE(
+        hash_agmm_identity(std::nullopt, tt::tt_metal::DataType::BFLOAT16, ttnn::DeviceComputeKernelConfig{}),
+        baseline);
+
+    auto changed_compute_config = ttnn::DeviceComputeKernelConfig{};
+    changed_compute_config.math_approx_mode = !changed_compute_config.math_approx_mode;
+    EXPECT_NE(hash_agmm_identity(std::nullopt, std::nullopt, changed_compute_config), baseline);
+}

--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -42,6 +42,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
 )
 
 set(UNIT_TESTS_TTNN_CCL_SOURCES
+    ccl/test_all_gather_minimal_matmul_async_cache_identity.cpp
     ccl/test_ccl_commands.cpp
     ccl/test_ccl_helpers.cpp
     ccl/test_ccl_reduce_scatter_host_helpers.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_device_operation_types.hpp
@@ -114,6 +114,9 @@ struct AllGatherMinimalMatmulAsyncParams {
         "num_workers_per_link",
         "num_buffers_per_channel",
         "config",
+        "fused_activation",
+        "output_dtype",
+        "compute_kernel_config",
         "chunks",
         "dim",
         "chunk_sizes",
@@ -133,6 +136,9 @@ struct AllGatherMinimalMatmulAsyncParams {
             this->num_workers_per_link,
             this->num_buffers_per_channel,
             this->config,
+            this->fused_activation,
+            this->output_dtype,
+            this->compute_kernel_config,
             this->chunks,
             this->dim,
             this->chunk_sizes,
@@ -142,6 +148,19 @@ struct AllGatherMinimalMatmulAsyncParams {
             this->fuse_swiglu);
     }
 };
+
+// attribute_names and attribute_values() are hand-synced: same fields, same order. This assert
+// guards arity ONLY (equal element count) — the most common drift, adding/removing a field on one
+// side. Field order and the name-to-value correspondence stay a hand-maintained invariant it cannot
+// check. Runtime-only members (semaphores, fused_ternary_scalar) and the input tensors are out of
+// the key by design (the tensors are keyed separately by the framework). fsdp_topology is a
+// program-structural CT arg that is NOT in the key; it is safe today only because validate TT_FATALs
+// it to Linear whenever FSDP fusion is active, so it cannot vary — relaxing that check would require
+// keying it here.
+static_assert(
+    std::tuple_size_v<decltype(AllGatherMinimalMatmulAsyncParams::attribute_names)> ==
+        std::tuple_size_v<decltype(std::declval<const AllGatherMinimalMatmulAsyncParams>().attribute_values())>,
+    "AGMM attribute_names and attribute_values() must stay in lockstep");
 
 // Per-chunk widths (elements): explicit `chunk_sizes`, else the uniform N/chunks split.
 inline std::vector<uint32_t> resolve_chunk_sizes(const AllGatherMinimalMatmulAsyncParams& params, uint32_t N) {


### PR DESCRIPTION
## Summary
- Add `fused_activation`, `output_dtype`, and `compute_kernel_config` to `AllGatherMinimalMatmulAsyncParams` program-cache attributes (`attribute_names` and `attribute_values()`), preventing cache-key collisions when compile-affecting parameters vary.
- Add `static_assert` locking `attribute_names` and `attribute_values()` arities together to eliminate key-drift bugs at compile time.
- Add device-free C++ GTest verifying compile-affecting attributes produce distinct cache identities, and add multi-mesh pytest regression with execution enforcement.

## Test plan
- [x] Host unit test: `pytest models/tt_dit/tests/models/wan2_2/test_all_gather_minimal_matmul_async.py -k test_fused_activation` passes.
- [x] Host C++ test: `test_all_gather_minimal_matmul_async_cache_identity.cpp` registered in `UNIT_TESTS_TTNN_CCL_SOURCES`.
- [x] Device regression: `test_linear_cache_identity` parameterized across (2,4) FABRIC_1D and (4,8) FABRIC_1D_RING meshes.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=smarton/agmm-cache-identity-20260909)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:smarton/agmm-cache-identity-20260909)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=smarton/agmm-cache-identity-20260909)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:smarton/agmm-cache-identity-20260909)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=smarton/agmm-cache-identity-20260909)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:smarton/agmm-cache-identity-20260909)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=smarton/agmm-cache-identity-20260909)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:smarton/agmm-cache-identity-20260909)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=smarton/agmm-cache-identity-20260909)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:smarton/agmm-cache-identity-20260909)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=smarton/agmm-cache-identity-20260909)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:smarton/agmm-cache-identity-20260909)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smarton/agmm-cache-identity-20260909)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smarton/agmm-cache-identity-20260909)