### PR TITLE
[Feature][LLK] Quasar perf counters in the perf harness

### DIFF
--- a/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
+++ b/tt_metal/tt-llk/docs/performance_counters/performance_counters.md
@@ -38,7 +38,7 @@ Every test source under `tests/sources/*_perf.cpp` is compiled twice from the sa
 | NC (no counters) | defined | undefined | `ZONE_SCOPED` (timing) + `MEASURE_PERF_COUNTERS` (barrier only) | Per-zone wall-clock cycles (`RISCV_DEBUG_REG_WALL_CLOCK_L`), reported differently per run type: `L1_TO_L1` is the unpack-start to pack-end cross-thread span, the isolates are the measured thread's own zone, and `L1_CONGESTION` yields two columns, `[UNPACK]` and `[PACK]` |
 | WC (with counters) | defined | defined | `MEASURE_PERF_COUNTERS` **and** `ZONE_SCOPED` | Per-zone HW counter snapshot **and** wall-clock cycles |
 
-`START_PERF_MEASURE(name)` expands to `MEASURE_PERF_COUNTERS(name)` + `ZONE_SCOPED(name)`. In the NC build, `MEASURE_PERF_COUNTERS` performs the same real three-thread rendezvous with an empty action (so it is not free, and it moves the NC baseline); on Quasar it expands to nothing and `ZONE_SCOPED` records the per-zone wall-clock timestamps. In the WC build **both** are live: the counter scope performs the rendezvous *and* arms/freezes the HW counters, while `ZONE_SCOPED` records the per-zone wall-clock timestamps without adding another rendezvous. A single WC run therefore yields both counter and wall-clock data per zone under the same name; the host driver keys everything by `(test_variant, zone)` and can merge NC and WC results (or use the WC wall-clock directly).
+`START_PERF_MEASURE(name)` expands to `MEASURE_PERF_COUNTERS(name)` + `ZONE_SCOPED(name)`. In the NC build, `MEASURE_PERF_COUNTERS` performs the same real rendezvous with an empty action (so it is not free, and it moves the NC baseline). The rendezvous has three threads on Wormhole and Blackhole and four on Quasar, where the SFPU TRISC takes part too: `sfpu_stub.h` opens the same `INIT` and `TILE_LOOP` zones, so a kernel with no SFPU half still completes it. In the WC build **both** are live: the counter scope performs the rendezvous *and* arms/freezes the HW counters, while `ZONE_SCOPED` records the per-zone wall-clock timestamps without adding another rendezvous. A single WC run therefore yields both counter and wall-clock data per zone under the same name; the host driver keys everything by `(test_variant, zone)` and can merge NC and WC results (or use the WC wall-clock directly).
 
 Source-side, this is the pattern:
 
@@ -101,11 +101,11 @@ The barrier is `llk_barrier::rendezvous` in `barrier.h`, on the `PACK_DONE` **ha
 
 Every thread announces by incrementing; the action thread waits for all of them, runs its action, then drains the count back to zero, and that return to zero is the release. Two consequences worth being explicit about. The action thread spins **twice**, once before the action and once draining after it, so on entry that drain runs inside the counter window. And the barrier is not free: ablation showed the exit rendezvous merely existing was worth +11 of the +12 cycles by which the counter build differed from the no-counter build on `MATH_ISOLATE`. What the shared barrier buys is that both builds pay the same cost at zone entry, not that the cost is zero.
 
-The semaphore is used rather than L1 because its release is symmetric, detection is a short `pc_buf` poll, and it puts no traffic on the L1 being measured. Quasar has no spare semaphore and keeps the L1 form in `profiler.h`.
+The semaphore is used rather than L1 because its release is symmetric, detection is a short `pc_buf` poll, and it puts no traffic on the L1 being measured. Quasar has no spare semaphore, so there the same function is an L1 generation barrier over four per-thread slots (`barrier_slots`, set up in `trisc.cpp`); it is still one implementation compiled identically into both builds.
 
 ### Configure-once from BRISC
 
