### PR TITLE
[Cleanup] Transfer bevformer code ownership to njovanovicTT

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -594,7 +594,7 @@ models/demos/wormhole/mamba @esmalTT @uaydonat @kpaigwar
 models/demos/wormhole/sentence_bert @arginugaTT @tenstorrent/cse-developer-ttnn
 models/experimental/ @uaydonat @mtairum
 models/experimental/SSD512 @dvartaniansTT @tenstorrent/cse-developer-ttnn
-models/experimental/bevformer/ @mbezuljTT @ddjekicTT
+models/experimental/bevformer/ @mbezuljTT @njovanovicTT
 models/experimental/efficientdetd0 @dvartaniansTT @tenstorrent/cse-developer-ttnn
 models/experimental/efficientnetb0 @ssinghalTT @tenstorrent/cse-developer-ttnn
 models/experimental/exaone45_vl @changh95 @uaydonat @mtairum


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Ownership of `models/experimental/bevformer/` moves from @ddjekicTT to
@njovanovicTT; @mbezuljTT stays as co-owner. Without this, bevformer PRs keep
routing review to the person no longer maintaining the model.

Closes #56053

### Notes for reviewers

One-line change in `.github/CODEOWNERS`, scoped to the bevformer entry.

### CI Status

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=njovanovic/26-09-bevformer-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:njovanovic/26-09-bevformer-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=njovanovic/26-09-bevformer-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:njovanovic/26-09-bevformer-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njovanovic/26-09-bevformer-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njovanovic/26-09-bevformer-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=njovanovic/26-09-bevformer-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:njovanovic/26-09-bevformer-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njovanovic/26-09-bevformer-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njovanovic/26-09-bevformer-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njovanovic/26-09-bevformer-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njovanovic/26-09-bevformer-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njovanovic/26-09-bevformer-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njovanovic/26-09-bevformer-codeowners)