### PR TITLE
[Bug fix] pool: clamp MPWI increment-CB fill to one tile

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/reader_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/reader_mpwi.cpp
@@ -144,10 +144,11 @@ ALWI void initialize_return_indices_data() {
     // initialize the increment CBs
     // TODO we used to fill the 16 bit values two at a time, but this technically resulted in overflow with odd
     // c dimensions so for now we do it one at a time for both 16 and 32 bit indexes
+    constexpr uint32_t inc_rows = is_large_kernel ? sticks_per_chunk : window_size_hw;
     if constexpr (indexes_32_bit) {
         auto fill_inc_32 = [&](DataflowBuffer& inc_cb, uint32_t inc) __attribute__((always_inline)) {
             volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_cb.get_write_ptr());
-            for (uint32_t k = 0; k < window_size_hw; ++k) {
+            for (uint32_t k = 0; k < inc_rows; ++k) {
                 for (uint32_t c = 0; c < fill_c; ++c) {
                     ptr[k * TILE_WIDTH + c] = inc;
                 }
@@ -185,7 +186,7 @@ ALWI void initialize_return_indices_data() {
             uint16_t inc_16 = (uint16_t)inc;
             uint32_t inc_32_bit = (uint32_t)inc_16 | ((uint32_t)inc_16 << 16);
             volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_cb.get_write_ptr());
-            for (uint32_t k = 0; k < window_size_hw; ++k) {
+            for (uint32_t k = 0; k < inc_rows; ++k) {
                 for (uint32_t c = 0; c < fill_c_32_bit; ++c) {
                     ptr[k * HALF_TILE_WIDTH + c] = inc_32_bit;
                 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
@@ -142,10 +142,11 @@ ALWI void initialize_return_indices_data() {
     // initialize the increment CBs
     // TODO we used to fill the 16 bit values two at a time, but this technically resulted in overflow with odd
     // c dimensions so for now we do it one at a time for both 16 and 32 bit indexes
+    constexpr uint32_t inc_rows = is_large_kernel ? sticks_per_chunk : window_size_hw;
     if constexpr (indexes_32_bit) {
         auto fill_inc_32 = [&](DataflowBuffer& inc_dfb, uint32_t inc) __attribute__((always_inline)) {
             volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_dfb.get_write_ptr());
-            for (uint32_t k = 0; k < window_size_hw; ++k) {
+            for (uint32_t k = 0; k < inc_rows; ++k) {
                 for (uint32_t c = 0; c < fill_c; ++c) {
                     ptr[k * TILE_WIDTH + c] = inc;
                 }
@@ -183,7 +184,7 @@ ALWI void initialize_return_indices_data() {
             uint16_t inc_16 = (uint16_t)inc;
             uint32_t inc_32_bit = (uint32_t)inc_16 | ((uint32_t)inc_16 << 16);
             volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_dfb.get_write_ptr());
-            for (uint32_t k = 0; k < window_size_hw; ++k) {
+            for (uint32_t k = 0; k < inc_rows; ++k) {
                 for (uint32_t c = 0; c < fill_c_32_bit; ++c) {
                     ptr[k * HALF_TILE_WIDTH + c] = inc_32_bit;
                 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Relates to #51226 (item 1).

MPWI wrote `window_size_hw` rows into increment CBs that are one tile. Large kernels (e.g. 13×13, 169 rows) overflowed L1. Clamp the fill to `sticks_per_chunk` on the large-kernel path, matching `fill_indexes`. Same clamp in Quasar `reader_mpwi.cpp`.

### Notes for reviewers
Compute only copies tile 0. `sticks_per_chunk = min(kernel_w, max_sticks_for_reduction)` (16 or 32), so the fill stays in the tile.

Wormhole: `pytest tests/ttnn/unit_tests/operations/pool/test_mpwi.py::test_mpwi_large_kernel_sizes -v` — 16 passed, including `[2,64,159,159,13,13,...]` bf16 and bfloat8_b. Watcher clean.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ijankowski/fix-mpwi-inc-cb-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ijankowski/fix-mpwi-inc-cb-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ijankowski/fix-mpwi-inc-cb-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ijankowski/fix-mpwi-inc-cb-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ijankowski/fix-mpwi-inc-cb-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ijankowski/fix-mpwi-inc-cb-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ijankowski/fix-mpwi-inc-cb-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ijankowski/fix-mpwi-inc-cb-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ijankowski/fix-mpwi-inc-cb-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ijankowski/fix-mpwi-inc-cb-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ijankowski/fix-mpwi-inc-cb-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ijankowski/fix-mpwi-inc-cb-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ijankowski/fix-mpwi-inc-cb-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ijankowski/fix-mpwi-inc-cb-overflow)