-Before any TRISC kernel runs, BRISC executes `configure_and_arm_from_brisc()` once (called from `brisc.cpp` when the WC build flag is set). This:
+Before any TRISC kernel runs, BRISC executes `configure_and_arm_from_brisc()` once (called from `brisc.cpp` when the WC build flag is set). Quasar has no BRISC in this harness, so the unpack TRISC calls the same `configure_and_arm()` from `trisc.cpp`, after `device_setup()` and before it clears the other TRISCs out of soft reset; the registers are reached through the NEO local debug window instead of the RISC-V debug block. This:
 
 - Writes the per-architecture `BUILTIN_COUNTER_CONFIG` (110 slots on WH, 101 on BH, since only one L1 mux group is emitted) into the shared L1 config buffer at `0x169000`. That array is built at compile time from the canonical metal inventory, see [Counter inventory single source](#counter-inventory-single-source).
 - Clears every per-zone data area and sync word.
@@ -135,7 +135,7 @@ The LLK test suite uses a two-phase pytest flow: a compile-producer phase that b
 ```bash
 ./setup_testing_env.sh        # installs the SFPI toolchain; run it, do not source it (it calls exit)
 cd tt_metal/tt-llk/tests     # LLK_HOME is defaulted by conftest.py; you do not need to set it
-export CHIP_ARCH=blackhole   # or wormhole; counters are not compiled on quasar
+export CHIP_ARCH=blackhole   # or wormhole or quasar
 
 # Phase 1: build all variants (no HW access)
 pytest --compile-producer --enable-perf-counters -n 8 -x ./python_tests/perf_eltwise_binary.py
@@ -147,6 +147,8 @@ pytest --compile-consumer --enable-perf-counters -x ./python_tests/perf_eltwise_
 Wipe the artefact root (`/tmp/tt-llk-build`, or `$RUNNER_TEMP/tt-llk-build`) when switching between the two builds: the variant hash and the build markers ignore the counter flags, so the ELFs are otherwise reused.
 
 To capture a different L1 mux group, `export LLK_PERF_L1_MUX_GROUP=<0-5>` before **both** phases. It is an environment variable rather than a CLI flag and is compiled into `brisc.elf`, so each group needs its own producer run; the readout checks the group found in L1 against the one requested and fails the run if they disagree, so a stale `brisc.elf` cannot return a self-consistently mislabelled dataset.
+
+Quasar has no L1 counter bank. Its bank slot 3 can carry one event of the L1 client CSR instead: `export LLK_PERF_L1_CLIENT_SEL=<subport*8+event>` before the producer phase (default off). Sub-ports are 0-3 TRISC, 4 THCON, 5-24 unpacker reads, 25-36 packer writes; events 1-7 are named in `perf_metrics_common.py`, event 0 is unused and THCON events 1-3 are rejected at compile time because they alias the TRISC port. The counter is clear-on-read and has no reference counter of its own, so it is referenced to the INSTRN bank's cycles, and its metric column is named after the selection (`l1_client_<port>_<event>_pct`, or `_ratio` for the pending-request carry).
 
 
 The `--enable-perf-counters` flag triggers two things:
@@ -191,6 +193,8 @@ The NC build emits per-zone wall-clock cycle counts in the same results DataFram
 
 **Blackhole** has `PACK_COUNT = 1`; per-engine packer busy and dest-read signals for engines 1–3 are tied to constants in RTL and are omitted from the inventory. Only counters 11, 18, 267, 271, 272 remain on the `TDMA_PACK` bank. BH compensates with more L1 mux positions (4 extra) which expose additional NoC rings and miscellaneous L1 ports.
 
+**Quasar** has four TRISCs per NEO and no L1 counter bank: `INSTRN_THREAD` (51 slots, four threads), `FPU` (3), `TDMA_UNPACK` (18) and `TDMA_PACK` (5), listed in `tt_metal/hw/inc/internal/tt-2xx/quasar/hw_counters.h`. `PERF_CNT_ALL` reaches only the INSTRN and FPU banks there, so the TDMA banks are armed and frozen through their own start/stop registers. The SFPU TRISC is a measured thread of its own under the `SFPU_ISOLATE` run type. The L1 client CSR described under How to Run stands in for the L1 bank.
+
 **INSTRN_THREAD bank.** Counters 0–8 and 12–23 are per-thread instruction-type availability (CFG/SYNC/THCON/MOVE/FPU/UNPACK/PACK, 3 threads each, 21 slots; the XSEARCH sels 9–11 are tied off in RTL and are not in the inventory). Counters 24–26 are per-thread total stall cycles. The stall-reason layout differs:
 
 - WH: the four shared stall reasons (SRCA/B clear/valid) are replicated per thread in HW but only the first slot of each is enumerated, at sels 27/30/33/36; per-thread stall reasons then occupy counters 39–65.
@@ -200,7 +204,7 @@ Bit-8-extended counters 256/264/272 expose `THREAD_INSTRUCTIONS_{0,1,2}` (one pe
 
 ### Counter inventory single source
 
-The counter id↔name inventory is **defined once**, in metal's canonical `tt_metal/hw/inc/internal/tt-1xx/<arch>/hw_counters.h`, as grouped `{PerfCounterType, id}` arrays per bank (`instrn_counters`, `fpu_counters`, `unpack_counters`, `pack_counters`, `l1_0..5_counters`). Both sides of the perf infra derive from it, so the list is never hand-maintained twice:
+The counter id↔name inventory is **defined once**, in metal's canonical `tt_metal/hw/inc/internal/tt-1xx/<arch>/hw_counters.h` (`tt-2xx/quasar/hw_counters.h` for Quasar), as grouped `{PerfCounterType, id}` arrays per bank (`instrn_counters`, `fpu_counters`, `unpack_counters`, `pack_counters`, `l1_0..5_counters`). Both sides of the perf infra derive from it, so the list is never hand-maintained twice:
 
 - **Device (`counters.h`)** `#include`s `hw_counters.h` (with the `PerfCounterType` enum from `perf_counters.hpp`) and builds `BUILTIN_COUNTER_CONFIG[]` from those arrays at compile time, a `constexpr` concatenation in the fixed bank order the readout expects (INSTRN, FPU, TDMA_UNPACK, TDMA_PACK, then the single selected L1 mux group).
 
@@ -241,7 +245,7 @@ The 200-word shared config is the authoritative runtime record of which counters
 
 ## Hardware Register Reference
 
-The following addresses are used (offsets from `RISCV_DEBUG_REGS_START_ADDR = 0xFFB12000`):
+The following addresses are used (offsets from `RISCV_DEBUG_REGS_START_ADDR = 0xFFB12000`). On Quasar the same registers sit in the NEO local window: `counters.h` takes the NEO0 debug-register addresses from `tensix_neo_reg.h` and rebases them onto `LOCAL_REGS_BASE` (0x00800000), so each NEO's TRISCs reach their own block. Quasar has no `PERF_CNT_MUX_CTRL`; the L1 client CSR pair (`L1_CLIENT_GROUP_PERF_CTRL` and the clear-on-read `L1_CLIENT_GROUP_PERF_CNT`) lives in the same window.
 
 | Register | Offset | Description |
 |----------|--------|-------------|
@@ -316,7 +320,7 @@ A metric whose counters this architecture does not expose, or whose counter grou
 - **Never guard `PERF_RUN_TYPE` with `#ifndef`.** It arrives as a `constexpr` in the generated `build.h`, so a preprocessor guard cannot see it, always fires, and silently compiles every run type as the fallback. Identical values and identical `TEXT_SIZE` across run types is the symptom (PR #51918).
 - **`L1_CONGESTION` is not free-running everywhere yet.** `eltwise_binary_sfpu`, `eltwise_unary_sfpu`, `eltwise_unary_typecast`, `sfpu_binop_scalar` and `sfpu_ternary` still run its pack path on the math handshake, so they measure the handshake rather than L1 contention.
 - **`PACK_DONE` is reserved by the barrier.** It is safe only because the count returns to zero each time, so a measured kernel must not use `semaphore::PACK_DONE` for its own handshake.
-- **The host asserts zones do not overlap across threads.** No thread may open `TILE_LOOP` before every thread has closed `INIT`. A failure almost always means a kernel used `ZONE_SCOPED` instead of `START_PERF_MEASURE`, which is what supplies the entry rendezvous. Skipped on Quasar.
+- **The host asserts zones do not overlap across threads.** No thread may open `TILE_LOOP` before every thread has closed `INIT`. A failure almost always means a kernel used `ZONE_SCOPED` instead of `START_PERF_MEASURE`, which is what supplies the entry rendezvous.
 - **Both builds write the same report path.** `perf_data/<module>/<module>.csv` is written by whichever invocation ran last, so move the first report aside before running the second build; there is no cross-build merge in code.
 - **`--logging-level DEBUG` or `TRACE` recompiles the measured kernel** with `-DDEBUG_PRINT_ENABLED`, which perturbs the numbers. Do not use it for a measurement run.
 - **`no zone returned counter data` means the test was never measured.** The counter and metric columns will be absent; a with-counters versus no-counters comparison for that test is meaningless, not zero.

--- a/tt_metal/tt-llk/tests/helpers/include/barrier.h
+++ b/tt_metal/tt-llk/tests/helpers/include/barrier.h
@@ -22,6 +22,9 @@ namespace llk_barrier
 
 #if defined(ARCH_QUASAR)
 constexpr std::uint32_t NUM_THREADS = 4; // unpack, math, pack, sfpu
+#ifndef QUASAR_POLL_BACKOFF_NOPS
+#define QUASAR_POLL_BACKOFF_NOPS 32
+#endif
 #else
 constexpr std::uint32_t NUM_THREADS = 3; // unpack, math, pack
 #endif
@@ -97,6 +100,17 @@ __attribute__((always_inline)) inline void rendezvous(bool is_action_thread, Act
 // Quasar has no free semaphore, so it gets an L1 rendezvous; trisc.cpp supplies the address.
 extern volatile std::uint32_t* barrier_slots;
 
+// A waiting thread polls an L1 word, and on an isolate run type three threads do so for the whole
+// measured window, competing with the unpacker for L1 reads: on the emulator the unpack windows
+// came out 4% longer than with no waiters. Spacing the polls out takes that back.
+__attribute__((always_inline)) inline void poll_backoff()
+{
+    for (std::uint32_t k = 0; k < QUASAR_POLL_BACKOFF_NOPS; ++k)
+    {
+        asm volatile("nop");
+    }
+}
+
 // Generations only increase, so a late thread still sees the round it missed; hence < and not ==.
 template <typename Action>
 __attribute__((always_inline)) inline void rendezvous(bool is_action_thread, Action action)
@@ -112,6 +126,7 @@ __attribute__((always_inline)) inline void rendezvous(bool is_action_thread, Act
     {
         while (i != THREAD_ID && slots[i] < arrive_gen)
         {
+            poll_backoff();
             ckernel::invalidate_data_cache();
         }
     }
@@ -128,6 +143,7 @@ __attribute__((always_inline)) inline void rendezvous(bool is_action_thread, Act
     {
         while (i != THREAD_ID && slots[i] < release_gen)
         {
+            poll_backoff();
             ckernel::invalidate_data_cache();
         }
     }

--- a/tt_metal/tt-llk/tests/helpers/include/counters.h
+++ b/tt_metal/tt-llk/tests/helpers/include/counters.h
@@ -14,20 +14,83 @@
 #include "profiler.h" // the zone/timestamp layer (TRISC only)
 
 // BRISC builds the config only; the per-zone measurement layer below also needs LLK_PROFILER.
-
-#ifdef ARCH_QUASAR
-#error "Perf counters are not supported on Quasar yet (no Quasar hw_counters.h; untested register set)."
-#endif
+// Quasar has no BRISC in this harness: the unpack TRISC does the one-time setup before it releases the others.
 
 // Include order matters: hw_counters.h uses PerfCounterType, which perf_counters.hpp defines.
 #include <array>
 // clang-format off
 #include "perf_counters.hpp"
+// Metal's kernel build gives the Quasar tables a named section; here they are folded at compile time.
+#ifndef PERF_COUNTER_TABLE
+#define PERF_COUNTER_TABLE
+#endif
 #include "hw_counters.h"
 // clang-format on
+#if defined(ARCH_QUASAR)
+#include "tensix_neo_reg.h"
+#endif
 
 namespace llk_perf
 {
+
+// Register map. tt-1xx names come from tensix.h. Quasar's hw_counters.h names NEO0's NoC window; a TRISC reaches its
+// own NEO's registers through the local window at the same offsets, so they are rebased onto LOCAL_REGS_BASE here.
+namespace reg
+{
+#if defined(ARCH_QUASAR)
+constexpr std::uint32_t local(std::uint32_t neo0_addr)
+{
+    return neo0_addr - NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_INSTRN_THREAD0_REG_ADDR + LOCAL_REGS_BASE;
+}
+
+constexpr std::uint32_t INSTRN_THREAD0      = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_INSTRN_THREAD0_REG_ADDR);
+constexpr std::uint32_t INSTRN_THREAD1      = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_INSTRN_THREAD1_REG_ADDR);
+constexpr std::uint32_t FPU0                = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_FPU0_REG_ADDR);
+constexpr std::uint32_t FPU1                = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_FPU1_REG_ADDR);
+constexpr std::uint32_t TDMA_UNPACK0        = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_TDMA_UNPACK0_REG_ADDR);
+constexpr std::uint32_t TDMA_UNPACK1        = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_TDMA_UNPACK1_REG_ADDR);
+constexpr std::uint32_t TDMA_UNPACK2        = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_TDMA_UNPACK2_REG_ADDR);
+constexpr std::uint32_t TDMA_PACK0          = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_TDMA_PACK0_REG_ADDR);
+constexpr std::uint32_t TDMA_PACK1          = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_TDMA_PACK1_REG_ADDR);
+constexpr std::uint32_t TDMA_PACK2          = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_TDMA_PACK2_REG_ADDR);
+constexpr std::uint32_t PERF_CNT_ALL        = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_ALL_REG_ADDR);
+constexpr std::uint32_t DBG_FEATURE_DISABLE = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_DBG_FEATURE_DISABLE_REG_ADDR);
+constexpr std::uint32_t OUT_L_INSTRN_THREAD = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_OUT_L_INSTRN_THREAD_REG_ADDR);
+constexpr std::uint32_t OUT_L_FPU           = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_OUT_L_FPU_REG_ADDR);
+constexpr std::uint32_t OUT_L_TDMA_UNPACK   = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_OUT_L_TDMA_UNPACK_REG_ADDR);
+constexpr std::uint32_t OUT_L_TDMA_PACK     = local(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_PERF_CNT_OUT_L_TDMA_PACK_REG_ADDR);
+// Quasar has no L1 counter bank; bank slot 3 carries the l1_client CSR instead (see counter_bank).
+constexpr std::uint32_t L1_0           = 0;
+constexpr std::uint32_t L1_1           = 0;
+constexpr std::uint32_t L1_2           = 0;
+constexpr std::uint32_t OUT_L_DBG_L1   = 0;
+constexpr std::uint32_t MUX_CTRL       = 0;
+constexpr std::uint32_t L1_CLIENT_CTRL = local(NEO_REGS_0__LOCAL_REGS_L1_CLIENT_GROUP_PERF_CTRL_REG_ADDR);
+constexpr std::uint32_t L1_CLIENT_CNT  = local(NEO_REGS_0__LOCAL_REGS_L1_CLIENT_GROUP_PERF_CNT_REG_ADDR);
+#else
+constexpr std::uint32_t INSTRN_THREAD0      = RISCV_DEBUG_REG_PERF_CNT_INSTRN_THREAD0;
+constexpr std::uint32_t INSTRN_THREAD1      = RISCV_DEBUG_REG_PERF_CNT_INSTRN_THREAD1;
+constexpr std::uint32_t FPU0                = RISCV_DEBUG_REG_PERF_CNT_FPU0;
+constexpr std::uint32_t FPU1                = RISCV_DEBUG_REG_PERF_CNT_FPU1;
+constexpr std::uint32_t TDMA_UNPACK0        = RISCV_DEBUG_REG_PERF_CNT_TDMA_UNPACK0;
+constexpr std::uint32_t TDMA_UNPACK1        = RISCV_DEBUG_REG_PERF_CNT_TDMA_UNPACK1;
+constexpr std::uint32_t TDMA_UNPACK2        = RISCV_DEBUG_REG_PERF_CNT_TDMA_UNPACK2;
+constexpr std::uint32_t TDMA_PACK0          = RISCV_DEBUG_REG_PERF_CNT_TDMA_PACK0;
+constexpr std::uint32_t TDMA_PACK1          = RISCV_DEBUG_REG_PERF_CNT_TDMA_PACK1;
+constexpr std::uint32_t TDMA_PACK2          = RISCV_DEBUG_REG_PERF_CNT_TDMA_PACK2;
+constexpr std::uint32_t PERF_CNT_ALL        = RISCV_DEBUG_REG_PERF_CNT_ALL;
+constexpr std::uint32_t DBG_FEATURE_DISABLE = RISCV_DEBUG_REG_DBG_FEATURE_DISABLE;
+constexpr std::uint32_t OUT_L_INSTRN_THREAD = RISCV_DEBUG_REG_PERF_CNT_OUT_L_INSTRN_THREAD;
+constexpr std::uint32_t OUT_L_FPU           = RISCV_DEBUG_REG_PERF_CNT_OUT_L_FPU;
+constexpr std::uint32_t OUT_L_TDMA_UNPACK   = RISCV_DEBUG_REG_PERF_CNT_OUT_L_TDMA_UNPACK;
+constexpr std::uint32_t OUT_L_TDMA_PACK     = RISCV_DEBUG_REG_PERF_CNT_OUT_L_TDMA_PACK;
+constexpr std::uint32_t L1_0                = RISCV_DEBUG_REG_PERF_CNT_L1_0;
+constexpr std::uint32_t L1_1                = RISCV_DEBUG_REG_PERF_CNT_L1_1;
+constexpr std::uint32_t L1_2                = RISCV_DEBUG_REG_PERF_CNT_L1_2;
+constexpr std::uint32_t OUT_L_DBG_L1        = RISCV_DEBUG_REG_PERF_CNT_OUT_L_DBG_L1;
+constexpr std::uint32_t MUX_CTRL            = RISCV_DEBUG_REG_PERF_CNT_MUX_CTRL;
+#endif
+} // namespace reg
 
 constexpr std::uint32_t PERF_COUNTERS_MAX_ZONES = 8;
 constexpr std::uint32_t SYNC_ZONE_COMPLETE      = 0xFFu; // written after readout; host polls for it
