### PR TITLE
[Test Only] Fix socket race condition within H2DSocketLoopbackMultiThreadedStress

### DIFF
--- a/tests/tt_metal/distributed/test_hd_sockets.cpp
+++ b/tests/tt_metal/distributed/test_hd_sockets.cpp
@@ -13,7 +13,10 @@
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <algorithm>
 #include <chrono>
+#include <exception>
 #include <random>
+#include <stdexcept>
+#include <thread>
 #include "gmock/gmock.h"
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
@@ -23,6 +26,8 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
 #include "tt_metal/distributed/mesh_socket_serialization.hpp"
+#include "tt_metal/impl/buffers/d2h_socket_internal.hpp"
+#include "tt_metal/impl/buffers/h2d_socket_internal.hpp"
 #include <tt-metalium/experimental/sockets/h2d_socket.hpp>
 #include <tt-metalium/experimental/sockets/d2h_socket.hpp>
 #include <tt-metalium/system_mesh.hpp>
@@ -315,30 +320,82 @@ void test_hd_socket_multithreaded_loopback(
 
     uint32_t page_size_words = page_size / sizeof(uint32_t);
     uint32_t data_size_words = data_size / sizeof(uint32_t);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
 
-    // Socket Read/Write done over different threads.
-    std::thread write_thread([&]() {
-        for (uint32_t i = 0; i < num_iterations; i++) {
-            for (uint32_t j = 0; j < num_txns; j++) {
-                input_socket.write(src_vec.data() + (i * data_size_words) + (j * page_size_words), 1);
+    auto retry_until_deadline = [deadline](auto&& operation, const char* timeout_message) {
+        while (!operation()) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                throw std::runtime_error(timeout_message);
             }
+            std::this_thread::yield();
+        }
+    };
+
+    std::exception_ptr write_error;
+    std::exception_ptr read_error;
+
+    // Socket read/write are done on different threads, with each socket confined to one host thread.
+    std::thread write_thread([&]() {
+        try {
+            for (uint32_t i = 0; i < num_iterations; i++) {
+                for (uint32_t j = 0; j < num_txns; j++) {
+                    retry_until_deadline(
+                        [&]() {
+                            return experimental::detail::try_write(
+                                input_socket,
+                                src_vec.data() + (i * data_size_words) + (j * page_size_words),
+                                /*num_pages=*/1);
+                        },
+                        "Timed out waiting for space in the H2D socket");
+                }
+            }
+        } catch (...) {
+            write_error = std::current_exception();
         }
     });
 
     std::thread read_thread([&]() {
-        for (uint32_t i = 0; i < num_iterations; i++) {
-            for (uint32_t j = 0; j < num_txns; j++) {
-                output_socket.read(dst_vec.data() + (i * data_size_words) + (j * page_size_words), 1);
+        try {
+            for (uint32_t i = 0; i < num_iterations; i++) {
+                for (uint32_t j = 0; j < num_txns; j++) {
+                    retry_until_deadline(
+                        [&]() {
+                            return experimental::detail::try_read(
+                                output_socket,
+                                dst_vec.data() + (i * data_size_words) + (j * page_size_words),
+                                /*num_pages=*/1);
+                        },
+                        "Timed out waiting for data in the D2H socket");
+                }
             }
+        } catch (...) {
+            read_error = std::current_exception();
         }
     });
-    // Barrier with a timeout in the main thread ensure that the read/write threads are not hung.
-    input_socket.barrier(10000);
-    output_socket.barrier(10000);
 
     write_thread.join();
     read_thread.join();
 
+    auto report_thread_error = [](const char* thread_name, const std::exception_ptr& error) {
+        if (!error) {
+            return;
+        }
+        try {
+            std::rethrow_exception(error);
+        } catch (const std::exception& e) {
+            ADD_FAILURE() << thread_name << " failed: " << e.what();
+        } catch (...) {
+            ADD_FAILURE() << thread_name << " failed with an unknown exception";
+        }
+    };
+    report_thread_error("H2D writer thread", write_error);
+    report_thread_error("D2H reader thread", read_error);
+    if (write_error || read_error) {
+        return;
+    }
+
+    input_socket.barrier(10000);
+    output_socket.barrier(10000);
     EXPECT_EQ(src_vec, dst_vec);
 }
 

--- a/tests/tt_metal/distributed/test_hd_sockets.cpp
+++ b/tests/tt_metal/distributed/test_hd_sockets.cpp
@@ -16,6 +16,7 @@
 #include <exception>
 #include <random>
 #include <stdexcept>
+#include <string>
 #include <thread>
 #include "gmock/gmock.h"
 #include <tt-metalium/experimental/fabric/fabric.hpp>
@@ -235,7 +236,7 @@ void test_hd_socket_loopback(
                 static_cast<uint32_t>(scratch_buffer->address()),
             }});
 
-    uint32_t num_txns = data_size / page_size;
+    const uint32_t num_txns = data_size / page_size;
     std::vector<uint32_t> src_vec(data_size / sizeof(uint32_t));
     std::vector<uint32_t> dst_vec(data_size / sizeof(uint32_t));
 
@@ -318,18 +319,22 @@ void test_hd_socket_multithreaded_loopback(
     input_socket.set_page_size(page_size);
     output_socket.set_page_size(page_size);
 
-    uint32_t page_size_words = page_size / sizeof(uint32_t);
-    uint32_t data_size_words = data_size / sizeof(uint32_t);
+    const uint32_t page_size_words = page_size / sizeof(uint32_t);
+    const uint32_t data_size_words = data_size / sizeof(uint32_t);
+    const uint32_t total_pages = num_iterations * num_txns;
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
 
-    auto retry_until_deadline = [deadline](auto&& operation, const char* timeout_message) {
-        while (!operation()) {
-            if (std::chrono::steady_clock::now() >= deadline) {
-                throw std::runtime_error(timeout_message);
+    auto retry_until_deadline =
+        [deadline](auto&& operation, const char* timeout_message, uint32_t completed_pages, uint32_t total_pages) {
+            while (!operation()) {
+                if (std::chrono::steady_clock::now() >= deadline) {
+                    throw std::runtime_error(
+                        std::string(timeout_message) + " after " + std::to_string(completed_pages) + "/" +
+                        std::to_string(total_pages) + " pages completed");
+                }
+                std::this_thread::yield();
             }
-            std::this_thread::yield();
-        }
-    };
+        };
 
     std::exception_ptr write_error;
     std::exception_ptr read_error;
@@ -346,7 +351,9 @@ void test_hd_socket_multithreaded_loopback(
                                 src_vec.data() + (i * data_size_words) + (j * page_size_words),
                                 /*num_pages=*/1);
                         },
-                        "Timed out waiting for space in the H2D socket");
+                        "Timed out waiting for space in the H2D socket",
+                        i * num_txns + j,
+                        total_pages);
                 }
             }
         } catch (...) {
@@ -365,7 +372,9 @@ void test_hd_socket_multithreaded_loopback(
                                 dst_vec.data() + (i * data_size_words) + (j * page_size_words),
                                 /*num_pages=*/1);
                         },
