### PR TITLE
[Cleanup] Pin JIT kernel LTO partitioning and job count

### DIFF
--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -55,11 +55,12 @@ import ttnn
 
 
 def _raise_nproc_limit():
-    """tt-metal JIT-compiles device kernels in parallel, and each `g++ -flto=auto` fans out to
-    `make -j<nproc>` — a burst of hundreds/thousands of short-lived processes. A low RLIMIT_NPROC
-    (e.g. a 512 soft default) makes clone3 fail with EAGAIN mid-build, which gcc reports as
-    "posix_spawn: Operation not permitted" and aborts the kernel link. Raise the soft limit to the
-    hard limit (allowed without privileges) so the build never starves."""
+    """tt-metal JIT-compiles device kernels in parallel, and each target is its own chain of
+    short-lived processes (g++/cc1plus/as to compile; g++/collect2/lto-wrapper/lto1/as/ld to link),
+    so the live process count runs to roughly a dozen times the build's parallelism. A low
+    RLIMIT_NPROC (e.g. a 512 soft default) makes clone3 fail with EAGAIN mid-build, which gcc
+    reports as "posix_spawn: Operation not permitted" and aborts the kernel link. Raise the soft
+    limit to the hard limit (allowed without privileges) so the build never starves."""
     soft, hard = resource.getrlimit(resource.RLIMIT_NPROC)
     if soft != resource.RLIM_INFINITY and (hard == resource.RLIM_INFINITY or soft < hard):
         try:

--- a/models/demos/minimax_m3/tests/perf/profile_prefill.py
+++ b/models/demos/minimax_m3/tests/perf/profile_prefill.py
@@ -98,9 +98,10 @@ import ttnn  # noqa: E402
 
 
 def _raise_nproc_limit():
-    """tt-metal JIT-compiles device kernels in parallel and each `g++ -flto=auto` fans out to
-    `make -j<nproc>`; a low RLIMIT_NPROC makes clone3 fail mid-build ("posix_spawn: Operation not
-    permitted"). Raise the soft limit to the hard limit. Copied from galaxy_prefill_kv_pcc.py."""
+    """tt-metal JIT-compiles device kernels in parallel and each target spawns its own chain of
+    short-lived processes (g++, cc1plus/lto1, as, ld); a low RLIMIT_NPROC makes clone3 fail
+    mid-build ("posix_spawn: Operation not permitted"). Raise the soft limit to the hard limit.
+    Copied from galaxy_prefill_kv_pcc.py."""
     soft, hard = resource.getrlimit(resource.RLIMIT_NPROC)
     if soft != resource.RLIM_INFINITY and (hard == resource.RLIM_INFINITY or soft < hard):
         try:

--- a/scripts/build_kernel_clang_tidy_commands.py
+++ b/scripts/build_kernel_clang_tidy_commands.py
@@ -28,7 +28,8 @@ SFPI-GCC invocation is translated into an equivalent clang one:
     (mapped from -mcpu=tt-wh / tt-bh / tt-wh-tensix / ...)
   * SFPI-GCC-only flags dropped: -ftt-nttp -ftt-constinit -ftt-consteval
     -ftt-no-dyninit, -mno-tt-fix-whbhebreak, --param=min-pagesize=0,
-    -fno-tree-loop-distribute-patterns, -flto=auto, dep-file flags (-MMD/-MF)
+    -fno-tree-loop-distribute-patterns, every -flto* spelling, dep-file flags
+    (-MMD/-MF)
   * -std=c++17 -> -std=c++20 (the dropped -ftt-nttp/-ftt-constinit/
     -ftt-consteval backport C++20 features into SFPI's C++17 mode; tt-llk
     headers rely on them)
