### PR TITLE
prefill: reject a headed last rank under trace

### DIFF
--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -102,6 +102,13 @@ assert not (DFLASH_ENABLED and USE_TRACE), (
     "trace-captured. Run DFlash with PREFILL_USE_TRACE=0."
 )
 
+assert KV_ONLY_LAST_LAYER or not USE_TRACE, (
+    "PREFILL_KV_ONLY_LAST_LAYER=0 is incompatible with PREFILL_USE_TRACE=1: the last rank then builds the "
+    "norm/LM-head tail, whose logit read-back synchronizes the device, and event synchronization is "
+    "rejected during trace capture. The runner emits no token, so run it headless (the default) or with "
+    "PREFILL_USE_TRACE=0."
+)
+
 # Traced writes go through the metadata tensors, which cannot supply the host kv_actual_global the
 # TP-sharded reader needs to pick its 1/tp source window. Unreachable today (trace is already rejected for
 # every sparse/DSA model, and tp_shard_kv is sparse-only), so this is the tripwire for when that lifts.


### PR DESCRIPTION


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/assert_trace_lm_head)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/assert_trace_lm_head)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/assert_trace_lm_head)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/assert_trace_lm_head)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/assert_trace_lm_head)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/assert_trace_lm_head)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/assert_trace_lm_head)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/assert_trace_lm_head)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/assert_trace_lm_head)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/assert_trace_lm_head)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/assert_trace_lm_head)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/assert_trace_lm_head)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/assert_trace_lm_head)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/assert_trace_lm_head)