@@ -57,7 +120,8 @@ constexpr std::uint32_t PERF_COUNTERS_LAYOUT_END        = PERF_COUNTERS_VALID_CO
 // A literal because BRISC has no llk_profiler namespace; the LLK_PROFILER section asserts it symbolically.
 static_assert(PERF_COUNTERS_LAYOUT_END <= 0x16AFF0u, "Perf counter L1 layout overflows into the profiler region");
 
-// On-wire bank IDs; the order is a contract with base_addrs[], banks[] and the host.
+// On-wire bank IDs; the order is a contract with base_addrs[], banks[] and the host. On Quasar, which has no L1
+// counter bank, slot 3 carries the l1_client event CSR: its counter_sel field holds the subport*8+event selection.
 enum class counter_bank : std::uint8_t
 {
     instrn_thread = 0,
@@ -66,6 +130,30 @@ enum class counter_bank : std::uint8_t
     l1            = 3,
     tdma_pack     = 4,
 };
+
+#if defined(ARCH_QUASAR)
+// -1 leaves the l1_client CSR out; otherwise subport*8 + event, as TT_METAL_PROFILE_PERF_COUNTERS_L1_SEL in metal.
+#ifndef LLK_PERF_L1_CLIENT_SEL
+#define LLK_PERF_L1_CLIENT_SEL (-1)
+#endif
+constexpr int L1_CLIENT_SEL                = LLK_PERF_L1_CLIENT_SEL;
+constexpr bool L1_CLIENT_ENABLED           = L1_CLIENT_SEL >= 0;
+constexpr std::uint32_t L1_CLIENT_SUBPORTS = QUASAR_L1_CLIENT_NUM_SUBPORTS;
+constexpr std::uint32_t L1_CLIENT_EVENTS   = QUASAR_L1_CLIENT_NUM_EVENTS;
+static_assert(
+    !L1_CLIENT_ENABLED || L1_CLIENT_SEL < static_cast<int>(L1_CLIENT_SUBPORTS * L1_CLIENT_EVENTS), "LLK_PERF_L1_CLIENT_SEL is subport*8 + event, below 296");
+static_assert(!L1_CLIENT_ENABLED || L1_CLIENT_SEL % static_cast<int>(L1_CLIENT_EVENTS) != 0, "l1_client event 0 is unused in the RTL");
+static_assert(
+    !L1_CLIENT_ENABLED || !(L1_CLIENT_SEL / static_cast<int>(L1_CLIENT_EVENTS) == 4 && L1_CLIENT_SEL % static_cast<int>(L1_CLIENT_EVENTS) <= 3),
+    "THCON events 1-3 read the TRISC port's SBank 0 counters; select them through sub-port 0");
+
+constexpr std::uint32_t l1_client_ctrl_word()
+{
+    return (static_cast<std::uint32_t>(L1_CLIENT_SEL / static_cast<int>(L1_CLIENT_EVENTS)) << QUASAR_L1_CLIENT_PERF_SUBPORT_SHIFT) |
+           (static_cast<std::uint32_t>(L1_CLIENT_SEL % static_cast<int>(L1_CLIENT_EVENTS)) << QUASAR_L1_CLIENT_PERF_EVENT_SHIFT) |
+           QUASAR_L1_CLIENT_PERF_CTRL_ENABLE;
+}
+#endif
 
 constexpr std::uint32_t COUNTER_BANK_COUNT = 5;
 
@@ -80,10 +168,14 @@ constexpr std::uint32_t PERF_CFG_COUNTER_SHIFT = 8; // bits 16:8 (9-bit counter_
 constexpr std::uint32_t PERF_CFG_COUNTER_MASK  = 0x1FFu;
 constexpr std::uint32_t PERF_CFG_BANK_MASK     = 0xFFu; // bits 7:0
 
-// hw_counters.h is the authority and L1_MUX_MASK arrives already shifted.
+// hw_counters.h is the authority and L1_MUX_MASK arrives already shifted. Quasar has no L1 mux.
 constexpr std::uint32_t PERF_CNT_MUX_CTRL_SHIFT = 4;
-constexpr std::uint32_t PERF_CNT_MUX_CTRL_MASK  = L1_MUX_MASK;
-constexpr std::uint32_t PERF_L1_MUX_MAX         = PERF_CNT_MUX_CTRL_MASK >> PERF_CNT_MUX_CTRL_SHIFT;
+#if defined(ARCH_QUASAR)
+constexpr std::uint32_t PERF_CNT_MUX_CTRL_MASK = 0;
+#else
+constexpr std::uint32_t PERF_CNT_MUX_CTRL_MASK = L1_MUX_MASK;
+#endif
+constexpr std::uint32_t PERF_L1_MUX_MAX = PERF_CNT_MUX_CTRL_MASK >> PERF_CNT_MUX_CTRL_SHIFT;
 
 constexpr std::uint32_t _perf_cfg(std::uint8_t bank, std::uint16_t cid, std::uint8_t mux = 0)
 {
@@ -95,11 +187,11 @@ constexpr std::uint32_t _perf_cfg(std::uint8_t bank, std::uint16_t cid, std::uin
 inline std::uint32_t get_counter_base_addr(counter_bank bank)
 {
     static constexpr std::uint32_t base_addrs[COUNTER_BANK_COUNT] = {
-        RISCV_DEBUG_REG_PERF_CNT_INSTRN_THREAD0,
-        RISCV_DEBUG_REG_PERF_CNT_FPU0,
-        RISCV_DEBUG_REG_PERF_CNT_TDMA_UNPACK0,
-        RISCV_DEBUG_REG_PERF_CNT_L1_0,
-        RISCV_DEBUG_REG_PERF_CNT_TDMA_PACK0,
+        reg::INSTRN_THREAD0,
+        reg::FPU0,
+        reg::TDMA_UNPACK0,
+        reg::L1_0,
+        reg::TDMA_PACK0,
     };
     static_assert(
         static_cast<std::uint32_t>(counter_bank::tdma_pack) == COUNTER_BANK_COUNT - 1, "counter_bank enumerators must be contiguous 0..COUNTER_BANK_COUNT-1");
@@ -115,6 +207,13 @@ inline std::uint32_t get_counter_base_addr(counter_bank bank)
 
 constexpr std::uint8_t L1_MUX_GROUP = LLK_PERF_L1_MUX_GROUP;
 
+#if defined(ARCH_QUASAR)
+// Slot 3 holds the one l1_client selection when it is enabled.
+constexpr std::uint32_t l1_group_size(std::uint8_t)
+{
+    return L1_CLIENT_ENABLED ? 1u : 0u;
+}
+#else
 constexpr std::uint32_t l1_group_size(std::uint8_t mux)
 {
     return mux == 0   ? l1_0_counters.size()
@@ -128,6 +227,7 @@ constexpr std::uint32_t l1_group_size(std::uint8_t mux)
 
 static_assert(L1_MUX_GROUP <= PERF_L1_MUX_MAX, "LLK_PERF_L1_MUX_GROUP does not fit this architecture's PERF_CNT_MUX_CTRL mux field");
 static_assert(l1_group_size(L1_MUX_GROUP) > 0, "LLK_PERF_L1_MUX_GROUP selects an L1 mux group this architecture does not expose");
+#endif
 
 constexpr std::uint32_t builtin_counter_count()
 {
@@ -150,6 +250,12 @@ constexpr std::array<std::uint32_t, builtin_counter_count()> build_builtin_confi
     emit(fpu_counters, counter_bank::fpu, 0);
     emit(unpack_counters, counter_bank::tdma_unpack, 0);
     emit(pack_counters, counter_bank::tdma_pack, 0);
+#if defined(ARCH_QUASAR)
+    if constexpr (L1_CLIENT_ENABLED)
+    {
+        cfg[k++] = _perf_cfg(static_cast<std::uint8_t>(counter_bank::l1), static_cast<std::uint16_t>(L1_CLIENT_SEL), 0);
+    }
+#else
     if constexpr (L1_MUX_GROUP == 0)
     {
         emit(l1_0_counters, counter_bank::l1, 0);
@@ -174,6 +280,7 @@ constexpr std::array<std::uint32_t, builtin_counter_count()> build_builtin_confi
     {
         emit(l1_5_counters, counter_bank::l1, 5);
     }
+#endif
     return cfg;
 }
 
@@ -208,14 +315,27 @@ inline void configure_hardware()
             continue;
         }
         const counter_bank bank = static_cast<counter_bank>(bank_id);
+#if defined(ARCH_QUASAR)
+        if (bank == counter_bank::l1)
+        {
+            // The l1_client CSR: route the selection, then read once so the clear-on-read count starts at zero.
+            if constexpr (L1_CLIENT_ENABLED)
+            {
+                ckernel::reg_write(reg::L1_CLIENT_CTRL, l1_client_ctrl_word());
+                (void)ckernel::reg_read(reg::L1_CLIENT_CNT);
+            }
+            configured_mask |= bank_bit;
+            continue;
+        }
+#else
         if (bank == counter_bank::l1)
         {
             const std::uint8_t l1_mux = (metadata >> PERF_CFG_L1_MUX_SHIFT) & PERF_CFG_L1_MUX_MASK;
-            std::uint32_t cur         = ckernel::reg_read(RISCV_DEBUG_REG_PERF_CNT_MUX_CTRL);
+            std::uint32_t cur         = ckernel::reg_read(reg::MUX_CTRL);
             ckernel::reg_write(
-                RISCV_DEBUG_REG_PERF_CNT_MUX_CTRL,
-                (cur & ~PERF_CNT_MUX_CTRL_MASK) | ((static_cast<std::uint32_t>(l1_mux) << PERF_CNT_MUX_CTRL_SHIFT) & PERF_CNT_MUX_CTRL_MASK));
+                reg::MUX_CTRL, (cur & ~PERF_CNT_MUX_CTRL_MASK) | ((static_cast<std::uint32_t>(l1_mux) << PERF_CNT_MUX_CTRL_SHIFT) & PERF_CNT_MUX_CTRL_MASK));
         }
+#endif
         std::uint32_t counter_base = get_counter_base_addr(bank);
         ckernel::reg_write(counter_base, 0xFFFFFFFF);
         ckernel::reg_write(counter_base + 4, 0);
@@ -232,11 +352,15 @@ inline void arm_hardware()
             continue;
         }
         std::uint32_t counter_base = get_counter_base_addr(static_cast<counter_bank>(b));
+        if (counter_base == 0)
+        {
+            continue; // Quasar slot 3: the l1_client CSR has no start/stop register
+        }
         ckernel::reg_write(counter_base + 8, 1);
         ckernel::reg_write(counter_base + 8, 0);
     }
-    ckernel::reg_write(RISCV_DEBUG_REG_PERF_CNT_ALL, 1);
-    ckernel::reg_write(RISCV_DEBUG_REG_PERF_CNT_ALL, 0);
+    ckernel::reg_write(reg::PERF_CNT_ALL, 1);
+    ckernel::reg_write(reg::PERF_CNT_ALL, 0);
 }
 
 inline void configure_all_zones()