@@ -87,8 +88,6 @@ SFPI_GXX_RE = re.compile(r"riscv(32)?-tt-elf-g\+\+$")
 
 # Flags dropped verbatim (SFPI-GCC-only or irrelevant/harmful for parsing).
 DROP_EXACT = {
-    "-flto=auto",
-    "-flto",
     "--param=min-pagesize=0",
     "-fno-tree-loop-distribute-patterns",
     "-mno-tt-fix-whbhebreak",
@@ -102,6 +101,11 @@ DROP_EXACT = {
 DROP_PREFIX = (
     "-ftt-",  # SFPI-GCC extensions (-ftt-nttp, -ftt-constinit, ...)
     "-fdump-",  # GCC dump flags (TT_METAL_JIT_ANALYTICS / build-map modes)
+    # Every LTO spelling, matched by prefix so the build's choice can change without
+    # breaking lint again. clang's -flto= accepts only thin|full, so GCC's job-count
+    # and partitioning forms are hard errors ("unsupported argument '1'", "unknown
+    # argument: '-flto-partition=one'") rather than something clang-tidy can ignore.
+    "-flto",
 )
 # Flags that consume the NEXT argv element and are dropped with it.
 DROP_WITH_ARG = {"-MF", "-o"}
@@ -401,7 +405,8 @@ def self_test():
         "-O3",
         "-std=c++17",
         "-ftt-nttp",
-        "-flto=auto",
+        "-flto=1",
+        "-flto-partition=one",
         "-MMD",
         "-mcpu=tt-wh-tensix",
         "-I.",
@@ -425,7 +430,7 @@ def self_test():
     link_line = (
         "2026-01-01 00:00:02.000 | info     |    BuildKernels |     g++ link cmd: "
         f"cd {out_dir}/ && {gxx} -O3 -Wl,--just-symbols=/x/trisc1_weakened.elf -mcpu=tt-wh "
-        f"-flto=auto -T/x/kernel_trisc1.ld -Wl,--emit-relocs ._7_0_trisck.o /x/substitutes.o "
+        f"-flto=1 -flto-partition=one -T/x/kernel_trisc1.ld -Wl,--emit-relocs ._7_0_trisck.o /x/substitutes.o "
         f"-o {out_dir}/trisc1.elf (build.cpp:777)\n"
     )
     # Same line as tt-logger emits it with colour on: SGR escapes wrap the
@@ -472,8 +477,16 @@ def self_test():
     out = transform(entries[0]["arguments"], "clang++")
     assert "--target=riscv32-unknown-elf" in out and "-march=rv32im" in out
     assert "-std=c++20" in out and "-std=c++17" not in out
-    for banned in ("-ftt-nttp", "-flto=auto", "-MMD", "-MF", "-o", "-mcpu=tt-wh-tensix"):
+    for banned in ("-ftt-nttp", "-flto=1", "-flto-partition=one", "-MMD", "-MF", "-o", "-mcpu=tt-wh-tensix"):
         assert banned not in out, f"{banned} must be dropped"
+
+    # Every -flto spelling must be dropped, not just the one the build happens to pass
+    # today: clang errors out on GCC's job-count and partitioning forms, and logs
+    # captured before the build was pinned still carry -flto=auto.
+    for spelling in ("-flto", "-flto=auto", "-flto=1", "-flto-partition=one"):
+        got = transform([gxx, "-c", "-mcpu=tt-wh-tensix", spelling, "x.cc"], "clang++")
+        assert got is not None, f"transform rejected {spelling}"
+        assert spelling not in got, f"{spelling} must be dropped"
     assert '-DFULL_KERNEL_NAME="reduce_h/42"' in out, "defines must pass through verbatim"
 
     # SFPI headers must reach clang as system includes, in either -I spelling,

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -168,8 +168,13 @@ void JitBuildEnv::init(
         "-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval "
         // Ban dynamic initializations, via a check we've added
         "-ftt-no-dyninit "
-        // Rely on Link Time Optimization (removes globally unreachable code)
-        "-flto=auto "
+        // Rely on Link Time Optimization (removes globally unreachable code).
+        // Partitioning and job count are pinned rather than left to -flto=auto: the JIT
+        // scheduler already builds ~30 kernels at once, and with no make jobserver to
+        // consult 'auto' resolves to the host CPU count, letting each of those links fan
+        // out on top of it. A single partition is what kernels this size already produce,
+        // so pinning holds current behavior instead of leaving it to a size threshold.
+        "-flto=1 -flto-partition=one "
         // Fast math allows non-IEEE compliant optimizations ...
         "-ffast-math "
         // ... but we require these IEEE behaviors

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -254,7 +254,7 @@ public:
         // -fno-lto: emit a plain (non-LTO) object for this TU. With -flto the RVV builtins are
         // streamed as GIMPLE and re-expanded by the link-stage LTRANS units, which do not carry
         // the vector -march, breaking code generation at link time (observed with sfpi 7.70.0).
-        // The link itself stays stock (-flto=auto): a fat-free object simply opts out of LTO.
+        // The link itself stays stock: a fat-free object simply opts out of LTO.
         //
         // -fno-tree-vectorize -fno-tree-slp-vectorize: the vector unit is only reachable through
         // explicit intrinsics; keep the auto-vectorizers from touching scalar kernel/LLK code.


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

JIT kernel compiles and links pass `-flto=auto`. `auto` means "use the GNU make jobserver if one is present, otherwise detect the host CPU count". The JIT build has no jobserver, so it resolves to the host CPU count — while the JIT scheduler is already building ~30 kernels concurrently. Every one of those links is therefore authorized to fan out internally on top of the outer parallelism.

That does not fire today, only because kernels this size produce a single LTRANS partition, leaving the job cap unexercised. This pins both so the property holds by construction rather than by coincidence:

- **`-flto-partition=one`** keeps codegen in a single partition, which is what kernels already produce, and keeps cross-function optimization scope from shrinking if they grow.
- **`-flto=1`** caps LTRANS job count, so an additional partition can never turn ~30 concurrent links into a thundering herd.

Note that `-flto=N` bounds the number of parallel LTRANS *jobs* and does not by itself decide how many *partitions* exist, which is why both flags are needed to state the intent.

**This is not a performance change.** Measured on the GLM5 dense-layer workload (Blackhole, 5,178 kernel targets, 5 iterations per arm, device reset and cold cache per iteration), `-flto=1` against `-flto=auto`:

| metric | `-flto=auto` | `-flto=1` | delta |
|---|---|---|---|
| summed compile+link | 10,342.2 s | 10,333.9 s | −0.08% (t=−0.17) |
| JIT wall span | 335.7 s | 333.0 s | −0.80% (t=−0.94) |
| per target | 2,001.2 ms | 1,999.6 ms | −0.08% |

Every delta sits inside the 0.70–0.77% run-to-run spread measured within each arm, so the change is free rather than beneficial. It is a robustness and readability change.

### Notes for reviewers

Verified by replaying real captured kernel compile and link commands for all five core types (brisc, ncrisc, trisc0/1/2):

- exactly **one** LTRANS partition before and after, counted from `.ltrans<N>` outputs under `-save-temps` (the naming is easy to miscount: per partition the wrapper leaves both `.ltransN.o`, the IR input, and `.ltransN.ltrans.o`, the machine code it produced)
- `.text` **byte-identical** to `-flto=auto` on every core type
- no new compile diagnostics. `common_flags` feeds both `cflags_` and `lflags_`, so `-flto-partition=one` also lands on compile commands, where it is inert and draws no "unused argument" complaint under `-Wall -Werror`
- 73/73 `unit_tests_jit_build` pass

One operational note: compile flags feed the kernel cache key, so the first build after this merges is a one-time cold kernel rebuild.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/jit-pin-lto-partitioning)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/jit-pin-lto-partitioning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/jit-pin-lto-partitioning)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/jit-pin-lto-partitioning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/jit-pin-lto-partitioning)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/jit-pin-lto-partitioning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/jit-pin-lto-partitioning)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/jit-pin-lto-partitioning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/jit-pin-lto-partitioning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/jit-pin-lto-partitioning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/jit-pin-lto-partitioning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/jit-pin-lto-partitioning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/jit-pin-lto-partitioning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/jit-pin-lto-partitioning)