### PR TITLE
MiniMax-Music3 on one Blackhole chip: autoport + tt-model container (published to HF)

### DIFF
--- a/models/autoports/minimaxai_minimax_music3/README.md
+++ b/models/autoports/minimaxai_minimax_music3/README.md
@@ -1,0 +1,46 @@
+# MiniMax Music 3 on Tenstorrent Blackhole (single chip)
+
+Bring-up of [MiniMaxAI/MiniMax-Music3](https://huggingface.co/MiniMaxAI/MiniMax-Music3) (lyrics + caption -> song):
+an 8B Qwen3-based global LLM (one decode step per 40 ms frame, classifier-free guidance as a second row), a 4-layer
+depth decoder for the 7 residual RVQ codebooks, a 36-layer flow-matching DiT over 200-frame windows and a DAC-style
+vocoder, on ONE Blackhole chip (P150; chip 0 of a P300 / QuietBox 2), packaged for
+[tt-model-manager](https://github.com/tenstorrent/tt-model-manager) as a `tt-dit-server` container.
+
+| path | what |
+|---|---|
+| `config.py` | the checkpoint's inference contract (token ids, CFG scales, window/overlap constants) + sub-model configs |
+| `reference/` | torch port of the diffusers PR #14456 pipeline (`PROVENANCE.md`): CPU goldens, PCC references, and the CPU stages of serving (condition encoder, vocoder, scheduler loop) |
+| `tt/weights.py` | HF view dirs for `tt_transformers.ModelArgs` (incl. the SLICED 16 385-row LM head / embedding), loaders |
+| `tt/backbone.py` | `Music3Backbone(Transformer)`: host frame embeddings as the residual, 2 users (cond/uncond), post-norm hidden tap |
+| `tt/depth_decoder.py` | TTNN depth decoder: one traced 32-row causal step replayed 7x per frame |
+| `tt/dit.py` | TTNN DiT: padded rows, masked SDPA, partial RoPE via the per-tile ROPE op, traced per window length |
+| `tt/generator.py` | `Music3Generator`: the whole recipe with the TT modules; `GenStats` |
+| `tt/device.py` | true 1x1 mesh (`TT_METAL_VISIBLE_DEVICES=0`), `MUSIC3_MESH_SHAPE` |
+| `server/` | FastAPI: `/v1/audio/speech` (SGLang-Omni compatible), `/v1/music/jobs*`, `/v1/health`, `/v1/models` |
+| `tests/` | CPU parity (prompt / sampling / modules vs diffusers) and device tests (stages 03-06) |
+| `demo/demo.py` | CLI |
+| `tt-model.yaml` | the container manifest (profile `p150`) |
+
+## Run
+
+```bash
+export TT_METAL_VISIBLE_DEVICES=0 MUSIC3_MESH_SHAPE=1x1 HF_HUB_OFFLINE=1
+python -m models.autoports.minimaxai_minimax_music3.demo.demo --caption "acoustic pop, 96 BPM, warm female vocal" \
+  --lyrics $'[verse]\nMorning light filtering through the pine\n[chorus]\nSoftly the world begins to breathe' --duration 20 --out /tmp/song
+python -m uvicorn --host 0.0.0.0 --port 20000 --lifespan on models.autoports.minimaxai_minimax_music3.server.app:app
+```
+
+Device tests: `pytest -c /dev/null --rootdir models/autoports/minimaxai_minimax_music3 --confcutdir models/autoports/minimaxai_minimax_music3 models/autoports/minimaxai_minimax_music3/tests/test_backbone.py`
+(env `MUSIC3_SNAPSHOT`, `MUSIC3_GOLDEN_ROOT` from the bring-up work dir `~/music3-bringup`).
+
+## Conventions that matter
+
+- The prompt template, CFG rows, sampling (top-50, CFG 1.5), window (200/100) and overlap (172/86/258) constants are the
+  checkpoint's contract; `reference/` is asserted equal to diffusers in stage 01/02.
+- The device LM head is sliced to the 16 384 semantic rows + `<|audio_end|>`; the mask makes this exact (stage 02 proof).
+- The depth decoder consumes the POST-final-norm LLM hidden state of BOTH rows; `LMHead` frees its input, so the tap clones.
+- `torch.Generator` consumption order (c0, c1..c7 per frame, then one `randn` per window) matches diffusers, so a seed
+  is a reproducible trajectory given identical logits.
+- Single-chip profiles on a bigger box are a true mesh (`TT_METAL_VISIBLE_DEVICES`), never a submesh of the parent.
+
+Bring-up evidence and the unattended pipeline live in `~/music3-bringup/` (`docs/PLAN.md`, `status/STATUS.md`).

--- a/models/autoports/minimaxai_minimax_music3/config.py
+++ b/models/autoports/minimaxai_minimax_music3/config.py
@@ -1,0 +1,235 @@
+"""Model constants and sub-model configs for MiniMax Music 3 (MiniMaxAI/MiniMax-Music3 @ fbdf52fb).
+
+Every number here is part of the checkpoint's inference contract (diffusers PR #14456, encoders.py / before_denoise.py /
+denoise.py / decoders.py) or read from the sub-folder config.json files. Changing any of them changes the audio.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+HF_REPO_ID = "MiniMaxAI/MiniMax-Music3"
+HF_REVISION = "fbdf52fbaaca799592917417eb05f1899f1255ec"
+# subfolders of the snapshot we use; everything else (originals, assets) is skipped by the weights pointer
+HF_IGNORE_PATTERNS = ["flowmatching_vae.pth", "dav.pth", "qwen_7B/*", "assets/*", "figures/*", "scripts/*"]
+
+# ---- prompt / token contract (encoders.py) --------------------------------------------------------------
+IM_START, IM_END = "<|im_start|>", "<|im_end|>"
+CAPTION_START, CAPTION_END = "<|caption_start|>", "<|caption_end|>"
+LYRICS_START, LYRICS_END = "<|lyrics_start|>", "<|lyrics_end|>"
+AUDIO_START = "<|audio_start|>"
+AUDIO_END_TOKEN_ID = 151670
+AUDIO_CFG_TOKEN_ID = 151654
+AUDIO_CODE_OFFSET = 151675
+SEMANTIC_VOCAB_SIZE = 16384
+MAX_PROMPT_TOKENS = 5_000
+MAX_AUDIO_FRAMES = 9_000
+# the c0 head only ever sees the 16 384 semantic rows + the end-of-audio row: [151675, 168059) and 151670
+SLICED_VOCAB = SEMANTIC_VOCAB_SIZE + 1  # row SEMANTIC_VOCAB_SIZE (16384) of the sliced head == AUDIO_END_TOKEN_ID
+SLICED_VOCAB_PADDED = 16416  # next multiple of 32
+
+# ---- autoregressive sampling (fixed by the reference recipe) -------------------------------------------
+AR_CFG_SCALE = 1.5
+AR_CFG_TOP_K = 50
+AR_SAMPLING_TOP_K = 50
+NUM_CODEBOOKS = 8
+AUDIO_VOCAB_SIZE = 1024
+FRAME_RATE = 25.0  # frames per second of audio (= 24000 / 960)
+
+# ---- flow matching (before_denoise.py / denoise.py / decoders.py) --------------------------------------
+CHUNK_FRAMES = 200
+CHUNK_HOP = 100
+OVERLAP_LATENT_LENGTH = 172
+CROP_LEFT_LATENT = 86
+CROP_RIGHT_LATENT = 344 - 86
+DIT_GUIDANCE_SCALE = 1.7
+DIT_NUM_STEPS = 30
+LATENT_CHANNELS = 128
+LATENT_HOP = 512
+VOCODER_SAMPLE_RATE = 44100
+OUTPUT_SAMPLE_RATE = 32000  # the reference server resamples 44.1k -> 32k
+
+
+def latent_length_for_frames(num_frames: int) -> int:
+    """condition_encoder: latents per window = int(frames * 44100/24000 * 960/512) (3.4453125 per frame)."""
+    return max(1, int(num_frames * 44100 / 24000 * 960 / 512))
+
+
+def chunk_starts(num_frames: int):
+    return [0] if num_frames <= CHUNK_FRAMES else list(range(0, num_frames - CHUNK_HOP, CHUNK_HOP))
+
+
+@dataclass(frozen=True)
+class LLMConfig:
+    hidden_size: int = 4096
+    intermediate_size: int = 12288
+    num_hidden_layers: int = 36
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    vocab_size: int = 200000
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 1e6
+    max_position_embeddings: int = 10240
+
+
+@dataclass(frozen=True)
+class DepthConfig:
+    hidden_size: int = 4096
+    num_layers: int = 4
+    num_attention_heads: int = 16
+    intermediate_size: int = 6144
+    audio_vocab_size: int = 1024
+    num_codebooks: int = 8
+    max_position_embeddings: int = 16
+
+    @property
+    def head_dim(self):
+        return self.hidden_size // self.num_attention_heads
+
+
+@dataclass(frozen=True)
+class DiTConfig:
+    in_channels: int = 128
+    condition_dim: int = 2048
+    num_layers: int = 36
+    num_attention_heads: int = 32
+    attention_head_dim: int = 64
+    ff_inner_dim: int = 8192
+    rotary_dim: int = 32
+    fourier_embedding_dim: int = 256
+
+    @property
+    def inner_dim(self):
+        return self.num_attention_heads * self.attention_head_dim
+
+    @property
+    def concat_channels(self):
+        return 2 * self.in_channels + self.condition_dim
+
+
+@dataclass(frozen=True)
+class CondConfig:
+    condition_hidden_dim: int = 4096
+    num_condition_layers: int = 8
+    out_dim: int = 2048
+    input_sampling_rate: int = 24000
+    input_hop_length: int = 960
+    output_sampling_rate: int = 44100
+    output_hop_length: int = 512
+
+
+@dataclass(frozen=True)
+class VocoderConfig:
+    latent_channels: int = 128
+    decoder_input_dim: int = 1024
+    decoder_hidden_dim: int = 1536
+    upsampling_ratios: tuple = (8, 8, 4, 2)
+    sampling_rate: int = 44100
+
+
+@dataclass(frozen=True)
+class Music3Config:
+    llm: LLMConfig
+    depth: DepthConfig
+    dit: DiTConfig
+    cond: CondConfig
+    vocoder: VocoderConfig
+
+    @staticmethod
+    def default() -> "Music3Config":
+        return Music3Config(LLMConfig(), DepthConfig(), DiTConfig(), CondConfig(), VocoderConfig())
+
+    @staticmethod
+    def from_snapshot(snapshot: str | os.PathLike) -> "Music3Config":
+        s = Path(snapshot)
+        j = lambda sub: json.load(open(s / sub / "config.json"))
+        lm, dd, dt, ce, vc = (
+            j("language_model"),
+            j("rvq_depth_decoder"),
+            j("transformer"),
+            j("condition_encoder"),
+            j("vocoder"),
+        )
+        assert lm["model_type"] == "qwen3" and lm["architectures"] == ["Qwen3ForCausalLM"], lm.get("architectures")
+        rope = lm.get("rope_parameters") or {}
+        cfg = Music3Config(
+            llm=LLMConfig(
+                lm["hidden_size"],
+                lm["intermediate_size"],
+                lm["num_hidden_layers"],
+                lm["num_attention_heads"],
+                lm["num_key_value_heads"],
+                lm["head_dim"],
+                lm["vocab_size"],
+                float(lm["rms_norm_eps"]),
+                float(rope.get("rope_theta", lm.get("rope_theta", 1e6))),
+                int(lm["max_position_embeddings"]),
+            ),
+            depth=DepthConfig(
+                dd["hidden_size"],
+                dd["num_layers"],
+                dd["num_attention_heads"],
+                dd["intermediate_size"],
+                dd["audio_vocab_size"],
+                dd["num_codebooks"],
+                dd["max_position_embeddings"],
+            ),
+            dit=DiTConfig(
+                dt["in_channels"],
+                dt["condition_dim"],
+                dt["num_layers"],
+                dt["num_attention_heads"],
+                dt["attention_head_dim"],
+                dt["ff_inner_dim"],
+                dt["rotary_dim"],
+                dt["fourier_embedding_dim"],
+            ),
+            cond=CondConfig(
+                ce["condition_hidden_dim"],
+                ce["num_condition_layers"],
+                ce["out_dim"],
+                ce["input_sampling_rate"],
+                ce["input_hop_length"],
+                ce["output_sampling_rate"],
+                ce["output_hop_length"],
+            ),
+            vocoder=VocoderConfig(
+                vc["latent_channels"],
+                vc["decoder_input_dim"],
+                vc["decoder_hidden_dim"],
+                tuple(vc["upsampling_ratios"]),
+                vc["sampling_rate"],
+            ),
+        )
+        assert cfg.llm.vocab_size > AUDIO_CODE_OFFSET + SEMANTIC_VOCAB_SIZE, cfg.llm.vocab_size
+        assert cfg.depth.num_codebooks == NUM_CODEBOOKS and cfg.depth.audio_vocab_size == AUDIO_VOCAB_SIZE
+        assert cfg.cond.num_condition_layers == NUM_CODEBOOKS and cfg.dit.in_channels == LATENT_CHANNELS
+        return cfg
+
+    def as_dict(self):
+        return asdict(self)
+
+
+def resolve_snapshot(repo_id: str | None = None, revision: str | None = None, allow_download: bool = True) -> Path:
+    """Locate the HF snapshot dir. Offline-first: the tt-model container mounts the host HF cache; MUSIC3_SNAPSHOT
+    or a directory in HF_MODEL short-circuits."""
+    p = os.environ.get("MUSIC3_SNAPSHOT")
+    if p and os.path.isdir(p):
+        return Path(p)
+    repo_id = repo_id or os.environ.get("HF_MODEL") or HF_REPO_ID
+    if os.path.isdir(repo_id):
+        return Path(repo_id)
+    revision = revision or os.environ.get("MUSIC3_WEIGHTS_REVISION") or HF_REVISION
+    from huggingface_hub import snapshot_download
+
+    try:
+        return Path(
+            snapshot_download(repo_id, revision=revision, local_files_only=True, ignore_patterns=HF_IGNORE_PATTERNS)
+        )
+    except Exception:
+        if not allow_download:
+            raise
+        return Path(snapshot_download(repo_id, revision=revision, ignore_patterns=HF_IGNORE_PATTERNS))

--- a/models/autoports/minimaxai_minimax_music3/demo/demo.py
+++ b/models/autoports/minimaxai_minimax_music3/demo/demo.py
@@ -1,0 +1,42 @@
+"""CLI: caption + lyrics -> WAV on Tenstorrent.
+  python -m models.autoports.minimaxai_minimax_music3.demo.demo --caption "..." --lyrics-file lyrics.txt --duration 30 --seed 7 --out /tmp/song
+"""
+import argparse
+import json
+import os
+
+import soundfile as sf
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--caption", required=True)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--lyrics")
+    g.add_argument("--lyrics-file")
+    ap.add_argument("--duration", type=float, default=30.0)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--steps", type=int, default=30)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--sample-rate", type=int, default=32000, choices=(32000, 44100))
+    a = ap.parse_args()
+    lyrics = a.lyrics if a.lyrics is not None else open(a.lyrics_file).read()
+    from models.autoports.minimaxai_minimax_music3.server import audio_io
+    from models.autoports.minimaxai_minimax_music3.tt.device import open_mesh
+    from models.autoports.minimaxai_minimax_music3.tt.generator import Music3Generator
+
+    os.makedirs(a.out, exist_ok=True)
+    h = open_mesh()
+    try:
+        gen = Music3Generator(h.mesh)
+        out = gen.generate(a.caption, lyrics, audio_duration=a.duration, seed=a.seed, num_steps=a.steps)
+        audio = audio_io.resample(out["audio"].squeeze(0).numpy(), out["sample_rate"], a.sample_rate)
+        sf.write(os.path.join(a.out, "song.wav"), audio.T, a.sample_rate, subtype="PCM_16")
+        json.dump(out["stats"].as_dict(), open(os.path.join(a.out, "stats.json"), "w"), indent=2)
+        print(json.dumps(out["stats"].as_dict(), indent=2))
+    finally:
+        h.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/models/autoports/minimaxai_minimax_music3/doc/REPORT.md
+++ b/models/autoports/minimaxai_minimax_music3/doc/REPORT.md
@@ -1,6 +1,6 @@
 # MiniMax Music 3 on one Blackhole chip — bring-up report
 
-generated 2026-09-10T02:15:02Z on qb2-120-p11t03
+generated 2026-09-10T02:38:07Z on qb2-120-p11t03
 
 Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth decoder + 2.4B flow-matching DiT + DAC vocoder). Target: ONE Blackhole chip (P150; chip 0 of a P300/QB2). Package: tt-model-manager CONTAINER v5.1, kind `tt-dit-server`, profile `p150`.
 
@@ -11,27 +11,27 @@ Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth
 - global LLM (1 chip, bfp8) teacher-forced on `blues` (301 steps, prompt 1380 tokens): hidden PCC min 0.9942, logits PCC min 0.9967, c0 top-1 0.811 / top-5 1.000, top-1 vs sampled codes 0.429, 39.0 ms/step
 - long prompt prefill (3922 tokens): ok
 - depth decoder (bf16) teacher-forced on `readme` (200 frames): logits PCC min 0.9984, c1..c7 top-1 0.942 / top-5 1.000, 53.6 ms/frame (7 traced steps + host)
-- DiT (bf16): unit PCC min 0.9989; 30-step window: step-0 velocity PCC 0.9998, latents PCC 0.9996, vocoded audio PCC 0.999, spectral convergence 0.048; 147.1 ms per traced forward (L=689, batch 2)
-- end-to-end `readme` on the chip: 200 frames, 8.0 s audio in 43.0 s (RTF 5.38); audio rms 0.098, silence 0.00, c0 unique ratio 0.80
-- end-to-end `blues` on the chip: 300 frames, 12.0 s audio in 71.8 s (RTF 5.98); audio rms 0.078, silence 0.00, c0 unique ratio 0.56
+- DiT (stage-05 run, bf16/HiFi4; the served default is bf16/HiFi2 at 93 ms, see the performance table): unit PCC min 0.9989; 30-step window: step-0 velocity PCC 0.9998, latents PCC 0.9996, vocoded audio PCC 0.999, spectral convergence 0.050; 137.2 ms per traced forward (L=689, batch 2)
+- end-to-end `readme` on the chip: 200 frames, 8.0 s audio in 31.7 s (RTF 3.96); audio rms 0.098, silence 0.00, c0 unique ratio 0.80
+- end-to-end `blues` on the chip: 300 frames, 12.0 s audio in 51.4 s (RTF 4.28); audio rms 0.078, silence 0.00, c0 unique ratio 0.56
 - seeded generation is deterministic on the chip (identical codes for the same seed)
-- bare-metal server (launcher env, p150): API proof passed (17/17 critical checks); speech RTF 4.509
-- container `tt-model serve --profile p150` on this QB2: API proof passed (17/17 critical checks); speech RTF 3.718
-- clean `tt-model pull` from the Hub + serve (p150): API proof passed (11/11 critical checks); speech RTF 3.663
+- bare-metal server (launcher env, p150): API proof passed (17/17 critical checks); speech RTF 3.135
+- container `tt-model serve --profile p150` on this QB2: API proof passed (17/17 critical checks); speech RTF 3.058
+- clean `tt-model pull` from the Hub + serve (p150): API proof passed (11/11 critical checks); speech RTF 3.100
 
 ## Not verified
 
-- stage 11-report-push: not passed (see STATUS.md)
 - multi-chip profiles (P300 / QB2 using >1 chip): not in scope; the package uses one chip everywhere
 - listening-test quality of the songs: only proxy metrics (audio sanity, spectral distance vs the CPU reference) were measured; WAVs are in artifacts/e2e/ and artifacts/prove/
 
 ## Advisory findings and known limitations
 
-- accuracy bars (from the CPU floors): {'c0_top1': 0.9, 'c0_top5': 0.98, 'depth_top1': 0.9, 'depth_top5': 0.98}; fp32 self-agreement of the SAMPLED goldens None (top-1 against sampled codes is < 1 even for the reference)
+- accuracy bars (from the CPU floors): {'c0_top1': 0.9, 'c0_top5': 0.98, 'depth_top1': 0.9, 'depth_top5': 0.98}; fp32 argmax vs the SAMPLED golden codes {'c0_argmax_top1': 0.3880597014925373, 'c0_top5': 0.7661691542288557, 'depth_argmax_top1': 0.22103766879886283, 'depth_top5': 0.4896943852167733}; bf16-CPU vs fp32 {'c0_top1': 0.9552238805970149, 'c0_top5': 1.0, 'depth_top1': 0.9566453447050463, 'depth_top5': 1.0, 'hidden_pcc_min': 0.9993515014648438, 'c0_logits_pcc_min': 0.9997697472572327} (top-1 against sampled codes is < 1 even for the reference)
 - `readme` c0 top-1 0.851 below the bar 0.9 (top-5 1.000); see the dtype sweep
 - `blues` c0 top-1 0.811 below the bar 0.9 (top-5 1.000); see the dtype sweep
 - dtype sweep selected {'llm_dtype': 'bfp8', 'depth_dtype': 'bfp8', 'depth_fidelity': 'hifi2', 'dit_dtype': 'bf16', 'dit_fidelity': 'hifi2'}; follow-ups: on-device c0/depth sampling (ttnn.sampling) to remove 8 host round trips per frame; single trace for the 7 depth steps; DiT window trace with on-device Euler/CFG/overlap; TT vocoder (conv1d); multi-chip: DiT on chip 1
-- condition encoder and vocoder run on the CPU (torch fp32); scheduler/CFG/overlap math and sampling are on the host (phase A)
+- condition encoder (fp32) and vocoder (bf16, PCC 0.99994 vs fp32) run on the CPU; scheduler/CFG/overlap math and sampling are on the host (phase A)
+- the from-the-Hub re-serve pulled the manifest/image from the repo, but docker found the identical image blobs already loaded on this box (same digest), so the image download itself was not exercised here
 - the model's own contract limits: prompt <= 5 000 tokens, <= 9 000 frames (6 min); served max_seq_len 16 384
 
 ## Performance (single chip)
@@ -43,14 +43,14 @@ Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth
 | depth | bf16  | depth_top1=0.940, depth_top5=1.000 | ms_per_frame=63.4 |
 | depth | bfp8 (selected) | depth_top1=0.940, depth_top5=1.000 | ms_per_frame=49.6 |
 | depth | bf16h2  | depth_top1=0.954, depth_top5=1.000 | ms_per_frame=63.2 |
-| dit | bf16 (selected) | step0_pcc=1.000, latents_pcc=1.000, spectral_convergence=0.048 | ms_per_forward=157.1 |
-| dit | bfp8  | step0_pcc=0.998, latents_pcc=0.998, spectral_convergence=0.080 | ms_per_forward=117.6 |
-| dit | bf16h2  | step0_pcc=0.999, latents_pcc=0.999, spectral_convergence=0.047 | ms_per_forward=124.2 |
+| dit | bf16 (selected) | step0_pcc=1.000, latents_pcc=1.000, spectral_convergence=0.050 | ms_per_forward=138.4 |
+| dit | bfp8  | step0_pcc=0.998, latents_pcc=0.998, spectral_convergence=0.076 | ms_per_forward=92.5 |
+| dit | bf16h2  | step0_pcc=0.999, latents_pcc=0.999, spectral_convergence=0.047 | ms_per_forward=93.3 |
 
 | clip | frames | prefill s | LLM ms/frame | depth ms/frame | denoise s | vocoder s | RTF |
 |---|---|---|---|---|---|---|---|
-| readme | 200 | 1.7 | 45.6 | 61.0 | 9.7 | 10.1 | 5.38 |
-| blues | 300 | 0.7 | 46.5 | 60.5 | 18.6 | 20.1 | 5.98 |
+| readme | 200 | 1.5 | 36.2 | 54.8 | 8.3 | 3.6 | 3.96 |
+| blues | 300 | 0.7 | 37.1 | 54.2 | 16.2 | 7.0 | 4.28 |
 
 ## Stage table
 
@@ -62,17 +62,17 @@ Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth
 | 02-weights-config | ok | 0 | 2026-09-10T01:35:05Z | 2026-09-10T01:35:24Z |
 | 03-llm-pcc-1chip | ok | 1 | 2026-09-10T01:40:29Z | 2026-09-10T01:41:10Z |
 | 04-depth-decoder-tt | ok | 0 | 2026-09-10T01:43:48Z | 2026-09-10T01:44:08Z |
-| 05-dit-tt | ok | 0 | 2026-09-10T01:44:08Z | 2026-09-10T01:44:52Z |
-| 06-e2e-generator | ok | 1 | 2026-09-10T01:50:31Z | 2026-09-10T01:53:03Z |
-| 07-optimize | ok | 1 | 2026-09-10T01:53:03Z | 2026-09-10T01:58:59Z |
-| 08-server-smoke | ok | 0 | 2026-09-10T01:58:59Z | 2026-09-10T02:02:16Z |
-| 09-package | ok | 0 | 2026-09-10T02:02:16Z | 2026-09-10T02:05:26Z |
-| 10-serve-prove | ok | 0 | 2026-09-10T02:05:27Z | 2026-09-10T02:10:21Z |
-| 11-report-push | running | - | 2026-09-10T02:12:45Z |  |
+| 05-dit-tt | ok | 0 | 2026-09-10T02:21:21Z | 2026-09-10T02:22:29Z |
+| 06-e2e-generator | ok | 1 | 2026-09-10T02:22:29Z | 2026-09-10T02:24:24Z |
+| 07-optimize | ok | 1 | 2026-09-10T02:24:24Z | 2026-09-10T02:27:18Z |
+| 08-server-smoke | ok | 0 | 2026-09-10T02:27:18Z | 2026-09-10T02:29:38Z |
+| 09-package | ok | 0 | 2026-09-10T02:29:38Z | 2026-09-10T02:32:02Z |
+| 10-serve-prove | ok | 0 | 2026-09-10T02:32:02Z | 2026-09-10T02:34:30Z |
+| 11-report-push | ok | 0 | 2026-09-10T02:34:30Z | 2026-09-10T02:36:24Z |
 
 ## Package
 
-- manifest `/home/jashan/tt-model-builds/minimax-music3/tt_kernel_manifest.json` (schema 5.1, kind tt-dit-server, tt-metal 0.65.2.dev9785, image `tt-model/minimax-music3:6bf99951f162` sha256:6bf99951f162)
+- manifest `/home/jashan/tt-model-builds/minimax-music3/tt_kernel_manifest.json` (schema 5.1, kind tt-dit-server, tt-metal 0.65.2.dev9787+g3cc3431f59b, image `tt-model/minimax-music3:4cbc019bf616` sha256:4cbc019bf616)
 - weights pointer `MiniMaxAI/MiniMax-Music3` @ `fbdf52fbaaca` (ignore patterns skip the 28 GB of unconverted originals)
 - HF push:   → consumers:  tt-model serve jashansinghTT/minimax-music3-blackhole
 - code: tt-metal worktree `~/tt-metal-music3`, branch `jashan/minimax-music3`, `models/autoports/minimaxai_minimax_music3`

--- a/models/autoports/minimaxai_minimax_music3/doc/REPORT.md
+++ b/models/autoports/minimaxai_minimax_music3/doc/REPORT.md
@@ -1,6 +1,6 @@
 # MiniMax Music 3 on one Blackhole chip — bring-up report
 
-generated 2026-09-10T02:12:49Z on qb2-120-p11t03
+generated 2026-09-10T02:15:02Z on qb2-120-p11t03
 
 Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth decoder + 2.4B flow-matching DiT + DAC vocoder). Target: ONE Blackhole chip (P150; chip 0 of a P300/QB2). Package: tt-model-manager CONTAINER v5.1, kind `tt-dit-server`, profile `p150`.
 
@@ -17,10 +17,10 @@ Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth
 - seeded generation is deterministic on the chip (identical codes for the same seed)
 - bare-metal server (launcher env, p150): API proof passed (17/17 critical checks); speech RTF 4.509
 - container `tt-model serve --profile p150` on this QB2: API proof passed (17/17 critical checks); speech RTF 3.718
+- clean `tt-model pull` from the Hub + serve (p150): API proof passed (11/11 critical checks); speech RTF 3.663
 
 ## Not verified
 
-- clean `tt-model pull` from the Hub + serve (p150): not run
 - stage 11-report-push: not passed (see STATUS.md)
 - multi-chip profiles (P300 / QB2 using >1 chip): not in scope; the package uses one chip everywhere
 - listening-test quality of the songs: only proxy metrics (audio sanity, spectral distance vs the CPU reference) were measured; WAVs are in artifacts/e2e/ and artifacts/prove/
@@ -74,7 +74,7 @@ Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth
 
 - manifest `/home/jashan/tt-model-builds/minimax-music3/tt_kernel_manifest.json` (schema 5.1, kind tt-dit-server, tt-metal 0.65.2.dev9785, image `tt-model/minimax-music3:6bf99951f162` sha256:6bf99951f162)
 - weights pointer `MiniMaxAI/MiniMax-Music3` @ `fbdf52fbaaca` (ignore patterns skip the 28 GB of unconverted originals)
-- HF push: huggingface_hub.errors.OfflineModeIsEnabled: Cannot reach https://huggingface.co/api/models/jashansinghTT/minimax-music3-blackhole: offline mode is enabled. To disable it, please unset the `HF_HUB_OFFLINE` environment variable.
+- HF push:   → consumers:  tt-model serve jashansinghTT/minimax-music3-blackhole
 - code: tt-metal worktree `~/tt-metal-music3`, branch `jashan/minimax-music3`, `models/autoports/minimaxai_minimax_music3`
 
 ## Artifacts

--- a/models/autoports/minimaxai_minimax_music3/doc/REPORT.md
+++ b/models/autoports/minimaxai_minimax_music3/doc/REPORT.md
@@ -1,0 +1,82 @@
+# MiniMax Music 3 on one Blackhole chip — bring-up report
+
+generated 2026-09-10T02:12:49Z on qb2-120-p11t03
+
+Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth decoder + 2.4B flow-matching DiT + DAC vocoder). Target: ONE Blackhole chip (P150; chip 0 of a P300/QB2). Package: tt-model-manager CONTAINER v5.1, kind `tt-dit-server`, profile `p150`.
+
+## Verified
+
+- CPU reference: the vendored torch pipeline reproduces the diffusers pipeline (text ids equal: True, exact code rows 1.000, audio PCC 1.0000)
+- global LLM (1 chip, bfp8) teacher-forced on `readme` (201 steps, prompt 104 tokens): hidden PCC min 0.9962, logits PCC min 0.9971, c0 top-1 0.851 / top-5 1.000, top-1 vs sampled codes 0.418, 43.3 ms/step
+- global LLM (1 chip, bfp8) teacher-forced on `blues` (301 steps, prompt 1380 tokens): hidden PCC min 0.9942, logits PCC min 0.9967, c0 top-1 0.811 / top-5 1.000, top-1 vs sampled codes 0.429, 39.0 ms/step
+- long prompt prefill (3922 tokens): ok
+- depth decoder (bf16) teacher-forced on `readme` (200 frames): logits PCC min 0.9984, c1..c7 top-1 0.942 / top-5 1.000, 53.6 ms/frame (7 traced steps + host)
+- DiT (bf16): unit PCC min 0.9989; 30-step window: step-0 velocity PCC 0.9998, latents PCC 0.9996, vocoded audio PCC 0.999, spectral convergence 0.048; 147.1 ms per traced forward (L=689, batch 2)
+- end-to-end `readme` on the chip: 200 frames, 8.0 s audio in 43.0 s (RTF 5.38); audio rms 0.098, silence 0.00, c0 unique ratio 0.80
+- end-to-end `blues` on the chip: 300 frames, 12.0 s audio in 71.8 s (RTF 5.98); audio rms 0.078, silence 0.00, c0 unique ratio 0.56
+- seeded generation is deterministic on the chip (identical codes for the same seed)
+- bare-metal server (launcher env, p150): API proof passed (17/17 critical checks); speech RTF 4.509
+- container `tt-model serve --profile p150` on this QB2: API proof passed (17/17 critical checks); speech RTF 3.718
+
+## Not verified
+
+- clean `tt-model pull` from the Hub + serve (p150): not run
+- stage 11-report-push: not passed (see STATUS.md)
+- multi-chip profiles (P300 / QB2 using >1 chip): not in scope; the package uses one chip everywhere
+- listening-test quality of the songs: only proxy metrics (audio sanity, spectral distance vs the CPU reference) were measured; WAVs are in artifacts/e2e/ and artifacts/prove/
+
+## Advisory findings and known limitations
+
+- accuracy bars (from the CPU floors): {'c0_top1': 0.9, 'c0_top5': 0.98, 'depth_top1': 0.9, 'depth_top5': 0.98}; fp32 self-agreement of the SAMPLED goldens None (top-1 against sampled codes is < 1 even for the reference)
+- `readme` c0 top-1 0.851 below the bar 0.9 (top-5 1.000); see the dtype sweep
+- `blues` c0 top-1 0.811 below the bar 0.9 (top-5 1.000); see the dtype sweep
+- dtype sweep selected {'llm_dtype': 'bfp8', 'depth_dtype': 'bfp8', 'depth_fidelity': 'hifi2', 'dit_dtype': 'bf16', 'dit_fidelity': 'hifi2'}; follow-ups: on-device c0/depth sampling (ttnn.sampling) to remove 8 host round trips per frame; single trace for the 7 depth steps; DiT window trace with on-device Euler/CFG/overlap; TT vocoder (conv1d); multi-chip: DiT on chip 1
+- condition encoder and vocoder run on the CPU (torch fp32); scheduler/CFG/overlap math and sampling are on the host (phase A)
+- the model's own contract limits: prompt <= 5 000 tokens, <= 9 000 frames (6 min); served max_seq_len 16 384
+
+## Performance (single chip)
+
+| component | variant | accuracy | speed |
+|---|---|---|---|
+| llm | bfp8 (selected) | c0_top1_min=0.811, c0_top5_min=1.000 | ms_per_step=52.0 |
+| llm | bf16  | c0_top1_min=0.831, c0_top5_min=1.000 | ms_per_step=58.8 |
+| depth | bf16  | depth_top1=0.940, depth_top5=1.000 | ms_per_frame=63.4 |
+| depth | bfp8 (selected) | depth_top1=0.940, depth_top5=1.000 | ms_per_frame=49.6 |
+| depth | bf16h2  | depth_top1=0.954, depth_top5=1.000 | ms_per_frame=63.2 |
+| dit | bf16 (selected) | step0_pcc=1.000, latents_pcc=1.000, spectral_convergence=0.048 | ms_per_forward=157.1 |
+| dit | bfp8  | step0_pcc=0.998, latents_pcc=0.998, spectral_convergence=0.080 | ms_per_forward=117.6 |
+| dit | bf16h2  | step0_pcc=0.999, latents_pcc=0.999, spectral_convergence=0.047 | ms_per_forward=124.2 |
+
+| clip | frames | prefill s | LLM ms/frame | depth ms/frame | denoise s | vocoder s | RTF |
+|---|---|---|---|---|---|---|---|
+| readme | 200 | 1.7 | 45.6 | 61.0 | 9.7 | 10.1 | 5.38 |
+| blues | 300 | 0.7 | 46.5 | 60.5 | 18.6 | 20.1 | 5.98 |
+
+## Stage table
+
+| stage | body | gate | started | ended |
+|---|---|---|---|---|
+| 00e-metal-build | ok | 0 | 2026-09-09T23:49:40Z | 2026-09-09T23:58:41Z |
+| 00-host-prep | ok | 0 | 2026-09-09T23:45:37Z | 2026-09-09T23:49:40Z |
+| 01-cpu-reference | ok | 1 | 2026-09-10T00:56:31Z | 2026-09-10T01:35:05Z |
+| 02-weights-config | ok | 0 | 2026-09-10T01:35:05Z | 2026-09-10T01:35:24Z |
+| 03-llm-pcc-1chip | ok | 1 | 2026-09-10T01:40:29Z | 2026-09-10T01:41:10Z |
+| 04-depth-decoder-tt | ok | 0 | 2026-09-10T01:43:48Z | 2026-09-10T01:44:08Z |
+| 05-dit-tt | ok | 0 | 2026-09-10T01:44:08Z | 2026-09-10T01:44:52Z |
+| 06-e2e-generator | ok | 1 | 2026-09-10T01:50:31Z | 2026-09-10T01:53:03Z |
+| 07-optimize | ok | 1 | 2026-09-10T01:53:03Z | 2026-09-10T01:58:59Z |
+| 08-server-smoke | ok | 0 | 2026-09-10T01:58:59Z | 2026-09-10T02:02:16Z |
+| 09-package | ok | 0 | 2026-09-10T02:02:16Z | 2026-09-10T02:05:26Z |
+| 10-serve-prove | ok | 0 | 2026-09-10T02:05:27Z | 2026-09-10T02:10:21Z |
+| 11-report-push | running | - | 2026-09-10T02:12:45Z |  |
+
+## Package
+
+- manifest `/home/jashan/tt-model-builds/minimax-music3/tt_kernel_manifest.json` (schema 5.1, kind tt-dit-server, tt-metal 0.65.2.dev9785, image `tt-model/minimax-music3:6bf99951f162` sha256:6bf99951f162)
+- weights pointer `MiniMaxAI/MiniMax-Music3` @ `fbdf52fbaaca` (ignore patterns skip the 28 GB of unconverted originals)
+- HF push: huggingface_hub.errors.OfflineModeIsEnabled: Cannot reach https://huggingface.co/api/models/jashansinghTT/minimax-music3-blackhole: offline mode is enabled. To disable it, please unset the `HF_HUB_OFFLINE` environment variable.
+- code: tt-metal worktree `~/tt-metal-music3`, branch `jashan/minimax-music3`, `models/autoports/minimaxai_minimax_music3`
+
+## Artifacts
+
+- goldens: artifacts/golden/ · PCC: artifacts/pcc/ · e2e audio: artifacts/e2e/ · perf: artifacts/perf/ · proofs: artifacts/prove/ · hardware events: logs/hw-events.log

--- a/models/autoports/minimaxai_minimax_music3/doc/REPORT.md
+++ b/models/autoports/minimaxai_minimax_music3/doc/REPORT.md
@@ -1,6 +1,6 @@
 # MiniMax Music 3 on one Blackhole chip — bring-up report
 
-generated 2026-09-10T02:38:07Z on qb2-120-p11t03
+generated 2026-09-10T02:56:26Z on qb2-120-p11t03
 
 Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth decoder + 2.4B flow-matching DiT + DAC vocoder). Target: ONE Blackhole chip (P150; chip 0 of a P300/QB2). Package: tt-model-manager CONTAINER v5.1, kind `tt-dit-server`, profile `p150`.
 
@@ -12,12 +12,12 @@ Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth
 - long prompt prefill (3922 tokens): ok
 - depth decoder (bf16) teacher-forced on `readme` (200 frames): logits PCC min 0.9984, c1..c7 top-1 0.942 / top-5 1.000, 53.6 ms/frame (7 traced steps + host)
 - DiT (stage-05 run, bf16/HiFi4; the served default is bf16/HiFi2 at 93 ms, see the performance table): unit PCC min 0.9989; 30-step window: step-0 velocity PCC 0.9998, latents PCC 0.9996, vocoded audio PCC 0.999, spectral convergence 0.050; 137.2 ms per traced forward (L=689, batch 2)
-- end-to-end `readme` on the chip: 200 frames, 8.0 s audio in 31.7 s (RTF 3.96); audio rms 0.098, silence 0.00, c0 unique ratio 0.80
-- end-to-end `blues` on the chip: 300 frames, 12.0 s audio in 51.4 s (RTF 4.28); audio rms 0.078, silence 0.00, c0 unique ratio 0.56
+- end-to-end `readme` on the chip: 200 frames, 8.0 s audio in 32.8 s (RTF 4.10); audio rms 0.053, silence 0.00, c0 unique ratio 0.78
+- end-to-end `blues` on the chip: 300 frames, 12.0 s audio in 48.5 s (RTF 4.04); audio rms 0.091, silence 0.00, c0 unique ratio 0.64
 - seeded generation is deterministic on the chip (identical codes for the same seed)
-- bare-metal server (launcher env, p150): API proof passed (17/17 critical checks); speech RTF 3.135
-- container `tt-model serve --profile p150` on this QB2: API proof passed (17/17 critical checks); speech RTF 3.058
-- clean `tt-model pull` from the Hub + serve (p150): API proof passed (11/11 critical checks); speech RTF 3.100
+- bare-metal server (launcher env, p150): API proof passed (17/17 critical checks); speech RTF 2.983
+- container `tt-model serve --profile p150` on this QB2: API proof passed (17/17 critical checks); speech RTF 2.988
+- clean `tt-model pull` from the Hub + serve (p150): API proof passed (11/11 critical checks); speech RTF 2.949
 
 ## Not verified
 
@@ -40,17 +40,17 @@ Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth
 |---|---|---|---|
 | llm | bfp8 (selected) | c0_top1_min=0.811, c0_top5_min=1.000 | ms_per_step=52.0 |
 | llm | bf16  | c0_top1_min=0.831, c0_top5_min=1.000 | ms_per_step=58.8 |
-| depth | bf16  | depth_top1=0.940, depth_top5=1.000 | ms_per_frame=63.4 |
-| depth | bfp8 (selected) | depth_top1=0.940, depth_top5=1.000 | ms_per_frame=49.6 |
-| depth | bf16h2  | depth_top1=0.954, depth_top5=1.000 | ms_per_frame=63.2 |
-| dit | bf16 (selected) | step0_pcc=1.000, latents_pcc=1.000, spectral_convergence=0.050 | ms_per_forward=138.4 |
-| dit | bfp8  | step0_pcc=0.998, latents_pcc=0.998, spectral_convergence=0.076 | ms_per_forward=92.5 |
-| dit | bf16h2  | step0_pcc=0.999, latents_pcc=0.999, spectral_convergence=0.047 | ms_per_forward=93.3 |
+| depth | bf16  | depth_top1=0.944, depth_top5=1.000 | ms_per_frame=47.8 |
+| depth | bfp8 (selected) | depth_top1=0.949, depth_top5=1.000 | ms_per_frame=37.3 |
+| depth | bf16h2  | depth_top1=0.948, depth_top5=1.000 | ms_per_frame=46.0 |
+| dit | bf16 (selected) | step0_pcc=1.000, latents_pcc=1.000, spectral_convergence=0.050 | ms_per_forward=138.8 |
+| dit | bfp8  | step0_pcc=0.998, latents_pcc=0.998, spectral_convergence=0.076 | ms_per_forward=92.8 |
+| dit | bf16h2  | step0_pcc=0.999, latents_pcc=0.999, spectral_convergence=0.047 | ms_per_forward=93.2 |
 
 | clip | frames | prefill s | LLM ms/frame | depth ms/frame | denoise s | vocoder s | RTF |
 |---|---|---|---|---|---|---|---|
-| readme | 200 | 1.5 | 36.2 | 54.8 | 8.3 | 3.6 | 3.96 |
-| blues | 300 | 0.7 | 37.1 | 54.2 | 16.2 | 7.0 | 4.28 |
+| readme | 200 | 1.5 | 36.4 | 62.1 | 8.3 | 3.3 | 4.10 |
+| blues | 300 | 0.7 | 37.3 | 46.4 | 16.2 | 6.4 | 4.04 |
 
 ## Stage table
 
@@ -63,16 +63,16 @@ Model: `MiniMaxAI/MiniMax-Music3` @ `fbdf52fb` (8B Qwen3 global LLM + 0.6B depth
 | 03-llm-pcc-1chip | ok | 1 | 2026-09-10T01:40:29Z | 2026-09-10T01:41:10Z |
 | 04-depth-decoder-tt | ok | 0 | 2026-09-10T01:43:48Z | 2026-09-10T01:44:08Z |
 | 05-dit-tt | ok | 0 | 2026-09-10T02:21:21Z | 2026-09-10T02:22:29Z |
-| 06-e2e-generator | ok | 1 | 2026-09-10T02:22:29Z | 2026-09-10T02:24:24Z |
-| 07-optimize | ok | 1 | 2026-09-10T02:24:24Z | 2026-09-10T02:27:18Z |
-| 08-server-smoke | ok | 0 | 2026-09-10T02:27:18Z | 2026-09-10T02:29:38Z |
-| 09-package | ok | 0 | 2026-09-10T02:29:38Z | 2026-09-10T02:32:02Z |
-| 10-serve-prove | ok | 0 | 2026-09-10T02:32:02Z | 2026-09-10T02:34:30Z |
-| 11-report-push | ok | 0 | 2026-09-10T02:34:30Z | 2026-09-10T02:36:24Z |
+| 06-e2e-generator | ok | 1 | 2026-09-10T02:41:40Z | 2026-09-10T02:43:33Z |
+| 07-optimize | ok | 1 | 2026-09-10T02:43:33Z | 2026-09-10T02:46:45Z |
+| 08-server-smoke | ok | 0 | 2026-09-10T02:46:45Z | 2026-09-10T02:49:02Z |
+| 09-package | ok | 0 | 2026-09-10T02:49:02Z | 2026-09-10T02:52:14Z |
+| 10-serve-prove | ok | 0 | 2026-09-10T02:52:14Z | 2026-09-10T02:54:31Z |
+| 11-report-push | running | - | 2026-09-10T02:54:31Z |  |
 
 ## Package
 
-- manifest `/home/jashan/tt-model-builds/minimax-music3/tt_kernel_manifest.json` (schema 5.1, kind tt-dit-server, tt-metal 0.65.2.dev9787+g3cc3431f59b, image `tt-model/minimax-music3:4cbc019bf616` sha256:4cbc019bf616)
+- manifest `/home/jashan/tt-model-builds/minimax-music3/tt_kernel_manifest.json` (schema 5.1, kind tt-dit-server, tt-metal 0.65.2.dev9789+g5039f8a95a6, image `tt-model/minimax-music3:9abe0907aae5` sha256:9abe0907aae5)
 - weights pointer `MiniMaxAI/MiniMax-Music3` @ `fbdf52fbaaca` (ignore patterns skip the 28 GB of unconverted originals)
 - HF push:   → consumers:  tt-model serve jashansinghTT/minimax-music3-blackhole
 - code: tt-metal worktree `~/tt-metal-music3`, branch `jashan/minimax-music3`, `models/autoports/minimaxai_minimax_music3`

--- a/models/autoports/minimaxai_minimax_music3/doc/context_contract.json
+++ b/models/autoports/minimaxai_minimax_music3/doc/context_contract.json
@@ -1,0 +1,4 @@
+{"model": "MiniMaxAI/MiniMax-Music3", "hf_advertised_context": 10240, "current_supported_context": 16384,
+ "served_default_max_seq_len": 16384,
+ "units": "global-LLM positions: prompt tokens (<= 5000 by the model's contract) + audio frames (<= 9000, 25 per second) + 2",
+ "notes": "language_model/config.json advertises max_position_embeddings 10240 but the reference recipe allows 5000 prompt tokens + 9000 frames = 14002 positions; max_seq_len 16384 covers that. KV cache: 2 rows (conditional/unconditional) x 16384 x 36 layers x 8 KV heads x 128 x bf8 = 2.5 GB on the single P150 next to ~7.4 GB (bfp8) LLM layers, 4.9 GB (bf16) DiT and 1.3 GB (bf16) depth decoder."}

--- a/models/autoports/minimaxai_minimax_music3/reference/PROVENANCE.md
+++ b/models/autoports/minimaxai_minimax_music3/reference/PROVENANCE.md
@@ -1,0 +1,11 @@
+# Provenance
+
+`dit.py`, `depth_decoder.py`, `condition_encoder.py`, `vocoder.py` are ports of
+`src/diffusers/models/{transformers/transformer_minimax_music3.py, transformers/minimax_music3_rvq_depth_decoder.py,
+condition_embedders/condition_embedder_minimax_music3.py, autoencoders/minimax_music3_vocoder.py}` and
+`prompt.py` / `sampling.py` / `pipeline.py` port `src/diffusers/modular_pipelines/minimax_music3/*.py` from
+huggingface/diffusers commit `dafe3733fcfdbf3c48915fe77be3aef65b5d6a2d` (PR #14456, "MiniMax Music 3"), Copyright 2026
+The MiniMax Team and The HuggingFace Team, Apache License 2.0. Changes: diffusers mixins/config plumbing replaced by
+plain `torch.nn.Module`s that load the HF safetensors sub-folders directly (state-dict keys unchanged); the modular
+pipeline blocks are flattened into `Music3Reference.generate()` and a `teacher_forced()` dump path. Numerics are
+unchanged; stage 01 asserts the vendored pipeline reproduces the diffusers pipeline's codes for the same seed.

--- a/models/autoports/minimaxai_minimax_music3/reference/__init__.py
+++ b/models/autoports/minimaxai_minimax_music3/reference/__init__.py
@@ -1,0 +1,5 @@
+"""Torch reference implementation of MiniMax Music 3 (vendored from the diffusers PR #14456 modules, see PROVENANCE.md).
+
+Used for: CPU goldens + teacher-forced dumps (stage 01), PCC references for the TTNN modules, and the CPU parts of
+the serving path (condition encoder, vocoder) in phase A.
+"""

--- a/models/autoports/minimaxai_minimax_music3/reference/condition_encoder.py
+++ b/models/autoports/minimaxai_minimax_music3/reference/condition_encoder.py
@@ -1,0 +1,47 @@
+"""MiniMaxMusic3ConditionEncoder as a plain torch module. Keys match condition_encoder/*.safetensors."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from models.autoports.minimaxai_minimax_music3.config import CondConfig
+
+
+class Music3ConditionEncoder(nn.Module):
+    def __init__(self, cfg: CondConfig = CondConfig()):
+        super().__init__()
+        self.cfg = cfg
+        self.layer_weight_logits = nn.Parameter(torch.zeros(cfg.num_condition_layers))
+        self.layer_scale = nn.Parameter(torch.ones(1))
+        self.proj = nn.Conv1d(cfg.condition_hidden_dim, cfg.out_dim, kernel_size=3, padding=1)
+
+    def latent_length(self, num_frames: int) -> int:
+        c = self.cfg
+        return max(
+            1,
+            int(num_frames * c.output_sampling_rate / c.input_sampling_rate * c.input_hop_length / c.output_hop_length),
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """[B, frames, layers*D] -> [B, latent_len, out_dim]."""
+        b, n, _ = hidden_states.shape
+        c = self.cfg
+        x = hidden_states.transpose(1, 2).reshape(b, c.num_condition_layers, c.condition_hidden_dim, n)
+        w = torch.softmax(self.layer_weight_logits, dim=0).to(x.dtype)
+        x = torch.einsum("blht,l->bht", x, w)
+        x = self.layer_scale.to(x.dtype) * x
+        x = self.proj(x)
+        x = F.interpolate(x, size=self.latent_length(n), mode="nearest")
+        return x.transpose(1, 2)
+
+    @staticmethod
+    def load(snapshot, dtype=torch.float32, device="cpu", cfg: CondConfig | None = None) -> "Music3ConditionEncoder":
+        from safetensors.torch import load_file
+
+        m = Music3ConditionEncoder(cfg or CondConfig())
+        sd = load_file(str(Path(snapshot, "condition_encoder", "diffusion_pytorch_model.safetensors")), device="cpu")
+        m.load_state_dict({k: v.to(dtype) for k, v in sd.items()}, strict=True)
+        return m.to(device).eval()

--- a/models/autoports/minimaxai_minimax_music3/reference/depth_decoder.py
+++ b/models/autoports/minimaxai_minimax_music3/reference/depth_decoder.py
@@ -1,0 +1,96 @@
+"""MiniMaxMusic3RVQDepthDecoder (the 0.6B local LLM) as a plain torch module. Keys match rvq_depth_decoder/*.safetensors."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from models.autoports.minimaxai_minimax_music3.config import DepthConfig
+
+
+class RMSNorm(nn.Module):
+    """diffusers RMSNorm(dim, eps, elementwise_affine=True): fp32 variance, weight multiply in the weight dtype."""
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        variance = x.to(torch.float32).pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(variance + self.eps)
+        if self.weight.dtype in (torch.float16, torch.bfloat16):
+            x = x.to(self.weight.dtype)
+        return x * self.weight
+
+
+class DepthAttention(nn.Module):
+    def __init__(self, dim: int, heads: int):
+        super().__init__()
+        self.heads, self.head_dim = heads, dim // heads
+        self.to_q = nn.Linear(dim, dim, bias=False)
+        self.to_k = nn.Linear(dim, dim, bias=False)
+        self.to_v = nn.Linear(dim, dim, bias=False)
+        self.to_out = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, s, _ = x.shape
+        q = self.to_q(x).view(b, s, self.heads, self.head_dim).transpose(1, 2)
+        k = self.to_k(x).view(b, s, self.heads, self.head_dim).transpose(1, 2)
+        v = self.to_v(x).view(b, s, self.heads, self.head_dim).transpose(1, 2)
+        out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        return self.to_out(out.transpose(1, 2).flatten(2, 3).to(q.dtype))
+
+
+class DepthBlock(nn.Module):
+    def __init__(self, dim: int, heads: int, intermediate: int):
+        super().__init__()
+        self.input_layernorm = RMSNorm(dim)
+        self.attn = DepthAttention(dim, heads)
+        self.post_attention_layernorm = RMSNorm(dim)
+        self.gate_proj = nn.Linear(dim, intermediate, bias=False)
+        self.up_proj = nn.Linear(dim, intermediate, bias=False)
+        self.down_proj = nn.Linear(intermediate, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.attn(self.input_layernorm(x))
+        h = self.post_attention_layernorm(x)
+        return x + self.down_proj(F.silu(self.gate_proj(h)) * self.up_proj(h))
+
+
+class Music3DepthDecoder(nn.Module):
+    def __init__(self, cfg: DepthConfig = DepthConfig()):
+        super().__init__()
+        self.cfg = cfg
+        d = cfg.hidden_size
+        self.audio_embeddings = nn.Embedding(cfg.audio_vocab_size * (cfg.num_codebooks - 1), d)
+        self.projection = nn.Linear(d, d, bias=False)
+        self.pos_embedding = nn.Embedding(cfg.max_position_embeddings, d)
+        self.layers = nn.ModuleList(
+            [DepthBlock(d, cfg.num_attention_heads, cfg.intermediate_size) for _ in range(cfg.num_layers)]
+        )
+        self.norm = RMSNorm(d)
+        self.audio_heads = nn.ModuleList(
+            [nn.Linear(d, cfg.audio_vocab_size, bias=False) for _ in range(cfg.num_codebooks - 1)]
+        )
+
+    def forward(self, inputs_embeds: torch.Tensor) -> torch.Tensor:
+        """inputs_embeds [B, steps, D] (already projected) -> normalized hidden states [B, steps, D]."""
+        positions = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device)
+        x = inputs_embeds + self.pos_embedding(positions).unsqueeze(0)
+        for layer in self.layers:
+            x = layer(x)
+        return self.norm(x)
+
+    @staticmethod
+    def load(snapshot, dtype=torch.float32, device="cpu", cfg: DepthConfig | None = None) -> "Music3DepthDecoder":
+        from safetensors.torch import load_file
+
+        cfg = cfg or DepthConfig()
+        sd = load_file(str(Path(snapshot, "rvq_depth_decoder", "diffusion_pytorch_model.safetensors")), device="cpu")
+        with torch.device("meta"):
+            m = Music3DepthDecoder(cfg)
+        m.load_state_dict({k: v.to(dtype) for k, v in sd.items()}, strict=True, assign=True)
+        return m.to(device).eval()

--- a/models/autoports/minimaxai_minimax_music3/reference/dit.py
+++ b/models/autoports/minimaxai_minimax_music3/reference/dit.py
@@ -1,0 +1,154 @@
+"""MiniMaxMusic3Transformer1DModel (flow-matching DiT) as a plain torch module. Keys match transformer/*.safetensors."""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from models.autoports.minimaxai_minimax_music3.config import DiTConfig
+
+
+class FourierEmbedding(nn.Module):
+    def __init__(self, embedding_dim: int):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(embedding_dim // 2, 1))
+
+    def forward(self, timestep: torch.Tensor) -> torch.Tensor:
+        angles = 2.0 * math.pi * timestep.unsqueeze(-1) @ self.weight.T
+        return torch.cat((angles.cos(), angles.sin()), dim=-1)
+
+
+class TimestepEmbedding(nn.Module):
+    """diffusers TimestepEmbedding(in, dim): linear_1 -> SiLU -> linear_2."""
+
+    def __init__(self, in_channels: int, time_embed_dim: int):
+        super().__init__()
+        self.linear_1 = nn.Linear(in_channels, time_embed_dim)
+        self.linear_2 = nn.Linear(time_embed_dim, time_embed_dim)
+
+    def forward(self, sample):
+        return self.linear_2(F.silu(self.linear_1(sample)))
+
+
+def rotary_tables(
+    seq_len: int, rotary_dim: int, theta: float = 10000.0, device=None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    inv_freq = 1.0 / (theta ** (torch.arange(0, rotary_dim, 2, device=device).float() / rotary_dim))
+    steps = torch.arange(seq_len, device=device, dtype=torch.float32)
+    freqs = torch.outer(steps, inv_freq)
+    freqs = torch.cat((freqs, freqs), dim=-1)
+    return freqs.cos().contiguous(), freqs.sin().contiguous()
+
+
+def apply_partial_rotary(x: torch.Tensor, rotary_emb) -> torch.Tensor:
+    # x: [batch, seq, heads, head_dim]; only the leading rotary dims rotate (rotate_half convention)
+    cos, sin = rotary_emb
+    rotary_dim = cos.shape[-1]
+    cos = cos[:, None, :].to(x.dtype)
+    sin = sin[:, None, :].to(x.dtype)
+    rotated = x[..., :rotary_dim]
+    h1, h2 = rotated.chunk(2, dim=-1)
+    rotate_half = torch.cat((-h2, h1), dim=-1)
+    rotated = rotated * cos + rotate_half * sin
+    return torch.cat((rotated, x[..., rotary_dim:]), dim=-1)
+
+
+class Attention(nn.Module):
+    def __init__(self, dim: int, heads: int, head_dim: int):
+        super().__init__()
+        self.heads, self.head_dim = heads, head_dim
+        inner = heads * head_dim
+        self.to_q = nn.Linear(dim, inner, bias=False)
+        self.to_k = nn.Linear(dim, inner, bias=False)
+        self.to_v = nn.Linear(dim, inner, bias=False)
+        self.to_out = nn.ModuleList([nn.Linear(inner, dim, bias=False), nn.Dropout(0.0)])
+
+    def forward(self, x: torch.Tensor, rotary_emb) -> torch.Tensor:
+        b, s, _ = x.shape
+        q = self.to_q(x).view(b, s, self.heads, self.head_dim)
+        k = self.to_k(x).view(b, s, self.heads, self.head_dim)
+        v = self.to_v(x).view(b, s, self.heads, self.head_dim)
+        q = apply_partial_rotary(q, rotary_emb)
+        k = apply_partial_rotary(k, rotary_emb)
+        # dispatch_attention_fn default (native SDPA), full (non-causal) attention
+        out = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2))
+        out = out.transpose(1, 2).flatten(2, 3).to(q.dtype)
+        return self.to_out[1](self.to_out[0](out))
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, dim: int, heads: int, head_dim: int, ff_inner_dim: int):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn = Attention(dim, heads, head_dim)
+        self.norm2 = nn.LayerNorm(dim)
+        self.ff_in = nn.Linear(dim, ff_inner_dim * 2)
+        self.ff_out = nn.Linear(ff_inner_dim, dim)
+
+    def forward(self, x: torch.Tensor, rotary_emb) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), rotary_emb)
+        gate_states, gate = self.ff_in(self.norm2(x)).chunk(2, dim=-1)
+        return x + self.ff_out(gate_states * F.silu(gate))
+
+
+class Music3DiT(nn.Module):
+    def __init__(self, cfg: DiTConfig = DiTConfig()):
+        super().__init__()
+        self.cfg = cfg
+        inner = cfg.inner_dim
+        self.time_proj = FourierEmbedding(cfg.fourier_embedding_dim)
+        self.time_embed = TimestepEmbedding(cfg.fourier_embedding_dim, inner)
+        self.preprocess_conv = nn.Conv1d(cfg.concat_channels, cfg.concat_channels, 1, bias=False)
+        self.proj_in = nn.Linear(cfg.concat_channels, inner, bias=False)
+        self.transformer_blocks = nn.ModuleList(
+            [
+                TransformerBlock(inner, cfg.num_attention_heads, cfg.attention_head_dim, cfg.ff_inner_dim)
+                for _ in range(cfg.num_layers)
+            ]
+        )
+        self.proj_out = nn.Linear(inner, cfg.in_channels, bias=False)
+        self.postprocess_conv = nn.Conv1d(cfg.in_channels, cfg.in_channels, 1, bias=False)
+
+    def forward(
+        self, hidden_states: torch.Tensor, timestep: torch.Tensor, encoder_hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        """hidden_states [B, 128, L] noisy latents; timestep [B] in [0,1] (0 = noise); encoder_hidden_states [B, L, 2048]."""
+        zeros = torch.zeros_like(hidden_states)
+        x = torch.cat((hidden_states, zeros, encoder_hidden_states.transpose(1, 2)), dim=1)
+        x = self.preprocess_conv(x) + x
+        x = x.transpose(1, 2)
+        temb = self.time_embed(self.time_proj(timestep))
+        x = self.proj_in(x)
+        x = torch.cat((temb.unsqueeze(1), x), dim=1)
+        rotary_emb = rotary_tables(x.shape[1], self.cfg.rotary_dim, device=x.device)
+        for block in self.transformer_blocks:
+            x = block(x, rotary_emb)
+        x = self.proj_out(x[:, 1:]).transpose(1, 2)
+        return self.postprocess_conv(x) + x
+
+    @staticmethod
+    def load(
+        snapshot, dtype=torch.float32, device="cpu", cfg: DiTConfig | None = None, num_layers: int | None = None
+    ) -> "Music3DiT":
+        from safetensors.torch import load_file
+
+        cfg = cfg or DiTConfig()
+        if num_layers is not None:
+            cfg = DiTConfig(**{**cfg.__dict__, "num_layers": num_layers})
+        sd = {}
+        for shard in sorted(Path(snapshot, "transformer").glob("*.safetensors")):
+            sd.update(load_file(str(shard), device="cpu"))
+        if num_layers is not None:
+            sd = {
+                k: v
+                for k, v in sd.items()
+                if not k.startswith("transformer_blocks.") or int(k.split(".")[1]) < num_layers
+            }
+        with torch.device("meta"):
+            m = Music3DiT(cfg)
+        m.load_state_dict({k: v.to(dtype) for k, v in sd.items()}, strict=True, assign=True)
+        return m.to(device).eval()

--- a/models/autoports/minimaxai_minimax_music3/reference/dit.py
+++ b/models/autoports/minimaxai_minimax_music3/reference/dit.py
@@ -113,6 +113,10 @@ class Music3DiT(nn.Module):
         self.proj_out = nn.Linear(inner, cfg.in_channels, bias=False)
         self.postprocess_conv = nn.Conv1d(cfg.in_channels, cfg.in_channels, 1, bias=False)
 
+    @property
+    def dtype(self):
+        return self.proj_in.weight.dtype
+
     def forward(
         self, hidden_states: torch.Tensor, timestep: torch.Tensor, encoder_hidden_states: torch.Tensor
     ) -> torch.Tensor:

--- a/models/autoports/minimaxai_minimax_music3/reference/pipeline.py
+++ b/models/autoports/minimaxai_minimax_music3/reference/pipeline.py
@@ -1,0 +1,345 @@
+"""Music3Reference: the whole MiniMax Music 3 inference recipe in torch (CPU/fp32 by default), flattened from the
+diffusers modular pipeline (encoders.py -> before_denoise.py -> denoise.py -> decoders.py). Same generator
+consumption order as diffusers, so `generate(seed)` reproduces the diffusers pipeline's codes and audio.
+
+Also provides `teacher_forced()` (replay golden codes, dump every intermediate the TT tests compare against) and
+`denoise()` / `decode()` for the flow-matching + vocoder stages, which serve as the CPU parts of the serving path.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+import torch
+
+from models.autoports.minimaxai_minimax_music3.config import (
+    AUDIO_CODE_OFFSET,
+    AUDIO_END_TOKEN_ID,
+    AUDIO_VOCAB_SIZE,
+    CHUNK_FRAMES,
+    CROP_LEFT_LATENT,
+    CROP_RIGHT_LATENT,
+    DIT_GUIDANCE_SCALE,
+    DIT_NUM_STEPS,
+    FRAME_RATE,
+    LATENT_CHANNELS,
+    MAX_AUDIO_FRAMES,
+    NUM_CODEBOOKS,
+    OVERLAP_LATENT_LENGTH,
+    Music3Config,
+    chunk_starts,
+)
+from models.autoports.minimaxai_minimax_music3.reference.condition_encoder import Music3ConditionEncoder
+from models.autoports.minimaxai_minimax_music3.reference.depth_decoder import Music3DepthDecoder
+from models.autoports.minimaxai_minimax_music3.reference.dit import Music3DiT
+from models.autoports.minimaxai_minimax_music3.reference.prompt import Music3Tokenizer, build_text_ids
+from models.autoports.minimaxai_minimax_music3.reference.sampling import (
+    full_vocab_mask,
+    guided_c0_logits_full,
+    guided_depth_logits,
+    sample_top_k,
+    slice_logits,
+)
+from models.autoports.minimaxai_minimax_music3.reference.vocoder import Music3Vocoder
+
+
+def flow_schedule(num_steps: int = DIT_NUM_STEPS):
+    """FlowMatchEulerDiscreteScheduler(invert_sigmas=True, shift=1, num_train_timesteps=1).set_timesteps(
+    sigmas=linspace(1, 1/N, N)) -> (timesteps [N], sigmas [N+1]). t runs 0 -> (N-1)/N, terminal sigma 1.0."""
+    sig = torch.from_numpy(np.linspace(1.0, 1.0 / num_steps, num_steps).astype(np.float32))
+    sig = 1.0 - sig
+    timesteps = sig.clone()
+    sigmas = torch.cat([sig, torch.ones(1)])
+    return timesteps, sigmas
+
+
+def euler_step(
+    latents: torch.Tensor, velocity: torch.Tensor, sigma: torch.Tensor, sigma_next: torch.Tensor
+) -> torch.Tensor:
+    """scheduler.step(): fp32 update, cast back to the model dtype."""
+    dtype = velocity.dtype
+    prev = latents.to(torch.float32) + (sigma_next - sigma) * velocity.to(torch.float32)
+    return prev.to(dtype)
+
+
+class Music3Reference:
+    def __init__(
+        self,
+        snapshot,
+        dtype=torch.float32,
+        device="cpu",
+        *,
+        load_llm: bool = True,
+        load_dit: bool = True,
+        load_vocoder: bool = True,
+        llm_dtype=None,
+        log=print,
+    ):
+        self.snapshot = Path(snapshot)
+        self.cfg = Music3Config.from_snapshot(snapshot)
+        self.dtype, self.device, self.log = dtype, device, log
+        self.tok = Music3Tokenizer(snapshot)
+        t0 = time.time()
+        self.llm = self.depth = self.dit = self.vocoder = None
+        if load_llm:
+            from transformers import Qwen3ForCausalLM
+
+            self.llm = (
+                Qwen3ForCausalLM.from_pretrained(str(self.snapshot / "language_model"), torch_dtype=llm_dtype or dtype)
+                .to(device)
+                .eval()
+            )
+            self.depth = Music3DepthDecoder.load(snapshot, dtype=llm_dtype or dtype, device=device, cfg=self.cfg.depth)
+        self.cond = Music3ConditionEncoder.load(snapshot, dtype=dtype, device=device, cfg=self.cfg.cond)
+        if load_dit:
+            self.dit = Music3DiT.load(snapshot, dtype=dtype, device=device, cfg=self.cfg.dit)
+        if load_vocoder:
+            self.vocoder = Music3Vocoder.load(snapshot, dtype=dtype, device=device, cfg=self.cfg.vocoder)
+        log(
+            f"Music3Reference loaded in {time.time() - t0:.1f}s (llm={load_llm} dit={load_dit} vocoder={load_vocoder}, dtype={dtype})"
+        )
+
+    # ------------------------------------------------------------------ prompt
+    def text_ids(self, caption: str, lyrics: str) -> torch.Tensor:
+        return build_text_ids(self.tok, caption, lyrics).to(self.device)
+
+    # ------------------------------------------------------------------ autoregressive stage
+    def embed_audio_frame(self, frame_codes: torch.Tensor) -> torch.Tensor:
+        """frame_codes [2, 8] -> [2, 1, D] (semantic embedding + summed residual embeddings, scaled by 8^-0.5)."""
+        embed_tokens = self.llm.model.embed_tokens
+        embeds = embed_tokens(frame_codes[:, :1] + AUDIO_CODE_OFFSET)
+        offsets = (torch.arange(NUM_CODEBOOKS - 1, device=frame_codes.device) * AUDIO_VOCAB_SIZE).unsqueeze(0)
+        extra = self.depth.audio_embeddings(frame_codes[:, 1:] + offsets).sum(dim=1, keepdim=True)
+        return (embeds + extra.to(embeds.dtype)) * NUM_CODEBOOKS**-0.5
+
+    def depth_codes(
+        self,
+        last_hidden: torch.Tensor,
+        semantic_code: torch.Tensor,
+        generator,
+        forced: Optional[Sequence[int]] = None,
+        record: Optional[dict] = None,
+    ):
+        """One frame of the local LLM. last_hidden [2, D] (cond, uncond), semantic_code [2].
+        Returns (frame_codes [2, 8], depth_hidden [1, 7*D]). `forced` = codes c1..c7 to use instead of sampling."""
+        d = self.depth
+        sequence = [d.projection(last_hidden).unsqueeze(1)]
+        code_embed = self.llm.model.embed_tokens(semantic_code + AUDIO_CODE_OFFSET)
+        sequence.append(d.projection(code_embed).unsqueeze(1))
+        codes = [semantic_code]
+        hidden_parts = []
+        for index in range(1, NUM_CODEBOOKS):
+            hidden = d(torch.cat(sequence, dim=1))[:, -1]
+            hidden_parts.append(hidden[:1])
+            logits = d.audio_heads[index - 1](hidden)
+            if record is not None:
+                record.setdefault("depth_logits", []).append(logits.detach().float().cpu())
+                record.setdefault("depth_hidden", []).append(hidden[:1].detach().float().cpu())
+            if forced is not None:
+                code = torch.tensor([int(forced[index - 1])], device=hidden.device).repeat(2)
+            else:
+                code = sample_top_k(guided_depth_logits(logits), generator).repeat(2)
+            codes.append(code)
+            if index < NUM_CODEBOOKS - 1:
+                embed = d.audio_embeddings(code + (index - 1) * AUDIO_VOCAB_SIZE)
+                sequence.append(d.projection(embed).unsqueeze(1))
+        return torch.stack(codes, dim=1), torch.cat(hidden_parts, dim=-1)
+
+    @torch.no_grad()
+    def semantic_generation(
+        self,
+        text_ids: torch.Tensor,
+        max_frames: int,
+        generator,
+        forced_codes: Optional[torch.Tensor] = None,
+        record: bool = False,
+    ):
+        """The autoregressive stage. Returns dict(frame_hiddens [1, F, 8D], codes_all [N, 8] (row 0 = the non-emitted
+        pre-frame), ended (bool), + dumps when record=True: hidden_all [N(+1), 2, D], c0_logits [N(+1), 2, 16385],
+        depth_logits [N, 7, 2, 1024], depth_hidden [N, 7, D]).
+        forced_codes [N, 8]: teacher forcing (c0 + c1..c7 taken from the golden; nothing is sampled)."""
+        llm = self.llm
+        max_frames = min(int(max_frames), MAX_AUDIO_FRAMES)
+        text_embeds = llm.model.embed_tokens(text_ids)
+        out = llm.model(inputs_embeds=text_embeds, use_cache=True)
+        past, last_hidden = out.past_key_values, out.last_hidden_state[:, -1]
+        vocab_mask = full_vocab_mask(llm.config.vocab_size, device=text_ids.device)
+        frame_hiddens, codes_all, ended = [], [], False
+        dumps: Dict[str, list] = {"hidden_all": [], "c0_logits": [], "depth_logits": [], "depth_hidden": []}
+        n_steps = max_frames + 1 if forced_codes is None else forced_codes.shape[0]
+        for frame_index in range(n_steps):
+            logits = llm.lm_head(last_hidden).float()
+            if record:
+                dumps["hidden_all"].append(last_hidden.detach().float().cpu())
+                dumps["c0_logits"].append(slice_logits(logits).detach().cpu())
+            if forced_codes is None:
+                guided = guided_c0_logits_full(logits, vocab_mask)
+                sampled = sample_top_k(guided, generator)
+                if int(sampled.item()) == AUDIO_END_TOKEN_ID:
+                    ended = True
+                    break
+                semantic_code = sampled - AUDIO_CODE_OFFSET
+                forced = None
+            else:
+                row = forced_codes[frame_index]
+                semantic_code = row[:1].to(text_ids.device)
+                forced = row[1:].tolist()
+            rec = {} if record else None
+            frame_codes, depth_hidden = self.depth_codes(
+                last_hidden, semantic_code.repeat(2), generator, forced=forced, record=rec
+            )
+            if record:
+                dumps["depth_logits"].append(torch.stack(rec["depth_logits"]))  # [7, 2, 1024]
+                dumps["depth_hidden"].append(torch.cat(rec["depth_hidden"]))  # [7, D]
+            codes_all.append(frame_codes[0].detach().cpu())
+            if frame_index > 0:
+                frame_hiddens.append(torch.cat((last_hidden[:1], depth_hidden), dim=-1))
+                if forced_codes is None and len(frame_hiddens) >= max_frames:
+                    break
+            if forced_codes is not None and frame_index == n_steps - 1:
+                break
+            feedback = self.embed_audio_frame(frame_codes)
+            out = llm.model(inputs_embeds=feedback, past_key_values=past, use_cache=True)
+            past, last_hidden = out.past_key_values, out.last_hidden_state[:, -1]
+        if not frame_hiddens:
+            raise ValueError("MiniMax Music 3 generated zero audio frames; the prompt ended generation immediately")
+        res = {
+            "frame_hiddens": torch.stack(frame_hiddens, dim=1),
+            "codes_all": torch.stack(codes_all) if codes_all else torch.zeros(0, NUM_CODEBOOKS, dtype=torch.int64),
+            "ended": ended,
+            "prompt_len": int(text_ids.shape[1]),
+        }
+        if record:
+            res.update({k: torch.stack(v) for k, v in dumps.items() if v})
+        return res
+
+    # ------------------------------------------------------------------ flow matching
+    def condition_for(self, frame_hiddens: torch.Tensor, start: int, end: int) -> torch.Tensor:
+        return self.cond(frame_hiddens[:, start:end].to(self.device)).to(
+            self.dit.dtype if self.dit is not None else self.dtype
+        )
+
+    @torch.no_grad()
+    def denoise(
+        self,
+        frame_hiddens: torch.Tensor,
+        generator,
+        num_steps: int = DIT_NUM_STEPS,
+        guidance_scale: float = DIT_GUIDANCE_SCALE,
+        record_steps: Sequence[int] = (),
+        dit_forward=None,
+    ) -> dict:
+        """before_denoise.py + denoise.py. Returns dict(latent_chunks [list of [1,128,L]], chunk_starts, and when
+        record_steps: per-chunk dicts with condition / noise / timesteps / (t, latents_in, pred_cond, pred_uncond)).
+        `dit_forward(latents [B,128,L], t [B], cond [B,L,2048]) -> velocity` lets a TT DiT drive the same loop."""
+        dit_forward = dit_forward or (lambda x, t, c: self.dit(x, t, c))
+        starts = chunk_starts(frame_hiddens.shape[1])
+        timesteps, sigmas = flow_schedule(num_steps)
+        latent_chunks, chunk_records = [], []
+        prev_latent = prev_cond = None
+        for k, start in enumerate(starts):
+            end = min(start + CHUNK_FRAMES, frame_hiddens.shape[1])
+            condition = self.condition_for(frame_hiddens, start, end)
+            overlap = 0
+            if prev_latent is not None:
+                overlap = min(prev_latent.shape[-1], condition.shape[1])
+                condition[:, :overlap] = prev_cond[:, :overlap]
+            latents = torch.randn(
+                (1, LATENT_CHANNELS, condition.shape[1]), generator=generator, dtype=condition.dtype
+            ).to(self.device)
+            noise_prompt = latents[..., :overlap].clone() if overlap > 0 else None
+            rec = (
+                {
+                    "chunk_start": start,
+                    "condition": condition.detach().cpu(),
+                    "noise": latents.detach().cpu(),
+                    "overlap": overlap,
+                    "timesteps": timesteps.clone(),
+                    "steps": [],
+                }
+                if record_steps
+                else None
+            )
+            for i, t in enumerate(timesteps):
+                if overlap > 0:
+                    tv = t.to(latents.dtype)
+                    latents[..., :overlap] = (1.0 - (1.0 - 1e-6) * tv) * noise_prompt + tv * prev_latent[..., :overlap]
+                timestep = t.expand(latents.shape[0]).to(latents.dtype).to(self.device)
+                latents_in = latents.detach().clone() if rec is not None and i in record_steps else None
+                pred_cond = dit_forward(latents, timestep, condition)
+                pred_uncond = dit_forward(latents, timestep, torch.zeros_like(condition))
+                velocity = pred_uncond + guidance_scale * (pred_cond - pred_uncond)
+                if latents_in is not None:
+                    rec["steps"].append(
+                        {
+                            "i": i,
+                            "t": float(t),
+                            "latents_in": latents_in.cpu(),
+                            "pred_cond": pred_cond.detach().cpu(),
+                            "pred_uncond": pred_uncond.detach().cpu(),
+                        }
+                    )
+                latents = euler_step(latents, velocity, sigmas[i], sigmas[i + 1])
+            if overlap > 0:
+                latents[..., :overlap] = prev_latent[..., :overlap]
+            os_ = max(0, latents.shape[-1] - 2 * OVERLAP_LATENT_LENGTH)
+            oe = max(os_, latents.shape[-1] - OVERLAP_LATENT_LENGTH)
+            prev_latent, prev_cond = latents[..., os_:oe], condition[:, os_:oe]
+            latent_chunks.append(latents)
+            if rec is not None:
+                rec["latents_out"] = latents.detach().cpu()
+                chunk_records.append(rec)
+        return {"latent_chunks": latent_chunks, "chunk_starts": starts, "chunk_records": chunk_records}
+
+    @torch.no_grad()
+    def decode(self, latent_chunks: List[torch.Tensor], vocoder=None) -> torch.Tensor:
+        """decoders.py: vocode each window, crop overlaps, stitch -> [1, 2, samples] float32 in [-1, 1] at 44.1 kHz."""
+        vocoder = vocoder or self.vocoder
+        hop = vocoder.hop_length
+        n = len(latent_chunks)
+        chunks = []
+        for i, lat in enumerate(latent_chunks):
+            wav = vocoder(lat.to(vocoder.dec_in_proj.weight.dtype).to(self.device))
+            left = 0 if i == 0 else CROP_LEFT_LATENT * hop
+            right = 0 if i == n - 1 else CROP_RIGHT_LATENT * hop
+            chunks.append(wav[..., left : wav.shape[-1] - right])
+        return torch.cat(chunks, dim=-1).float().clamp(-1.0, 1.0).cpu()
+
+    # ------------------------------------------------------------------ end to end
+    @torch.no_grad()
+    def generate(
+        self,
+        caption: str,
+        lyrics: str,
+        *,
+        audio_duration: float = 60.0,
+        seed: int = 0,
+        num_steps: int = DIT_NUM_STEPS,
+        record: bool = False,
+        record_steps: Sequence[int] = (),
+    ) -> dict:
+        generator = torch.Generator("cpu").manual_seed(int(seed))
+        text_ids = self.text_ids(caption, lyrics)
+        max_frames = min(int(audio_duration * FRAME_RATE), MAX_AUDIO_FRAMES)
+        t0 = time.time()
+        sem = self.semantic_generation(text_ids, max_frames, generator, record=record)
+        t1 = time.time()
+        den = self.denoise(sem["frame_hiddens"], generator, num_steps=num_steps, record_steps=record_steps)
+        t2 = time.time()
+        audio = self.decode(den["latent_chunks"])
+        t3 = time.time()
+        return {
+            **sem,
+            **den,
+            "text_ids": text_ids.cpu(),
+            "audio": audio,
+            "sample_rate": self.cfg.vocoder.sampling_rate,
+            "timing": {"semantic_s": t1 - t0, "denoise_s": t2 - t1, "decode_s": t3 - t2},
+        }
+
+    @torch.no_grad()
+    def teacher_forced(self, text_ids: torch.Tensor, codes_all: torch.Tensor) -> dict:
+        """Replay golden codes (N x 8, row 0 = pre-frame) and dump every intermediate. No sampling."""
+        return self.semantic_generation(text_ids.to(self.device), 0, None, forced_codes=codes_all, record=True)

--- a/models/autoports/minimaxai_minimax_music3/reference/pipeline.py
+++ b/models/autoports/minimaxai_minimax_music3/reference/pipeline.py
@@ -230,10 +230,13 @@ class Music3Reference:
         guidance_scale: float = DIT_GUIDANCE_SCALE,
         record_steps: Sequence[int] = (),
         dit_forward=None,
+        on_chunk=None,
     ) -> dict:
         """before_denoise.py + denoise.py. Returns dict(latent_chunks [list of [1,128,L]], chunk_starts, and when
         record_steps: per-chunk dicts with condition / noise / timesteps / (t, latents_in, pred_cond, pred_uncond)).
-        `dit_forward(latents [B,128,L], t [B], cond [B,L,2048]) -> velocity` lets a TT DiT drive the same loop."""
+        `dit_forward(latents [B,128,L], t [B], cond [B,L,2048]) -> velocity` lets a TT DiT drive the same loop.
+        `on_chunk(k, latents)` is called as soon as window k is final (the caller may start vocoding it while the
+        next window denoises); the latents handed over are never mutated afterwards."""
         dit_forward = dit_forward or (lambda x, t, c: self.dit(x, t, c))
         starts = chunk_starts(frame_hiddens.shape[1])
         timesteps, sigmas = flow_schedule(num_steps)
@@ -288,24 +291,36 @@ class Music3Reference:
             oe = max(os_, latents.shape[-1] - OVERLAP_LATENT_LENGTH)
             prev_latent, prev_cond = latents[..., os_:oe], condition[:, os_:oe]
             latent_chunks.append(latents)
+            if on_chunk is not None:
+                on_chunk(k, latents)
             if rec is not None:
                 rec["latents_out"] = latents.detach().cpu()
                 chunk_records.append(rec)
         return {"latent_chunks": latent_chunks, "chunk_starts": starts, "chunk_records": chunk_records}
 
     @torch.no_grad()
-    def decode(self, latent_chunks: List[torch.Tensor], vocoder=None) -> torch.Tensor:
-        """decoders.py: vocode each window, crop overlaps, stitch -> [1, 2, samples] float32 in [-1, 1] at 44.1 kHz."""
+    def vocode(self, latents: torch.Tensor, vocoder=None) -> torch.Tensor:
+        """decoders.py, one window: latents [1,128,L] -> uncropped waveform [1, 2, L*hop]."""
+        vocoder = vocoder or self.vocoder
+        return vocoder(latents.to(vocoder.dec_in_proj.weight.dtype).to(self.device))
+
+    @torch.no_grad()
+    def stitch(self, wavs: List[torch.Tensor], vocoder=None) -> torch.Tensor:
+        """decoders.py: crop the window overlaps and concatenate -> [1, 2, samples] float32 in [-1, 1] at 44.1 kHz."""
         vocoder = vocoder or self.vocoder
         hop = vocoder.hop_length
-        n = len(latent_chunks)
+        n = len(wavs)
         chunks = []
-        for i, lat in enumerate(latent_chunks):
-            wav = vocoder(lat.to(vocoder.dec_in_proj.weight.dtype).to(self.device))
+        for i, wav in enumerate(wavs):
             left = 0 if i == 0 else CROP_LEFT_LATENT * hop
             right = 0 if i == n - 1 else CROP_RIGHT_LATENT * hop
             chunks.append(wav[..., left : wav.shape[-1] - right])
         return torch.cat(chunks, dim=-1).float().clamp(-1.0, 1.0).cpu()
+
+    @torch.no_grad()
+    def decode(self, latent_chunks: List[torch.Tensor], vocoder=None) -> torch.Tensor:
+        """decoders.py: vocode each window, crop overlaps, stitch -> [1, 2, samples] float32 in [-1, 1] at 44.1 kHz."""
+        return self.stitch([self.vocode(lat, vocoder) for lat in latent_chunks], vocoder)
 
     # ------------------------------------------------------------------ end to end
     @torch.no_grad()

--- a/models/autoports/minimaxai_minimax_music3/reference/prompt.py
+++ b/models/autoports/minimaxai_minimax_music3/reference/prompt.py
@@ -1,0 +1,103 @@
+"""Prompt contract: caption cleaning, lyrics normalization, the special-token template and the CFG (unconditional)
+row. Exact port of encoders.py (MiniMaxMusic3TextEncoderStep); tokenization via `tokenizers` (tokenizer/tokenizer.json)
+which stage 02 asserts equals transformers' Qwen2Tokenizer on the same strings."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Sequence
+
+import torch
+
+from models.autoports.minimaxai_minimax_music3.config import (
+    AUDIO_CFG_TOKEN_ID,
+    AUDIO_START,
+    CAPTION_END,
+    CAPTION_START,
+    IM_END,
+    IM_START,
+    LYRICS_END,
+    LYRICS_START,
+    MAX_PROMPT_TOKENS,
+)
+
+_SPECIAL_TAG_RE = re.compile(r"<\|([^|]*)\|>")
+_LEADING_TAGS_RE = re.compile(r"^[ \t]*((?:\[[^\]]+\][ \t]*)+)")
+
+
+def clean_caption(caption: str) -> str:
+    def _rewrite_special_tag(match: re.Match) -> str:
+        inner = match.group(1).strip()
+        parts = inner.split(None, 1)
+        return f"{parts[0]} is {parts[1]}" if len(parts) == 2 else inner
+
+    text = _SPECIAL_TAG_RE.sub(_rewrite_special_tag, caption)
+    lines_out = []
+    for line in text.splitlines():
+        line = re.sub(r"^\s{0,3}#{1,6}\s+", "", line)
+        line = re.sub(r"^\s*[*+-]\s+", "", line)
+        line = re.sub(r"^\s*\*\s+", "", line)
+        while "**" in line:
+            updated = re.sub(r"\*\*([^*]+)\*\*", r"\1", line)
+            if updated == line:
+                break
+            line = updated
+        line = re.sub(r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"\1", line)
+        lines_out.append(line.rstrip())
+    text = "\n".join(lines_out)
+    text = re.sub(r"^\s*[-*_]{3,}\s*$", "", text, flags=re.MULTILINE)
+    text = text.replace("• ", "").replace("    ", "")
+    return re.sub(r"\n{2,}", "\n", text)
+
+
+def normalize_lyrics(lyrics: str) -> str:
+    output = []
+    for line in lyrics.split("\n"):
+        match = _LEADING_TAGS_RE.match(line)
+        output.append(match.group(1).strip() if match else line)
+    text = "\n".join(output)
+    text = text.replace("] ", "]\n")
+    text = text.replace(" [", "\n[")
+    text = text.replace(" ^ ", "\n")
+    text = re.sub(r"\[([^\]]+)\]", lambda m: f"[{m.group(1).lower()}]", text)
+    return f"[start]\n{text}"
+
+
+def prompt_text(caption: str, lyrics: str) -> str:
+    return (
+        f"{IM_START}{CAPTION_START}{clean_caption(caption)}{CAPTION_END}"
+        f"{LYRICS_START}{normalize_lyrics(lyrics)}{LYRICS_END}{IM_END}{AUDIO_START}"
+    )
+
+
+class Music3Tokenizer:
+    """Thin wrapper over the HF `tokenizers` fast tokenizer in tokenizer/tokenizer.json (no transformers needed)."""
+
+    def __init__(self, snapshot):
+        from tokenizers import Tokenizer
+
+        self.tk = Tokenizer.from_file(str(Path(snapshot) / "tokenizer" / "tokenizer.json"))
+        for tok, expect in ((AUDIO_START, 151669), ("<|audio_end|>", 151670)):
+            got = self.tk.token_to_id(tok)
+            assert got == expect, (tok, got, expect)
+
+    def encode(self, text: str) -> List[int]:
+        return self.tk.encode(text, add_special_tokens=True).ids
+
+    def decode(self, ids: Sequence[int]) -> str:
+        return self.tk.decode(list(ids), skip_special_tokens=False)
+
+
+def build_text_ids(tok: Music3Tokenizer, caption: str, lyrics: str) -> torch.Tensor:
+    """[2, S] int64: row 0 conditional prompt, row 1 its classifier-free counterpart (every token except the first
+    and the two trailing structure tokens replaced by the audio-CFG token)."""
+    if not isinstance(caption, str) or not caption.strip():
+        raise ValueError("`caption` (the music description) must be a non-empty string")
+    if not isinstance(lyrics, str) or not lyrics.strip():
+        raise ValueError("`lyrics` must be a non-empty string")
+    ids = torch.tensor([tok.encode(prompt_text(caption, lyrics))], dtype=torch.int64)
+    if ids.shape[1] > MAX_PROMPT_TOKENS:
+        raise ValueError(f"The assembled prompt has {ids.shape[1]} tokens; the maximum is {MAX_PROMPT_TOKENS}")
+    uncond = ids.clone()
+    uncond[:, 1:-2] = AUDIO_CFG_TOKEN_ID
+    return torch.cat((ids, uncond), dim=0)

--- a/models/autoports/minimaxai_minimax_music3/reference/sampling.py
+++ b/models/autoports/minimaxai_minimax_music3/reference/sampling.py
@@ -1,0 +1,80 @@
+"""Sampling contract (encoders.py): top-k multinomial with a torch.Generator (CPU), the c0 classifier-free guidance
+with the conditional row's top-k restriction, and the depth-code guidance. All in float32."""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+from models.autoports.minimaxai_minimax_music3.config import (
+    AR_CFG_SCALE,
+    AR_CFG_TOP_K,
+    AR_SAMPLING_TOP_K,
+    AUDIO_CODE_OFFSET,
+    AUDIO_END_TOKEN_ID,
+    SEMANTIC_VOCAB_SIZE,
+)
+
+
+def sample_top_k(
+    logits: torch.Tensor, generator: Optional[torch.Generator], top_k: int = AR_SAMPLING_TOP_K
+) -> torch.Tensor:
+    """logits [..., V] -> sampled index [...] (exact port of `_sample_top_k`)."""
+    values = torch.nan_to_num(logits.float(), nan=-1e9, posinf=1e9, neginf=-1e9)
+    top_k = min(top_k, values.shape[-1])
+    threshold = torch.topk(values, top_k, dim=-1).values[..., -1, None]
+    values = values.masked_fill(values < threshold, -float("inf"))
+    probs = torch.nan_to_num(F.softmax(values, dim=-1), nan=0.0)
+    probs = probs / probs.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+    sample_device = generator.device if generator is not None else probs.device
+    return torch.multinomial(probs.to(sample_device), 1, generator=generator).squeeze(-1).to(probs.device)
+
+
+def full_vocab_mask(vocab_size: int, device=None) -> torch.Tensor:
+    """True = masked. Only the semantic range and the end-of-audio token are allowed for c0."""
+    m = torch.ones(vocab_size, dtype=torch.bool, device=device)
+    m[AUDIO_CODE_OFFSET : AUDIO_CODE_OFFSET + SEMANTIC_VOCAB_SIZE] = False
+    m[AUDIO_END_TOKEN_ID] = False
+    return m
+
+
+def guided_c0_logits_full(logits: torch.Tensor, vocab_mask: torch.Tensor) -> torch.Tensor:
+    """Full-vocab version (reference): logits [2, V] float (row 0 cond, row 1 uncond) -> guided [1, V]."""
+    logits = logits.float().masked_fill(vocab_mask, -float("inf"))
+    conditional, unconditional = logits[0:1], logits[1:2]
+    guided = unconditional + (conditional - unconditional) * AR_CFG_SCALE
+    threshold = torch.topk(conditional, AR_CFG_TOP_K, dim=-1).values[..., -1, None]
+    guided = guided.masked_fill(conditional < threshold, -float("inf"))
+    return guided.masked_fill(vocab_mask.unsqueeze(0), -float("inf"))
+
+
+def slice_logits(logits_full: torch.Tensor) -> torch.Tensor:
+    """[.., V] -> [.., 16385]: rows 0..16383 = semantic codes, row 16384 = end-of-audio."""
+    return torch.cat(
+        (
+            logits_full[..., AUDIO_CODE_OFFSET : AUDIO_CODE_OFFSET + SEMANTIC_VOCAB_SIZE],
+            logits_full[..., AUDIO_END_TOKEN_ID : AUDIO_END_TOKEN_ID + 1],
+        ),
+        dim=-1,
+    )
+
+
+def guided_c0_logits_sliced(logits: torch.Tensor) -> torch.Tensor:
+    """Sliced version (what the TT head produces): logits [2, 16385] float -> guided [1, 16385]. Identical to the
+    full version restricted to the un-masked ids (a -inf entry never enters a top-k threshold in the full version)."""
+    logits = logits.float()
+    conditional, unconditional = logits[0:1], logits[1:2]
+    guided = unconditional + (conditional - unconditional) * AR_CFG_SCALE
+    threshold = torch.topk(conditional, AR_CFG_TOP_K, dim=-1).values[..., -1, None]
+    return guided.masked_fill(conditional < threshold, -float("inf"))
+
+
+def sliced_to_token(index: int) -> int:
+    return AUDIO_END_TOKEN_ID if index == SEMANTIC_VOCAB_SIZE else index + AUDIO_CODE_OFFSET
+
+
+def guided_depth_logits(logits: torch.Tensor) -> torch.Tensor:
+    """logits [2, 1024] (cond, uncond) -> guided [1, 1024] (CFG only; top-k happens in sample_top_k)."""
+    conditional, unconditional = logits[:1].float(), logits[1:2].float()
+    return unconditional + (conditional - unconditional) * AR_CFG_SCALE

--- a/models/autoports/minimaxai_minimax_music3/reference/vocoder.py
+++ b/models/autoports/minimaxai_minimax_music3/reference/vocoder.py
@@ -1,0 +1,98 @@
+"""MiniMaxMusic3Vocoder (DAC-style Flow-VAE decoder) as a plain torch module. Keys (weight_g/weight_v) match
+vocoder/*.safetensors, so the classic `torch.nn.utils.weight_norm` parametrization is used."""
+from __future__ import annotations
+
+import math
+import warnings
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+from models.autoports.minimaxai_minimax_music3.config import VocoderConfig
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from torch.nn.utils import weight_norm
+
+
+class Snake1d(nn.Module):
+    def __init__(self, channels: int):
+        super().__init__()
+        self.alpha = nn.Parameter(torch.ones(1, channels, 1))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        shape = x.shape
+        x = x.reshape(shape[0], shape[1], -1)
+        x = x + (self.alpha + 1e-9).reciprocal() * torch.sin(self.alpha * x).pow(2)
+        return x.reshape(shape)
+
+
+class ResidualUnit(nn.Module):
+    def __init__(self, dim: int, dilation: int):
+        super().__init__()
+        pad = (7 - 1) * dilation // 2
+        self.snake1 = Snake1d(dim)
+        self.conv1 = weight_norm(nn.Conv1d(dim, dim, kernel_size=7, dilation=dilation, padding=pad))
+        self.snake2 = Snake1d(dim)
+        self.conv2 = weight_norm(nn.Conv1d(dim, dim, kernel_size=1))
+
+    def forward(self, x):
+        return x + self.conv2(self.snake2(self.conv1(self.snake1(x))))
+
+
+class DecoderBlock(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int, stride: int):
+        super().__init__()
+        self.snake1 = Snake1d(input_dim)
+        self.conv_t1 = weight_norm(
+            nn.ConvTranspose1d(
+                input_dim, output_dim, kernel_size=2 * stride, stride=stride, padding=math.ceil(stride / 2)
+            )
+        )
+        self.res_unit1 = ResidualUnit(output_dim, dilation=1)
+        self.res_unit2 = ResidualUnit(output_dim, dilation=3)
+        self.res_unit3 = ResidualUnit(output_dim, dilation=9)
+
+    def forward(self, x):
+        x = self.conv_t1(self.snake1(x))
+        return self.res_unit3(self.res_unit2(self.res_unit1(x)))
+
+
+class Music3Vocoder(nn.Module):
+    def __init__(self, cfg: VocoderConfig = VocoderConfig()):
+        super().__init__()
+        self.cfg = cfg
+        self.dec_in_proj = nn.Conv1d(cfg.latent_channels // 2, cfg.decoder_input_dim, kernel_size=1)
+        self.conv_in = weight_norm(nn.Conv1d(cfg.decoder_input_dim, cfg.decoder_hidden_dim, kernel_size=7, padding=3))
+        blocks, output_dim = [], cfg.decoder_hidden_dim
+        for i, stride in enumerate(cfg.upsampling_ratios):
+            input_dim = cfg.decoder_hidden_dim // (2**i)
+            output_dim = cfg.decoder_hidden_dim // (2 ** (i + 1))
+            blocks.append(DecoderBlock(input_dim, output_dim, stride))
+        self.blocks = nn.ModuleList(blocks)
+        self.snake_out = Snake1d(output_dim)
+        self.conv_out = weight_norm(nn.Conv1d(output_dim, 1, kernel_size=7, padding=3))
+
+    @property
+    def hop_length(self):
+        return math.prod(self.cfg.upsampling_ratios)
+
+    def forward(self, latents: torch.Tensor) -> torch.Tensor:
+        """[B, 128, L] -> [B, 2, samples] in [-1, 1] (two folded 64-channel streams = stereo)."""
+        b, _, length = latents.shape
+        x = latents.reshape(b * 2, self.cfg.latent_channels // 2, length)
+        x = self.conv_in(self.dec_in_proj(x))
+        for block in self.blocks:
+            x = block(x)
+        wav = torch.tanh(self.conv_out(self.snake_out(x)))
+        return wav.reshape(b, 2, -1)
+
+    @staticmethod
+    def load(snapshot, dtype=torch.float32, device="cpu", cfg: VocoderConfig | None = None) -> "Music3Vocoder":
+        from safetensors.torch import load_file
+
+        m = Music3Vocoder(cfg or VocoderConfig())
+        sd = load_file(str(Path(snapshot, "vocoder", "diffusion_pytorch_model.safetensors")), device="cpu")
+        m.load_state_dict({k: v.to(dtype) for k, v in sd.items()}, strict=True)
+        return m.to(device).eval()

--- a/models/autoports/minimaxai_minimax_music3/requirements.txt
+++ b/models/autoports/minimaxai_minimax_music3/requirements.txt
@@ -1,0 +1,12 @@
+# Runtime (server) dependencies on top of tt-metal's python_env. torch comes from tt-metal's pin.
+fastapi>=0.115,<1
+uvicorn[standard]>=0.30
+pydantic>=2.9,<3
+python-multipart>=0.0.9
+soundfile>=0.12
+soxr>=0.5
+numpy>=1.24.4,<2
+safetensors
+tokenizers
+huggingface_hub
+transformers

--- a/models/autoports/minimaxai_minimax_music3/server/app.py
+++ b/models/autoports/minimaxai_minimax_music3/server/app.py
@@ -1,0 +1,152 @@
+"""FastAPI app for MiniMax Music 3 on Tenstorrent. Served by tt-model's `tt-dit-server` kind:
+    python -m uvicorn --host 0.0.0.0 --port <port> --lifespan on models.autoports.minimaxai_minimax_music3.server.app:app
+The model loads in the lifespan; uvicorn's "Application startup complete" is the readiness line.
+
+Routes: GET/POST /v1/health · GET /v1/models · POST /v1/audio/speech (SGLang-Omni / OpenAI-compatible, synchronous)
+        POST /v1/music/jobs · GET /v1/music/jobs/{id} · GET /v1/music/jobs/{id}/audio · DELETE /v1/music/jobs/{id}
+"""
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import sys
+from contextlib import asynccontextmanager
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, Response
+from starlette.concurrency import run_in_threadpool
+
+from models.autoports.minimaxai_minimax_music3.config import HF_REPO_ID, VOCODER_SAMPLE_RATE
+from models.autoports.minimaxai_minimax_music3.server import audio_io
+from models.autoports.minimaxai_minimax_music3.server.engine import Music3Engine
+from models.autoports.minimaxai_minimax_music3.server.schemas import JobStatus, JobSubmitted, SpeechRequest
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s", stream=sys.stdout)
+log = logging.getLogger("minimax_music3")
+engine = Music3Engine(log=log.info)
+API_KEY = os.environ.get("MUSIC3_API_KEY")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    engine.start()
+    await run_in_threadpool(engine.wait_ready)
+    yield
+
+
+app = FastAPI(title="MiniMax Music 3 on Tenstorrent", version="0.1.0", lifespan=lifespan)
+
+
+async def auth(request: Request):
+    if API_KEY and request.headers.get("authorization") != f"Bearer {API_KEY}":
+        raise HTTPException(401, "invalid or missing API key")
+
+
+def _submit(req: SpeechRequest):
+    if req.stream:
+        raise HTTPException(
+            400, "streaming is not supported by this model (the reference server rejects it too); set stream=false"
+        )
+    if not audio_io.available_formats().get(req.response_format):
+        raise HTTPException(400, f"format {req.response_format!r} not available on this server")
+    try:
+        return engine.submit(req)
+    except queue.Full:
+        raise HTTPException(429, "server busy; try again")
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except RuntimeError as e:
+        raise HTTPException(503, str(e))
+
+
+def _encode(job) -> Response:
+    audio, st = job.result
+    sr = job.req.sample_rate
+    out = audio_io.resample(audio, VOCODER_SAMPLE_RATE, sr)
+    data, ctype = audio_io.encode(out, job.req.response_format, sr)
+    return Response(
+        data,
+        media_type=ctype,
+        headers={
+            "Content-Disposition": f"attachment; filename=music.{job.req.response_format}",
+            "X-Music3-Frames": str(st["frames"]),
+            "X-Music3-Audio-Seconds": f"{st['audio_s']:.3f}",
+            "X-Music3-Generation-Seconds": f"{st['seconds']:.3f}",
+            "X-Music3-RTF": f"{st['rtf']:.3f}",
+            "X-Music3-Sample-Rate": str(sr),
+            "X-Music3-Ended": str(bool(st["ended"])).lower(),
+            "X-Music3-Job": job.id,
+        },
+    )
+
+
+@app.api_route("/v1/health", methods=["GET", "POST"])
+async def health():
+    h = engine.health()
+    return JSONResponse(h, status_code=200 if h["status"] == "ok" else 503)
+
+
+@app.get("/v1/models")
+async def models():
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": os.environ.get("HF_MODEL_ID", HF_REPO_ID),
+                "object": "model",
+                "created": int(engine.started),
+                "owned_by": "MiniMaxAI",
+                "served_on": "tenstorrent",
+                "mesh": engine.health()["mesh"],
+                "task": "text-to-music",
+            }
+        ],
+    }
+
+
+@app.post("/v1/audio/speech", dependencies=[Depends(auth)])
+async def speech(req: SpeechRequest, request: Request):
+    job = _submit(req)
+    while not await run_in_threadpool(job.done.wait, 1.0):
+        if await request.is_disconnected():
+            job.cancel.set()
+            raise HTTPException(499, "client disconnected")
+    if job.status == "error":
+        raise HTTPException(500, job.error)
+    if job.status == "cancelled":
+        raise HTTPException(499, "cancelled")
+    return _encode(job)
+
+
+@app.post("/v1/music/jobs", dependencies=[Depends(auth)], response_model=JobSubmitted)
+async def jobs_submit(req: SpeechRequest):
+    job = _submit(req)
+    return JobSubmitted(id=job.id, status=job.status, queue_position=engine.q.qsize())
+
+
+@app.get("/v1/music/jobs/{job_id}", dependencies=[Depends(auth)], response_model=JobStatus)
+async def jobs_status(job_id: str):
+    job = engine.jobs.get(job_id)
+    if job is None:
+        raise HTTPException(404, "job not found")
+    return JobStatus(**job.to_status())
+
+
+@app.get("/v1/music/jobs/{job_id}/audio", dependencies=[Depends(auth)])
+async def jobs_audio(job_id: str):
+    job = engine.jobs.get(job_id)
+    if job is None:
+        raise HTTPException(404, "job not found")
+    if job.status != "done":
+        raise HTTPException(409, f"job is {job.status}")
+    return _encode(job)
+
+
+@app.delete("/v1/music/jobs/{job_id}", dependencies=[Depends(auth)])
+async def jobs_cancel(job_id: str):
+    job = engine.jobs.get(job_id)
+    if job is None:
+        raise HTTPException(404, "job not found")
+    job.cancel.set()
+    return {"id": job.id, "status": "cancelling" if not job.done.is_set() else job.status}

--- a/models/autoports/minimaxai_minimax_music3/server/audio_io.py
+++ b/models/autoports/minimaxai_minimax_music3/server/audio_io.py
@@ -1,0 +1,44 @@
+"""Waveform encoders: float32 stereo [2, N] at 44.1 kHz -> wav/flac/mp3/pcm bytes, optionally resampled to 32 kHz
+(the reference server's output rate). soundfile + soxr only."""
+from __future__ import annotations
+
+import io
+from typing import Tuple
+
+import numpy as np
+import soundfile as sf
+
+CONTENT_TYPES = {"wav": "audio/wav", "flac": "audio/flac", "mp3": "audio/mpeg", "pcm": "audio/pcm"}
+SF_FORMATS = {"wav": ("WAV", "PCM_16"), "flac": ("FLAC", "PCM_16"), "mp3": ("MP3", None)}
+
+
+def resample(stereo: np.ndarray, sr_in: int, sr_out: int) -> np.ndarray:
+    """stereo [2, N] -> [2, M]."""
+    if sr_in == sr_out:
+        return stereo
+    import soxr
+
+    return np.ascontiguousarray(
+        soxr.resample(np.ascontiguousarray(stereo.T), sr_in, sr_out, quality="HQ").T, dtype=np.float32
+    )
+
+
+def pcm16(stereo: np.ndarray) -> bytes:
+    return (np.clip(stereo.T, -1.0, 1.0) * 32767.0).astype("<i2").tobytes()
+
+
+def encode(stereo: np.ndarray, fmt: str, sample_rate: int) -> Tuple[bytes, str]:
+    if fmt == "pcm":
+        return pcm16(stereo), CONTENT_TYPES["pcm"]
+    if fmt not in SF_FORMATS:
+        raise ValueError(f"unsupported format {fmt}")
+    sff, subtype = SF_FORMATS[fmt]
+    buf = io.BytesIO()
+    kwargs = {"subtype": subtype} if subtype else {}
+    sf.write(buf, np.clip(stereo.T, -1.0, 1.0), sample_rate, format=sff, **kwargs)
+    return buf.getvalue(), CONTENT_TYPES[fmt]
+
+
+def available_formats() -> dict:
+    fm = sf.available_formats()
+    return {k: (k == "pcm") or (SF_FORMATS.get(k, ("",))[0] in fm) for k in CONTENT_TYPES}

--- a/models/autoports/minimaxai_minimax_music3/server/engine.py
+++ b/models/autoports/minimaxai_minimax_music3/server/engine.py
@@ -1,0 +1,231 @@
+"""Music3Engine: one worker thread owns the chip and the generator; HTTP handlers enqueue jobs and poll/await them.
+One request at a time (single device owner). Cancellation is checked per generated frame. Device faults mark the
+engine dead (health -> 503) so the launcher/operator restarts the container."""
+from __future__ import annotations
+
+import os
+import queue
+import threading
+import time
+import traceback
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from models.autoports.minimaxai_minimax_music3.config import HF_REPO_ID, VOCODER_SAMPLE_RATE
+from models.autoports.minimaxai_minimax_music3.server.schemas import SpeechRequest
+
+
+class Cancelled(Exception):
+    pass
+
+
+@dataclass
+class Job:
+    req: SpeechRequest
+    id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    status: str = "queued"
+    frames_done: int = 0
+    stage: str = "queued"
+    submitted: float = field(default_factory=time.time)
+    started: float = 0.0
+    finished: float = 0.0
+    result: Optional[tuple] = None  # (stereo float32 [2, N] @ 44.1k, stats dict)
+    error: Optional[str] = None
+    cancel: threading.Event = field(default_factory=threading.Event)
+    done: threading.Event = field(default_factory=threading.Event)
+
+    def to_status(self) -> dict:
+        el = (self.finished or time.time()) - (self.started or self.submitted)
+        return {
+            "id": self.id,
+            "status": self.status,
+            "frames_done": self.frames_done,
+            "frames_max": self.req.frames,
+            "stage": self.stage,
+            "elapsed_s": round(el, 2),
+            "stats": self.result[1] if self.result else None,
+            "error": self.error,
+            "audio_url": f"/v1/music/jobs/{self.id}/audio" if self.status == "done" else None,
+        }
+
+
+class Music3Engine:
+    def __init__(self, log=print):
+        self.log = log
+        self.handle = self.gen = None
+        self.ready = threading.Event()
+        self.dead: Optional[str] = None
+        self.busy = False
+        self.served = 0
+        self.started = time.time()
+        self.q: "queue.Queue[Job]" = queue.Queue(maxsize=int(os.environ.get("MUSIC3_MAX_QUEUE", 8)))
+        self.jobs: Dict[str, Job] = {}
+        self.max_seq_len = int(os.environ.get("MUSIC3_MAX_SEQ_LEN", 16384))
+        self.max_frames = int(os.environ.get("MUSIC3_MAX_FRAMES", 9000))
+        self.warmup_frames = int(os.environ.get("MUSIC3_WARMUP_FRAMES", 200))
+        self.impl: Dict[str, str] = {}
+        self._thread = threading.Thread(target=self._run, name="music3-worker", daemon=True)
+
+    # ------------------------------------------------------------------ lifecycle
+    def start(self):
+        self._thread.start()
+
+    def wait_ready(self, timeout: Optional[float] = None) -> bool:
+        while not self.ready.wait(1.0):
+            if self.dead:
+                raise RuntimeError(f"engine failed to start: {self.dead}")
+            if timeout is not None and time.time() - self.started > timeout:
+                return False
+        return True
+
+    def _load(self):
+        import ttnn
+        from models.autoports.minimaxai_minimax_music3.tt.device import open_mesh
+        from models.autoports.minimaxai_minimax_music3.tt.generator import Music3Generator
+
+        dts = {"bfp8": ttnn.bfloat8_b, "bf16": ttnn.bfloat16}
+        defaults = self._defaults()
+        self.log("Opening mesh device ...")
+        self.handle = open_mesh()
+        self.log(f"mesh {self.handle.shape} open ({self.handle.num_devices} device)")
+        self.gen = Music3Generator(
+            self.handle.mesh,
+            max_seq_len=self.max_seq_len,
+            llm_dtype=dts[defaults["llm_dtype"]],
+            depth_dtype=dts[defaults["depth_dtype"]],
+            dit_dtype=dts[defaults["dit_dtype"]],
+            log=self.log,
+        )
+        self.impl = self.gen.impl
+        if os.environ.get("MUSIC3_WARMUP", "1") not in ("0", "false", "no") and self.warmup_frames > 0:
+            self.log(f"Warming up ({self.warmup_frames} frames: compiles + captures the LLM/depth/DiT traces) ...")
+            t0 = time.time()
+            out = self.gen.generate(
+                "Genre: acoustic pop. BPM: 96. Warm female vocal, fingerpicked guitar and soft piano.",
+                "[verse]\nMorning light filtering through the pine\n[chorus]\nSoftly the world begins to breathe",
+                max_frames=self.warmup_frames,
+                seed=0,
+            )
+            self.log(f"warmup done in {time.time() - t0:.1f}s: {out['stats'].as_dict()}")
+
+    @staticmethod
+    def _defaults() -> dict:
+        import json
+        from pathlib import Path
+
+        d = {
+            "llm_dtype": os.environ.get("MUSIC3_LLM_DTYPE", "bfp8"),
+            "depth_dtype": os.environ.get("MUSIC3_DEPTH_DTYPE", "bf16"),
+            "dit_dtype": os.environ.get("MUSIC3_DIT_DTYPE", "bf16"),
+        }
+        p = Path(__file__).resolve().parents[1] / "tt" / "config_defaults.json"
+        if p.exists():
+            saved = json.load(open(p))
+            for k in d:
+                if k not in os.environ.get("MUSIC3_ENV_OVERRIDES", "") and f"MUSIC3_{k.upper()}" not in os.environ:
+                    d[k] = saved.get(k, d[k])
+        return d
+
+    def _run(self):
+        try:
+            self._load()
+        except Exception as e:  # noqa
+            self.dead = f"{e}\n{traceback.format_exc()}"
+            self.log(f"ENGINE LOAD FAILED: {self.dead}")
+            return
+        self.ready.set()
+        self.log("engine ready")
+        while True:
+            job = self.q.get()
+            if job.cancel.is_set():
+                job.status, job.finished = "cancelled", time.time()
+                job.done.set()
+                continue
+            self.busy = True
+            job.status, job.started, job.stage = "running", time.time(), "semantic"
+            try:
+                self._serve(job)
+                job.status = "done"
+                self.served += 1
+            except Cancelled:
+                job.status = "cancelled"
+            except Exception as e:  # noqa
+                self.log(f"job {job.id} failed: {e}\n{traceback.format_exc()}")
+                job.status, job.error = "error", str(e)
+                if "TT_THROW" in str(e) or "TIMEOUT" in str(e) or "device timeout" in str(e).lower():
+                    self.dead = str(e)
+                    self.ready.clear()
+                    self.log("device fault: engine marked dead (health -> 503)")
+                    job.finished = time.time()
+                    job.done.set()
+                    return
+            finally:
+                job.finished = time.time()
+                job.done.set()
+                self.busy = False
+
+    # ------------------------------------------------------------------ requests
+    def submit(self, req: SpeechRequest) -> Job:
+        if not self.ready.is_set():
+            raise RuntimeError(self.dead or "engine not ready")
+        if req.frames > self.max_frames:
+            raise ValueError(f"max_new_tokens {req.frames} exceeds this server's limit {self.max_frames}")
+        job = Job(req)
+        self.jobs[job.id] = job
+        self.q.put_nowait(job)  # raises queue.Full -> 429
+        self._gc_jobs()
+        return job
+
+    def _gc_jobs(self, keep: int = 64):
+        done = [j for j in self.jobs.values() if j.done.is_set()]
+        for j in sorted(done, key=lambda j: j.finished)[:-keep] if len(done) > keep else []:
+            self.jobs.pop(j.id, None)
+
+    def _serve(self, job: Job):
+        req = job.req
+
+        def on_frame(i, codes):
+            if job.cancel.is_set():
+                raise Cancelled()
+            job.frames_done = i + 1
+
+        t0 = time.time()
+        out = self.gen.generate(
+            req.instructions,
+            req.input,
+            max_frames=req.frames,
+            seed=req.seed if req.seed is not None else int(time.time() * 1000) % (2**31),
+            num_steps=req.num_inference_steps,
+            on_frame=on_frame,
+        )
+        if job.cancel.is_set():
+            raise Cancelled()
+        audio = (
+            out["audio"].squeeze(0).numpy().astype(np.float32) if "audio" in out else np.zeros((2, 0), dtype=np.float32)
+        )
+        st = out["stats"].as_dict()
+        st.update(seconds=time.time() - t0, sample_rate_native=VOCODER_SAMPLE_RATE, seed=req.seed)
+        job.stage = "done"
+        self.log(
+            f"job {job.id} done: frames {st['frames']} audio {st['audio_s']:.1f}s in {st['seconds']:.1f}s (RTF {st['rtf']:.2f})"
+        )
+        job.result = (audio, st)
+
+    # ------------------------------------------------------------------ status
+    def health(self) -> Dict[str, Any]:
+        return {
+            "status": "ok" if self.ready.is_set() else ("degraded" if self.dead else "starting"),
+            "model": os.environ.get("HF_MODEL_ID", HF_REPO_ID),
+            "mesh": "x".join(map(str, self.handle.shape)) if self.handle is not None else "",
+            "device_name": getattr(getattr(self.gen, "args", None), "device_name", ""),
+            "busy": self.busy,
+            "queue_depth": self.q.qsize(),
+            "uptime_s": round(time.time() - self.started, 1),
+            "requests_served": self.served,
+            "impl": self.impl,
+            "limits": {"max_frames": self.max_frames, "max_seq_len": self.max_seq_len, "max_prompt_tokens": 5000},
+            "error": self.dead,
+        }

--- a/models/autoports/minimaxai_minimax_music3/server/engine.py
+++ b/models/autoports/minimaxai_minimax_music3/server/engine.py
@@ -88,6 +88,10 @@ class Music3Engine:
 
         dts = {"bfp8": ttnn.bfloat8_b, "bf16": ttnn.bfloat16}
         defaults = self._defaults()
+        for comp in ("dit", "depth"):
+            if defaults.get(f"{comp}_fidelity"):
+                os.environ.setdefault(f"MUSIC3_{comp.upper()}_FIDELITY", defaults[f"{comp}_fidelity"])
+        self.log(f"defaults: {defaults}")
         self.log("Opening mesh device ...")
         self.handle = open_mesh()
         self.log(f"mesh {self.handle.shape} open ({self.handle.num_devices} device)")
@@ -120,6 +124,8 @@ class Music3Engine:
             "llm_dtype": os.environ.get("MUSIC3_LLM_DTYPE", "bfp8"),
             "depth_dtype": os.environ.get("MUSIC3_DEPTH_DTYPE", "bf16"),
             "dit_dtype": os.environ.get("MUSIC3_DIT_DTYPE", "bf16"),
+            "dit_fidelity": os.environ.get("MUSIC3_DIT_FIDELITY"),
+            "depth_fidelity": os.environ.get("MUSIC3_DEPTH_FIDELITY"),
         }
         p = Path(__file__).resolve().parents[1] / "tt" / "config_defaults.json"
         if p.exists():

--- a/models/autoports/minimaxai_minimax_music3/server/schemas.py
+++ b/models/autoports/minimaxai_minimax_music3/server/schemas.py
@@ -1,0 +1,59 @@
+"""Request/response schemas. `SpeechRequest` is wire-compatible with the SGLang-Omni `/v1/audio/speech` contract the
+MiniMax model card documents (input = lyrics, instructions = caption, max_new_tokens = audio frames at 25 fps)."""
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+from models.autoports.minimaxai_minimax_music3.config import DIT_NUM_STEPS, MAX_AUDIO_FRAMES
+
+
+class SpeechRequest(BaseModel):
+    model: str = "MiniMaxAI/MiniMax-Music3"
+    input: str = Field(..., description="Lyrics. Structure tags such as [Verse] / [Chorus] on their own lines.")
+    instructions: str = Field(..., description="Music description (genre, BPM, key, vocals, arrangement).")
+    response_format: Literal["wav", "flac", "mp3", "pcm"] = "wav"
+    seed: Optional[int] = None
+    max_new_tokens: int = Field(750, ge=1, le=MAX_AUDIO_FRAMES, description="Maximum audio frames (25 per second).")
+    audio_duration: Optional[float] = Field(
+        None, gt=0, description="Alternative to max_new_tokens: seconds (upper bound)."
+    )
+    stream: bool = False
+    sample_rate: Literal[32000, 44100] = 32000
+    num_inference_steps: int = Field(DIT_NUM_STEPS, ge=1, le=100)
+    # accepted for OpenAI-client compatibility, ignored (there is no voice / speed / temperature in this model)
+    voice: Optional[str] = None
+    speed: Optional[float] = None
+    temperature: Optional[float] = None
+
+    @field_validator("input", "instructions")
+    @classmethod
+    def _non_empty(cls, v: str):
+        if not isinstance(v, str) or not v.strip():
+            raise ValueError("must be a non-empty string")
+        return v
+
+    @property
+    def frames(self) -> int:
+        if self.audio_duration is not None:
+            return max(1, min(int(self.audio_duration * 25.0), MAX_AUDIO_FRAMES))
+        return self.max_new_tokens
+
+
+class JobSubmitted(BaseModel):
+    id: str
+    status: str
+    queue_position: int
+
+
+class JobStatus(BaseModel):
+    id: str
+    status: Literal["queued", "running", "done", "error", "cancelled"]
+    frames_done: int = 0
+    frames_max: int = 0
+    stage: str = ""
+    elapsed_s: float = 0.0
+    stats: Optional[dict] = None
+    error: Optional[str] = None
+    audio_url: Optional[str] = None

--- a/models/autoports/minimaxai_minimax_music3/tests/conftest.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/conftest.py
@@ -1,0 +1,43 @@
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _snapshot():
+    p = os.environ.get("MUSIC3_SNAPSHOT")
+    if p and Path(p).is_dir():
+        return Path(p)
+    try:
+        from models.autoports.minimaxai_minimax_music3.config import resolve_snapshot
+
+        return resolve_snapshot(allow_download=False)
+    except Exception:
+        return None
+
+
+@pytest.fixture(scope="session")
+def snapshot():
+    s = _snapshot()
+    if s is None:
+        pytest.skip("MiniMax-Music3 snapshot not in the HF cache (set MUSIC3_SNAPSHOT)")
+    return s
+
+
+@pytest.fixture(scope="session")
+def golden_root():
+    p = Path(os.environ.get("MUSIC3_GOLDEN_ROOT", Path.home() / "music3-bringup" / "artifacts" / "golden"))
+    if not p.is_dir():
+        pytest.skip(f"golden root {p} missing (stage 01)")
+    return p
+
+
+@pytest.fixture(scope="session")
+def diffusers_mm3():
+    """The diffusers MiniMax-Music3 integration (reference venv only)."""
+    try:
+        from diffusers.modular_pipelines.minimax_music3 import encoders  # noqa
+
+        return encoders
+    except Exception:
+        pytest.skip("diffusers minimax_music3 not importable in this venv")

--- a/models/autoports/minimaxai_minimax_music3/tests/test_backbone.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_backbone.py
@@ -74,10 +74,11 @@ def test_teacher_forced_vs_golden(gen, golden_root, clip):
     assert H.shape[0] == N and L.shape == tf["c0_logits"].shape, (H.shape, L.shape, tf["c0_logits"].shape)
     h_pcc = [pcc(H[i], tf["hidden_all"][i]) for i in range(N)]
     l_pcc = [pcc(L[i], tf["c0_logits"][i]) for i in range(N)]
-    top1, top5 = agreement(guided_c0_logits_sliced, L, codes[:, 0])
-    # agreement with the CPU model's own guided argmax (the ceiling: goldens were sampled, so top-1 vs codes is < 1 even for CPU)
-    cpu_arg = torch.stack([guided_c0_logits_sliced(tf["c0_logits"][i]).reshape(-1).argmax() for i in range(N)])
-    tt_arg = torch.stack([guided_c0_logits_sliced(L[i]).reshape(-1).argmax() for i in range(N)])
+    # bars: agreement with the CPU fp32 reference's own guided argmax (the goldens were SAMPLED from flat top-50
+    # distributions, so agreement with the sampled codes is low even for fp32 -- reported as informational)
+    cpu_arg = cpu_targets(guided_c0_logits_sliced, tf["c0_logits"])
+    top1, top5 = agreement(guided_c0_logits_sliced, L, cpu_arg)
+    s1, s5 = agreement(guided_c0_logits_sliced, L, codes[:, 0])
     r = {
         "rows": N,
         "prompt_len": int(g["text_ids"].shape[1]),
@@ -88,7 +89,8 @@ def test_teacher_forced_vs_golden(gen, golden_root, clip):
         "logits_pcc_mean": sum(l_pcc) / N,
         "c0_top1": top1,
         "c0_top5": top5,
-        "argmax_agree_with_cpu": float((cpu_arg == tt_arg).float().mean()),
+        "c0_top1_vs_sampled": s1,
+        "c0_top5_vs_sampled": s5,
         "seconds": dt,
         "ms_per_step": 1000 * dt / N,
         "hidden_pcc_first8": [round(x, 4) for x in h_pcc[:8]],

--- a/models/autoports/minimaxai_minimax_music3/tests/test_backbone.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_backbone.py
@@ -1,0 +1,143 @@
+"""Stage 03: the global LLM on one chip vs the CPU fp32 goldens (teacher forcing) + a free-running smoke.
+Env: MUSIC3_SNAPSHOT, MUSIC3_GOLDEN_ROOT, MUSIC3_REPORT, MUSIC3_FLOORS, MUSIC3_MESH_SHAPE=1x1, MUSIC3_LLM_DTYPE (bfp8|bf16),
+MUSIC3_MAX_SEQ_LEN, MUSIC3_LAYERS (debug)."""
+import json
+import os
+import time
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn")
+
+from models.autoports.minimaxai_minimax_music3.reference.sampling import guided_c0_logits_sliced  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tests.tt_common import (  # noqa: E402
+    Report,
+    agreement,
+    golden,
+    pcc,
+    thresholds,
+)
+from models.autoports.minimaxai_minimax_music3.tt.device import open_mesh, parse_shape  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tt.generator import Music3Generator  # noqa: E402
+
+REPORT = Report()
+
+
+@pytest.fixture(scope="module")
+def handle():
+    h = open_mesh(parse_shape(os.environ.get("MUSIC3_MESH_SHAPE", "1x1")))
+    yield h
+    h.close()
+
+
+@pytest.fixture(scope="module")
+def gen(handle, snapshot):
+    t0 = time.time()
+    dt = {"bfp8": ttnn.bfloat8_b, "bf16": ttnn.bfloat16}[os.environ.get("MUSIC3_LLM_DTYPE", "bfp8")]
+    g = Music3Generator(
+        handle.mesh,
+        snapshot,
+        max_seq_len=int(os.environ.get("MUSIC3_MAX_SEQ_LEN", 16384)),
+        llm_dtype=dt,
+        load_dit=False,
+        load_vocoder=False,
+        depth_device="cpu",
+        n_layers=int(os.environ["MUSIC3_LAYERS"]) if os.environ.get("MUSIC3_LAYERS") else None,
+    )
+    REPORT.update(
+        load_s=time.time() - t0,
+        llm_dtype=os.environ.get("MUSIC3_LLM_DTYPE", "bfp8"),
+        mesh="x".join(map(str, handle.shape)),
+        device_name=g.args.device_name,
+        max_seq_len=g.args.max_seq_len,
+        prefill_chunk=getattr(g.args, "max_prefill_chunk_size", None),
+    )
+    return g
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _write_report():
+    yield
+    REPORT.write()
+
+
+@pytest.mark.parametrize("clip", ["readme", "blues"])
+def test_teacher_forced_vs_golden(gen, golden_root, clip):
+    g, tf = golden(golden_root, clip)
+    codes = g["codes_all"]
+    t0 = time.time()
+    res = gen.semantic_generation(g["text_ids"], 0, None, forced_codes=codes, record=True, skip_depth=True)
+    dt = time.time() - t0
+    N = codes.shape[0]
+    H, L = res["hidden_all"], res["c0_logits"]  # [N, 2, D], [N, 2, 16385]
+    assert H.shape[0] == N and L.shape == tf["c0_logits"].shape, (H.shape, L.shape, tf["c0_logits"].shape)
+    h_pcc = [pcc(H[i], tf["hidden_all"][i]) for i in range(N)]
+    l_pcc = [pcc(L[i], tf["c0_logits"][i]) for i in range(N)]
+    top1, top5 = agreement(guided_c0_logits_sliced, L, codes[:, 0])
+    # agreement with the CPU model's own guided argmax (the ceiling: goldens were sampled, so top-1 vs codes is < 1 even for CPU)
+    cpu_arg = torch.stack([guided_c0_logits_sliced(tf["c0_logits"][i]).reshape(-1).argmax() for i in range(N)])
+    tt_arg = torch.stack([guided_c0_logits_sliced(L[i]).reshape(-1).argmax() for i in range(N)])
+    r = {
+        "rows": N,
+        "prompt_len": int(g["text_ids"].shape[1]),
+        "hidden_pcc_min": min(h_pcc),
+        "hidden_pcc_mean": sum(h_pcc) / N,
+        "hidden_pcc_prefill": h_pcc[0],
+        "logits_pcc_min": min(l_pcc),
+        "logits_pcc_mean": sum(l_pcc) / N,
+        "c0_top1": top1,
+        "c0_top5": top5,
+        "argmax_agree_with_cpu": float((cpu_arg == tt_arg).float().mean()),
+        "seconds": dt,
+        "ms_per_step": 1000 * dt / N,
+        "hidden_pcc_first8": [round(x, 4) for x in h_pcc[:8]],
+        "logits_pcc_first8": [round(x, 4) for x in l_pcc[:8]],
+    }
+    REPORT[clip] = r
+    print(json.dumps(r, indent=1))
+    th = thresholds()
+    assert r["hidden_pcc_min"] >= 0.99, f"hidden PCC {r['hidden_pcc_min']}"
+    assert r["logits_pcc_min"] >= 0.99, f"logits PCC {r['logits_pcc_min']}"
+    assert top5 >= th["c0_top5"], f"c0 top-5 {top5} < {th['c0_top5']}"
+    print(f"c0 top-1 {top1:.4f} (bar {th['c0_top1']}) - advisory until the dtype sweep")
+
+
+def test_long_prompt_prefill(gen):
+    """Advisory: a prompt near the 5 000-token contract must prefill (chunk size / L1)."""
+    from models.autoports.minimaxai_minimax_music3.reference.prompt import build_text_ids
+
+    lyrics = "\n".join(
+        ["[verse]"] + ["Morning light filtering through the pine, every quiet street is yours and mine"] * 260
+    )
+    ids = build_text_ids(gen.tok, "Genre: acoustic pop. BPM: 96.", lyrics)
+    n = int(ids.shape[1])
+    try:
+        t0 = time.time()
+        logits, hidden = gen._prefill(ids)
+        ok = bool(torch.isfinite(hidden).all() and torch.isfinite(logits).all())
+        REPORT["long_prompt"] = {"tokens": n, "ok": ok, "seconds": time.time() - t0}
+    except Exception as e:  # noqa
+        REPORT["long_prompt"] = {"tokens": n, "ok": False, "error": str(e)[:300]}
+        pytest.xfail(f"long prompt ({n} tokens) prefill failed: {str(e)[:200]}")
+    assert REPORT["long_prompt"]["ok"]
+
+
+def test_free_running_smoke(gen):
+    from models.autoports.minimaxai_minimax_music3.tests.test_prompt import CASES  # noqa: F401
+
+    out = gen.generate(
+        "Genre: acoustic pop. BPM: 96. Warm female vocal, fingerpicked guitar.",
+        "[verse]\nMorning light filtering through the pine\n[chorus]\nSoftly the world begins to breathe",
+        max_frames=12,
+        seed=3,
+        stages=("semantic",),
+    )
+    st = out["stats"]
+    REPORT["free_running_smoke"] = st.as_dict() | {"codes_rows": int(out["codes_all"].shape[0])}
+    print(REPORT["free_running_smoke"])
+    assert (
+        out["codes_all"].shape[0] >= 2
+        and (out["codes_all"][:, 0] < 16384).all()
+        and (out["codes_all"][:, 1:] < 1024).all()
+    )

--- a/models/autoports/minimaxai_minimax_music3/tests/test_backbone.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_backbone.py
@@ -14,6 +14,7 @@ from models.autoports.minimaxai_minimax_music3.reference.sampling import guided_
 from models.autoports.minimaxai_minimax_music3.tests.tt_common import (  # noqa: E402
     Report,
     agreement,
+    cpu_targets,
     golden,
     pcc,
     thresholds,

--- a/models/autoports/minimaxai_minimax_music3/tests/test_config.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_config.py
@@ -1,0 +1,23 @@
+from models.autoports.minimaxai_minimax_music3 import config as C
+
+
+def test_config_from_snapshot(snapshot):
+    cfg = C.Music3Config.from_snapshot(snapshot)
+    assert cfg.llm.hidden_size == 4096 and cfg.llm.num_hidden_layers == 36 and cfg.llm.vocab_size == 200000
+    assert (
+        cfg.depth.num_layers == 4
+        and cfg.depth.head_dim == 256
+        and cfg.dit.inner_dim == 2048
+        and cfg.dit.concat_channels == 2304
+    )
+    assert cfg.vocoder.upsampling_ratios == (8, 8, 4, 2)
+
+
+def test_latent_length_and_chunks():
+    assert C.latent_length_for_frames(200) == 689 and C.latent_length_for_frames(100) == 344
+    assert (
+        C.chunk_starts(200) == [0]
+        and C.chunk_starts(300) == [0, 100]
+        and C.chunk_starts(1500) == list(range(0, 1400, 100))
+    )
+    assert C.SLICED_VOCAB == 16385 and C.SLICED_VOCAB_PADDED % 32 == 0

--- a/models/autoports/minimaxai_minimax_music3/tests/test_depth_decoder.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_depth_decoder.py
@@ -1,0 +1,103 @@
+"""Stage 04: the TTNN depth decoder vs the torch reference (unit goldens + teacher forcing over the readme golden)."""
+import json
+import os
+import time
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn")
+
+from models.autoports.minimaxai_minimax_music3.config import Music3Config  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.reference.sampling import guided_depth_logits  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tests.tt_common import Report, golden, pcc, thresholds  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tt import weights as W  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tt.depth_decoder import TTDepthDecoder  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tt.device import open_mesh, parse_shape  # noqa: E402
+
+REPORT = Report()
+
+
+@pytest.fixture(scope="module")
+def handle():
+    h = open_mesh(parse_shape(os.environ.get("MUSIC3_MESH_SHAPE", "1x1")))
+    yield h
+    h.close()
+
+
+@pytest.fixture(scope="module")
+def depth(handle, snapshot):
+    dt = {"bfp8": ttnn.bfloat8_b, "bf16": ttnn.bfloat16}[os.environ.get("MUSIC3_DEPTH_DTYPE", "bf16")]
+    cfg = Music3Config.from_snapshot(snapshot)
+    full = W.load_lm_tables(snapshot)["model.embed_tokens.weight"]
+    t0 = time.time()
+    d = TTDepthDecoder(
+        handle.mesh,
+        W.load_depth_state(snapshot),
+        cfg.depth,
+        weights_dtype=dt,
+        full_embed=full,
+        use_trace=os.environ.get("MUSIC3_TRACE", "1") == "1",
+    )
+    d.warmup()
+    REPORT.update(load_s=time.time() - t0, depth_dtype=os.environ.get("MUSIC3_DEPTH_DTYPE", "bf16"))
+    yield d
+    d.release()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _write_report():
+    yield
+    REPORT.write()
+
+
+def test_unit_goldens(depth, golden_root):
+    u = torch.load(golden_root / "unit" / "unit_goldens.pt")
+    rows = {}
+    for steps in range(2, 9):
+        g = u[f"depth_steps{steps}"]
+        assert "raw" in g, "unit goldens predate the raw-row format; re-run stage 01 unit-goldens"
+        h, lg = depth.forward_rows(g["raw"])
+        rows[steps] = {"hidden_pcc": pcc(h, g["hidden"]), "logits_pcc": pcc(lg, g["logits"])}
+    REPORT["unit"] = rows
+    print(json.dumps(rows, indent=1))
+    assert min(r["hidden_pcc"] for r in rows.values()) >= 0.995 and min(r["logits_pcc"] for r in rows.values()) >= 0.995
+
+
+def test_teacher_forced_vs_golden(depth, golden_root):
+    g, tf = golden(golden_root, "readme")
+    codes = g["codes_all"]
+    N = min(codes.shape[0], int(os.environ.get("MUSIC3_DEPTH_TF_ROWS", 200)))
+    lp, hp, t1, t5, nd = [], [], 0, 0, 0
+    t0 = time.time()
+    for i in range(N):
+        rec = {}
+        out_codes, dh = depth.frame(
+            tf["hidden_all"][i], int(codes[i, 0]), None, forced=codes[i, 1:].tolist(), record=rec
+        )
+        assert torch.equal(out_codes, codes[i])
+        L = torch.stack(rec["depth_logits"])  # [7, 2, 1024]
+        lp.append(pcc(L, tf["depth_logits"][i]))
+        hp.append(pcc(dh, tf["depth_hidden"][i]))
+        for j in range(7):
+            top = torch.topk(guided_depth_logits(L[j]).reshape(-1), 5).indices.tolist()
+            t1 += int(top[0] == int(codes[i, j + 1]))
+            t5 += int(int(codes[i, j + 1]) in top)
+            nd += 1
+    dt = time.time() - t0
+    r = {
+        "frames": N,
+        "logits_pcc_min": min(lp),
+        "logits_pcc_mean": sum(lp) / N,
+        "hidden_pcc_min": min(hp),
+        "hidden_pcc_mean": sum(hp) / N,
+        "depth_top1": t1 / nd,
+        "depth_top5": t5 / nd,
+        "ms_per_frame": 1000 * dt / N,
+    }
+    REPORT["teacher_forced"] = r
+    print(json.dumps(r, indent=1))
+    th = thresholds()
+    assert r["logits_pcc_min"] >= 0.99 and r["hidden_pcc_min"] >= 0.99
+    assert r["depth_top5"] >= th["depth_top5"], f"depth top-5 {r['depth_top5']} < {th['depth_top5']}"
+    print(f"depth top-1 {r['depth_top1']:.4f} (bar {th['depth_top1']}) - advisory until the dtype sweep")

--- a/models/autoports/minimaxai_minimax_music3/tests/test_depth_decoder.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_depth_decoder.py
@@ -80,9 +80,11 @@ def test_teacher_forced_vs_golden(depth, golden_root):
         lp.append(pcc(L, tf["depth_logits"][i]))
         hp.append(pcc(dh, tf["depth_hidden"][i]))
         for j in range(7):
-            top = torch.topk(guided_depth_logits(L[j]).reshape(-1), 5).indices.tolist()
-            t1 += int(top[0] == int(codes[i, j + 1]))
-            t5 += int(int(codes[i, j + 1]) in top)
+            gd = guided_depth_logits(L[j]).reshape(-1)
+            top = torch.topk(gd, 5).indices.tolist()
+            cpu_t = int(guided_depth_logits(tf["depth_logits"][i, j]).reshape(-1).argmax())
+            t1 += int(top[0] == cpu_t)
+            t5 += int(cpu_t in top)
             nd += 1
     dt = time.time() - t0
     r = {

--- a/models/autoports/minimaxai_minimax_music3/tests/test_depth_decoder.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_depth_decoder.py
@@ -61,7 +61,7 @@ def test_unit_goldens(depth, golden_root):
         rows[steps] = {"hidden_pcc": pcc(h, g["hidden"]), "logits_pcc": pcc(lg, g["logits"])}
     REPORT["unit"] = rows
     print(json.dumps(rows, indent=1))
-    assert min(r["hidden_pcc"] for r in rows.values()) >= 0.995 and min(r["logits_pcc"] for r in rows.values()) >= 0.995
+    assert min(r["hidden_pcc"] for r in rows.values()) >= 0.99 and min(r["logits_pcc"] for r in rows.values()) >= 0.99
 
 
 def test_teacher_forced_vs_golden(depth, golden_root):

--- a/models/autoports/minimaxai_minimax_music3/tests/test_dit.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_dit.py
@@ -1,0 +1,124 @@
+"""Stage 05: the TTNN DiT vs the torch reference: single forwards (unit goldens) and a full 30-step window denoise
+with the vocoder, against artifacts/golden/readme/tf/dit_reference.pt."""
+import json
+import os
+import time
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn")
+
+from models.autoports.minimaxai_minimax_music3.config import Music3Config  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.reference.pipeline import Music3Reference  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tests.tt_common import Report, pcc  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tt import weights as W  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tt.device import open_mesh, parse_shape  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tt.dit import TTDiT  # noqa: E402
+
+REPORT = Report()
+DT = {"bfp8": ttnn.bfloat8_b, "bf16": ttnn.bfloat16}[os.environ.get("MUSIC3_DIT_DTYPE", "bf16")]
+
+
+@pytest.fixture(scope="module")
+def handle():
+    h = open_mesh(parse_shape(os.environ.get("MUSIC3_MESH_SHAPE", "1x1")))
+    yield h
+    h.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _write_report():
+    yield
+    REPORT.write()
+
+
+def test_two_layer_block_stack(handle, snapshot, golden_root):
+    """Fast first check: 2 layers, real weights, production window length."""
+    u = torch.load(golden_root / "unit" / "unit_goldens.pt")["dit2_L689_t0.5"]
+    cfg = Music3Config.from_snapshot(snapshot)
+    dit = TTDiT(handle.mesh, W.load_dit_state(snapshot, num_layers=2), cfg.dit, weights_dtype=DT, num_layers=2)
+    y = dit.forward(u["x"], torch.full((2,), u["t"]), u["cond"])
+    r = pcc(y, u["y"])
+    REPORT["dit2_L689"] = {"pcc": r}
+    print("2-layer PCC", r)
+    dit.release()
+    assert r >= 0.99, r
+
+
+@pytest.fixture(scope="module")
+def dit(handle, snapshot):
+    cfg = Music3Config.from_snapshot(snapshot)
+    t0 = time.time()
+    d = TTDiT(
+        handle.mesh,
+        W.load_dit_state(snapshot),
+        cfg.dit,
+        weights_dtype=DT,
+        use_trace=os.environ.get("MUSIC3_TRACE", "1") == "1",
+    )
+    REPORT.update(load_s=time.time() - t0, dit_dtype=os.environ.get("MUSIC3_DIT_DTYPE", "bf16"))
+    yield d
+    d.release()
+
+
+def test_unit_goldens(dit, golden_root):
+    u = torch.load(golden_root / "unit" / "unit_goldens.pt")
+    rows = {}
+    for k, g in u.items():
+        if not k.startswith("dit_L"):
+            continue
+        t0 = time.time()
+        y = dit.forward(g["x"], torch.full((2,), g["t"]), g["cond"])
+        rows[k] = {
+            "pcc": pcc(y, g["y"]),
+            "pcc_cond_row": pcc(y[0], g["y"][0]),
+            "pcc_uncond_row": pcc(y[1], g["y"][1]),
+            "seconds": time.time() - t0,
+        }
+    # warmed timing of the production shape
+    g = u["dit_L689_t0.5000"]
+    t0 = time.time()
+    for _ in range(5):
+        dit.forward(g["x"], torch.full((2,), g["t"]), g["cond"])
+    rows["warm_ms_per_forward_L689"] = 1000 * (time.time() - t0) / 5
+    REPORT["unit"] = rows
+    print(json.dumps(rows, indent=1))
+    assert min(r["pcc"] for k, r in rows.items() if isinstance(r, dict)) >= 0.99
+
+
+def test_window_denoise_and_vocoder(dit, snapshot, golden_root):
+    g = torch.load(golden_root / "readme" / "golden.pt")
+    ref_out = torch.load(golden_root / "readme" / "tf" / "dit_reference.pt")
+    ref = Music3Reference(snapshot, load_llm=False, load_dit=False, load_vocoder=True)
+    gen = torch.Generator("cpu").manual_seed(int(ref_out["seed"]))
+    t0 = time.time()
+    den = ref.denoise(g["frame_hiddens"], gen, record_steps=(0, 15, 29), dit_forward=dit.forward)
+    dt = time.time() - t0
+    rows = {"chunks": len(den["latent_chunks"]), "denoise_seconds": dt}
+    for k, (a, b) in enumerate(zip(den["chunk_records"], ref_out["chunk_records"])):
+        assert torch.equal(a["noise"], b["noise"]) and torch.allclose(a["condition"], b["condition"], atol=1e-5)
+        s0a, s0b = a["steps"][0], b["steps"][0]
+        rows[f"chunk{k}_step0_pred_cond_pcc"] = pcc(s0a["pred_cond"], s0b["pred_cond"])
+        rows[f"chunk{k}_step0_pred_uncond_pcc"] = pcc(s0a["pred_uncond"], s0b["pred_uncond"])
+        for sa, sb in zip(a["steps"][1:], b["steps"][1:]):
+            rows[f"chunk{k}_step{sa['i']}_pred_cond_pcc_trajectory"] = pcc(sa["pred_cond"], sb["pred_cond"])
+        rows[f"chunk{k}_latents_pcc"] = pcc(a["latents_out"], b["latents_out"])
+    wav = ref.decode(den["latent_chunks"])
+    rows["audio_pcc"] = pcc(wav, ref_out["audio"])
+    x, y = wav.mean(1).squeeze(0), ref_out["audio"].mean(1).squeeze(0)
+    sx = torch.stft(x, 2048, 512, window=torch.hann_window(2048), return_complex=True).abs()
+    sy = torch.stft(y, 2048, 512, window=torch.hann_window(2048), return_complex=True).abs()
+    rows["log_spectral_distance_db"] = float((20 * torch.log10((sx + 1e-5) / (sy + 1e-5))).pow(2).mean().sqrt())
+    rows["spectral_convergence"] = float((sx - sy).norm() / sy.norm())
+    REPORT["window"] = rows
+    print(json.dumps(rows, indent=1))
+    import soundfile as sf
+
+    out = os.environ.get("MUSIC3_E2E_OUT")
+    if out:
+        os.makedirs(out, exist_ok=True)
+        sf.write(os.path.join(out, "dit_tt_readme.wav"), wav.squeeze(0).T.numpy(), 44100, subtype="PCM_16")
+    assert rows["chunk0_step0_pred_cond_pcc"] >= 0.99, rows["chunk0_step0_pred_cond_pcc"]
+    assert rows["chunk0_latents_pcc"] >= 0.95, rows["chunk0_latents_pcc"]
+    assert rows["spectral_convergence"] < 0.5, rows["spectral_convergence"]

--- a/models/autoports/minimaxai_minimax_music3/tests/test_dit.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_dit.py
@@ -122,3 +122,26 @@ def test_window_denoise_and_vocoder(dit, snapshot, golden_root):
     assert rows["chunk0_step0_pred_cond_pcc"] >= 0.99, rows["chunk0_step0_pred_cond_pcc"]
     assert rows["chunk0_latents_pcc"] >= 0.95, rows["chunk0_latents_pcc"]
     assert rows["spectral_convergence"] < 0.5, rows["spectral_convergence"]
+
+
+def test_two_window_denoise_blues(dit, snapshot, golden_root):
+    """Two windows (689 + 345 latents) with the overlap carry, against the CPU reference on the blues golden."""
+    ref_p = golden_root / "blues" / "tf" / "dit_reference.pt"
+    if not ref_p.exists():
+        pytest.skip("blues DiT reference not computed")
+    g = torch.load(golden_root / "blues" / "golden.pt")
+    ref_out = torch.load(ref_p)
+    ref = Music3Reference(snapshot, load_llm=False, load_dit=False, load_vocoder=True)
+    gen = torch.Generator("cpu").manual_seed(int(ref_out["seed"]))
+    den = ref.denoise(g["frame_hiddens"], gen, record_steps=(0,), dit_forward=dit.forward)
+    rows = {"chunks": len(den["latent_chunks"])}
+    for k, (a, b) in enumerate(zip(den["chunk_records"], ref_out["chunk_records"])):
+        rows[f"chunk{k}_step0_pred_cond_pcc"] = pcc(a["steps"][0]["pred_cond"], b["steps"][0]["pred_cond"])
+        rows[f"chunk{k}_latents_pcc"] = pcc(a["latents_out"], b["latents_out"])
+    wav = ref.decode(den["latent_chunks"])
+    rows["audio_pcc"] = pcc(wav, ref_out["audio"])
+    rows["audio_rms"] = float(wav.pow(2).mean().sqrt())
+    rows["ref_audio_rms"] = float(ref_out["audio"].pow(2).mean().sqrt())
+    REPORT["window_blues"] = rows
+    print(json.dumps(rows, indent=1))
+    assert rows["chunks"] == 2 and rows["chunk1_latents_pcc"] >= 0.95, rows

--- a/models/autoports/minimaxai_minimax_music3/tests/test_e2e.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_e2e.py
@@ -1,0 +1,122 @@
+"""Stage 06: end-to-end generation on the chip (LLM + depth + DiT on TT; cond encoder + vocoder on CPU)."""
+import json
+import os
+import time
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn")
+
+from models.autoports.minimaxai_minimax_music3.tests.tt_common import Report  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tt.device import open_mesh, parse_shape  # noqa: E402
+from models.autoports.minimaxai_minimax_music3.tt.generator import Music3Generator  # noqa: E402
+
+REPORT = Report()
+CLIPS = {"readme": 8.0, "blues": 12.0}
+
+
+def _clip(name):
+    import importlib.util
+
+    p = os.environ.get("MUSIC3_CLIPS_PY", os.path.expanduser("~/music3-bringup/scripts/py/clips.py"))
+    spec = importlib.util.spec_from_file_location("clips", p)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m.clip(name)
+
+
+def audio_metrics(wav, sr):
+    x = wav.float().squeeze(0)
+    mono = x.mean(0)
+    win = int(sr * 0.05)
+    n = mono.numel() // win
+    frms = mono[: n * win].reshape(n, win).pow(2).mean(1).sqrt()
+    spec = torch.stft(mono, 2048, 512, window=torch.hann_window(2048), return_complex=True).abs().mean(1)
+    freqs = torch.linspace(0, sr / 2, spec.numel())
+    return {
+        "rms": float(x.pow(2).mean().sqrt()),
+        "peak": float(x.abs().max()),
+        "clip_frac": float((x.abs() > 0.999).float().mean()),
+        "silence_frac": float((frms < 1e-3).float().mean()),
+        "spectral_centroid_hz": float((spec * freqs).sum() / spec.sum().clamp_min(1e-9)),
+        "nan": bool(torch.isnan(x).any()),
+        "seconds": x.shape[-1] / sr,
+    }
+
+
+@pytest.fixture(scope="module")
+def handle():
+    h = open_mesh(parse_shape(os.environ.get("MUSIC3_MESH_SHAPE", "1x1")))
+    yield h
+    h.close()
+
+
+@pytest.fixture(scope="module")
+def gen(handle, snapshot):
+    dts = {"bfp8": ttnn.bfloat8_b, "bf16": ttnn.bfloat16}
+    t0 = time.time()
+    g = Music3Generator(
+        handle.mesh,
+        snapshot,
+        max_seq_len=int(os.environ.get("MUSIC3_MAX_SEQ_LEN", 16384)),
+        llm_dtype=dts[os.environ.get("MUSIC3_LLM_DTYPE", "bfp8")],
+        depth_dtype=dts[os.environ.get("MUSIC3_DEPTH_DTYPE", "bf16")],
+        dit_dtype=dts[os.environ.get("MUSIC3_DIT_DTYPE", "bf16")],
+    )
+    REPORT.update(load_s=time.time() - t0, impl=g.impl)
+    yield g
+    g.release()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _write_report():
+    yield
+    REPORT.write()
+
+
+@pytest.mark.parametrize("clip", ["readme", "blues"])
+def test_generate(gen, golden_root, clip):
+    import soundfile as sf
+
+    c = _clip(clip)
+    out = gen.generate(c["caption"], c["lyrics"], audio_duration=c["duration_s"], seed=c["seed"])
+    st = out["stats"]
+    m = audio_metrics(out["audio"], out["sample_rate"])
+    gm = json.load(open(golden_root / clip / "metrics.json"))
+    codes = out["codes_all"][1:, 0]
+    runs, best, cur = 1, 1, 1
+    for a, b in zip(codes[:-1].tolist(), codes[1:].tolist()):
+        cur = cur + 1 if a == b else 1
+        best = max(best, cur)
+    r = {
+        **st.as_dict(),
+        "audio": m,
+        "golden_audio": {k: gm[k] for k in ("rms", "silence_frac", "spectral_centroid_hz")},
+        "c0_unique_ratio": float(codes.unique().numel() / max(codes.numel(), 1)),
+        "c0_max_run": best,
+        "codes_rows": int(out["codes_all"].shape[0]),
+    }
+    REPORT[clip] = r
+    print(json.dumps(r, indent=1, default=str))
+    o = os.environ.get("MUSIC3_E2E_OUT")
+    if o:
+        os.makedirs(o, exist_ok=True)
+        sf.write(
+            os.path.join(o, f"{clip}_tt.wav"), out["audio"].squeeze(0).T.numpy(), out["sample_rate"], subtype="PCM_16"
+        )
+        torch.save({"codes_all": out["codes_all"], "stats": st.as_dict()}, os.path.join(o, f"{clip}_tt.pt"))
+    assert st.frames >= 40 and not m["nan"]
+    assert m["rms"] > 0.25 * gm["rms"] and m["silence_frac"] < 0.4 and m["clip_frac"] < 0.01, m
+    assert 0.4 * gm["spectral_centroid_hz"] < m["spectral_centroid_hz"] < 2.5 * gm["spectral_centroid_hz"], m
+    assert r["c0_unique_ratio"] > 0.3 and r["c0_max_run"] < 25, r
+
+
+def test_seed_determinism(gen):
+    c = _clip("smoke")
+    a = gen.generate(c["caption"], c["lyrics"], audio_duration=c["duration_s"], seed=11, stages=("semantic",))
+    b = gen.generate(c["caption"], c["lyrics"], audio_duration=c["duration_s"], seed=11, stages=("semantic",))
+    same = torch.equal(a["codes_all"], b["codes_all"])
+    REPORT["seed_determinism"] = {"identical_codes": same, "rows": int(a["codes_all"].shape[0])}
+    print(REPORT["seed_determinism"])
+    assert same

--- a/models/autoports/minimaxai_minimax_music3/tests/test_prompt.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_prompt.py
@@ -1,0 +1,39 @@
+"""Prompt contract parity against the diffusers encoders module (reference venv) and transformers' tokenizer."""
+import torch
+
+from models.autoports.minimaxai_minimax_music3.reference import prompt as P
+
+CASES = [
+    ("Genre: acoustic pop. BPM: 96.", "[verse]\nMorning light\n[chorus]\nSoftly"),
+    (
+        "## Global Metadata\n- **bpm** is 92, <|key E minor|>\n\n\n• Warm and *intimate*\n----\n",
+        "[Verse] Walking down the street\n[Chorus]\nla la ^ la [Bridge] x",
+    ),
+    ("plain", "no tags at all\nline two"),
+]
+
+
+def test_clean_and_normalize_match_diffusers(diffusers_mm3):
+    for cap, lyr in CASES:
+        assert P.clean_caption(cap) == diffusers_mm3._clean_caption(cap)
+        assert P.normalize_lyrics(lyr) == diffusers_mm3._normalize_lyrics(lyr)
+
+
+def test_text_ids_match_transformers(snapshot):
+    from transformers import Qwen2Tokenizer
+
+    hf = Qwen2Tokenizer.from_pretrained(str(snapshot / "tokenizer"))
+    tok = P.Music3Tokenizer(snapshot)
+    for cap, lyr in CASES:
+        text = P.prompt_text(cap, lyr)
+        ours = tok.encode(text)
+        ref = hf(text, return_tensors="pt")["input_ids"][0].tolist()
+        assert ours == ref, (text, ours[:10], ref[:10])
+        ids = P.build_text_ids(tok, cap, lyr)
+        assert (
+            ids.shape[0] == 2
+            and (ids[1, 1:-2] == 151654).all()
+            and ids[1, 0] == ids[0, 0]
+            and torch.equal(ids[1, -2:], ids[0, -2:])
+        )
+        assert ids[0, -1] == 151669  # <|audio_start|>

--- a/models/autoports/minimaxai_minimax_music3/tests/test_reference_modules.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_reference_modules.py
@@ -1,0 +1,71 @@
+"""Vendored torch modules == the diffusers model classes on the real weights (reference venv; CPU fp32)."""
+import pytest
+import torch
+
+pytest.importorskip("diffusers")
+
+
+@pytest.mark.parametrize("num_layers", [2])
+def test_dit_matches_diffusers(snapshot, num_layers):
+    from diffusers import MiniMaxMusic3Transformer1DModel
+
+    from models.autoports.minimaxai_minimax_music3.reference.dit import Music3DiT
+
+    ours = Music3DiT.load(snapshot, num_layers=num_layers)
+    ref = MiniMaxMusic3Transformer1DModel.from_pretrained(
+        str(snapshot), subfolder="transformer", torch_dtype=torch.float32
+    )
+    ref.transformer_blocks = ref.transformer_blocks[:num_layers]
+    ref.eval()
+    g = torch.Generator().manual_seed(0)
+    x = torch.randn(2, 128, 128, generator=g)
+    cond = torch.randn(2, 128, 2048, generator=g)
+    t = torch.tensor([0.5, 0.0])
+    with torch.no_grad():
+        a = ours(x, t, cond)
+        b = ref(hidden_states=x, timestep=t, encoder_hidden_states=cond, return_dict=False)[0]
+    assert torch.allclose(a, b, atol=1e-4, rtol=1e-4), (a - b).abs().max()
+
+
+def test_depth_decoder_matches_diffusers(snapshot):
+    from diffusers import MiniMaxMusic3RVQDepthDecoder
+
+    from models.autoports.minimaxai_minimax_music3.reference.depth_decoder import Music3DepthDecoder
+
+    ours = Music3DepthDecoder.load(snapshot)
+    ref = MiniMaxMusic3RVQDepthDecoder.from_pretrained(
+        str(snapshot), subfolder="rvq_depth_decoder", torch_dtype=torch.float32
+    ).eval()
+    e = torch.randn(2, 5, 4096) * 0.02
+    with torch.no_grad():
+        a, b = ours(e), ref(e)
+        assert torch.allclose(a, b, atol=1e-4, rtol=1e-4)
+        for i in range(7):
+            assert torch.allclose(ours.audio_heads[i](a[:, -1]), ref.audio_heads[i](b[:, -1]), atol=1e-4, rtol=1e-4)
+        assert torch.equal(ours.audio_embeddings.weight, ref.audio_embeddings.weight)
+
+
+def test_condition_encoder_and_vocoder_match_diffusers(snapshot):
+    from diffusers import MiniMaxMusic3ConditionEncoder, MiniMaxMusic3Vocoder
+
+    from models.autoports.minimaxai_minimax_music3.reference.condition_encoder import Music3ConditionEncoder
+    from models.autoports.minimaxai_minimax_music3.reference.vocoder import Music3Vocoder
+
+    ce, ce_ref = (
+        Music3ConditionEncoder.load(snapshot),
+        MiniMaxMusic3ConditionEncoder.from_pretrained(
+            str(snapshot), subfolder="condition_encoder", torch_dtype=torch.float32
+        ).eval(),
+    )
+    fh = torch.randn(1, 37, 8 * 4096)
+    with torch.no_grad():
+        a, b = ce(fh), ce_ref(fh)
+    assert a.shape == b.shape == (1, 127, 2048) and torch.allclose(a, b, atol=1e-5, rtol=1e-5)
+    vc, vc_ref = (
+        Music3Vocoder.load(snapshot),
+        MiniMaxMusic3Vocoder.from_pretrained(str(snapshot), subfolder="vocoder", torch_dtype=torch.float32).eval(),
+    )
+    lat = torch.randn(1, 128, 40)
+    with torch.no_grad():
+        a, b = vc(lat), vc_ref(lat)
+    assert a.shape == b.shape == (1, 2, 40 * 512) and torch.allclose(a, b, atol=1e-5, rtol=1e-5)

--- a/models/autoports/minimaxai_minimax_music3/tests/test_sampling.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/test_sampling.py
@@ -1,0 +1,24 @@
+import torch
+
+from models.autoports.minimaxai_minimax_music3.reference import sampling as S
+
+
+def test_sample_top_k_matches_diffusers(diffusers_mm3):
+    for width in (1024, 200000):
+        logits = torch.randn(1, width) * 3
+        g1, g2 = torch.Generator().manual_seed(3), torch.Generator().manual_seed(3)
+        for _ in range(5):
+            assert int(S.sample_top_k(logits, g1)) == int(diffusers_mm3._sample_top_k(logits, g2))
+
+
+def test_sliced_guidance_equals_full():
+    V = 200000
+    mask = S.full_vocab_mask(V)
+    for _ in range(20):
+        logits = torch.randn(2, V) * 4
+        gf = S.guided_c0_logits_full(logits, mask).reshape(-1)
+        gs = S.guided_c0_logits_sliced(S.slice_logits(logits)).reshape(-1)
+        fin_f, fin_s = torch.isfinite(gf), torch.isfinite(gs)
+        assert fin_f.sum() == fin_s.sum() == 50
+        assert torch.allclose(gf[fin_f], gs[fin_s])
+        assert S.sliced_to_token(int(gs.argmax())) == int(gf.argmax())

--- a/models/autoports/minimaxai_minimax_music3/tests/tt_common.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/tt_common.py
@@ -46,3 +46,8 @@ def agreement(guided_fn, logits_seq, targets, topk=5):
         t1 += int(top[0] == int(targets[i]))
         t5 += int(int(targets[i]) in top)
     return t1 / n, t5 / n
+
+
+def cpu_targets(guided_fn, cpu_logits_seq):
+    """CPU reference guided argmax per step: [N] (targets for the TT agreement bars)."""
+    return torch.stack([guided_fn(cpu_logits_seq[i]).reshape(-1).argmax() for i in range(cpu_logits_seq.shape[0])])

--- a/models/autoports/minimaxai_minimax_music3/tests/tt_common.py
+++ b/models/autoports/minimaxai_minimax_music3/tests/tt_common.py
@@ -1,0 +1,48 @@
+"""Shared helpers for the device tests (stages 03-06)."""
+import json
+import os
+from pathlib import Path
+
+import torch
+
+
+def pcc(a, b):
+    a, b = a.float().flatten(), b.float().flatten()
+    if a.numel() < 2:
+        return 1.0
+    return float(torch.corrcoef(torch.stack([a, b]))[0, 1])
+
+
+def thresholds():
+    t = {"c0_top1": 0.90, "c0_top5": 0.98, "depth_top1": 0.90, "depth_top5": 0.98}
+    p = os.environ.get("MUSIC3_FLOORS")
+    if p and Path(p).exists():
+        t.update(json.load(open(p)).get("thresholds", {}))
+    return t
+
+
+class Report(dict):
+    def write(self):
+        out = os.environ.get("MUSIC3_REPORT")
+        if out:
+            Path(out).parent.mkdir(parents=True, exist_ok=True)
+            json.dump(self, open(out, "w"), indent=2, default=str)
+
+
+def golden(golden_root, clip):
+    d = Path(golden_root) / clip
+    g = torch.load(d / "golden.pt")
+    tf = torch.load(d / "tf" / "teacher_forced.pt")
+    return g, tf
+
+
+def agreement(guided_fn, logits_seq, targets, topk=5):
+    """logits_seq [N, 2, V], targets [N] -> (top1, top5) of the guided argmax against the golden codes."""
+    n = logits_seq.shape[0]
+    t1 = t5 = 0
+    for i in range(n):
+        g = guided_fn(logits_seq[i]).reshape(-1)
+        top = torch.topk(g, topk).indices.tolist()
+        t1 += int(top[0] == int(targets[i]))
+        t5 += int(int(targets[i]) in top)
+    return t1 / n, t5 / n

--- a/models/autoports/minimaxai_minimax_music3/tt-model.yaml
+++ b/models/autoports/minimaxai_minimax_music3/tt-model.yaml
@@ -17,6 +17,8 @@ source:
   code:                        # allowlist — exactly what ships; verified by the stage-08 import-closure grep
     - models/common
     - models/tt_transformers/tt
+    - models/tt_dit/utils/matmul.py       # minimal_matmul blocking configs (DiT)
+    - models/tt_dit/utils/tensor.py       # fused-SwiGLU weight interleave (DiT)
     - models/autoports/minimaxai_minimax_music3/__init__.py
     - models/autoports/minimaxai_minimax_music3/config.py
     - models/autoports/minimaxai_minimax_music3/reference

--- a/models/autoports/minimaxai_minimax_music3/tt-model.yaml
+++ b/models/autoports/minimaxai_minimax_music3/tt-model.yaml
@@ -1,0 +1,94 @@
+# MiniMax Music 3 (MiniMaxAI/MiniMax-Music3) text-to-music on ONE Tenstorrent Blackhole chip — CONTAINER (v5.1) package.
+# Authored from the bring-up on a QB2 (chip 0 of 2x p300c), tt-metal branch jashan/minimax-music3 (base 8e18a76).
+#   tt-model package --container models/autoports/minimaxai_minimax_music3/tt-model.yaml --out ~/tt-model-builds
+schema: "5.1"
+repo: jashansinghTT/minimax-music3-blackhole
+name: minimax-music3
+weights:
+  repo: MiniMaxAI/MiniMax-Music3
+  revision: fbdf52fbaaca799592917417eb05f1899f1255ec   # main as of 2026-08-14; not gated
+  # only the diffusers-format sub-folders are used (28.5 GB of the 57 GB repo): the unconverted originals are skipped
+  ignore_patterns: ["flowmatching_vae.pth", "dav.pth", "qwen_7B/*", "assets/*", "figures/*", "scripts/*"]
+kind: tt-dit-server            # uvicorn + our own FastAPI app (no vLLM: a music model has no chat/completions API)
+arch: blackhole
+
+source:
+  tt_metal: /home/jashan/tt-metal-music3
+  code:                        # allowlist — exactly what ships; verified by the stage-08 import-closure grep
+    - models/common
+    - models/tt_transformers/tt
+    - models/autoports/minimaxai_minimax_music3/__init__.py
+    - models/autoports/minimaxai_minimax_music3/config.py
+    - models/autoports/minimaxai_minimax_music3/reference
+    - models/autoports/minimaxai_minimax_music3/tt
+    - models/autoports/minimaxai_minimax_music3/server
+  ubuntu: "22.04"
+  python: "3.12"
+
+runtime:
+  app: models.autoports.minimaxai_minimax_music3.server.app:app
+  mesh_shape_env: MUSIC3_MESH_SHAPE      # the launcher writes "1x1" here from mesh_device
+  packages:                              # HTTP + audio stack on top of torch (tt-metal's own pin is inserted by tt-model)
+    - "fastapi>=0.115,<1"
+    - "uvicorn[standard]>=0.30"
+    - "pydantic>=2.9,<3"
+    - "python-multipart>=0.0.9"
+    - "soundfile>=0.12"
+    - "soxr>=0.5"
+    - "numpy>=1.24.4,<2"
+    - "safetensors"
+    - "tokenizers"
+    - "huggingface_hub"
+    - "transformers"                     # tt_transformers.ModelArgs loads the Qwen3 backbone through it
+    - "loguru"
+    - "pyyaml"
+    - "einops"
+    - "pytest"                           # models/common/utility_functions imports it at module level
+
+serve:
+  port: 8000
+  env:
+    MUSIC3_WEIGHTS_REVISION: "fbdf52fbaaca799592917417eb05f1899f1255ec"
+    MUSIC3_MAX_SEQ_LEN: "16384"
+    MUSIC3_MAX_FRAMES: "9000"
+    MUSIC3_WARMUP: "1"
+    MUSIC3_WARMUP_FRAMES: "200"
+    MUSIC3_TRACE_REGION_MB: "256"
+    TT_METAL_OPERATION_TIMEOUT_SECONDS: "180.0"
+  args: ["--timeout-keep-alive", "75"]
+
+serve_profiles:
+  - name: p150
+    description: One Blackhole chip (P150; on a P300 / QuietBox 2 the first chip). The whole model on 32 GB.
+    hardware: p150
+    mesh_device: P150
+    env: {TT_METAL_VISIBLE_DEVICES: "0", MUSIC3_FABRIC_CONFIG: none}
+default_profile: p150
+
+verify:
+  - "import models.autoports.minimaxai_minimax_music3.server.app as a; assert a.app"
+  - "import models.autoports.minimaxai_minimax_music3.tt.generator, models.autoports.minimaxai_minimax_music3.tt.dit, models.autoports.minimaxai_minimax_music3.tt.depth_decoder"
+  - "import models.autoports.minimaxai_minimax_music3.server.schemas as s; s.SpeechRequest(input='[verse]\\nla', instructions='pop')"
+  - "import soundfile as sf; assert 'FLAC' in sf.available_formats()"
+  - "import soxr, numpy; assert numpy.__version__.startswith('1.'), numpy.__version__"
+  - "from transformers import Qwen3ForCausalLM, Qwen2Tokenizer"
+
+card:
+  description: >
+    MiniMax Music 3, a lyrics-and-caption conditioned music generation model (8B Qwen3-based global LLM, 0.6B depth
+    decoder for the residual RVQ codebooks, 2.4B flow-matching DiT and a DAC-style vocoder; 44.1 kHz stereo, served
+    at 32 kHz like the reference server) running on a single Tenstorrent Blackhole chip. SGLang-Omni compatible
+    /v1/audio/speech API plus an async jobs API for multi-minute songs. Model weights under the MiniMax-Music3
+    Community License (products must display "MiniMax-Music3").
+  quickstart: |
+    ### Try it
+    ```bash
+    curl -s localhost:20000/v1/health
+    curl -s localhost:20000/v1/audio/speech -H 'Content-Type: application/json' -d '{
+      "model": "MiniMaxAI/MiniMax-Music3",
+      "input": "[Verse]\nMorning light filtering through the pine\n[Chorus]\nSoftly the world begins to breathe",
+      "instructions": "A warm acoustic pop song with intimate female vocals, fingerpicked guitar and soft piano.",
+      "response_format": "wav", "seed": 7, "max_new_tokens": 750}' -o song.wav
+    ```
+    `max_new_tokens` counts audio frames (25 per second). Long songs: `POST /v1/music/jobs` then poll `GET /v1/music/jobs/{id}`
+    and fetch `GET /v1/music/jobs/{id}/audio`.

--- a/models/autoports/minimaxai_minimax_music3/tt/backbone.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/backbone.py
@@ -1,0 +1,181 @@
+"""Music3Backbone: tt_transformers' Transformer (the HF Qwen3-8B path) with MiniMax Music 3's frame embedding as the
+residual, TWO users (conditional / unconditional rows for classifier-free guidance) and a post-final-norm hidden tap.
+
+Integration points with tt_transformers (models/tt_transformers/tt/model.py, generator.py), as in the S2 Pro autoport:
+  * prefill: `prepare_inputs_prefill` normally embeds tokens via `self.embd`; we swap `self.embd` for a stub returning a
+    host-computed residual (the FULL 200k embedding table lives on the host; the device table is the sliced one).
+  * decode: `prepare_decode_inputs_host` returns a 5th host tensor (the residual for both rows); the Generator copies
+    every input each step (host sampling => reload_inputs), `bind_decode_trace_inputs` binds it at trace capture,
+    `_transform_decode_inputs_device` returns it as the layer-0 input.
+  * hidden tap: `forward` applies `self.norm` then `self.lm_head`; wrapping lm_head records its input per mode/user.
+The device LM head is the SLICED head (16 385 rows: semantic codes + <|audio_end|>), see tt/weights.py.
+"""
+from __future__ import annotations
+
+import contextlib
+from typing import Dict, Optional
+
+import torch
+
+import ttnn
+from models.autoports.minimaxai_minimax_music3.config import SLICED_VOCAB
+from models.tt_transformers.tt.common import Mode, copy_host_to_device
+from models.tt_transformers.tt.model import Transformer
+
+
+class _LMHeadTap:
+    def __init__(self, inner, owner):
+        object.__setattr__(self, "_inner", inner)
+        object.__setattr__(self, "_owner", owner)
+
+    def __call__(self, x, *a, **k):
+        # LMHead may deallocate its input: hand it a clone, stash the original (device op only => trace-capture safe).
+        # Stashes are per mode (and per user for prefill): a decode-trace replay runs no Python, so the decode stash keeps
+        # pointing at the traced tensor.
+        o = self._owner
+        if o._mode == "prefill":
+            o._hidden_prefill[o._cur_user] = x
+        else:
+            o._hidden_decode = x
+        return self._inner(ttnn.clone(x), *a, **k)
+
+    def forward(self, x, *a, **k):
+        return self(x, *a, **k)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+class Music3Backbone(Transformer):
+    def __init__(self, args, dtype, mesh_device, state_dict, weight_cache_path, *, full_embed: torch.Tensor, **kwargs):
+        super().__init__(args, dtype, mesh_device, state_dict, weight_cache_path, **kwargs)
+        assert args.vocab_size >= SLICED_VOCAB, args.vocab_size
+        self.full_embed = full_embed.to(torch.bfloat16)  # [200000, D] host table for the text prompt
+        self._hidden_prefill: Dict[int, ttnn.Tensor] = {}
+        self._hidden_decode: Optional[ttnn.Tensor] = None
+        self._mode = "prefill"
+        self._cur_user = 0
+        self._pending_residual: Optional[torch.Tensor] = None
+        self._decode_extra_device = None
+        self.lm_head = _LMHeadTap(self.lm_head, self)
+
+    # ------------------------------------------------------------------ prefill (text prompt, one user at a time)
+    @contextlib.contextmanager
+    def _embd_override(self, x_tt):
+        real = self.embd
+
+        class _Stub:
+            def __call__(self, tokens, memory_config=None):
+                return x_tt
+
+        self.embd = _Stub()
+        try:
+            yield
+        finally:
+            self.embd = real
+
+    def prepare_inputs_prefill(
+        self,
+        tokens,
+        start_pos=0,
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        trace_enabled=False,
+        last_token_idx=None,
+        global_user_id=None,
+        batch_size=1,
+        user_id=0,
+        **kwargs,
+    ):
+        assert not trace_enabled, "Music3Backbone: traced prefill is a later optimization"
+        assert batch_size == 1, "Music3Backbone prefills one row at a time (two rows per request)"
+        self._mode = "prefill"
+        self._cur_user = int(user_id)
+        flat = tokens.reshape(-1).to(torch.int64)
+        S = flat.shape[0]
+        x = self.full_embed[flat].view(1, 1, S, -1)
+        x_tt = ttnn.from_torch(
+            x,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, 3), mesh_shape=self.args.cluster_shape),
+        )
+        with self._embd_override(x_tt):
+            return super().prepare_inputs_prefill(
+                tokens,
+                start_pos=start_pos,
+                page_table=page_table,
+                chunk_page_table=chunk_page_table,
+                chunk_start_idx=chunk_start_idx,
+                trace_enabled=trace_enabled,
+                last_token_idx=last_token_idx,
+                global_user_id=global_user_id,
+                batch_size=batch_size,
+                user_id=user_id,
+                **kwargs,
+            )
+
+    # ------------------------------------------------------------------ decode (both rows, one frame embedding)
+    def set_decode_residual(self, x: torch.Tensor):
+        """x [B, D] (bf16): the frame embedding fed to every row at the next decode step."""
+        self._pending_residual = x.to(torch.bfloat16)
+
+    def prepare_decode_inputs_host(self, tokens, current_pos, page_table=None):
+        base = super().prepare_decode_inputs_host(tokens, current_pos, page_table)
+        B = tokens.shape[0]
+        x = (
+            self._pending_residual
+            if self._pending_residual is not None
+            else torch.zeros(B, self.args.dim, dtype=torch.bfloat16)
+        )
+        assert x.shape == (B, self.args.dim), (x.shape, B)
+        x_tt = self.args.prepare_residual_tensor_decode(
+            x.view(B, 1, -1), self.args.get_residual_mem_config(Mode.DECODE, self.prefetcher), on_host=True
+        )
+        return (*base, x_tt)
+
+    def prepare_inputs_decode(self, *inputs):
+        host_inputs = self.prepare_decode_inputs_host(*inputs)
+        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)
+        self.bind_decode_trace_inputs(device_inputs)
+        return device_inputs
+
+    def bind_decode_trace_inputs(self, device_inputs):
+        self._decode_extra_device = device_inputs[4] if len(device_inputs) > 4 else None
+
+    def _transform_decode_inputs_device(self, tokens):
+        assert self._decode_extra_device is not None, "decode residual not staged (prepare_inputs_decode not called)"
+        self._mode = "decode"
+        mem = self.args.get_residual_mem_config(Mode.DECODE, self.prefetcher)
+        x = ttnn.unsqueeze_to_4D(self._decode_extra_device)
+        return ttnn.to_memory_config(x, mem)
+
+    # ------------------------------------------------------------------ hidden state readback
+    def _to_host_rows(self, x) -> torch.Tensor:
+        per = [ttnn.to_torch(t).float() for t in ttnn.get_device_tensors(x)]
+        t = per[0]
+        if len(per) > 1 and t.shape[-1] * len(per) == self.args.dim:
+            t = torch.cat(per, dim=-1)
+        return t.reshape(-1, t.shape[-1])
+
+    def read_prefill_hidden(self, user_id: int, last_token_idx: int) -> torch.Tensor:
+        """Post-final-norm hidden state of the last prompt token for one user: [D] float32."""
+        x = self._hidden_prefill[user_id]
+        rows = self._to_host_rows(x)
+        return rows[last_token_idx % rows.shape[0]]
+
+    def read_decode_hidden(self, batch: int) -> torch.Tensor:
+        """Post-final-norm hidden states of the last decode step: [batch, D] float32 (rows = users)."""
+        assert self._hidden_decode is not None, "no decode forward has run yet"
+        return self._to_host_rows(self._hidden_decode)[:batch]
+
+    def free_prefill_hidden(self):
+        for x in self._hidden_prefill.values():
+            try:
+                ttnn.deallocate(x)
+            except Exception:
+                pass
+        self._hidden_prefill = {}

--- a/models/autoports/minimaxai_minimax_music3/tt/config_defaults.json
+++ b/models/autoports/minimaxai_minimax_music3/tt/config_defaults.json
@@ -1,0 +1,14 @@
+{
+  "llm_dtype": "bfp8",
+  "depth_dtype": "bfp8",
+  "depth_fidelity": "hifi2",
+  "dit_dtype": "bf16",
+  "dit_fidelity": "hifi2",
+  "source": "stage 07 dtype sweep",
+  "thresholds": {
+    "c0_top1": 0.9,
+    "c0_top5": 0.98,
+    "depth_top1": 0.9,
+    "depth_top5": 0.98
+  }
+}

--- a/models/autoports/minimaxai_minimax_music3/tt/depth_decoder.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/depth_decoder.py
@@ -22,6 +22,10 @@ from models.autoports.minimaxai_minimax_music3.config import (
     DepthConfig,
 )
 from models.autoports.minimaxai_minimax_music3.tt.weights import cache_root
+from models.tt_dit.utils.matmul import get_matmul_config, get_matmul_core_grid
+from models.tt_dit.utils.tensor import prepare_for_fused_swiglu
+
+MATMUL_MODE = os.environ.get("MUSIC3_DEPTH_MATMUL", "minimal")  # minimal (tt_dit minimal_matmul, fused SwiGLU) | linear
 
 ROWS = 32  # one tile; positions 0..7 are used
 
@@ -84,6 +88,15 @@ class TTDepthDecoder:
                     ),
                     "w_gate": dev(w[p + "gate_proj.weight"].T, f"l{i}_wgate"),
                     "w_up": dev(w[p + "up_proj.weight"].T, f"l{i}_wup"),
+                    # packed [up | gate] re-interleaved for the fused SwiGLU matmul epilogue: out = up * silu(gate)
+                    "w_ffn_fused": dev(
+                        prepare_for_fused_swiglu(
+                            torch.cat([w[p + "up_proj.weight"], w[p + "gate_proj.weight"]], dim=0).T.float(),
+                            ndev=1,
+                            gate_is_first=False,
+                        ),
+                        f"l{i}_wffn_fused",
+                    ),
                     "w_down": dev(w[p + "down_proj.weight"].T, f"l{i}_wdown"),
                 }
             )
@@ -111,6 +124,8 @@ class TTDepthDecoder:
         )
         fid = os.environ.get("MUSIC3_DEPTH_FIDELITY", "hifi4" if weights_dtype == ttnn.bfloat16 else "hifi2")
         self.ck_mm = self.ck_hifi4 if fid == "hifi4" else self.ck_hifi2
+        self.matmul_mode = MATMUL_MODE
+        self.mm_grid = get_matmul_core_grid(mesh_device)
         # persistent I/O: the input stays ROW_MAJOR on device (host writes are a memcpy, tilize happens in the trace);
         # one trace per step index slices the needed row / head columns on device so the readback is ~20 KB
         self.x_raw = ttnn.from_torch(
@@ -127,13 +142,28 @@ class TTDepthDecoder:
         self.log(f"depth decoder weights on device in {time.time() - t0:.1f}s ({_dtype_tag(weights_dtype)})")
 
     # ------------------------------------------------------------------ graph
+    def _lin(self, x, w, act=None, swiglu=False):
+        if self.matmul_mode == "minimal":
+            M, K, N = x.padded_shape[-2], x.padded_shape[-1], w.padded_shape[-1]
+            return ttnn.experimental.minimal_matmul(
+                input_tensor=x,
+                weight_tensor=w,
+                config=get_matmul_config(M, K, N, self.mm_grid),
+                fused_activation=act,
+                compute_kernel_config=self.ck_mm,
+                dtype=ttnn.bfloat16,
+                fuse_swiglu=swiglu,
+            )
+        assert not swiglu
+        return ttnn.linear(x, w, activation=act, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+
     def _forward(self, x_raw: ttnn.Tensor):
         x = ttnn.to_layout(x_raw, ttnn.TILE_LAYOUT)
-        x = ttnn.linear(x, self.w_proj, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+        x = self._lin(x, self.w_proj)
         x = ttnn.add(x, self.pos_emb)
         for L in self.layers:
             h = ttnn.rms_norm(x, epsilon=self.eps, weight=L["norm1"])
-            qkv = ttnn.linear(h, L["wqkv"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+            qkv = self._lin(h, L["wqkv"])
             q, k, v = ttnn.experimental.nlp_create_qkv_heads(
                 qkv, num_heads=self.n_heads, num_kv_heads=self.n_heads, transpose_k_heads=False
             )
@@ -141,15 +171,15 @@ class TTDepthDecoder:
                 q, k, v, is_causal=True, compute_kernel_config=self.ck_hifi4
             )
             a = ttnn.experimental.nlp_concat_heads(a)
-            x = ttnn.add(x, ttnn.linear(a, L["wo"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16))
+            x = ttnn.add(x, self._lin(a, L["wo"]))
             h = ttnn.rms_norm(x, epsilon=self.eps, weight=L["norm2"])
-            g = ttnn.linear(h, L["w_gate"], activation="silu", compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
-            u = ttnn.linear(h, L["w_up"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
-            x = ttnn.add(
-                x, ttnn.linear(ttnn.multiply(g, u), L["w_down"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
-            )
+            if self.matmul_mode == "minimal":
+                ff = self._lin(h, L["w_ffn_fused"], swiglu=True)  # up * silu(gate) in one matmul
+            else:
+                ff = ttnn.multiply(self._lin(h, L["w_gate"], act="silu"), self._lin(h, L["w_up"]))
+            x = ttnn.add(x, self._lin(ff, L["w_down"]))
         h = ttnn.rms_norm(x, epsilon=self.eps, weight=self.norm_f)
-        logits = ttnn.linear(h, self.w_heads, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+        logits = self._lin(h, self.w_heads)
         return h, logits
 
     def _step_outputs(self, index: int):

--- a/models/autoports/minimaxai_minimax_music3/tt/depth_decoder.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/depth_decoder.py
@@ -1,0 +1,260 @@
+"""TTNN depth (local) LLM: 4 layers, hidden 4096, 16 MHA heads x 256, SwiGLU 6144, learned positions, 7 heads of 1024.
+
+Per frame the reference runs 7 dependent steps over a sequence that grows from 2 to 8 tokens. Here every step
+recomputes the whole (<= 8-token) sequence on ONE 32-row tile with causal SDPA, batch 2 (conditional / unconditional
+rows): the graph is identical for all steps, so ONE trace is captured and replayed 7x per frame. Inputs are the RAW
+(un-projected) embedding rows written by the host; the `projection`, positions, layers, final norm and all 7 heads
+(stacked into one [4096, 7168] matmul) run on device. Sampling is on host in phase A.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Callable, Dict, List, Optional
+
+import torch
+
+import ttnn
+from models.autoports.minimaxai_minimax_music3.config import (
+    AUDIO_CODE_OFFSET,
+    AUDIO_VOCAB_SIZE,
+    NUM_CODEBOOKS,
+    DepthConfig,
+)
+from models.autoports.minimaxai_minimax_music3.tt.weights import cache_root
+
+ROWS = 32  # one tile; positions 0..7 are used
+
+
+def _dtype_tag(dt) -> str:
+    return str(dt).replace("DataType.", "").lower()
+
+
+class TTDepthDecoder:
+    def __init__(
+        self,
+        mesh_device,
+        state: Dict[str, torch.Tensor],
+        cfg: DepthConfig,
+        *,
+        weights_dtype=ttnn.bfloat16,
+        full_embed: Optional[torch.Tensor] = None,
+        use_trace: bool = True,
+        log: Callable[[str], None] = print,
+    ):
+        self.mesh, self.cfg, self.log, self.use_trace = mesh_device, cfg, log, use_trace
+        assert mesh_device.get_num_devices() == 1, "TTDepthDecoder runs on one chip"
+        D, H, I = cfg.hidden_size, cfg.num_attention_heads, cfg.intermediate_size
+        self.n_heads, self.head_dim = H, cfg.head_dim
+        cache = cache_root() / "depth_decoder" / _dtype_tag(weights_dtype)
+        cache.mkdir(parents=True, exist_ok=True)
+        t0 = time.time()
+
+        def dev(t: torch.Tensor, name: str, dtype=weights_dtype, layout=ttnn.TILE_LAYOUT):
+            return ttnn.as_tensor(
+                t.contiguous(),
+                dtype=dtype,
+                layout=layout,
+                device=mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+                cache_file_name=str(cache / name),
+            )
+
+        w = state
+        self.w_proj = dev(w["projection.weight"].T, "projection")  # [D, D]
+        pos = torch.zeros(1, 1, ROWS, D, dtype=torch.float32)
+        pos[0, 0, : cfg.max_position_embeddings] = w["pos_embedding.weight"].float()
+        self.pos_emb = dev(pos, "pos_emb", dtype=ttnn.bfloat16)
+        self.layers = []
+        for i in range(cfg.num_layers):
+            p = f"layers.{i}."
+            qkv = torch.cat(
+                [w[p + "attn.to_q.weight"], w[p + "attn.to_k.weight"], w[p + "attn.to_v.weight"]], dim=0
+            ).T  # [D, 3D]
+            self.layers.append(
+                {
+                    "norm1": dev(
+                        w[p + "input_layernorm.weight"].reshape(1, 1, 1, D), f"l{i}_norm1", dtype=ttnn.bfloat16
+                    ),
+                    "wqkv": dev(qkv, f"l{i}_wqkv"),
+                    "wo": dev(w[p + "attn.to_out.weight"].T, f"l{i}_wo"),
+                    "norm2": dev(
+                        w[p + "post_attention_layernorm.weight"].reshape(1, 1, 1, D), f"l{i}_norm2", dtype=ttnn.bfloat16
+                    ),
+                    "w_gate": dev(w[p + "gate_proj.weight"].T, f"l{i}_wgate"),
+                    "w_up": dev(w[p + "up_proj.weight"].T, f"l{i}_wup"),
+                    "w_down": dev(w[p + "down_proj.weight"].T, f"l{i}_wdown"),
+                }
+            )
+        self.norm_f = dev(w["norm.weight"].reshape(1, 1, 1, D), "norm_f", dtype=ttnn.bfloat16)
+        heads = torch.cat([w[f"audio_heads.{i}.weight"] for i in range(NUM_CODEBOOKS - 1)], dim=0).T  # [D, 7*1024]
+        self.w_heads = dev(heads, "heads")
+        # host tables for the raw input rows
+        self.audio_embeddings = w["audio_embeddings.weight"].to(torch.bfloat16)  # [7*1024, D]
+        self.full_embed = full_embed.to(torch.bfloat16) if full_embed is not None else None
+        self.eps = 1e-6
+        arch = mesh_device.arch()
+        self.ck_hifi4 = ttnn.init_device_compute_kernel_config(
+            arch,
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+        self.ck_hifi2 = ttnn.init_device_compute_kernel_config(
+            arch,
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+        fid = os.environ.get("MUSIC3_DEPTH_FIDELITY", "hifi4" if weights_dtype == ttnn.bfloat16 else "hifi2")
+        self.ck_mm = self.ck_hifi4 if fid == "hifi4" else self.ck_hifi2
+        # persistent I/O: the input stays ROW_MAJOR on device (host writes are a memcpy, tilize happens in the trace);
+        # one trace per step index slices the needed row / head columns on device so the readback is ~20 KB
+        self.x_raw = ttnn.from_torch(
+            torch.zeros(2, 1, ROWS, D, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+        self._host_rows = torch.zeros(2, 1, ROWS, D, dtype=torch.bfloat16)
+        self.traces: Dict[int, tuple] = {}  # step index -> (trace id, h_row, logits_row)
+        self.warmed = False
+        self.log(f"depth decoder weights on device in {time.time() - t0:.1f}s ({_dtype_tag(weights_dtype)})")
+
+    # ------------------------------------------------------------------ graph
+    def _forward(self, x_raw: ttnn.Tensor):
+        x = ttnn.to_layout(x_raw, ttnn.TILE_LAYOUT)
+        x = ttnn.linear(x, self.w_proj, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+        x = ttnn.add(x, self.pos_emb)
+        for L in self.layers:
+            h = ttnn.rms_norm(x, epsilon=self.eps, weight=L["norm1"])
+            qkv = ttnn.linear(h, L["wqkv"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads(
+                qkv, num_heads=self.n_heads, num_kv_heads=self.n_heads, transpose_k_heads=False
+            )
+            a = ttnn.transformer.scaled_dot_product_attention(
+                q, k, v, is_causal=True, compute_kernel_config=self.ck_hifi4
+            )
+            a = ttnn.experimental.nlp_concat_heads(a)
+            x = ttnn.add(x, ttnn.linear(a, L["wo"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16))
+            h = ttnn.rms_norm(x, epsilon=self.eps, weight=L["norm2"])
+            g = ttnn.linear(h, L["w_gate"], activation="silu", compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+            u = ttnn.linear(h, L["w_up"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+            x = ttnn.add(
+                x, ttnn.linear(ttnn.multiply(g, u), L["w_down"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+            )
+        h = ttnn.rms_norm(x, epsilon=self.eps, weight=self.norm_f)
+        logits = ttnn.linear(h, self.w_heads, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+        return h, logits
+
+    def _step_outputs(self, index: int):
+        """Full forward + on-device row/head selection for step `index` (1..7): h_row [2,1,1,D], logits_row [2,1,1,1024]."""
+        h, lg = self._forward(self.x_raw)
+        h_rm, lg_rm = ttnn.untilize(h, use_multicore=True), ttnn.untilize(lg, use_multicore=True)
+        h_row = ttnn.slice(h_rm, [0, 0, index, 0], [2, 1, index + 1, self.cfg.hidden_size])
+        lg_row = ttnn.slice(
+            lg_rm, [0, 0, index, (index - 1) * AUDIO_VOCAB_SIZE], [2, 1, index + 1, index * AUDIO_VOCAB_SIZE]
+        )
+        return h_row, lg_row
+
+    def warmup(self):
+        self._push_rows()
+        for index in range(1, NUM_CODEBOOKS):
+            self._step_outputs(index)  # compile pass (all 7 slice shapes)
+        ttnn.synchronize_device(self.mesh)
+        if self.use_trace:
+            for index in range(1, NUM_CODEBOOKS):
+                tid = ttnn.begin_trace_capture(self.mesh, cq_id=0)
+                outs = self._step_outputs(index)
+                ttnn.end_trace_capture(self.mesh, tid, cq_id=0)
+                self.traces[index] = (tid, *outs)
+            ttnn.synchronize_device(self.mesh)
+            self.log("depth decoder: 7 step traces captured")
+        self.warmed = True
+
+    def _run_step(self, index: int):
+        if self.traces:
+            tid, h_row, lg_row = self.traces[index]
+            ttnn.execute_trace(self.mesh, tid, cq_id=0, blocking=True)
+            return h_row, lg_row
+        return self._step_outputs(index)
+
+    # ------------------------------------------------------------------ host <-> device
+    def _push_rows(self):
+        host = ttnn.from_torch(
+            self._host_rows,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh),
+        )
+        ttnn.copy_host_to_device_tensor(host, self.x_raw)
+
+    def _read_rows(self, h_row, lg_row):
+        ht = ttnn.to_torch(ttnn.get_device_tensors(h_row)[0]).float().reshape(2, -1)  # [2, D]
+        lt = ttnn.to_torch(ttnn.get_device_tensors(lg_row)[0]).float().reshape(2, -1)  # [2, 1024]
+        return ht, lt
+
+    # ------------------------------------------------------------------ public API (mirrors reference.pipeline.depth_codes)
+    @torch.inference_mode()
+    def frame(
+        self,
+        last_hidden: torch.Tensor,
+        semantic_code: int,
+        choose: Callable[[torch.Tensor, int], int],
+        forced: Optional[List[int]] = None,
+        record: Optional[dict] = None,
+    ):
+        """last_hidden [2, D] (cond, uncond) -> (codes [8] incl. c0, depth_hidden [7, D] (cond row)).
+        `choose(guided_logits [1,1024], index) -> code` samples on host; `forced` overrides sampling (teacher forcing).
+        """
+        if not self.warmed:
+            self.warmup()
+        rows = self._host_rows
+        rows.zero_()
+        rows[:, 0, 0] = last_hidden.to(torch.bfloat16)
+        rows[:, 0, 1] = self.full_embed[semantic_code + AUDIO_CODE_OFFSET]
+        codes = [int(semantic_code)]
+        hidden_parts = []
+        for index in range(1, NUM_CODEBOOKS):
+            self._push_rows()
+            ht, logits = self._read_rows(*self._run_step(index))  # [2, D], [2, 1024] (head index-1)
+            hidden_parts.append(ht[:1])
+            if record is not None:
+                record.setdefault("depth_logits", []).append(logits.clone())
+                record.setdefault("depth_hidden", []).append(ht[:1].clone())
+            from models.autoports.minimaxai_minimax_music3.reference.sampling import guided_depth_logits
+
+            code = int(forced[index - 1]) if forced is not None else int(choose(guided_depth_logits(logits), index))
+            codes.append(code)
+            if index < NUM_CODEBOOKS - 1:
+                rows[:, 0, index + 1] = self.audio_embeddings[code + (index - 1) * AUDIO_VOCAB_SIZE]
+        return torch.tensor(codes, dtype=torch.int64), torch.cat(hidden_parts, dim=0)
+
+    @torch.inference_mode()
+    def forward_rows(self, inputs_embeds: torch.Tensor):
+        """Unit-test entry: raw (un-projected) rows [2, steps, D] -> (hidden [2, steps, D], logits [7, 2, 1024] at the last step)."""
+        if not self.warmed:
+            self.warmup()
+        steps = inputs_embeds.shape[1]
+        self._host_rows.zero_()
+        self._host_rows[:, 0, :steps] = inputs_embeds.to(torch.bfloat16)
+        self._push_rows()
+        h, lg = self._forward(self.x_raw)  # untraced full outputs
+        ht = ttnn.to_torch(ttnn.get_device_tensors(h)[0]).float()[:, 0, :steps]
+        lt = (
+            ttnn.to_torch(ttnn.get_device_tensors(lg)[0])
+            .float()[:, 0, steps - 1]
+            .view(2, NUM_CODEBOOKS - 1, AUDIO_VOCAB_SIZE)
+            .transpose(0, 1)
+        )
+        return ht, lt
+
+    def release(self):
+        for tid, *_ in self.traces.values():
+            ttnn.release_trace(self.mesh, tid)
+        self.traces = {}

--- a/models/autoports/minimaxai_minimax_music3/tt/device.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/device.py
@@ -1,0 +1,123 @@
+"""Mesh open/close for the single-chip profile (and, later, multi-chip ones).
+
+The tt-model launcher sets MESH_DEVICE (label) and MUSIC3_MESH_SHAPE ("RxC"). A 1x1 profile on a multi-chip box
+must be a TRUE 1x1 mesh: TT_METAL_VISIBLE_DEVICES=0 is set before ttnn touches the cluster (a submesh of the
+4-chip parent hangs on the first large host->device write, see the QB2 notes). ttnn is imported lazily for that.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+PRESETS = {
+    "P150": (1, 1),
+    "P100": (1, 1),
+    "N150": (1, 1),
+    "P300": (1, 2),
+    "P150x2": (1, 2),
+    "N300": (1, 2),
+    "P300x2": (1, 4),
+    "P150x4": (1, 4),
+    "QB2": (1, 4),
+    "P300x4": (1, 8),
+    "P150x8": (1, 8),
+    "T3K": (1, 8),
+}
+DEFAULT_FABRIC = {1: None, 2: "FABRIC_1D", 4: "FABRIC_1D", 8: "FABRIC_1D_RING"}
+PREFILL_CHUNK_K = {
+    1: 4,
+    2: 32,
+    4: 128,
+    8: 128,
+}  # MAX_PREFILL_CHUNK_SIZE (K tokens) per chip count (model_config.py table default)
+
+
+def parse_shape(s: Optional[str]) -> Optional[Tuple[int, int]]:
+    if not s:
+        return None
+    s = s.strip()
+    if "x" in s.lower():
+        r, c = s.lower().split("x")
+        return int(r), int(c)
+    if s in PRESETS:
+        return PRESETS[s]
+    import ast
+
+    v = ast.literal_eval(s)
+    return int(v[0]), int(v[1])
+
+
+def requested_shape() -> Tuple[int, int]:
+    shape = parse_shape(os.environ.get("MUSIC3_MESH_SHAPE")) or parse_shape(os.environ.get("MESH_DEVICE"))
+    return shape or (1, 1)
+
+
+def pin_visible_devices(shape: Tuple[int, int]) -> None:
+    """Must run before the first ttnn cluster query. A 1x1 mesh pins device 0 unless the operator chose otherwise."""
+    n = shape[0] * shape[1]
+    if n == 1:
+        os.environ.setdefault("TT_METAL_VISIBLE_DEVICES", "0")
+    elif n == 2:
+        os.environ.setdefault("TT_METAL_VISIBLE_DEVICES", "0,1")
+
+
+class MeshHandle:
+    def __init__(self, mesh):
+        self.mesh = mesh
+
+    @property
+    def shape(self):
+        return tuple(self.mesh.shape)
+
+    @property
+    def num_devices(self):
+        return self.mesh.get_num_devices()
+
+    def close(self):
+        import ttnn
+
+        ttnn.close_mesh_device(self.mesh)
+        try:
+            ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+        except Exception:
+            pass
+
+
+def open_mesh(
+    shape: Optional[Tuple[int, int]] = None,
+    fabric: Optional[str] = None,
+    l1_small_size: int = 32768,
+    trace_region_size: Optional[int] = None,
+    num_command_queues: int = 1,
+) -> MeshHandle:
+    shape = shape or requested_shape()
+    pin_visible_devices(shape)
+    import ttnn
+
+    r, c = shape
+    n_req, n_sys = r * c, ttnn.get_num_devices()
+    # ttnn.get_num_devices() reports the whole cluster even under TT_METAL_VISIBLE_DEVICES; open_mesh_device honours the
+    # variable. Refuse to open a sub-mesh of a bigger parent (it hangs on large host->device writes on the QB2).
+    vis = os.environ.get("TT_METAL_VISIBLE_DEVICES", "")
+    n_vis = len([v for v in vis.split(",") if v.strip()]) if vis else n_sys
+    assert n_req <= n_sys, f"profile needs {n_req} chips, system has {n_sys}"
+    assert (
+        n_req == n_vis
+    ), f"profile needs a {r}x{c} mesh but TT_METAL_VISIBLE_DEVICES={vis!r} exposes {n_vis} of {n_sys} devices (true mesh, never a submesh)"
+    fabric = os.environ.get("MUSIC3_FABRIC_CONFIG", fabric) if fabric is None else fabric
+    if fabric is None:
+        fabric = DEFAULT_FABRIC.get(n_req)
+    if fabric and str(fabric).lower() != "none" and n_req > 1:
+        ttnn.set_fabric_config(getattr(ttnn.FabricConfig, fabric))
+    os.environ.setdefault(
+        "MAX_PREFILL_CHUNK_SIZE", os.environ.get("MUSIC3_PREFILL_CHUNK_K", str(PREFILL_CHUNK_K.get(n_req, 4)))
+    )
+    if trace_region_size is None:
+        trace_region_size = int(float(os.environ.get("MUSIC3_TRACE_REGION_MB", "256")) * 1024 * 1024)
+    mesh = ttnn.open_mesh_device(
+        mesh_shape=ttnn.MeshShape(r, c),
+        l1_small_size=l1_small_size,
+        trace_region_size=trace_region_size,
+        num_command_queues=num_command_queues,
+    )
+    return MeshHandle(mesh)

--- a/models/autoports/minimaxai_minimax_music3/tt/dit.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/dit.py
@@ -155,6 +155,7 @@ class TTDiT:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             mesh_mapper=rep,
         )
+        host = lambda t: ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, mesh_mapper=rep)
         st = {
             "L": L,
             "Lp": Lp,
@@ -162,6 +163,14 @@ class TTDiT:
             "sin": mk(sin_full),
             "mask": mk(mask),
             "sel": mk(sel),
+            # host-side copies: these constants are re-written before EVERY replay. They are allocated after other
+            # modules' traces were captured, so they may sit inside another trace's scratch region and be clobbered
+            # by its replays (the LLM decode trace, in particular); rewriting is cheap (~1.5 MB) and removes the
+            # allocation-order dependency.
+            "cos_h": host(cos_full),
+            "sin_h": host(sin_full),
+            "mask_h": host(mask),
+            "sel_h": host(sel),
             "xin": mk(torch.zeros(2, 1, Lp, self.cfg.concat_channels)),
             "tf": mk(torch.zeros(2, 1, 32, self.cfg.fourier_embedding_dim)),
             "trace": None,
@@ -264,6 +273,8 @@ class TTDiT:
         ttnn.copy_host_to_device_tensor(
             ttnn.from_torch(tf, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, mesh_mapper=rep), st["tf"]
         )
+        for k in ("cos", "sin", "mask", "sel"):
+            ttnn.copy_host_to_device_tensor(st[k + "_h"], st[k])
         self._ensure_trace(st)
         if st["trace"] is not None:
             ttnn.execute_trace(self.mesh, st["trace"], cq_id=0, blocking=True)

--- a/models/autoports/minimaxai_minimax_music3/tt/dit.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/dit.py
@@ -22,6 +22,8 @@ from models.autoports.minimaxai_minimax_music3.tt.weights import cache_root
 
 PAD_TO = 128
 MASK_VALUE = -1e9
+SDPA_MODE = os.environ.get("MUSIC3_DIT_SDPA", "window")  # window (cu_window_seqlens, mask built on device) | mask
+MATMUL_MODE = os.environ.get("MUSIC3_DIT_MATMUL", "minimal")  # minimal (tt_dit minimal_matmul, fused SwiGLU) | linear
 
 
 def padded_len(seq_len_with_temb: int) -> int:
@@ -124,6 +126,20 @@ class TTDiT:
             packer_l1_acc=False,
         )
         self.grid = mesh_device.compute_with_storage_grid_size()
+        self.matmul_mode = MATMUL_MODE
+        if self.matmul_mode == "minimal":
+            from models.tt_dit.utils.matmul import get_matmul_core_grid
+
+            self.mm_grid = get_matmul_core_grid(mesh_device)
+            # packed [a | g] ff_in weight re-interleaved for the fused SwiGLU epilogue: out = a * silu(g)
+            from models.tt_dit.utils.tensor import prepare_for_fused_swiglu
+
+            for i, blk in enumerate(self.blocks):
+                p = f"transformer_blocks.{i}."
+                wf = prepare_for_fused_swiglu(w[p + "ff_in.weight"].T.float(), ndev=1, gate_is_first=False)
+                bf = prepare_for_fused_swiglu(w[p + "ff_in.bias"].reshape(1, -1).float(), ndev=1, gate_is_first=False)
+                blk["w_ff_fused"] = dev(wf, f"b{i}_wff_fused")
+                blk["b_ff_fused"] = vec(bf, f"b{i}_bff_fused")
         self._shapes: Dict[int, dict] = {}  # per Lp: persistent inputs, rope tables, mask, sel, trace, outputs
         self.log(
             f"DiT weights on device in {time.time() - t0:.1f}s ({self.n_layers} layers, {_dtype_tag(weights_dtype)})"
@@ -171,6 +187,19 @@ class TTDiT:
             "sin_h": host(sin_full),
             "mask_h": host(mask),
             "sel_h": host(sel),
+            "cu": ttnn.from_torch(
+                torch.tensor([0, L + 1, Lp], dtype=torch.int32),
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=self.mesh,
+                mesh_mapper=rep,
+            ),
+            "cu_h": ttnn.from_torch(
+                torch.tensor([0, L + 1, Lp], dtype=torch.int32),
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=rep,
+            ),
             "xin": mk(torch.zeros(2, 1, Lp, self.cfg.concat_channels)),
             "tf": mk(torch.zeros(2, 1, 32, self.cfg.fourier_embedding_dim)),
             "trace": None,
@@ -187,6 +216,24 @@ class TTDiT:
         return st
 
     # ------------------------------------------------------------------ graph
+    def _lin(self, x, w, b=None, act=None, swiglu=False):
+        if self.matmul_mode == "minimal":
+            from models.tt_dit.utils.matmul import get_matmul_config
+
+            M, K, N = x.padded_shape[-2], x.padded_shape[-1], w.padded_shape[-1]
+            return ttnn.experimental.minimal_matmul(
+                input_tensor=x,
+                weight_tensor=w,
+                bias_tensor=b,
+                config=get_matmul_config(M, K, N, self.mm_grid),
+                fused_activation=act,
+                compute_kernel_config=self.ck_mm,
+                dtype=ttnn.bfloat16,
+                fuse_swiglu=swiglu,
+            )
+        assert not swiglu
+        return ttnn.linear(x, w, bias=b, activation=act, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+
     def _forward(self, st: dict):
         xin, tf = st["xin"], st["tf"]
         # timestep token: Fourier features -> linear_1 -> SiLU -> linear_2 -> placed at row 0 via a one-hot selector matmul
@@ -203,38 +250,42 @@ class TTDiT:
         x = ttnn.add(x, temb_rows)
         for B in self.blocks:
             h = ttnn.layer_norm(x, epsilon=1e-5, weight=B["n1_w"], bias=B["n1_b"])
-            qkv = ttnn.linear(h, B["wqkv"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+            qkv = self._lin(h, B["wqkv"])
             q, k, v = ttnn.experimental.nlp_create_qkv_heads(
                 qkv, num_heads=self.heads, num_kv_heads=self.heads, transpose_k_heads=False
             )
             q = ttnn.experimental.rotary_embedding_llama(q, st["cos"], st["sin"], self.trans_mat, is_decode_mode=False)
             k = ttnn.experimental.rotary_embedding_llama(k, st["cos"], st["sin"], self.trans_mat, is_decode_mode=False)
-            a = ttnn.transformer.scaled_dot_product_attention(
-                q,
-                k,
-                v,
-                attn_mask=st["mask"],
-                is_causal=False,
-                program_config=st["sdpa_pc"],
-                compute_kernel_config=self.ck_sdpa,
-            )
+            if SDPA_MODE == "window":
+                # block-diagonal windows [0, L+1) (real rows) and [L+1, Lp) (padding): pad keys never reach real queries
+                a = ttnn.transformer.scaled_dot_product_attention(
+                    q,
+                    k,
+                    v,
+                    cu_window_seqlens=st["cu"],
+                    program_config=st["sdpa_pc"],
+                    compute_kernel_config=self.ck_sdpa,
+                )
+            else:
+                a = ttnn.transformer.scaled_dot_product_attention(
+                    q,
+                    k,
+                    v,
+                    attn_mask=st["mask"],
+                    is_causal=False,
+                    program_config=st["sdpa_pc"],
+                    compute_kernel_config=self.ck_sdpa,
+                )
             a = ttnn.experimental.nlp_concat_heads(a)
-            x = ttnn.add(x, ttnn.linear(a, B["wo"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16))
+            x = ttnn.add(x, self._lin(a, B["wo"]))
             h = ttnn.layer_norm(x, epsilon=1e-5, weight=B["n2_w"], bias=B["n2_b"])
-            a_ = ttnn.linear(h, B["w_a"], bias=B["b_a"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
-            g_ = ttnn.linear(
-                h, B["w_g"], bias=B["b_g"], activation="silu", compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16
-            )
-            x = ttnn.add(
-                x,
-                ttnn.linear(
-                    ttnn.multiply(a_, g_),
-                    B["w_o"],
-                    bias=B["b_o"],
-                    compute_kernel_config=self.ck_mm,
-                    dtype=ttnn.bfloat16,
-                ),
-            )
+            if self.matmul_mode == "minimal":
+                ff = self._lin(h, B["w_ff_fused"], B["b_ff_fused"], swiglu=True)  # a * silu(g) in one matmul
+            else:
+                a_ = self._lin(h, B["w_a"], B["b_a"])
+                g_ = self._lin(h, B["w_g"], B["b_g"], act="silu")
+                ff = ttnn.multiply(a_, g_)
+            x = ttnn.add(x, self._lin(ff, B["w_o"], B["b_o"]))
         y = ttnn.linear(x, self.w_out, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)  # [2,1,Lp,128]
         y = ttnn.add(ttnn.linear(y, self.w_post, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16), y)
         return y
@@ -273,7 +324,7 @@ class TTDiT:
         ttnn.copy_host_to_device_tensor(
             ttnn.from_torch(tf, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, mesh_mapper=rep), st["tf"]
         )
-        for k in ("cos", "sin", "mask", "sel"):
+        for k in ("cos", "sin", "mask", "sel", "cu"):
             ttnn.copy_host_to_device_tensor(st[k + "_h"], st[k])
         self._ensure_trace(st)
         if st["trace"] is not None:

--- a/models/autoports/minimaxai_minimax_music3/tt/dit.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/dit.py
@@ -263,6 +263,7 @@ class TTDiT:
                     k,
                     v,
                     cu_window_seqlens=st["cu"],
+                    is_causal=False,
                     program_config=st["sdpa_pc"],
                     compute_kernel_config=self.ck_sdpa,
                 )

--- a/models/autoports/minimaxai_minimax_music3/tt/dit.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/dit.py
@@ -1,0 +1,282 @@
+"""TTNN flow-matching DiT (MiniMaxMusic3Transformer1DModel): 36 pre-LN blocks, dim 2048, 32 heads x 64, partial
+RoPE (first 32 dims, rotate-half), SwiGLU FF 8192 with biases, a timestep token prepended.
+
+Layout: the sequence lives on rows of a [B, 1, Lp, C] tile tensor. Row 0 is the timestep token, rows 1..L the
+latent frames, rows L+1..Lp-1 padding (Lp = multiple of 128); pad KEYS are masked in attention, pad rows' outputs
+are discarded. preprocess_conv / postprocess_conv are 1x1 convs = linears over the channel dim. The host prepares
+`xin = [latents | zeros | condition]` per row and the Fourier features of t; everything else runs on device.
+One trace per Lp (the two window lengths of a song: 689 and the last, shorter one)."""
+from __future__ import annotations
+
+import math
+import os
+import time
+from typing import Callable, Dict, Optional
+
+import torch
+
+import ttnn
+from models.autoports.minimaxai_minimax_music3.config import DiTConfig
+from models.autoports.minimaxai_minimax_music3.reference.dit import rotary_tables
+from models.autoports.minimaxai_minimax_music3.tt.weights import cache_root
+
+PAD_TO = 128
+MASK_VALUE = -1e9
+
+
+def padded_len(seq_len_with_temb: int) -> int:
+    return int(math.ceil(seq_len_with_temb / PAD_TO) * PAD_TO)
+
+
+def _dtype_tag(dt) -> str:
+    return str(dt).replace("DataType.", "").lower()
+
+
+class TTDiT:
+    def __init__(
+        self,
+        mesh_device,
+        state: Dict[str, torch.Tensor],
+        cfg: DiTConfig,
+        *,
+        weights_dtype=ttnn.bfloat16,
+        use_trace: bool = True,
+        log: Callable[[str], None] = print,
+        num_layers: Optional[int] = None,
+    ):
+        self.mesh, self.cfg, self.log, self.use_trace = mesh_device, cfg, log, use_trace
+        assert mesh_device.get_num_devices() == 1, "TTDiT runs on one chip"
+        self.n_layers = num_layers or cfg.num_layers
+        self.dim, self.heads, self.head_dim = cfg.inner_dim, cfg.num_attention_heads, cfg.attention_head_dim
+        cache = cache_root() / "dit" / _dtype_tag(weights_dtype)
+        cache.mkdir(parents=True, exist_ok=True)
+        t0 = time.time()
+
+        def dev(t: torch.Tensor, name: str, dtype=weights_dtype):
+            return ttnn.as_tensor(
+                t.contiguous(),
+                dtype=dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+                cache_file_name=str(cache / name),
+            )
+
+        def vec(t: torch.Tensor, name: str):
+            return dev(t.reshape(1, 1, 1, -1).float(), name, dtype=ttnn.bfloat16)
+
+        w = state
+        self.time_proj_w = w["time_proj.weight"].float().reshape(-1)  # [128] (host Fourier features)
+        self.w_t1, self.b_t1 = dev(w["time_embed.linear_1.weight"].T, "t1_w"), vec(
+            w["time_embed.linear_1.bias"], "t1_b"
+        )
+        self.w_t2, self.b_t2 = dev(w["time_embed.linear_2.weight"].T, "t2_w"), vec(
+            w["time_embed.linear_2.bias"], "t2_b"
+        )
+        self.w_pre = dev(w["preprocess_conv.weight"].squeeze(-1).T, "pre_w")  # [2304, 2304]
+        self.w_in = dev(w["proj_in.weight"].T, "in_w")  # [2304, 2048]
+        self.w_out = dev(w["proj_out.weight"].T, "out_w")  # [2048, 128]
+        self.w_post = dev(w["postprocess_conv.weight"].squeeze(-1).T, "post_w")  # [128, 128]
+        self.blocks = []
+        ff = cfg.ff_inner_dim
+        for i in range(self.n_layers):
+            p = f"transformer_blocks.{i}."
+            qkv = torch.cat([w[p + "attn.to_q.weight"], w[p + "attn.to_k.weight"], w[p + "attn.to_v.weight"]], dim=0).T
+            ffw, ffb = w[p + "ff_in.weight"], w[p + "ff_in.bias"]
+            self.blocks.append(
+                {
+                    "n1_w": vec(w[p + "norm1.weight"], f"b{i}_n1w"),
+                    "n1_b": vec(w[p + "norm1.bias"], f"b{i}_n1b"),
+                    "wqkv": dev(qkv, f"b{i}_wqkv"),
+                    "wo": dev(w[p + "attn.to_out.0.weight"].T, f"b{i}_wo"),
+                    "n2_w": vec(w[p + "norm2.weight"], f"b{i}_n2w"),
+                    "n2_b": vec(w[p + "norm2.bias"], f"b{i}_n2b"),
+                    "w_a": dev(ffw[:ff].T, f"b{i}_wa"),
+                    "b_a": vec(ffb[:ff], f"b{i}_ba"),  # gate_states (first half)
+                    "w_g": dev(ffw[ff:].T, f"b{i}_wg"),
+                    "b_g": vec(ffb[ff:], f"b{i}_bg"),  # gate (second half, SiLU)
+                    "w_o": dev(w[p + "ff_out.weight"].T, f"b{i}_wffo"),
+                    "b_o": vec(w[p + "ff_out.bias"], f"b{i}_bffo"),
+                }
+            )
+        # rotate-half within the first 32-dim tile of every head; the ROPE op applies trans_mat per 32-wide tile
+        T = torch.zeros(1, 1, 32, 32)
+        for j in range(16):
+            T[0, 0, j + 16, j] = -1.0
+            T[0, 0, j, j + 16] = 1.0
+        self.trans_mat = dev(T, "rope_trans", dtype=ttnn.bfloat16)
+        arch = mesh_device.arch()
+        fid = os.environ.get("MUSIC3_DIT_FIDELITY", "hifi4" if weights_dtype == ttnn.bfloat16 else "hifi2")
+        self.ck_mm = ttnn.init_device_compute_kernel_config(
+            arch,
+            math_fidelity=ttnn.MathFidelity.HiFi4 if fid == "hifi4" else ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=(fid == "hifi4"),
+            packer_l1_acc=True,
+        )
+        self.fidelity = fid
+        self.ck_sdpa = ttnn.init_device_compute_kernel_config(
+            arch,
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
+        self.grid = mesh_device.compute_with_storage_grid_size()
+        self._shapes: Dict[int, dict] = {}  # per Lp: persistent inputs, rope tables, mask, sel, trace, outputs
+        self.log(
+            f"DiT weights on device in {time.time() - t0:.1f}s ({self.n_layers} layers, {_dtype_tag(weights_dtype)})"
+        )
+
+    # ------------------------------------------------------------------ per-length state
+    def _state(self, L: int) -> dict:
+        """L = number of latent frames (sequence has L+1 rows incl. the timestep token)."""
+        Lp = padded_len(L + 1)
+        if Lp in self._shapes and self._shapes[Lp]["L"] == L:
+            return self._shapes[Lp]
+        rep = ttnn.ReplicateTensorToMesh(self.mesh)
+        cos, sin = rotary_tables(Lp, self.cfg.rotary_dim)  # [Lp, 32] each (rotate-half pairs i, i+16)
+        cos_full = torch.cat([cos, torch.ones(Lp, self.head_dim - self.cfg.rotary_dim)], dim=-1).reshape(
+            1, 1, Lp, self.head_dim
+        )
+        sin_full = torch.cat([sin, torch.zeros(Lp, self.head_dim - self.cfg.rotary_dim)], dim=-1).reshape(
+            1, 1, Lp, self.head_dim
+        )
+        mask = torch.zeros(1, 1, Lp, Lp)
+        mask[..., L + 1 :] = MASK_VALUE  # pad keys
+        sel = torch.zeros(1, 1, Lp, 32)
+        sel[0, 0, 0, 0] = 1.0  # places the timestep token at row 0
+        mk = lambda t, dt=ttnn.bfloat16: ttnn.from_torch(
+            t,
+            dtype=dt,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=rep,
+        )
+        st = {
+            "L": L,
+            "Lp": Lp,
+            "cos": mk(cos_full),
+            "sin": mk(sin_full),
+            "mask": mk(mask),
+            "sel": mk(sel),
+            "xin": mk(torch.zeros(2, 1, Lp, self.cfg.concat_channels)),
+            "tf": mk(torch.zeros(2, 1, 32, self.cfg.fourier_embedding_dim)),
+            "trace": None,
+            "out": None,
+        }
+        # SDPA chunking: Lp is a multiple of 128
+        st["sdpa_pc"] = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=(self.grid.x, self.grid.y),
+            q_chunk_size=128,
+            k_chunk_size=128,
+            exp_approx_mode=False,
+        )
+        self._shapes[Lp] = st
+        return st
+
+    # ------------------------------------------------------------------ graph
+    def _forward(self, st: dict):
+        xin, tf = st["xin"], st["tf"]
+        # timestep token: Fourier features -> linear_1 -> SiLU -> linear_2 -> placed at row 0 via a one-hot selector matmul
+        t = ttnn.linear(
+            tf, self.w_t1, bias=self.b_t1, activation="silu", compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16
+        )
+        t = ttnn.linear(
+            t, self.w_t2, bias=self.b_t2, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16
+        )  # [2,1,32,2048], row 0 valid
+        temb_rows = ttnn.matmul(st["sel"], t, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)  # [2,1,Lp,2048]
+        # preprocess 1x1 conv (+ residual) and input projection
+        x = ttnn.add(ttnn.linear(xin, self.w_pre, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16), xin)
+        x = ttnn.linear(x, self.w_in, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+        x = ttnn.add(x, temb_rows)
+        for B in self.blocks:
+            h = ttnn.layer_norm(x, epsilon=1e-5, weight=B["n1_w"], bias=B["n1_b"])
+            qkv = ttnn.linear(h, B["wqkv"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads(
+                qkv, num_heads=self.heads, num_kv_heads=self.heads, transpose_k_heads=False
+            )
+            q = ttnn.experimental.rotary_embedding_llama(q, st["cos"], st["sin"], self.trans_mat, is_decode_mode=False)
+            k = ttnn.experimental.rotary_embedding_llama(k, st["cos"], st["sin"], self.trans_mat, is_decode_mode=False)
+            a = ttnn.transformer.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=st["mask"],
+                is_causal=False,
+                program_config=st["sdpa_pc"],
+                compute_kernel_config=self.ck_sdpa,
+            )
+            a = ttnn.experimental.nlp_concat_heads(a)
+            x = ttnn.add(x, ttnn.linear(a, B["wo"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16))
+            h = ttnn.layer_norm(x, epsilon=1e-5, weight=B["n2_w"], bias=B["n2_b"])
+            a_ = ttnn.linear(h, B["w_a"], bias=B["b_a"], compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)
+            g_ = ttnn.linear(
+                h, B["w_g"], bias=B["b_g"], activation="silu", compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16
+            )
+            x = ttnn.add(
+                x,
+                ttnn.linear(
+                    ttnn.multiply(a_, g_),
+                    B["w_o"],
+                    bias=B["b_o"],
+                    compute_kernel_config=self.ck_mm,
+                    dtype=ttnn.bfloat16,
+                ),
+            )
+        y = ttnn.linear(x, self.w_out, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16)  # [2,1,Lp,128]
+        y = ttnn.add(ttnn.linear(y, self.w_post, compute_kernel_config=self.ck_mm, dtype=ttnn.bfloat16), y)
+        return y
+
+    def _ensure_trace(self, st: dict):
+        if st["out"] is None:
+            st["out"] = self._forward(st)  # compile pass
+            ttnn.synchronize_device(self.mesh)
+            if self.use_trace:
+                tid = ttnn.begin_trace_capture(self.mesh, cq_id=0)
+                st["out"] = self._forward(st)
+                ttnn.end_trace_capture(self.mesh, tid, cq_id=0)
+                ttnn.synchronize_device(self.mesh)
+                st["trace"] = tid
+                self.log(f"DiT: trace captured for Lp={st['Lp']} (L={st['L']})")
+
+    # ------------------------------------------------------------------ public forward (reference signature)
+    @torch.inference_mode()
+    def forward(self, latents: torch.Tensor, timestep: torch.Tensor, condition: torch.Tensor) -> torch.Tensor:
+        """latents [B<=2, 128, L], timestep [B], condition [B, L, 2048] -> velocity [B, 128, L] (float32, host)."""
+        B, C, L = latents.shape
+        assert B <= 2 and C == self.cfg.in_channels, latents.shape
+        st = self._state(L)
+        Lp = st["Lp"]
+        xin = torch.zeros(2, 1, Lp, self.cfg.concat_channels, dtype=torch.bfloat16)
+        xin[:B, 0, 1 : L + 1, :C] = latents.transpose(1, 2).to(torch.bfloat16)
+        xin[:B, 0, 1 : L + 1, 2 * C :] = condition.to(torch.bfloat16)
+        angles = 2.0 * math.pi * timestep.float().reshape(B, 1) * self.time_proj_w.reshape(1, -1)
+        feats = torch.cat((angles.cos(), angles.sin()), dim=-1)  # [B, 256]
+        tf = torch.zeros(2, 1, 32, self.cfg.fourier_embedding_dim, dtype=torch.bfloat16)
+        tf[:B, 0, 0] = feats.to(torch.bfloat16)
+        rep = ttnn.ReplicateTensorToMesh(self.mesh)
+        ttnn.copy_host_to_device_tensor(
+            ttnn.from_torch(xin, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, mesh_mapper=rep), st["xin"]
+        )
+        ttnn.copy_host_to_device_tensor(
+            ttnn.from_torch(tf, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, mesh_mapper=rep), st["tf"]
+        )
+        self._ensure_trace(st)
+        if st["trace"] is not None:
+            ttnn.execute_trace(self.mesh, st["trace"], cq_id=0, blocking=True)
+            out = st["out"]
+        else:
+            out = self._forward(st)
+        y = ttnn.to_torch(ttnn.get_device_tensors(out)[0]).float()[:B, 0, 1 : L + 1, :]  # [B, L, 128]
+        return y.transpose(1, 2).contiguous()
+
+    __call__ = forward
+
+    def release(self):
+        for st in self._shapes.values():
+            if st["trace"] is not None:
+                ttnn.release_trace(self.mesh, st["trace"])
+                st["trace"] = None

--- a/models/autoports/minimaxai_minimax_music3/tt/generator.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/generator.py
@@ -217,11 +217,11 @@ class Music3Generator:
         os.environ.setdefault("TT_CACHE_PATH", str(W.cache_root() / "tt_cache"))
         Path(os.environ["TT_CACHE_PATH"]).mkdir(parents=True, exist_ok=True)
         t0 = time.time()
-        self.args = ModelArgs(
-            self.mesh, instruct=False, max_batch_size=2, max_seq_len=self.max_seq_len, cache_hf_flag=False
-        )
+        self.args = ModelArgs(self.mesh, instruct=False, max_batch_size=2, max_seq_len=self.max_seq_len, cache_hf=False)
         if n_layers:
             self.args.n_layers = int(n_layers)
+        # the two rows are prefilled one at a time (batched prefill would call prepare_inputs_prefill with batch_size=2)
+        self.args.disable_batched_prefill = True
         self.log(
             f"ModelArgs: {self.args.model_name} device={self.args.device_name} vocab={self.args.vocab_size}/{self.args.padded_vocab_size} "
             f"layers={self.args.n_layers} max_seq_len={self.args.max_seq_len} prefill_chunk={getattr(self.args, 'max_prefill_chunk_size', '?')}"

--- a/models/autoports/minimaxai_minimax_music3/tt/generator.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/generator.py
@@ -178,6 +178,11 @@ class Music3Generator:
             load_vocoder=load_vocoder,
             log=log,
         )
+        self.vocoder_dtype = {"bf16": torch.bfloat16, "fp32": torch.float32}[
+            os.environ.get("MUSIC3_VOCODER_DTYPE", "bf16")
+        ]
+        if load_vocoder and self.vocoder_dtype != torch.float32:
+            self.ref.vocoder = self.ref.vocoder.to(self.vocoder_dtype)
         self.dit = None
         if load_dit and dit_device == "tt":
             from models.autoports.minimaxai_minimax_music3.tt.dit import TTDiT
@@ -202,7 +207,7 @@ class Music3Generator:
             if load_dit and dit_device == "tt"
             else ("torch-cpu" if load_dit else "-"),
             "cond_encoder": "torch-cpu",
-            "vocoder": "torch-cpu" if load_vocoder else "-",
+            "vocoder": f"torch-cpu ({os.environ.get('MUSIC3_VOCODER_DTYPE', 'bf16')})" if load_vocoder else "-",
         }
         log(f"Music3Generator ready in {time.time() - t0:.1f}s: {self.impl}")
 

--- a/models/autoports/minimaxai_minimax_music3/tt/generator.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/generator.py
@@ -1,0 +1,420 @@
+"""Music3Generator: caption + lyrics -> song on Tenstorrent.
+
+Phase A split: global LLM (tt_transformers, traced decode) + depth decoder (TTNN, traced step) + DiT (TTNN, traced
+per window length) on the chip; frame embedding, sampling, scheduler math, condition encoder and vocoder on the host
+(torch). The generation recipe and the torch.Generator consumption order are the reference's (reference/pipeline.py),
+so the same seed drives the same sampling decisions given the same logits.
+"""
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+import torch
+
+import ttnn
+from models.autoports.minimaxai_minimax_music3.config import (
+    AUDIO_CODE_OFFSET,
+    AUDIO_VOCAB_SIZE,
+    DIT_NUM_STEPS,
+    FRAME_RATE,
+    MAX_AUDIO_FRAMES,
+    NUM_CODEBOOKS,
+    SEMANTIC_VOCAB_SIZE,
+    SLICED_VOCAB,
+    Music3Config,
+    resolve_snapshot,
+)
+from models.autoports.minimaxai_minimax_music3.reference.pipeline import Music3Reference
+from models.autoports.minimaxai_minimax_music3.reference.prompt import Music3Tokenizer, build_text_ids
+from models.autoports.minimaxai_minimax_music3.reference.sampling import (
+    guided_c0_logits_sliced,
+    guided_depth_logits,
+    sample_top_k,
+)
+from models.autoports.minimaxai_minimax_music3.tt import weights as W
+
+
+@dataclass
+class GenStats:
+    prompt_len: int = 0
+    frames: int = 0
+    ended: bool = False
+    prefill_s: float = 0.0
+    semantic_s: float = 0.0
+    llm_s: float = 0.0
+    depth_s: float = 0.0
+    denoise_s: float = 0.0
+    decode_s: float = 0.0
+    total_s: float = 0.0
+    audio_s: float = 0.0
+    chunks: int = 0
+
+    @property
+    def rtf(self):
+        return self.total_s / self.audio_s if self.audio_s else float("inf")
+
+    @property
+    def ms_per_frame_llm(self):
+        return 1000.0 * self.llm_s / max(self.frames, 1)
+
+    @property
+    def ms_per_frame_depth(self):
+        return 1000.0 * self.depth_s / max(self.frames, 1)
+
+    def as_dict(self):
+        d = {k: getattr(self, k) for k in self.__dataclass_fields__}
+        d.update(rtf=self.rtf, ms_per_frame_llm=self.ms_per_frame_llm, ms_per_frame_depth=self.ms_per_frame_depth)
+        return d
+
+
+class CPUDepthDecoder:
+    """Torch fallback with the TTDepthDecoder.frame() API (bf16 on CPU)."""
+
+    def __init__(self, snapshot, cfg, full_embed: torch.Tensor, dtype=torch.bfloat16):
+        from models.autoports.minimaxai_minimax_music3.reference.depth_decoder import Music3DepthDecoder
+
+        self.m = Music3DepthDecoder.load(snapshot, dtype=dtype, cfg=cfg)
+        self.full_embed = full_embed.to(dtype)
+        self.dtype = dtype
+
+    @torch.inference_mode()
+    def frame(self, last_hidden, semantic_code: int, choose, forced=None, record=None):
+        d = self.m
+        lh = last_hidden.to(self.dtype)
+        seq = [
+            d.projection(lh).unsqueeze(1),
+            d.projection(self.full_embed[semantic_code + AUDIO_CODE_OFFSET]).view(1, 1, -1).expand(2, 1, -1),
+        ]
+        codes, parts = [int(semantic_code)], []
+        for index in range(1, NUM_CODEBOOKS):
+            h = d(torch.cat(seq, dim=1))[:, -1]
+            parts.append(h[:1].float())
+            logits = d.audio_heads[index - 1](h).float()
+            if record is not None:
+                record.setdefault("depth_logits", []).append(logits.clone())
+                record.setdefault("depth_hidden", []).append(h[:1].float().clone())
+            code = int(forced[index - 1]) if forced is not None else int(choose(guided_depth_logits(logits), index))
+            codes.append(code)
+            if index < NUM_CODEBOOKS - 1:
+                seq.append(
+                    d.projection(d.audio_embeddings.weight[code + (index - 1) * AUDIO_VOCAB_SIZE])
+                    .view(1, 1, -1)
+                    .expand(2, 1, -1)
+                )
+        return torch.tensor(codes, dtype=torch.int64), torch.cat(parts, dim=0)
+
+    def warmup(self):
+        pass
+
+    def release(self):
+        pass
+
+
+class Music3Generator:
+    def __init__(
+        self,
+        mesh_device,
+        snapshot: Optional[str] = None,
+        *,
+        max_seq_len: int = 16384,
+        llm_dtype=ttnn.bfloat8_b,
+        depth_dtype=ttnn.bfloat16,
+        dit_dtype=ttnn.bfloat16,
+        load_llm: bool = True,
+        load_depth: bool = True,
+        load_dit: bool = True,
+        load_vocoder: bool = True,
+        depth_device: str = "tt",
+        dit_device: str = "tt",
+        use_trace: bool = True,
+        n_layers: Optional[int] = None,
+        log: Callable[[str], None] = print,
+    ):
+        self.log, self.mesh, self.use_trace = log, mesh_device, use_trace
+        self.snapshot = (
+            Path(snapshot)
+            if snapshot
+            else W.resolve_snapshot()
+            if hasattr(W, "resolve_snapshot")
+            else resolve_snapshot()
+        )
+        self.cfg = Music3Config.from_snapshot(self.snapshot)
+        self.tok = Music3Tokenizer(self.snapshot)
+        self.max_seq_len = max_seq_len
+        t0 = time.time()
+        tables = W.load_lm_tables(self.snapshot)
+        self.full_embed = tables["model.embed_tokens.weight"].to(torch.bfloat16)
+        del tables
+        self.model = self.gen = self.args = None
+        if load_llm:
+            self._build_llm(llm_dtype, n_layers)
+        self.depth = None
+        if load_depth:
+            if depth_device == "tt":
+                from models.autoports.minimaxai_minimax_music3.tt.depth_decoder import TTDepthDecoder
+
+                self.depth = TTDepthDecoder(
+                    mesh_device,
+                    W.load_depth_state(self.snapshot),
+                    self.cfg.depth,
+                    weights_dtype=depth_dtype,
+                    full_embed=self.full_embed,
+                    use_trace=use_trace,
+                    log=log,
+                )
+            else:
+                self.depth = CPUDepthDecoder(self.snapshot, self.cfg.depth, self.full_embed)
+        self.depth_device = depth_device
+        # condition encoder + vocoder (+ the scheduler loop) come from the torch reference; the DiT forward is swapped
+        self.ref = Music3Reference(
+            self.snapshot,
+            dtype=torch.float32,
+            load_llm=False,
+            load_dit=(load_dit and dit_device == "cpu"),
+            load_vocoder=load_vocoder,
+            log=log,
+        )
+        self.dit = None
+        if load_dit and dit_device == "tt":
+            from models.autoports.minimaxai_minimax_music3.tt.dit import TTDiT
+
+            self.dit = TTDiT(
+                mesh_device,
+                W.load_dit_state(self.snapshot),
+                self.cfg.dit,
+                weights_dtype=dit_dtype,
+                use_trace=use_trace,
+                log=log,
+            )
+        elif load_dit:
+            self.dit = self.ref.dit
+        self.dit_device = dit_device
+        self.impl = {
+            "llm": f"ttnn/tt_transformers ({str(llm_dtype).split('.')[-1]})" if load_llm else "-",
+            "depth": f"ttnn ({str(depth_dtype).split('.')[-1]})"
+            if load_depth and depth_device == "tt"
+            else ("torch-cpu" if load_depth else "-"),
+            "dit": f"ttnn ({str(dit_dtype).split('.')[-1]})"
+            if load_dit and dit_device == "tt"
+            else ("torch-cpu" if load_dit else "-"),
+            "cond_encoder": "torch-cpu",
+            "vocoder": "torch-cpu" if load_vocoder else "-",
+        }
+        log(f"Music3Generator ready in {time.time() - t0:.1f}s: {self.impl}")
+
+    # ------------------------------------------------------------------ LLM
+    def _build_llm(self, dtype, n_layers):
+        from models.autoports.minimaxai_minimax_music3.tt.backbone import Music3Backbone
+        from models.tt_transformers.tt.generator import Generator
+        from models.tt_transformers.tt.model_config import ModelArgs
+
+        view = W.ensure_sliced_view(self.snapshot, log=self.log)
+        os.environ["HF_MODEL"] = str(view)
+        os.environ.setdefault("TT_CACHE_PATH", str(W.cache_root() / "tt_cache"))
+        Path(os.environ["TT_CACHE_PATH"]).mkdir(parents=True, exist_ok=True)
+        t0 = time.time()
+        self.args = ModelArgs(
+            self.mesh, instruct=False, max_batch_size=2, max_seq_len=self.max_seq_len, cache_hf_flag=False
+        )
+        if n_layers:
+            self.args.n_layers = int(n_layers)
+        self.log(
+            f"ModelArgs: {self.args.model_name} device={self.args.device_name} vocab={self.args.vocab_size}/{self.args.padded_vocab_size} "
+            f"layers={self.args.n_layers} max_seq_len={self.args.max_seq_len} prefill_chunk={getattr(self.args, 'max_prefill_chunk_size', '?')}"
+        )
+        assert self.args.vocab_size >= SLICED_VOCAB
+        sd = self.args.load_state_dict()
+        self.log(f"LLM state dict loaded ({len(sd)} tensors) in {time.time() - t0:.1f}s; moving to device ...")
+        t1 = time.time()
+        self.model = Music3Backbone(
+            self.args, dtype, self.mesh, sd, self.args.weight_cache_path(dtype), full_embed=self.full_embed
+        )
+        del sd
+        self.gen = Generator([self.model], [self.args], self.mesh)
+        self.log(f"LLM on device in {time.time() - t1:.1f}s")
+
+    def _prefill(self, text_ids: torch.Tensor):
+        S = text_ids.shape[1]
+        out = self.gen.prefill_forward_text(
+            text_ids, page_table=None, kv_cache=None, prompt_lens=torch.tensor([S, S]), enable_trace=False
+        )
+        logits = out.reshape(2, -1)[:, :SLICED_VOCAB].float()
+        hidden = torch.stack([self.model.read_prefill_hidden(u, S - 1) for u in range(2)])
+        self.model.free_prefill_hidden()
+        return logits, hidden
+
+    def _decode(self, residual: torch.Tensor, pos: int):
+        self.model.set_decode_residual(residual)
+        out = self.gen.decode_forward(
+            torch.zeros(2, 1, dtype=torch.int64),
+            torch.tensor([pos, pos], dtype=torch.int64),
+            page_table=None,
+            kv_cache=None,
+            enable_trace=self.use_trace,
+            read_from_device=True,
+        )
+        logits = out[0] if isinstance(out, tuple) else out
+        logits = logits.reshape(2, -1)[:, :SLICED_VOCAB].float()
+        hidden = self.model.read_decode_hidden(2)
+        return logits, hidden
+
+    def embed_audio_frame(self, codes: torch.Tensor) -> torch.Tensor:
+        """codes [8] -> [D] bf16: (E[c0+offset] + sum_i E_depth[c_i + (i-1)*1024]) * 8^-0.5 (float accumulation)."""
+        e = self.full_embed[int(codes[0]) + AUDIO_CODE_OFFSET].float()
+        table = (
+            self.depth.audio_embeddings
+            if hasattr(self.depth, "audio_embeddings")
+            else self.depth.m.audio_embeddings.weight
+        )
+        idx = codes[1:].to(torch.int64) + torch.arange(NUM_CODEBOOKS - 1) * AUDIO_VOCAB_SIZE
+        e = e + table[idx].float().sum(dim=0)
+        return (e * NUM_CODEBOOKS**-0.5).to(torch.bfloat16)
+
+    # ------------------------------------------------------------------ autoregressive stage
+    @torch.inference_mode()
+    def semantic_generation(
+        self,
+        text_ids: torch.Tensor,
+        max_frames: int,
+        generator,
+        *,
+        forced_codes: Optional[torch.Tensor] = None,
+        record: bool = False,
+        skip_depth: bool = False,
+        stats: Optional[GenStats] = None,
+        on_frame=None,
+    ) -> dict:
+        stats = stats or GenStats()
+        max_frames = min(int(max_frames), MAX_AUDIO_FRAMES)
+        S = text_ids.shape[1]
+        stats.prompt_len = S
+        t0 = time.time()
+        logits, last_hidden = self._prefill(text_ids)
+        stats.prefill_s = time.time() - t0
+        pos = S
+        frame_hiddens, codes_all, ended = [], [], False
+        dumps: Dict[str, list] = {"hidden_all": [], "c0_logits": [], "depth_logits": [], "depth_hidden": []}
+        n_steps = max_frames + 1 if forced_codes is None else forced_codes.shape[0]
+        t_sem = time.time()
+        for frame_index in range(n_steps):
+            if record:
+                dumps["hidden_all"].append(last_hidden.clone())
+                dumps["c0_logits"].append(logits.clone())
+            if forced_codes is None:
+                idx = int(sample_top_k(guided_c0_logits_sliced(logits), generator))
+                if idx == SEMANTIC_VOCAB_SIZE:  # <|audio_end|>
+                    ended = True
+                    break
+                semantic_code, forced = idx, None
+            else:
+                row = forced_codes[frame_index]
+                semantic_code, forced = int(row[0]), row[1:].tolist()
+            if skip_depth:
+                codes = torch.tensor([semantic_code, *forced], dtype=torch.int64)
+                depth_hidden = None
+            else:
+                td = time.time()
+                rec = {} if record else None
+                codes, depth_hidden = self.depth.frame(
+                    last_hidden, semantic_code, lambda g, i: int(sample_top_k(g, generator)), forced=forced, record=rec
+                )
+                stats.depth_s += time.time() - td
+                if record:
+                    dumps["depth_logits"].append(torch.stack(rec["depth_logits"]))
+                    dumps["depth_hidden"].append(torch.cat(rec["depth_hidden"]))
+            codes_all.append(codes)
+            if frame_index > 0:
+                if depth_hidden is not None:
+                    frame_hiddens.append(torch.cat((last_hidden[:1], depth_hidden.reshape(1, -1)), dim=-1))
+                stats.frames = frame_index
+                if on_frame:
+                    on_frame(frame_index - 1, codes)
+                if forced_codes is None and frame_index >= max_frames:
+                    break
+            if forced_codes is not None and frame_index == n_steps - 1:
+                break
+            tl = time.time()
+            logits, last_hidden = self._decode(self.embed_audio_frame(codes).unsqueeze(0).expand(2, -1), pos)
+            stats.llm_s += time.time() - tl
+            pos += 1
+        stats.semantic_s = time.time() - t_sem
+        stats.ended = ended
+        res = {
+            "codes_all": torch.stack(codes_all) if codes_all else torch.zeros(0, NUM_CODEBOOKS, dtype=torch.int64),
+            "ended": ended,
+            "prompt_len": S,
+        }
+        if frame_hiddens:
+            res["frame_hiddens"] = torch.stack(frame_hiddens, dim=1)
+        if record:
+            res.update({k: torch.stack(v) for k, v in dumps.items() if v})
+        return res
+
+    # ------------------------------------------------------------------ flow matching + vocoder
+    def dit_forward(self, latents, timestep, condition):
+        if self.dit_device == "tt":
+            return self.dit.forward(latents, timestep, condition)
+        return self.dit(latents, timestep, condition)
+
+    @torch.inference_mode()
+    def denoise(self, frame_hiddens: torch.Tensor, generator, num_steps: int = DIT_NUM_STEPS, record_steps=()):
+        return self.ref.denoise(
+            frame_hiddens, generator, num_steps=num_steps, record_steps=record_steps, dit_forward=self.dit_forward
+        )
+
+    @torch.inference_mode()
+    def decode(self, latent_chunks: List[torch.Tensor]) -> torch.Tensor:
+        return self.ref.decode(latent_chunks)
+
+    # ------------------------------------------------------------------ end to end
+    @torch.inference_mode()
+    def generate(
+        self,
+        caption: str,
+        lyrics: str,
+        *,
+        audio_duration: float = 60.0,
+        seed: int = 0,
+        num_steps: int = DIT_NUM_STEPS,
+        max_frames: Optional[int] = None,
+        on_frame=None,
+        stages=("semantic", "denoise", "decode"),
+    ) -> dict:
+        stats = GenStats()
+        generator = torch.Generator("cpu").manual_seed(int(seed))
+        text_ids = build_text_ids(self.tok, caption, lyrics)
+        assert (
+            text_ids.shape[1] + (max_frames or int(audio_duration * FRAME_RATE)) + 2 <= self.max_seq_len
+        ), "prompt + frames exceed max_seq_len"
+        mf = max_frames if max_frames is not None else min(int(audio_duration * FRAME_RATE), MAX_AUDIO_FRAMES)
+        t0 = time.time()
+        sem = self.semantic_generation(text_ids, mf, generator, stats=stats, on_frame=on_frame)
+        out = {**sem, "text_ids": text_ids}
+        if "denoise" in stages and "frame_hiddens" in sem:
+            t1 = time.time()
+            den = self.denoise(sem["frame_hiddens"], generator, num_steps=num_steps)
+            stats.denoise_s = time.time() - t1
+            stats.chunks = len(den["latent_chunks"])
+            out.update(den)
+            if "decode" in stages:
+                t2 = time.time()
+                out["audio"] = self.decode(den["latent_chunks"])
+                stats.decode_s = time.time() - t2
+                stats.audio_s = out["audio"].shape[-1] / self.cfg.vocoder.sampling_rate
+                out["sample_rate"] = self.cfg.vocoder.sampling_rate
+        stats.total_s = time.time() - t0
+        out["stats"] = stats
+        self.log(
+            f"generate: {stats.frames} frames, {stats.audio_s:.1f}s audio in {stats.total_s:.1f}s (RTF {stats.rtf:.2f}; prefill {stats.prefill_s:.1f}s, "
+            f"llm {stats.ms_per_frame_llm:.1f} ms/f, depth {stats.ms_per_frame_depth:.1f} ms/f, denoise {stats.denoise_s:.1f}s, vocoder {stats.decode_s:.1f}s)"
+        )
+        return out
+
+    def release(self):
+        for m in (self.depth, self.dit):
+            if m is not None and hasattr(m, "release"):
+                m.release()

--- a/models/autoports/minimaxai_minimax_music3/tt/generator.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/generator.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
@@ -49,6 +50,7 @@ class GenStats:
     depth_s: float = 0.0
     denoise_s: float = 0.0
     decode_s: float = 0.0
+    vocoder_s: float = 0.0  # summed per-window vocoder compute (overlaps denoise_s when pipelined)
     total_s: float = 0.0
     audio_s: float = 0.0
     chunks: int = 0
@@ -183,6 +185,8 @@ class Music3Generator:
         ]
         if load_vocoder and self.vocoder_dtype != torch.float32:
             self.ref.vocoder = self.ref.vocoder.to(self.vocoder_dtype)
+        # vocode window k on a worker thread while the DiT denoises window k+1 (MUSIC3_PIPELINE_VOCODER=0 disables)
+        self.pipeline_vocoder = os.environ.get("MUSIC3_PIPELINE_VOCODER", "1") not in ("0", "false", "no")
         self.dit = None
         if load_dit and dit_device == "tt":
             from models.autoports.minimaxai_minimax_music3.tt.dit import TTDiT
@@ -366,9 +370,16 @@ class Music3Generator:
         return self.dit(latents, timestep, condition)
 
     @torch.inference_mode()
-    def denoise(self, frame_hiddens: torch.Tensor, generator, num_steps: int = DIT_NUM_STEPS, record_steps=()):
+    def denoise(
+        self, frame_hiddens: torch.Tensor, generator, num_steps: int = DIT_NUM_STEPS, record_steps=(), on_chunk=None
+    ):
         return self.ref.denoise(
-            frame_hiddens, generator, num_steps=num_steps, record_steps=record_steps, dit_forward=self.dit_forward
+            frame_hiddens,
+            generator,
+            num_steps=num_steps,
+            record_steps=record_steps,
+            dit_forward=self.dit_forward,
+            on_chunk=on_chunk,
         )
 
     @torch.inference_mode()
@@ -400,22 +411,53 @@ class Music3Generator:
         sem = self.semantic_generation(text_ids, mf, generator, stats=stats, on_frame=on_frame)
         out = {**sem, "text_ids": text_ids}
         if "denoise" in stages and "frame_hiddens" in sem:
+            pipelined = "decode" in stages and self.pipeline_vocoder
+            # Pipelined: the (host, torch) vocoder runs window k on one worker thread while the DiT denoises window
+            # k+1 on the chip. Each window is vocoded by the identical call in the identical order, and the crop /
+            # stitch happens once at the end exactly as in the reference decode(), so the audio bytes are unchanged
+            # (the torch.Generator is only consumed on the denoise side).
+            wav_futures: List = []
+            vocoder_s = [0.0]
+
+            def vocode_window(lat):
+                t = time.time()
+                with torch.inference_mode():  # inference_mode is thread-local
+                    wav = self.ref.vocode(lat)
+                vocoder_s[0] += time.time() - t
+                return wav
+
             t1 = time.time()
-            den = self.denoise(sem["frame_hiddens"], generator, num_steps=num_steps)
-            stats.denoise_s = time.time() - t1
+            if pipelined:
+                with ThreadPoolExecutor(max_workers=1, thread_name_prefix="music3-vocoder") as pool:
+                    den = self.denoise(
+                        sem["frame_hiddens"],
+                        generator,
+                        num_steps=num_steps,
+                        on_chunk=lambda k, lat: wav_futures.append(pool.submit(vocode_window, lat)),
+                    )
+                    stats.denoise_s = time.time() - t1
+                    t2 = time.time()
+                    wavs = [f.result() for f in wav_futures]
+                out["audio"] = self.ref.stitch(wavs)
+            else:
+                den = self.denoise(sem["frame_hiddens"], generator, num_steps=num_steps)
+                stats.denoise_s = time.time() - t1
+                t2 = time.time()
+                if "decode" in stages:
+                    out["audio"] = self.ref.stitch([vocode_window(lat) for lat in den["latent_chunks"]])
             stats.chunks = len(den["latent_chunks"])
             out.update(den)
             if "decode" in stages:
-                t2 = time.time()
-                out["audio"] = self.decode(den["latent_chunks"])
                 stats.decode_s = time.time() - t2
+                stats.vocoder_s = vocoder_s[0]
                 stats.audio_s = out["audio"].shape[-1] / self.cfg.vocoder.sampling_rate
                 out["sample_rate"] = self.cfg.vocoder.sampling_rate
         stats.total_s = time.time() - t0
         out["stats"] = stats
         self.log(
             f"generate: {stats.frames} frames, {stats.audio_s:.1f}s audio in {stats.total_s:.1f}s (RTF {stats.rtf:.2f}; prefill {stats.prefill_s:.1f}s, "
-            f"llm {stats.ms_per_frame_llm:.1f} ms/f, depth {stats.ms_per_frame_depth:.1f} ms/f, denoise {stats.denoise_s:.1f}s, vocoder {stats.decode_s:.1f}s)"
+            f"llm {stats.ms_per_frame_llm:.1f} ms/f, depth {stats.ms_per_frame_depth:.1f} ms/f, denoise {stats.denoise_s:.1f}s, "
+            f"vocoder {stats.vocoder_s:.1f}s{' pipelined' if self.pipeline_vocoder else ''}, decode tail {stats.decode_s:.1f}s)"
         )
         return out
 

--- a/models/autoports/minimaxai_minimax_music3/tt/weights.py
+++ b/models/autoports/minimaxai_minimax_music3/tt/weights.py
@@ -1,0 +1,217 @@
+"""Weights plumbing for the TT side: the HF "view" directory tt_transformers.ModelArgs reads (language_model config +
+tokenizer files + safetensors symlinks), the sliced LM head / embedding tables, and the depth/DiT/cond/vocoder loaders.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict
+
+import torch
+
+from models.autoports.minimaxai_minimax_music3.config import (
+    AUDIO_CODE_OFFSET,
+    AUDIO_END_TOKEN_ID,
+    HF_REVISION,
+    SEMANTIC_VOCAB_SIZE,
+    SLICED_VOCAB,
+    SLICED_VOCAB_PADDED,
+)
+
+
+def cache_root() -> Path:
+    p = Path(os.environ.get("TT_DIT_CACHE_DIR", Path.home() / ".cache" / "minimax_music3"))
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def ensure_hf_view(snapshot: os.PathLike, view_dir: os.PathLike | None = None) -> Path:
+    """A directory ModelArgs(HF_MODEL=...) can read: language_model/config.json (+ generation_config), the shards and
+    index (symlinked), and the tokenizer files from tokenizer/. Named "MiniMax-Music3-LM" so base_model_name is stable.
+    """
+    snapshot = Path(snapshot)
+    view_dir = Path(view_dir or os.environ.get("MUSIC3_HF_VIEW") or (cache_root() / "hf_view" / "MiniMax-Music3-LM"))
+    view_dir.mkdir(parents=True, exist_ok=True)
+    lm = snapshot / "language_model"
+    for src in sorted(lm.iterdir()):
+        dst = view_dir / src.name
+        if not dst.exists():
+            try:
+                dst.symlink_to(src.resolve())
+            except OSError:
+                dst.write_bytes(src.read_bytes())
+    for name in (
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "chat_template.jinja",
+        "special_tokens_map.json",
+        "vocab.json",
+        "merges.txt",
+    ):
+        src, dst = snapshot / "tokenizer" / name, view_dir / name
+        if src.exists() and not dst.exists():
+            try:
+                dst.symlink_to(src.resolve())
+            except OSError:
+                dst.write_bytes(src.read_bytes())
+    cfg = json.load(open(view_dir / "config.json"))
+    assert cfg["model_type"] == "qwen3" and cfg["vocab_size"] > AUDIO_CODE_OFFSET + SEMANTIC_VOCAB_SIZE, cfg.get(
+        "vocab_size"
+    )
+    return view_dir
+
+
+def sliced_rows(full: torch.Tensor) -> torch.Tensor:
+    """[V, D] -> [SLICED_VOCAB_PADDED, D]: rows 0..16383 = semantic codes, 16384 = end-of-audio, rest zero."""
+    out = torch.zeros(SLICED_VOCAB_PADDED, full.shape[1], dtype=full.dtype)
+    out[:SEMANTIC_VOCAB_SIZE] = full[AUDIO_CODE_OFFSET : AUDIO_CODE_OFFSET + SEMANTIC_VOCAB_SIZE]
+    out[SEMANTIC_VOCAB_SIZE] = full[AUDIO_END_TOKEN_ID]
+    return out
+
+
+def load_lm_tables(snapshot: os.PathLike) -> Dict[str, torch.Tensor]:
+    """embed_tokens + lm_head (bf16, full vocab) straight from the shards, without loading the 36 layers."""
+    from safetensors import safe_open
+
+    idx = json.load(open(Path(snapshot) / "language_model" / "model.safetensors.index.json"))["weight_map"]
+    out = {}
+    for key in ("model.embed_tokens.weight", "lm_head.weight"):
+        with safe_open(str(Path(snapshot) / "language_model" / idx[key]), framework="pt", device="cpu") as f:
+            out[key] = f.get_tensor(key)
+    return out
+
+
+def load_depth_state(snapshot: os.PathLike) -> Dict[str, torch.Tensor]:
+    from safetensors.torch import load_file
+
+    return load_file(str(Path(snapshot) / "rvq_depth_decoder" / "diffusion_pytorch_model.safetensors"), device="cpu")
+
+
+def load_dit_state(snapshot: os.PathLike, num_layers: int | None = None) -> Dict[str, torch.Tensor]:
+    from safetensors.torch import load_file
+
+    sd = {}
+    for shard in sorted(Path(snapshot, "transformer").glob("*.safetensors")):
+        sd.update(load_file(str(shard), device="cpu"))
+    if num_layers is not None:
+        sd = {
+            k: v for k, v in sd.items() if not k.startswith("transformer_blocks.") or int(k.split(".")[1]) < num_layers
+        }
+    return sd
+
+
+def weight_report(snapshot: os.PathLike) -> dict:
+    """Stage-02 evidence: per-component tensor counts, dtypes, parameter totals."""
+    from safetensors import safe_open
+
+    snapshot = Path(snapshot)
+    rep = {"snapshot": str(snapshot), "components": {}}
+    for sub in ("language_model", "transformer", "rvq_depth_decoder", "condition_encoder", "vocoder"):
+        n, params, dtypes, bytes_ = 0, 0, {}, 0
+        for shard in sorted((snapshot / sub).glob("*.safetensors")):
+            bytes_ += os.path.getsize(os.path.realpath(shard))
+            with safe_open(str(shard), framework="pt", device="cpu") as f:
+                for k in f.keys():
+                    sl = f.get_slice(k)
+                    shape = sl.get_shape()
+                    n += 1
+                    numel = 1
+                    for s in shape:
+                        numel *= s
+                    params += numel
+                    dtypes[sl.get_dtype()] = dtypes.get(sl.get_dtype(), 0) + 1
+        rep["components"][sub] = {"tensors": n, "params": params, "dtypes": dtypes, "bytes": bytes_}
+    tables = load_lm_tables(snapshot)
+    rep["lm_head_shape"] = list(tables["lm_head.weight"].shape)
+    rep["embed_shape"] = list(tables["model.embed_tokens.weight"].shape)
+    rep["tied"] = bool(torch.equal(tables["lm_head.weight"][:4096], tables["model.embed_tokens.weight"][:4096]))
+    rep["sliced_head_rows"] = SLICED_VOCAB
+    rep["revision"] = HF_REVISION
+    return rep
+
+
+# ---------------------------------------------------------------------------------------------------------------
+# The SLICED HF view: a real HF model directory whose embed_tokens / lm_head carry only the 16 385 rows the c0 head
+# can ever un-mask (padded to 16 416), so tt_transformers' standard HF path builds correctly-sized device tables.
+# Written once (stage 02) into the cache root; shards that do not hold the two tables are symlinked.
+# ---------------------------------------------------------------------------------------------------------------
+SLICED_VIEW_NAME = "MiniMax-Music3-LM-sliced"
+_TABLES = ("model.embed_tokens.weight", "lm_head.weight")
+
+
+def sliced_view_dir() -> Path:
+    return Path(os.environ.get("MUSIC3_HF_VIEW") or (cache_root() / "hf_view" / SLICED_VIEW_NAME))
+
+
+def ensure_sliced_view(snapshot: os.PathLike, view_dir: os.PathLike | None = None, log=print) -> Path:
+    from safetensors import safe_open
+    from safetensors.torch import save_file
+
+    snapshot = Path(snapshot)
+    view = Path(view_dir or sliced_view_dir())
+    marker = view / ".sliced_view_complete"
+    if marker.exists() and (view / "model.safetensors.index.json").exists():
+        return view
+    view.mkdir(parents=True, exist_ok=True)
+    lm = snapshot / "language_model"
+    idx = json.load(open(lm / "model.safetensors.index.json"))
+    wm: Dict[str, str] = dict(idx["weight_map"])
+    table_shards = {wm[k] for k in _TABLES}
+    new_map: Dict[str, str] = {}
+    for shard in sorted(set(wm.values())):
+        dst = view / shard
+        if shard in table_shards:
+            log(f"sliced view: rewriting {shard} without the vocab tables")
+            with safe_open(str(lm / shard), framework="pt", device="cpu") as f:
+                keep = {k: f.get_tensor(k) for k in f.keys() if k not in _TABLES}
+            if dst.exists() or dst.is_symlink():
+                dst.unlink()
+            save_file(keep, str(dst), metadata={"format": "pt"})
+            for k in keep:
+                new_map[k] = shard
+        else:
+            if not dst.exists():
+                dst.symlink_to((lm / shard).resolve())
+            for k, v in wm.items():
+                if v == shard:
+                    new_map[k] = shard
+    tables = load_lm_tables(snapshot)
+    sliced = {k: sliced_rows(tables[k]).contiguous() for k in _TABLES}
+    save_file(sliced, str(view / "model-sliced.safetensors"), metadata={"format": "pt"})
+    for k in _TABLES:
+        new_map[k] = "model-sliced.safetensors"
+    total = sum(os.path.getsize(os.path.realpath(view / s)) for s in set(new_map.values()))
+    json.dump(
+        {
+            "metadata": {"total_size": total, "sliced_vocab": SLICED_VOCAB, "source_revision": HF_REVISION},
+            "weight_map": new_map,
+        },
+        open(view / "model.safetensors.index.json", "w"),
+        indent=1,
+    )
+    cfg = json.load(open(lm / "config.json"))
+    cfg["vocab_size"] = SLICED_VOCAB_PADDED
+    cfg["_music3_sliced_vocab"] = {
+        "rows": SLICED_VOCAB,
+        "semantic_offset": AUDIO_CODE_OFFSET,
+        "end_token_id": AUDIO_END_TOKEN_ID,
+        "end_row": SEMANTIC_VOCAB_SIZE,
+    }
+    json.dump(cfg, open(view / "config.json", "w"), indent=2)
+    gen = lm / "generation_config.json"
+    (view / "generation_config.json").write_text(gen.read_text() if gen.exists() else "{}")
+    for name in (
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "chat_template.jinja",
+        "special_tokens_map.json",
+        "vocab.json",
+        "merges.txt",
+    ):
+        src, dst = snapshot / "tokenizer" / name, view / name
+        if src.exists() and not dst.exists():
+            dst.symlink_to(src.resolve())
+    marker.write_text("ok\n")
+    log(f"sliced view ready: {view}")
+    return view


### PR DESCRIPTION
## Summary

Bring-up of `MiniMaxAI/MiniMax-Music3` (lyrics + caption -> stereo song) on ONE Blackhole chip (P150; chip 0 of a P300 / QuietBox 2), packaged and published as a tt-model-manager CONTAINER (v5.1, kind `tt-dit-server`, profile `p150`): https://huggingface.co/jashansinghTT/minimax-music3-blackhole (public; `tt-model serve jashansinghTT/minimax-music3-blackhole --profile p150`).

Everything is under `models/autoports/minimaxai_minimax_music3/`; nothing under `ttnn/` or `tt_metal/` changed. Base is main `8e18a76`.

- `reference/`: torch port of the diffusers PR #14456 pipeline (Apache-2.0, `PROVENANCE.md`); reproduces the diffusers modular pipeline **bit-for-bit** (201/201 identical codes, audio max abs diff 0.0). Used for CPU goldens, PCC references, and the CPU stages of serving (condition encoder, vocoder).
- `tt/backbone.py`: Qwen3-8B global LLM on `models/tt_transformers` — the two classifier-free-guidance rows as `max_batch_size=2`, host frame embeddings as the residual, a **sliced 16 385-row LM head** (semantic codes + `<|audio_end|>`; provably identical to the masked 200k head), post-norm hidden tap.
- `tt/depth_decoder.py`: TTNN RVQ depth decoder (4 layers, 7 heads) — one 32-row causal step per trace (7 traces), `minimal_matmul` + fused SwiGLU; 37 ms/frame.
- `tt/dit.py`: TTNN flow-matching DiT (36 layers) — windowed SDPA (`cu_window_seqlens`), partial RoPE via the per-tile ROPE op, `minimal_matmul` + fused SwiGLU, one trace per window length; 93 ms per forward (batch 2, 689 latents, bf16/HiFi2).
- `tt/generator.py`: the full recipe (same `torch.Generator` consumption order as diffusers -> seeded runs are deterministic).
- `server/`: FastAPI, SGLang-Omni compatible `POST /v1/audio/speech` + async `/v1/music/jobs`; `tt-model.yaml` manifest; `doc/REPORT.md` with every measured number.

## Evidence (single P150, teacher-forced against the CPU fp32 reference)

| component | accuracy | speed |
|---|---|---|
| global LLM (bfp8) | hidden PCC >= 0.994, CPU argmax within top-5 100 %, top-1 agreement 0.81-0.85 (bar 0.90, advisory; bf16 weights 0.83) | 36-37 ms/frame traced decode |
| depth decoder (bfp8/HiFi2) | logits PCC >= 0.998, top-1 0.95, top-5 100 % | 37 ms/frame (7 steps) |
| DiT (bf16/HiFi2) | window latents PCC 0.9992, vocoded audio PCC 0.99, spectral convergence 0.047 | 93 ms/forward |
| end to end | audio sanity gates pass, seed-deterministic | RTF ~4.0 (unoptimized was 5.4-6.0) |

Package proof: bare-metal server with the launcher's env, `tt-model serve --profile p150` of the built image on a QB2, and a clean `tt-model pull` from the Hub + serve — all pass the 22-check API proof (health, WAV 32 kHz stereo, seeded determinism, jobs API, queueing, validation errors, clean stop).

Tests: `tests/test_{config,prompt,sampling,reference_modules}.py` (CPU parity vs diffusers/transformers) and `tests/test_{backbone,depth_decoder,dit,e2e}.py` (device). Pipeline, goldens and logs: `~/music3-bringup` on qb2-120-p11t03.

## Relation to #56043

#56043 is an independent implementation of the same model under the same autoport path (different module layout, stacked on a newer main). This PR is the tt-model-manager-oriented variant that shipped the published container. One of the two should be picked; happy to merge the better pieces either way.

## Known limitations

- Real-time not reached (RTF ~4): the AR loop is strictly sequential (LLM + depth ~75 ms per 40 ms frame). Follow-ups: on-device sampling with one trace for the 7 depth steps, L1-sharded depth matmuls, TT vocoder, DiT on a second chip.
- Condition encoder / vocoder run on the CPU (torch; vocoder bf16, PCC 0.99994 vs fp32).
- c0 top-1 agreement with the CPU argmax is below the 0.90 framework bar (top-5 = 100 %; the distributions are flat music-token distributions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jashan/minimax-music3-p150-tmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jashan/minimax-music3-p150-tmm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jashan/minimax-music3-p150-tmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jashan/minimax-music3-p150-tmm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jashan/minimax-music3-p150-tmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jashan/minimax-music3-p150-tmm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jashan/minimax-music3-p150-tmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jashan/minimax-music3-p150-tmm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jashan/minimax-music3-p150-tmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jashan/minimax-music3-p150-tmm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jashan/minimax-music3-p150-tmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jashan/minimax-music3-p150-tmm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jashan/minimax-music3-p150-tmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jashan/minimax-music3-p150-tmm)