@@ -268,14 +392,15 @@ inline void configure_all_zones()
 
     if (found_valid)
     {
-        ckernel::reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0);
+        ckernel::reg_write(reg::DBG_FEATURE_DISABLE, 0);
         configure_hardware();
         arm_hardware();
     }
 }
 
-// Write shared config to L1, clear per-zone data, then configure + arm hw.
-inline void configure_and_arm_from_brisc()
+// Write shared config to L1, clear per-zone data, then configure + arm hw. BRISC runs it on tt-1xx before it
+// releases the TRISCs; on Quasar the unpack TRISC runs it before it releases the other three (trisc.cpp).
+inline void configure_and_arm()
 {
     volatile std::uint32_t* shared_config = reinterpret_cast<volatile std::uint32_t*>(PERF_COUNTERS_SHARED_CONFIG_ADDR);
     for (std::uint32_t i = 0; i < BUILTIN_COUNTER_COUNT; i++)
@@ -302,6 +427,11 @@ inline void configure_and_arm_from_brisc()
     }
 
     configure_all_zones();
+}
+
+inline void configure_and_arm_from_brisc()
+{
+    configure_and_arm();
 }
 
 namespace detail
@@ -350,20 +480,29 @@ static_assert(PERF_COUNTERS_LAYOUT_END <= llk_profiler::EPOCH_ADDR, "Perf counte
 inline __attribute__((always_inline)) void arm_all_counters()
 {
     ckernel::fence_compiler();
-    ckernel::reg_write(RISCV_DEBUG_REG_PERF_CNT_ALL, 1u);
-    ckernel::reg_write(RISCV_DEBUG_REG_PERF_CNT_TDMA_UNPACK2, 1u);
-    ckernel::reg_write(RISCV_DEBUG_REG_PERF_CNT_L1_2, 1u);
-    ckernel::reg_write(RISCV_DEBUG_REG_PERF_CNT_TDMA_PACK2, 1u);
+    ckernel::reg_write(reg::PERF_CNT_ALL, 1u);
+    ckernel::reg_write(reg::TDMA_UNPACK2, 1u);
+#if defined(ARCH_QUASAR)
+    if constexpr (L1_CLIENT_ENABLED)
+    {
+        (void)ckernel::reg_read(reg::L1_CLIENT_CNT); // clear-on-read: the window starts here
+    }
+#else
+    ckernel::reg_write(reg::L1_2, 1u);
+#endif
+    ckernel::reg_write(reg::TDMA_PACK2, 1u);
     ckernel::fence_compiler();
 }
 
 inline __attribute__((always_inline)) void freeze_and_read_all_counters(std::uint32_t zone_id)
 {
     ckernel::fence_compiler();
-    ckernel::reg_write(RISCV_DEBUG_REG_PERF_CNT_ALL, 2u);
-    ckernel::reg_write(RISCV_DEBUG_REG_PERF_CNT_TDMA_UNPACK2, 2u);
-    ckernel::reg_write(RISCV_DEBUG_REG_PERF_CNT_L1_2, 2u);
-    ckernel::reg_write(RISCV_DEBUG_REG_PERF_CNT_TDMA_PACK2, 2u);
+    ckernel::reg_write(reg::PERF_CNT_ALL, 2u);
+    ckernel::reg_write(reg::TDMA_UNPACK2, 2u);
+#if !defined(ARCH_QUASAR)
+    ckernel::reg_write(reg::L1_2, 2u);
+#endif
+    ckernel::reg_write(reg::TDMA_PACK2, 2u);
 
     struct bank_regs
     {
@@ -374,11 +513,11 @@ inline __attribute__((always_inline)) void freeze_and_read_all_counters(std::uin
     // Per-bank readout pair: mode_reg drives counter_sel; out_l is the bank's reference count, OUT_H (at out_l + 4)
     // the selected counter.
     static constexpr bank_regs banks[5] = {
-        {RISCV_DEBUG_REG_PERF_CNT_INSTRN_THREAD1, RISCV_DEBUG_REG_PERF_CNT_OUT_L_INSTRN_THREAD},
-        {RISCV_DEBUG_REG_PERF_CNT_FPU1, RISCV_DEBUG_REG_PERF_CNT_OUT_L_FPU},
-        {RISCV_DEBUG_REG_PERF_CNT_TDMA_UNPACK1, RISCV_DEBUG_REG_PERF_CNT_OUT_L_TDMA_UNPACK},
-        {RISCV_DEBUG_REG_PERF_CNT_L1_1, RISCV_DEBUG_REG_PERF_CNT_OUT_L_DBG_L1},
-        {RISCV_DEBUG_REG_PERF_CNT_TDMA_PACK1, RISCV_DEBUG_REG_PERF_CNT_OUT_L_TDMA_PACK},
+        {reg::INSTRN_THREAD1, reg::OUT_L_INSTRN_THREAD},
+        {reg::FPU1, reg::OUT_L_FPU},
+        {reg::TDMA_UNPACK1, reg::OUT_L_TDMA_UNPACK},
+        {reg::L1_1, reg::OUT_L_DBG_L1},
+        {reg::TDMA_PACK1, reg::OUT_L_TDMA_PACK},
     };
 
     std::uint32_t cycles_base              = PERF_COUNTERS_ZONES_BASE + zone_id * PERF_COUNTERS_ZONE_SIZE;
@@ -386,7 +525,9 @@ inline __attribute__((always_inline)) void freeze_and_read_all_counters(std::uin
     volatile std::uint32_t* counter_counts = bank_cycles + PERF_COUNTERS_BANK_CYCLES_WORDS;
     for (std::uint32_t b = 0; b < 5; ++b)
     {
-        bank_cycles[b] = ckernel::reg_read(banks[b].out_l);
+        // Quasar slot 3 has no reference counter; every bank is armed within a few cycles of INSTRN, so its count is
+        // reported over the INSTRN reference.
+        bank_cycles[b] = banks[b].out_l ? ckernel::reg_read(banks[b].out_l) : bank_cycles[0];
     }
 
     const volatile std::uint32_t* cfg = reinterpret_cast<volatile std::uint32_t*>(PERF_COUNTERS_SHARED_CONFIG_ADDR);
@@ -406,6 +547,14 @@ inline __attribute__((always_inline)) void freeze_and_read_all_counters(std::uin
             continue; // corrupt config word: do not index banks[] out of range
         }
         const bank_regs& br = banks[bank_id];
+#if defined(ARCH_QUASAR)
+        if (bank_id == static_cast<std::uint32_t>(counter_bank::l1))
+        {
+            counter_counts[out_idx] = ckernel::reg_read(reg::L1_CLIENT_CNT); // clear-on-read
+            ++out_idx;
+            continue;
+        }
+#endif
         // No mux write: it is fixed once by configure_hardware and cannot be re-aimed afterwards.
         const std::uint32_t expected_mode = counter_id << PERF_CFG_COUNTER_SHIFT;
         ckernel::reg_write(br.mode_reg, expected_mode);
@@ -423,7 +572,8 @@ inline __attribute__((always_inline)) void freeze_and_read_all_counters(std::uin
 
 constexpr bool is_single_thread_runtype(PerfRunType run_type)
 {
-    return run_type == PerfRunType::UNPACK_ISOLATE || run_type == PerfRunType::MATH_ISOLATE || run_type == PerfRunType::PACK_ISOLATE;
+    return run_type == PerfRunType::UNPACK_ISOLATE || run_type == PerfRunType::MATH_ISOLATE || run_type == PerfRunType::PACK_ISOLATE ||
+           run_type == PerfRunType::SFPU_ISOLATE;
 }
 
 // MATH and PACK_ISOLATE freeze on the measured thread; the rest need every thread stopped first.
@@ -440,6 +590,8 @@ constexpr bool is_measured_thread(PerfRunType run_type)
     return run_type == PerfRunType::MATH_ISOLATE;
 #elif defined(LLK_TRISC_PACK)
     return run_type == PerfRunType::PACK_ISOLATE;
+#elif defined(LLK_TRISC_ISOLATE_SFPU)
+    return run_type == PerfRunType::SFPU_ISOLATE;
 #else
     return false;
 #endif
@@ -467,7 +619,8 @@ struct perf_counter_scoped
         ckernel::fence_compiler();
         const std::uint32_t zid = zone_id;
         static_assert(
-            exit_barrier_for(RUN_TYPE) || RUN_TYPE == PerfRunType::MATH_ISOLATE || RUN_TYPE == PerfRunType::PACK_ISOLATE,
+            exit_barrier_for(RUN_TYPE) || RUN_TYPE == PerfRunType::MATH_ISOLATE || RUN_TYPE == PerfRunType::PACK_ISOLATE ||
+                RUN_TYPE == PerfRunType::SFPU_ISOLATE,
             "a run type that skips the exit barrier needs a measured thread in is_measured_thread() to freeze the counters");
         if constexpr (!exit_barrier_for(RUN_TYPE))
         {
@@ -498,8 +651,7 @@ struct perf_counter_scoped
 
 #else // !PERF_COUNTERS_COMPILED
 
-// rendezvous() only exists off Quasar, which reaches this branch with LLK_PROFILER but not counters.
-#if defined(LLK_PROFILER) && !defined(ARCH_QUASAR)
+#if defined(LLK_PROFILER)
 #define MEASURE_PERF_COUNTERS(zone_name) llk_barrier::rendezvous(llk_barrier::is_action_thread());
 #else
 #define MEASURE_PERF_COUNTERS(zone_name)
@@ -507,6 +659,10 @@ struct perf_counter_scoped
 
 namespace llk_perf
 {
+inline void configure_and_arm()
+{
+}
+
 inline void configure_and_arm_from_brisc()
 {
 }

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_stub.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_stub.h
@@ -12,12 +12,20 @@
 // build.h uses p_unpacr::UNP_A etc; bring ckernel namespace into scope
 using namespace ckernel;
 
+#include "counters.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
     (void)params;
-    // Stub: SFPU TRISC not used in this test; trisc.cpp will signal completion
+    // Stub: SFPU TRISC not used in this test; trisc.cpp will signal completion. It still enters the other
+    // threads' INIT and TILE_LOOP phases, because every zone boundary is a four-thread rendezvous.
+    {
+        START_PERF_MEASURE("INIT")
+    }
+    {
+        START_PERF_MEASURE("TILE_LOOP")
+    }
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/helpers/src/trisc.cpp
+++ b/tt_metal/tt-llk/tests/helpers/src/trisc.cpp
@@ -13,6 +13,7 @@
 #include "ckernel_helper.h" // Only for WH/BH
 #endif
 #include "boot.h"
+#include "counters.h"
 #include "profiler.h"
 
 #ifdef LLK_PROFILER
@@ -78,6 +79,10 @@ int main(void)
     *(mailbox_base + 3) = ckernel::RESET_VAL;
 #endif
     device_setup();
+#if defined(ARCH_QUASAR) && defined(PERF_COUNTERS_COMPILED)
+    // No BRISC on Quasar: the unpack TRISC writes the counter config and arms the units while the others are still held.
+    llk_perf::configure_and_arm();
+#endif
     clear_trisc_soft_reset(); // Release the rest of the triscs
 #endif
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/counters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/counters.py
@@ -10,17 +10,24 @@ from loguru import logger
 
 from .chip_architecture import ChipArchitecture, get_chip_architecture
 from .device_io import read_words_from_device
+from .perf.schema import PERF_METRICS_COMMON
 from .test_config import TestConfig
 
 COUNTER_SLOT_COUNT = TestConfig._PERF_COUNTERS_CONFIG_WORDS
 
+_IS_QUASAR = get_chip_architecture() == ChipArchitecture.QUASAR
+
+# Bank ids as counters.h numbers them. Quasar has no L1 counter bank, so slot 3 carries the
+# l1_client event CSR there; its counter_sel field is the subport*8 + event selection.
 COUNTER_BANK_NAMES = {
     0: "INSTRN_THREAD",
     1: "FPU",
     2: "TDMA_UNPACK",
-    3: "L1",
+    3: "L1_CLIENT" if _IS_QUASAR else "L1",
     4: "TDMA_PACK",
 }
+# Banks hw_counters.h can name (L1 only exists on tt-1xx).
+_NAMED_BANKS = ("INSTRN_THREAD", "FPU", "TDMA_UNPACK", "TDMA_PACK", "L1")
 
 
 # --- Counter id -> name tables, parsed live from the canonical metal hw_counters.h ---
@@ -32,8 +39,9 @@ _ARRAY_TO_BANK = {
     "pack_counters": "TDMA_PACK",
 }
 _ARCH_DIR = {
-    ChipArchitecture.WORMHOLE: "wormhole",
-    ChipArchitecture.BLACKHOLE: "blackhole",
+    ChipArchitecture.WORMHOLE: "tt-1xx/wormhole",
+    ChipArchitecture.BLACKHOLE: "tt-1xx/blackhole",
+    ChipArchitecture.QUASAR: "tt-2xx/quasar",
 }
 
 
@@ -78,9 +86,10 @@ PERF_CFG_BANK_MASK = _PERF_CFG["BANK_MASK"]
 
 def _parse_hw_counters(text: str) -> dict:
     """Parse one hw_counters.h into {bank: {id: name}}; L1 is keyed by (id, mux)."""
-    banks = {bank: {} for bank in COUNTER_BANK_NAMES.values()}
+    banks = {bank: {} for bank in _NAMED_BANKS}
 
-    decls = list(re.finditer(r"(\w+_counters)\s*=", text))
+    # Quasar's arrays carry a section attribute macro between the name and the "=".
+    decls = list(re.finditer(r"(\w+_counters)(?:\s+[A-Z_]+)?\s*=", text))
     for i, decl in enumerate(decls):
         name = decl.group(1)
         start = decl.end()
@@ -111,16 +120,13 @@ def _parse_hw_counters(text: str) -> dict:
 
 def _load_counter_names(arch: ChipArchitecture) -> dict:
     arch_dir = _ARCH_DIR.get(arch)
-    if arch_dir is None:  # Quasar / unsupported: no hw_counters.h yet.
-        return {bank: {} for bank in COUNTER_BANK_NAMES.values()}
-    header = _metal_root() / f"tt_metal/hw/inc/internal/tt-1xx/{arch_dir}/hw_counters.h"
+    if arch_dir is None:
+        return {bank: {} for bank in _NAMED_BANKS}
+    header = _metal_root() / f"tt_metal/hw/inc/internal/{arch_dir}/hw_counters.h"
     banks = _parse_hw_counters(header.read_text())
     # Silently, every column becomes UNKNOWN and metrics.py turns the misses into a page of zeros.
-    missing = [
-        b
-        for b in ("INSTRN_THREAD", "FPU", "TDMA_UNPACK", "TDMA_PACK", "L1")
-        if not banks.get(b)
-    ]
+    expected = [b for b in _NAMED_BANKS if b != "L1" or arch != ChipArchitecture.QUASAR]
+    missing = [b for b in expected if not banks.get(b)]
     if missing:
         raise RuntimeError(
             f"Could not parse counter names from {header}: empty banks {missing}. "
@@ -218,29 +224,9 @@ def _read_zone_counters(location: str, zone: int, zone_name: str) -> list[dict]:
         if (config_word & PERF_CFG_VALID_BIT) == 0:
             continue
 
-        bank_id = config_word & PERF_CFG_BANK_MASK
-        counter_id = (config_word >> PERF_CFG_COUNTER_SHIFT) & PERF_CFG_COUNTER_MASK
-        l1_mux = (config_word >> PERF_CFG_L1_MUX_SHIFT) & PERF_CFG_L1_MUX_MASK
-
-        bank_name = COUNTER_BANK_NAMES.get(bank_id, f"UNKNOWN_{bank_id}")
-
-        if bank_name == "L1" and l1_mux != TestConfig.PERF_L1_MUX_GROUP:
-            # The group is baked into brisc.elf and nothing keys a rebuild on it, so a stale ELF
-            # would otherwise return a self-consistently mislabelled dataset.
-            raise RuntimeError(
-                f"L1 counters were captured with mux group {l1_mux}, but "
-                f"LLK_PERF_L1_MUX_GROUP={TestConfig.PERF_L1_MUX_GROUP} was requested. The ELF predates "
-                "the change; recompile the producer (the group is a compile-time constant)."
-            )
-
-        if bank_name == "L1":
-            counter_name = COUNTER_NAMES["L1"].get(
-                (counter_id, l1_mux), f"L1_UNKNOWN_{counter_id}_{l1_mux}"
-            )
-        else:
-            counter_name = COUNTER_NAMES.get(bank_name, {}).get(
-                counter_id, f"{bank_name}_UNKNOWN_{counter_id}"
-            )
+        bank_id, bank_name, counter_id, counter_name, l1_mux = decode_config_word(
+            config_word
+        )
 
         cycles = bank_cycles[bank_id] if bank_id < bank_cycles_words else 0
         count = counter_counts[count_idx]
@@ -254,11 +240,52 @@ def _read_zone_counters(location: str, zone: int, zone_name: str) -> list[dict]:
                 "counter_id": counter_id,
                 "cycles": cycles,
                 "count": count,
-                "l1_mux": l1_mux if bank_name == "L1" else None,
+                "l1_mux": l1_mux,
             }
         )
 
     return results
+
+
+def decode_config_word(config_word: int) -> tuple:
+    """(bank_id, bank_name, counter_id, counter_name, l1_mux) for one valid config word.
+
+    l1_mux is None outside the tt-1xx L1 bank. Quasar's slot 3 is the l1_client CSR, whose
+    counter_sel is the subport*8 + event selection and names itself through the shared engine.
+    """
+    bank_id = config_word & PERF_CFG_BANK_MASK
+    counter_id = (config_word >> PERF_CFG_COUNTER_SHIFT) & PERF_CFG_COUNTER_MASK
+    l1_mux = (config_word >> PERF_CFG_L1_MUX_SHIFT) & PERF_CFG_L1_MUX_MASK
+
+    bank_name = COUNTER_BANK_NAMES.get(bank_id, f"UNKNOWN_{bank_id}")
+
+    if bank_name == "L1" and l1_mux != TestConfig.PERF_L1_MUX_GROUP:
+        # The group is baked into brisc.elf and nothing keys a rebuild on it, so a stale ELF
+        # would otherwise return a self-consistently mislabelled dataset.
+        raise RuntimeError(
+            f"L1 counters were captured with mux group {l1_mux}, but "
+            f"LLK_PERF_L1_MUX_GROUP={TestConfig.PERF_L1_MUX_GROUP} was requested. The ELF predates "
+            "the change; recompile the producer (the group is a compile-time constant)."
+        )
+
+    if bank_name == "L1":
+        counter_name = COUNTER_NAMES["L1"].get(
+            (counter_id, l1_mux), f"L1_UNKNOWN_{counter_id}_{l1_mux}"
+        )
+    elif bank_name == "L1_CLIENT":
+        counter_name = PERF_METRICS_COMMON.quasar_l1_client_label(counter_id)
+    else:
+        counter_name = COUNTER_NAMES.get(bank_name, {}).get(
+            counter_id, f"{bank_name}_UNKNOWN_{counter_id}"
+        )
+
+    return (
+        bank_id,
+        bank_name,
+        counter_id,
+        counter_name,
+        l1_mux if bank_name == "L1" else None,
+    )
 
 
 def read_counters(location: str = "0,0") -> pd.DataFrame:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/metrics.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/metrics.py
@@ -54,7 +54,14 @@ def _compute_single(df: pd.DataFrame) -> dict:
     """Compute derived metrics for one (zone, run) slice via the shared formula module."""
     if df.empty:
         return {}
-    return _mc.compute_metrics(_DfCounterView(df))
+    view = _DfCounterView(df)
+    metrics = _mc.compute_metrics(view)
+    # Quasar's l1_client event (bank L1_CLIENT) is named after the run's selection, so its
+    # metric is computed from the rows rather than from the static formula table.
+    l1_client = df.loc[df["bank"] == "L1_CLIENT", "counter_name"]
+    if not l1_client.empty:
+        metrics.update(_mc.compute_l1_client_metrics(view, l1_client))
+    return metrics
 
 
 def compute_metrics(df: pd.DataFrame) -> list[dict]:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
@@ -697,10 +697,7 @@ def assert_zones_dont_overlap(profiler_data: ProfilerData) -> None:
     how the perf kernels are written, not of the profiler, so it lives here and runs once per run.
 
     Within a thread a zone that contains another is a wrapper (trisc.cpp's KERNEL), not a phase.
-    Quasar has no entry rendezvous yet.
     """
-    if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR:
-        return
     # The profiler view pairs every ZONE_START with the ZONE_END that follows it.
     zones = profiler_data.zones().frame()
     if zones.empty:
@@ -1013,13 +1010,9 @@ class PerfConfig(TestConfig):
 
             get_stats = Profiler.STATS_FUNCTION[run_type]
             stats_df = get_stats(ProfilerData.concat(variant_raw_data))
-            # A WC build intentionally suppresses ZONE_SCOPED timing events and
-            # emits counter metrics instead. Quasar excludes the WC TRISC flag,
-            # so it still requires wall-clock stats even when counters are requested.
-            counter_only_build = (
-                TestConfig.ENABLE_PERF_COUNTERS
-                and TestConfig.CHIP_ARCH != ChipArchitecture.QUASAR
-            )
+            # A counter build may come back with counters and no wall-clock stats; only the
+            # no-counter build is required to produce timing.
+            counter_only_build = TestConfig.ENABLE_PERF_COUNTERS
             if not stats_df.empty or not counter_only_build:
                 PerfConfig._validate_profiler_stats(stats_df, run_type)
                 results.append(stats_df)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema_quasar.py
@@ -17,7 +17,15 @@ dtype/nullability/origin are the contract the Parquet writer enforces.
 Imports no device libraries, so it loads without hardware.
 """
 
-from .schema import MEAN, METRIC_BASES, RUN_TYPE_NAMES, STD, metric_column, stat_column
+from .schema import (
+    MEAN,
+    METRIC_BASES,
+    PERF_METRICS_COMMON,
+    RUN_TYPE_NAMES,
+    STD,
+    metric_column,
+    stat_column,
+)
 from .wide_schema import Column
 
 # Same PerfRunType timing grid as WH/BH, plus the 4-TRISC parallel FPU/SFPU
@@ -130,15 +138,34 @@ MANDATORY = [c.name for c in DB_SCHEMA if not c.nullable]
 # Columns a Quasar test emits but the published table intentionally drops.
 # TEXT_SIZE(...) is per-stage ELF code size; not used by the gate. SFPU_ISOLATE
 # is 4-TRISC-only (#53072) and must not live on the WH/BH dropped set.
-DROPPED_COLUMNS = {
-    "TEXT_SIZE(L1_TO_L1)",
-    "TEXT_SIZE(MATH_ISOLATE)",
-    "TEXT_SIZE(PACK_ISOLATE)",
-    "TEXT_SIZE(UNPACK_ISOLATE)",
-    "TEXT_SIZE(SFPU_ISOLATE)",
-} | {
-    metric_column(run_type, base)
-    for run_type in RUN_TYPE_NAMES
-    for metric in METRIC_BASES
-    for base in (metric, stat_column(metric, MEAN), stat_column(metric, STD))
-}
+_L1_CLIENT_METRIC_KEYS = tuple(
+    PERF_METRICS_COMMON.l1_client_metric_key(
+        PERF_METRICS_COMMON.quasar_l1_client_label(sel)
+    )
+    for sel in range(PERF_METRICS_COMMON.QUASAR_L1_CLIENT_NUM_SUBPORTS * 8)
+    if PERF_METRICS_COMMON.quasar_l1_client_selection_is_valid(sel)
+)
+
+DROPPED_COLUMNS = (
+    {
+        "TEXT_SIZE(L1_TO_L1)",
+        "TEXT_SIZE(MATH_ISOLATE)",
+        "TEXT_SIZE(PACK_ISOLATE)",
+        "TEXT_SIZE(UNPACK_ISOLATE)",
+        "TEXT_SIZE(SFPU_ISOLATE)",
+    }
+    | {
+        metric_column(run_type, base)
+        for run_type in RUN_TYPE_NAMES
+        for metric in METRIC_BASES
+        for base in (metric, stat_column(metric, MEAN), stat_column(metric, STD))
+    }
+    | {
+        # The l1_client metric is named after the run's LLK_PERF_L1_CLIENT_SEL, one column per
+        # selection that can carry data; like the other metrics it stays in the CSV only.
+        metric_column(run_type, base)
+        for run_type in RUN_TYPE_NAMES
+        for metric in _L1_CLIENT_METRIC_KEYS
+        for base in (metric, stat_column(metric, MEAN), stat_column(metric, STD))
+    }
+)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -218,6 +218,10 @@ class TestConfig:
     ENABLE_PERF_COUNTERS: ClassVar[bool] = False
     # One run observes one group of 8 L1 interfaces; sweep this to cover all of them.
     PERF_L1_MUX_GROUP: ClassVar[int] = int(os.environ.get("LLK_PERF_L1_MUX_GROUP", "0"))
+    # Quasar has no L1 counter bank; one l1_client event (subport*8 + event, -1 = none) rides in its slot.
+    PERF_L1_CLIENT_SEL: ClassVar[int] = int(
+        os.environ.get("LLK_PERF_L1_CLIENT_SEL", "-1")
+    )
     DUMP_PERF_COUNTERS: ClassVar[bool] = False
 
     # === Addresses ===
@@ -1708,18 +1712,19 @@ class TestConfig:
                 if not self.compile_time_formats:
                     optional_kernel_flags += " -DRUNTIME_FORMATS"
 
-                # EXPERIMENT: enable -DPERF_COUNTERS_COMPILED on TRISC.
-                # Quasar is intentionally excluded: it adds a 4th compute thread
-                # (SFPU) and the entry/exit barrier in `counters.h` posts a fixed
-                # number of tokens for 3 threads, so enabling perf counters on
-                # Quasar would deadlock the SFPU thread (it would spinwait on a
-                # semaphore that never gets the extra post). A static_assert in
-                # `counters.h` enforces this at compile time as a safety net.
-                if (
-                    TestConfig.ENABLE_PERF_COUNTERS
-                    and TestConfig.CHIP_ARCH != ChipArchitecture.QUASAR
-                ):
-                    optional_kernel_flags += f" -DPERF_COUNTERS_COMPILED -DLLK_PERF_L1_MUX_GROUP={TestConfig.PERF_L1_MUX_GROUP}"
+                # The counter build. tt-1xx selects one L1 mux group; Quasar has no L1 bank and
+                # takes one l1_client event instead (the unpack TRISC does the setup BRISC does
+                # elsewhere, see trisc.cpp).
+                if TestConfig.ENABLE_PERF_COUNTERS:
+                    optional_kernel_flags += " -DPERF_COUNTERS_COMPILED"
+                    if TestConfig.CHIP_ARCH == ChipArchitecture.QUASAR:
+                        optional_kernel_flags += (
+                            f" -DLLK_PERF_L1_CLIENT_SEL={TestConfig.PERF_L1_CLIENT_SEL}"
+                        )
+                    else:
+                        optional_kernel_flags += (
+                            f" -DLLK_PERF_L1_MUX_GROUP={TestConfig.PERF_L1_MUX_GROUP}"
+                        )
 
                 coverage_args = (
                     [

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -974,3 +974,86 @@ def test_wrapper_on_threads_without_phases_is_not_an_overlap():
     events = [(t, "KERNEL", 9, 90, 1100) for t in _THREADS]
     events += [("math", "INIT", 0, 100, 200), ("math", "TILE_LOOP", 1, 210, 1000)]
     assert_zones_dont_overlap(ProfilerData(_zones(*events)))
+
+
+# ── Quasar counters: names, l1_client decode, schema ──────────────────────────
+
+
+def test_quasar_counter_names_come_from_the_quasar_header():
+    from helpers.chip_architecture import ChipArchitecture
+    from helpers.counters import _load_counter_names
+
+    banks = _load_counter_names(ChipArchitecture.QUASAR)
+    assert banks["INSTRN_THREAD"] and banks["FPU"]
+    assert banks["TDMA_UNPACK"] and banks["TDMA_PACK"]
+    # Quasar has no L1 counter bank; slot 3 is the l1_client CSR instead.
+    assert banks["L1"] == {}
+    assert banks["INSTRN_THREAD"][0] == "CFG_INSTRN_AVAILABLE_0"
+
+
+def test_hw_counters_parser_accepts_a_section_attribute():
+    from helpers.counters import _parse_hw_counters
+
+    text = (
+        "constexpr std::array<std::pair<PerfCounterType, std::uint16_t>, 2> fpu_counters "
+        "PERF_COUNTER_TABLE = {{{PerfCounterType::FPU_COUNTER, 0}, "
+        "{PerfCounterType::MATH_COUNTER, 257}}};"
+    )
+    assert _parse_hw_counters(text)["FPU"] == {0: "FPU_COUNTER", 257: "MATH_COUNTER"}
+
+
+def test_quasar_l1_client_slot_decodes_to_the_selection_label(monkeypatch):
+    import helpers.counters as counters
+    from helpers.perf.schema import PERF_METRICS_COMMON as mc
+
+    monkeypatch.setitem(counters.COUNTER_BANK_NAMES, 3, "L1_CLIENT")
+    sel = 1 * 8 + 1  # TRISC sub-port 1, SBANK_POP (per SBank event)
+    word = counters.PERF_CFG_VALID_BIT | (sel << counters.PERF_CFG_COUNTER_SHIFT) | 3
+    bank_id, bank, counter_id, name, l1_mux = counters.decode_config_word(word)
+    assert (bank_id, bank, counter_id) == (3, "L1_CLIENT", sel)
+    assert name == mc.quasar_l1_client_label(sel) == "L1_CLIENT_TRISC_SBANK1_SBANK_POP"
+    assert l1_mux is None
+
+
+def test_l1_client_rows_yield_their_own_metric():
+    from helpers.metrics import compute_metrics
+    from helpers.perf.schema import PERF_METRICS_COMMON as mc
+
+    name = mc.quasar_l1_client_label(5 * 8 + 1)  # UNPACK0_IF0_LANE0 SBANK_POP
+    df = pd.DataFrame(
+        [
+            {
+                "zone": "ZONE_1",
+                "bank": "L1_CLIENT",
+                "counter_name": name,
+                "counter_id": 41,
+                "cycles": 200,
+                "count": 50,
+                "l1_mux": None,
+            },
+            {
+                "zone": "ZONE_1",
+                "bank": "INSTRN_THREAD",
+                "counter_name": "THREAD_STALLS_0",
+                "counter_id": 32,
+                "cycles": 200,
+                "count": 20,
+                "l1_mux": None,
+            },
+        ]
+    )
+    (row,) = compute_metrics(df)
+    assert row[mc.l1_client_metric_key(name)] == 25.0
+
+
+def test_quasar_schema_drops_every_l1_client_metric_column():
+    from helpers.perf.schema import PERF_METRICS_COMMON as mc
+    from helpers.perf.schema import metric_column
+    from helpers.perf.wide_schema_quasar import DROPPED_COLUMNS as QSR_DROPPED
+
+    pending = mc.QUASAR_L1_CLIENT_EVENT_NAMES.index("PENDING_REQS_CARRY")
+    for sel in (1 * 8 + 1, 25 * 8 + pending):
+        key = mc.l1_client_metric_key(mc.quasar_l1_client_label(sel))
+        for base in (key, stat_column(key, MEAN), stat_column(key, STD)):
+            assert metric_column("SFPU_ISOLATE", base) in QSR_DROPPED
+    assert metric_column("L1_TO_L1", "l1_client_invalid_0_pct") not in QSR_DROPPED

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -34,7 +35,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
@@ -50,7 +51,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -101,7 +102,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_faces   = params.num_faces;
 #endif
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // End-to-end and math-isolate runs require FPU destination ownership.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
@@ -129,7 +130,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -193,7 +194,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE / L1_CONGESTION: no math↔pack dest-dvalid handshake.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -212,7 +213,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -44,7 +45,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr std::uint32_t unp_sel_phase2 = (REUSE_DEST_TYPE == EltwiseBinaryReuseDestType::DEST_TO_SRCA) ? p_unpacr::UNP_B : p_unpacr::UNP_A;
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // Setup data valid scheme
         set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
 
@@ -58,7 +59,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -128,7 +129,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t OUTPUT_NUM_TILES_IN_BLOCK = params.OUTPUT_NUM_TILES_IN_BLOCK;
 #endif
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // L1_TO_L1 / MATH_ISOLATE keep the math↔pack handshake: set up FPU→PACK dest-dvalid.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
@@ -141,7 +142,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const int num_total_tiles = INPUT_NUM_TILES_IN_BLOCK * INPUT_NUM_BLOCKS;
         const int tiles_in_block  = OUTPUT_NUM_TILES_IN_BLOCK;
         const int num_tiles_accum = INPUT_NUM_TILES_IN_BLOCK / tiles_in_block;
@@ -215,7 +216,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -234,7 +235,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const int output_tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
         const int output_num_blocks     = OUTPUT_NUM_BLOCKS;
 

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -44,7 +45,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             // DEST DVALID handshake: T0 is the producer. The producer differs
@@ -88,7 +89,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
             if constexpr (!unpack_to_dest)
@@ -153,7 +154,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const DataFormat math_format = static_cast<DataFormat>(formats.math);
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             // DEST DVALID handshake. On the FPU path T1 is both the datacopy
@@ -200,7 +201,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             if constexpr (!unpack_to_dest)
@@ -267,7 +268,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             // PACK runs without the L1_TO_L1 producer chain in isolated modes.
@@ -294,7 +295,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -38,7 +39,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
@@ -54,7 +55,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -104,7 +105,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t NUM_TILES_IN_BLOCK = params.NUM_TILES_IN_BLOCK;
 #endif
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // End-to-end and math-isolate runs require FPU destination ownership.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
@@ -124,7 +125,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -190,7 +191,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // Clear a stale FPU-to-PACK wait in modes without a math handshake.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
@@ -208,7 +209,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
         }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -38,7 +39,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_tiles_per_unpack = unpack_to_dest ? tiles_in_block : 1;
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (unpack_to_dest)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
@@ -70,7 +71,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -150,7 +151,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             if constexpr (unpack_to_dest)
@@ -192,7 +193,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
@@ -263,7 +264,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -290,7 +291,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -34,7 +35,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
         unsigned l1_addr_16B;
@@ -66,7 +67,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
@@ -130,7 +131,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t DST_INDEX       = params.DST_INDEX;
 #endif
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // End-to-end and math-isolate runs require FPU destination ownership.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
@@ -144,7 +145,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -211,7 +212,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -231,7 +232,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -33,7 +34,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (unpack_to_dest)
         {
             _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>();
@@ -94,7 +95,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
             if constexpr (!unpack_to_dest)
@@ -152,7 +153,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const DataFormat sfpu_in_format = static_cast<DataFormat>(formats.sfpu_src);
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (unpack_to_dest)
         {
             _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(src_format, src_format);
@@ -210,7 +211,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             if constexpr (!unpack_to_dest)
@@ -281,7 +282,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
             ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
 
@@ -311,7 +312,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -47,7 +48,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         set_ttsync_enables<TRACK_ALL>(ckernel::TRISC_ID);
         // Matmul flips the unpacker roles: _llk_unpack_matmul_init_ arg0 drives UNPACR1/SrcB, arg1 drives
         // UNPACR0/SrcA -- so operand A is recorded under Unp1 and operand B under Unp0 (matches product).
@@ -68,7 +69,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -117,7 +118,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr ckernel::TensorShape tensor_shape_B = ckernel::make_tensor_shape(in1_face_r_dim, in1_face_c_dim, num_faces_r_dim_B, num_faces_c_dim_B);
 #endif
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // Only end-to-end and math-isolate runs use the FPU→PACK dest-dvalid
         // handshake.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -150,7 +151,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -208,7 +209,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr ckernel::TensorShape output_shape = ckernel::make_tensor_shape(in0_face_r_dim, in1_face_c_dim, num_faces_r_dim_A, num_faces_c_dim_B);
 #endif
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -226,7 +227,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
         }

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -36,7 +37,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (unpack_to_dest)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
@@ -78,7 +79,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
@@ -152,7 +153,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if constexpr (!unpack_to_dest)
     {
         {
-            ZONE_SCOPED("INIT")
+            START_PERF_MEASURE("INIT")
             // Only end-to-end and math-isolate runs use the FPU→PACK
             // dest-dvalid handshake.
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -168,7 +169,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             PROFILER_SYNC();
         }
         {
-            ZONE_SCOPED("TILE_LOOP")
+            START_PERF_MEASURE("TILE_LOOP")
             const std::uint32_t tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
             const std::uint32_t num_blocks     = static_cast<std::uint32_t>(INPUT_NUM_BLOCKS);
 
@@ -242,7 +243,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -270,7 +271,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const std::uint32_t output_num_blocks     = static_cast<std::uint32_t>(OUTPUT_NUM_BLOCKS);
         const std::uint32_t output_tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
 

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -35,7 +36,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (unpack_to_dest)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
@@ -68,7 +69,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
@@ -128,7 +129,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if constexpr (!unpack_to_dest)
     {
         {
-            ZONE_SCOPED("INIT")
+            START_PERF_MEASURE("INIT")
             // Only L1_TO_L1 and MATH_ISOLATE use the FPU→PACK dest-dvalid
             // handshake; the remaining isolate modes have no FPU consumer.
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -144,7 +145,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             PROFILER_SYNC();
         }
         {
-            ZONE_SCOPED("TILE_LOOP")
+            START_PERF_MEASURE("TILE_LOOP")
             if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
             {
             }
@@ -208,7 +209,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -237,7 +238,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -37,7 +38,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (unpack_to_dest)
         {
             // Only the end-to-end path uses the unpack→pack dest-dvalid
@@ -95,7 +96,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -165,7 +166,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if constexpr (!unpack_to_dest)
     {
         {
-            ZONE_SCOPED("INIT")
+            START_PERF_MEASURE("INIT")
             // PACK_ISOLATE and L1_CONGESTION measure pack without the
             // FPU→PACK dest-dvalid handshake (WH/BH style).
             if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE && PERF_RUN_TYPE != PerfRunType::L1_CONGESTION)
@@ -181,7 +182,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             PROFILER_SYNC();
         }
         {
-            ZONE_SCOPED("TILE_LOOP")
+            START_PERF_MEASURE("TILE_LOOP")
             if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
             {
             }
@@ -250,7 +251,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // Match WH/BH PACK_ISOLATE and L1_CONGESTION: no math↔pack handshake;
         // pack from whatever is in dest.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
@@ -294,7 +295,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         // _llk_pack_untilize_ packs one block ct_dim of tiles (one tile row) at a time.
         const std::uint32_t y_stride_external = FULL_CT_DIM * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
 

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -37,7 +38,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const ckernel::TensorShape tensor_shape_A = tensor_shape_from_params(params);
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(tensor_shape_A, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
 
@@ -51,7 +52,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -108,7 +109,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr std::uint32_t max_tiles_dest    = is_fp32_dest_acc_en ? 4 : 8;
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
@@ -139,7 +140,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -222,7 +223,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr std::uint32_t max_tiles_dest    = is_fp32_dest_acc_en ? 4 : 8;
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // Match WH/BH PACK_ISOLATE: no math↔pack handshake; pack from whatever is in dest.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -241,7 +242,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
         }

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_exp_parallel_matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_exp_parallel_matmul_quasar_test.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -39,7 +40,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         set_ttsync_enables<TRACK_ALL>(ckernel::TRISC_ID);
 
         const ckernel::TensorShape tensor_shape_A = ckernel::tensor_shape_from_num_faces(FACE_R_DIM, params.num_faces_A);
@@ -52,7 +53,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::SFPU_ISOLATE)
         {
         }
@@ -93,7 +94,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
             set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
@@ -105,7 +106,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::SFPU_ISOLATE)
         {
         }
@@ -186,7 +187,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     ckernel_template mop(PARAM_SRCS_SLICE_COUNT, 1 /*inner_loop_len*/, _exp_loadmacro_op_(num_sfpu_iterations));
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         const ckernel::TensorShape srcs_shape = tensor_shape_from_dimensions(PARAM_SRCS_YDIM, PARAM_SRCS_XDIM, PARAM_SRCS_ZDIM, PARAM_SRCS_ZDIM);
         _configure_buf_desc_table_(buf_desc_id_unpack, ckernel::trisc::construct_buf_desc(srcs_shape, L1_ADDRESS(params.buffer_S[0]), formats.unpack_S_src));
         _llk_unpack_configure_unary_<p_unpacr::UNP_S>(static_cast<DataFormat>(formats.unpack_S_dst));
@@ -212,7 +213,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::SFPU_ISOLATE)
         {
             // Full TRISC3 path: UNP_S -> SFPU exp (self-contained SFPLOADMACRO replay) -> PACK1.
@@ -251,7 +252,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
         // Explicitly clear wait_mask because CFG state can persist across run types.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -270,7 +271,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::SFPU_ISOLATE)
         {
         }

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -42,7 +43,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     LLK_ASSERT(TILE_CNT == 3, "Where stages three Dest tiles (cond, true, false)");
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (unpack_to_dest)
         {
             _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
@@ -89,7 +90,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
             if constexpr (!unpack_to_dest)
@@ -149,7 +150,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     DataFormat src_format = static_cast<DataFormat>(formats.math);
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
 
         if constexpr (!unpack_to_dest)
@@ -188,7 +189,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             if constexpr (!unpack_to_dest)
@@ -263,7 +264,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
             ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
 
@@ -293,7 +294,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -36,7 +37,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (unpack_to_dest)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
@@ -82,7 +83,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -204,7 +205,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     const DataFormat math_format = static_cast<DataFormat>(formats.math);
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             if constexpr (!unpack_to_dest)
@@ -227,7 +228,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -285,7 +286,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -311,7 +312,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
         }

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -39,7 +40,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const auto tensor_shape = tensor_shape_from_params(params);
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // SrcA is tilized out of a row-major tensor, so its descriptor must address L1 in units of a single
         // 16-datum row (y_dim = z_dim = 1) for every tile shape.
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0, ckernel::trisc::L1AccessMode::Strided>(
@@ -59,7 +60,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         std::uint32_t y_stride_external = FULL_CT_DIM * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
@@ -119,7 +120,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const auto tensor_shape = tensor_shape_from_params(params);
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // Only end-to-end and math-isolate runs use the FPU→PACK dest-dvalid
         // handshake.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -148,7 +149,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -209,7 +210,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const auto tensor_shape = tensor_shape_from_params(params);
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -229,7 +230,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
         }

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -34,7 +35,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (unpack_to_dest)
         {
             // UNP_DEST and PACK share DEST. Keep them on the producer/consumer
@@ -119,7 +120,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
         std::uint32_t y_stride_external         = FULL_CT_DIM * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
 
@@ -216,7 +217,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if constexpr (!unpack_to_dest)
     {
         {
-            ZONE_SCOPED("INIT")
+            START_PERF_MEASURE("INIT")
             // Only end-to-end and math-isolate runs use the FPU→PACK
             // dest-dvalid handshake.
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -232,7 +233,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             PROFILER_SYNC();
         }
         {
-            ZONE_SCOPED("TILE_LOOP")
+            START_PERF_MEASURE("TILE_LOOP")
             if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
             {
             }
@@ -300,7 +301,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE and SrcA/SrcB L1_CONGESTION have no active DEST producer,
         // so they must clear the persisted pack wait mask. UNP_DEST congestion
         // instead uses the unpack→pack chain because both threads share DEST.
@@ -321,7 +322,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "perf.h"
@@ -35,7 +36,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         if constexpr (unpack_to_dest)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
@@ -87,7 +88,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
@@ -153,7 +154,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if constexpr (!unpack_to_dest)
     {
         {
-            ZONE_SCOPED("INIT")
+            START_PERF_MEASURE("INIT")
             // Only end-to-end and math-isolate runs use the FPU→PACK
             // dest-dvalid handshake.
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -169,7 +170,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             PROFILER_SYNC();
         }
         {
-            ZONE_SCOPED("TILE_LOOP")
+            START_PERF_MEASURE("TILE_LOOP")
             if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
             {
             }
@@ -232,7 +233,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // PACK_ISOLATE and SrcA/SrcB L1_CONGESTION have no DEST producer.
         // Explicitly clear wait_mask because CFG persists across run types.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION && !unpack_to_dest))
@@ -259,7 +260,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)


### PR DESCRIPTION
### PR Category
Feature

### Summary
Closes #56031

Brings the LLK perf harness counters up on Quasar, on top of #55380 (which supplies `hw_counters.h` and `perf_counters.hpp` for the chip). Stacked on `mvlahovic/quasar-perf-counters`; merge that first.

- `counters.h`: the register block comes from the NEO local window on Quasar (`tensix_neo_reg.h` rebased onto `LOCAL_REGS_BASE`), the unpack TRISC does the one-time configure and arm from `trisc.cpp` since there is no BRISC, `PERF_CNT_ALL` only reaches INSTRN and FPU so the TDMA banks arm through their own registers, bank slot 3 carries one l1_client event chosen by `LLK_PERF_L1_CLIENT_SEL` (default off, invalid selections rejected at compile time), and `SFPU_ISOLATE` is a measured thread.
- The rendezvous has four threads on Quasar. `sfpu_stub.h` opens `INIT` and `TILE_LOOP` so kernels without an SFPU half still complete it, and the 18 Quasar perf kernels use `START_PERF_MEASURE`. `MEASURE_PERF_COUNTERS` is live in the no-counter build on Quasar as well, so the Quasar NC baseline moves the same way the tt-1xx one did.
- Host: `counters.py` parses `tt-2xx/quasar/hw_counters.h` and names the l1_client counter from its selection, `metrics.py` reports it as `l1_client_<port>_<event>_pct` (or `_ratio` for the pending carry), the Quasar Parquet schema drops those columns like the other metrics, and the zone overlap check now runs on Quasar.
- Docs updated; hardware-free tests added for the Quasar tables, the l1_client decode and the schema.
- The Quasar rendezvous spaces its L1 polls out with a short nop backoff (second commit). The counter build has an exit rendezvous on `UNPACK_ISOLATE`, `L1_TO_L1` and `L1_CONGESTION` that the plain build does not, so during an unpack isolate three idle threads were polling L1 for the whole window and the unpack windows came out 4% longer than NC. Bisecting on the emulator ruled out the counting, the debug register writes and the code layout one by one (unpack isolate 8612 cycles with counters, 8281 without, 8616 with every debug register access removed, 8269 with NC padded to the WC code size); with the backoff it is 8278 against 8264.

### Testing
- Producer sweeps of all 19 Quasar perf tests: 7144/7144 variants in both the NC and the WC build; `perf_eltwise_binary` on Blackhole compiles unchanged in both builds.
- Zebu emulator (emu-quasar-1x3), one variant from each of the 19 Quasar perf tests, WC build: 19/19 pass, every zone returns counter data, bank cycle references agree within a few cycles, banks idle in an isolate read zero, `SFPU_ISOLATE` measured on `sfpu_exp_parallel_matmul`.
- Same 19 variants in the NC build on the emulator for the WC vs NC comparison below.
- `LLK_PERF_L1_CLIENT_SEL=41` build and emulator run on `perf_pack_quasar`.

WC vs NC on the emulator, TILE_LOOP wall clock, 19 variants (one per test), backoff in both builds:

| run type | windows | mean WC-NC | median abs | max abs |
|---|---|---|---|---|
| UNPACK_ISOLATE | 19 | +0.08% | 13 cyc | 304 cyc |
| MATH_ISOLATE | 19 | -0.25% | 13 cyc | 92 cyc |
| PACK_ISOLATE | 19 | +0.01% | 4 cyc | 36 cyc |
| L1_CONGESTION[UNPACK] | 19 | +0.07% | 10 cyc | 101 cyc |
| L1_CONGESTION[PACK] | 19 | +0.36% | 12 cyc | 109 cyc |
| L1_TO_L1 | 19 | +0.22% | 15 cyc | 109 cyc |
| SFPU_ISOLATE | 1 | +0.02% | 4 cyc | 4 cyc |

Before the backoff the same comparison had UNPACK_ISOLATE at +3.76% mean (max +8.3%) and L1_CONGESTION at +2.7% (max +18.9%). Differences now go both ways and look like the usual build sensitivity.

### Notes for reviewers
- The l1_client CSR has no reference counter and is clear on read, so it is referenced to the INSTRN bank cycles and read once at arm to start from zero.
- `perf_matmul_quasar` still trips the strict Parquet check at session end (`in0_face_c_dim` and friends are not in `wide_schema_quasar`). That predates this change and the CSVs are already written when it fires; left for a separate fix.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvlahovic/llk-quasar-perf-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvlahovic/llk-quasar-perf-counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvlahovic/llk-quasar-perf-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvlahovic/llk-quasar-perf-counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvlahovic/llk-quasar-perf-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvlahovic/llk-quasar-perf-counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvlahovic/llk-quasar-perf-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvlahovic/llk-quasar-perf-counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvlahovic/llk-quasar-perf-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvlahovic/llk-quasar-perf-counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvlahovic/llk-quasar-perf-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvlahovic/llk-quasar-perf-counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvlahovic/llk-quasar-perf-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvlahovic/llk-quasar-perf-counters)