-                        "Timed out waiting for data in the D2H socket");
+                        "Timed out waiting for data in the D2H socket",
+                        i * num_txns + j,
+                        total_pages);
                 }
             }
         } catch (...) {

--- a/tests/tt_metal/distributed/test_hd_sockets.cpp
+++ b/tests/tt_metal/distributed/test_hd_sockets.cpp
@@ -376,22 +376,11 @@ void test_hd_socket_multithreaded_loopback(
     write_thread.join();
     read_thread.join();
 
-    auto report_thread_error = [](const char* thread_name, const std::exception_ptr& error) {
-        if (!error) {
-            return;
-        }
-        try {
-            std::rethrow_exception(error);
-        } catch (const std::exception& e) {
-            ADD_FAILURE() << thread_name << " failed: " << e.what();
-        } catch (...) {
-            ADD_FAILURE() << thread_name << " failed with an unknown exception";
-        }
-    };
-    report_thread_error("H2D writer thread", write_error);
-    report_thread_error("D2H reader thread", read_error);
-    if (write_error || read_error) {
-        return;
+    if (write_error) {
+        std::rethrow_exception(write_error);
+    }
+    if (read_error) {
+        std::rethrow_exception(read_error);
     }
 
     input_socket.barrier(10000);

--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -13,6 +13,10 @@ namespace tt::umd {
 class TlbWindow;
 }
 
+namespace tt::tt_metal::experimental::detail {
+struct D2HSocketTryReadAccess;
+}  // namespace tt::tt_metal::experimental::detail
+
 namespace tt::tt_metal::distributed {
 
 class NamedShm;
@@ -41,7 +45,13 @@ struct HDSocketConnectorState;
  * - Device kernel writes data and calls `socket_push_pages()` + `socket_notify_receiver()`
  * - Host calls `read()` which waits for data, copies it, and acknowledges consumption
  *
-
+ * Thread safety:
+ * - The FIFO is single-producer/single-consumer: one device producer writes data and one
+ *   host consumer reads and acknowledges it.
+ * - A D2HSocket instance is not internally synchronized. Calls on the same instance
+ *   must not overlap across host threads unless the caller provides external synchronization.
+ * - A descriptor attaches another handle to the same FIFO; it does not create an independent
+ *   channel. At most one host process may actively read through the owner/connector handles.
  *
  * Usage:
  * @code
@@ -363,8 +373,15 @@ private:
         const std::shared_ptr<MeshDevice>& mesh_device, std::optional<uint32_t> device_id = std::nullopt);
 
     void wait_for_bytes(uint32_t num_bytes);
+    void read_available(void* data, uint32_t num_bytes, bool notify_sender);
     void pop_bytes(uint32_t num_bytes);
     void notify_sender();
+
+    // Non-blocking read. Returns false if the FIFO does not currently contain `num_pages`.
+    // Accessible only via tt::tt_metal::experimental::detail::try_read.
+    bool try_read_impl(void* data, uint32_t num_pages, bool notify_sender);
+
+    friend struct tt::tt_metal::experimental::detail::D2HSocketTryReadAccess;
 
     // Shared host-side init: pins host memory (or hugepage fallback), writes socket metadata
     // into `config_buffer_address_`, and configures the sender-side TLB. The caller must

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -51,6 +51,14 @@ enum class H2DMode : uint8_t {
  * and the device kernel updates `bytes_acked` to indicate consumed data. The host blocks
  * on write() if the FIFO is full until the device acknowledges data.
  *
+ * Thread safety:
+ * - The FIFO is single-producer/single-consumer: one host producer writes data and one
+ *   device consumer acknowledges it.
+ * - An H2DSocket instance is not internally synchronized. Calls on the same instance
+ *   must not overlap across host threads unless the caller provides external synchronization.
+ * - A descriptor attaches another handle to the same FIFO; it does not create an independent
+ *   channel. At most one host process may actively write through the owner/connector handles.
+ *
  * Supports cross-process usage: the owner process creates the socket and exports a
  * flatbuffer descriptor. A remote process connects via the descriptor using only UMD
  * (no MetalContext required).

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -766,6 +766,7 @@ bool D2HSocket::try_read_impl(void* data, uint32_t num_pages, bool notify_sender
     }
     bytes_sent_ = bytes_sent_value;
     if (bytes_sent_value - bytes_acked_ < bytes_required) {
+        advance_d2h_simulator_socket_device(mesh_device_, sender_core_.device_coord);
         return false;
     }
 

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -10,6 +10,7 @@
 #include "tt_metal/distributed/hd_socket_descriptor.hpp"
 #include "tt_metal/distributed/pcie_core_writer.hpp"
 #include "tt_metal/distributed/shm_resource_tracker.hpp"
+#include "tt_metal/impl/buffers/d2h_socket_internal.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
 #include "tt_metal/llrt/tt_cluster.hpp"
@@ -713,7 +714,10 @@ void D2HSocket::read(void* data, uint32_t num_pages, bool notify_sender) {
     uint32_t num_bytes = num_pages * page_size_;
     TT_FATAL(num_bytes <= fifo_curr_size_, "Cannot read more pages than the socket FIFO size.");
     this->wait_for_bytes(num_bytes);
+    this->read_available(data, num_bytes, notify_sender);
+}
 
+void D2HSocket::read_available(void* data, uint32_t num_bytes, bool notify_sender) {
     uint32_t head_bytes = num_bytes;
     if (read_ptr_ + num_bytes > fifo_curr_size_) {
         head_bytes = fifo_curr_size_ - read_ptr_;
@@ -740,6 +744,33 @@ void D2HSocket::read(void* data, uint32_t num_pages, bool notify_sender) {
     if (notify_sender) {
         this->notify_sender();
     }
+}
+
+bool D2HSocket::try_read_impl(void* data, uint32_t num_pages, bool notify_sender) {
+    TT_FATAL(page_size_ > 0, "Page size must be set before reading.");
+    uint32_t num_bytes = num_pages * page_size_;
+    TT_FATAL(num_bytes <= fifo_curr_size_, "Cannot read more pages than the socket FIFO size.");
+    uint32_t bytes_required = num_bytes;
+    if (read_ptr_ + num_bytes >= fifo_curr_size_) {
+        bytes_required += fifo_size_ - fifo_curr_size_;
+    }
+
+    uint32_t bytes_sent_value;
+    if (using_hugepage_) {
+        _mm_clflush(const_cast<void*>(reinterpret_cast<const volatile void*>(hugepage_bytes_sent_host_ptr_)));
+        _mm_lfence();
+        bytes_sent_value = *hugepage_bytes_sent_host_ptr_;
+    } else {
+        tt_driver_atomics::mfence();
+        bytes_sent_value = bytes_sent_ptr_[0];
+    }
+    bytes_sent_ = bytes_sent_value;
+    if (bytes_sent_value - bytes_acked_ < bytes_required) {
+        return false;
+    }
+
+    this->read_available(data, num_bytes, notify_sender);
+    return true;
 }
 
 uint32_t D2HSocket::pages_available() {
@@ -862,3 +893,12 @@ std::unique_ptr<D2HSocket> D2HSocket::connect_from_descriptor(const HDSocketDesc
 }
 
 }  // namespace tt::tt_metal::distributed
+
+namespace tt::tt_metal::experimental::detail {
+
+bool D2HSocketTryReadAccess::try_read(
+    distributed::D2HSocket& socket, void* data, uint32_t num_pages, bool notify_sender) {
+    return socket.try_read_impl(data, num_pages, notify_sender);
+}
+
+}  // namespace tt::tt_metal::experimental::detail

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -886,6 +886,7 @@ bool H2DSocket::try_write_impl(void* data, uint32_t num_pages) {
         bytes_acked_ = bytes_acked_value;
         bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_);
         if (bytes_free < num_bytes) {
+            advance_h2d_simulator_socket_device(mesh_device_, recv_core_.device_coord);
             return false;
         }
     }

--- a/tt_metal/impl/buffers/d2h_socket_internal.hpp
+++ b/tt_metal/impl/buffers/d2h_socket_internal.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace tt::tt_metal::distributed {
+class D2HSocket;
+}  // namespace tt::tt_metal::distributed
+
+namespace tt::tt_metal::experimental::detail {
+
+// Friend access struct: lets internal callers reach D2HSocket::try_read_impl
+// without exposing it on the public D2HSocket surface.
+struct D2HSocketTryReadAccess {
+    static bool try_read(distributed::D2HSocket& socket, void* data, uint32_t num_pages, bool notify_sender);
+};
+
+// Non-blocking D2HSocket read. Returns true if `num_pages` were successfully
+// consumed; returns false immediately if that many pages are not yet available.
+inline bool try_read(distributed::D2HSocket& socket, void* data, uint32_t num_pages, bool notify_sender = true) {
+    return D2HSocketTryReadAccess::try_read(socket, data, num_pages, notify_sender);
+}
+
+}  // namespace tt::tt_metal::experimental::detail


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Closes #53875

* Added comments documenting H2D and D2H socket thread safety contracts
* Implemented proper deadline based polling for the stress test, joining workers before barriers
* Added D2HSocketTryReadAccess::try_read helper within experimental

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/fix-stress-test-race-condition)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/fix-stress-test-race-condition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/fix-stress-test-race-condition)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/fix-stress-test-race-condition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/fix-stress-test-race-condition)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/fix-stress-test-race-condition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/fix-stress-test-race-condition)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/fix-stress-test-race-condition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/fix-stress-test-race-condition)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/fix-stress-test-race-condition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/fix-stress-test-race-condition)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/fix-stress-test-race-condition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/fix-stress-test-race-condition)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/fix-stress-test-race-condition)