### PR TITLE
[Bug fix] pool: FLOAT32 nearest-rotate fill and bilinear C % TILE_WIDTH guard

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_rotate.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_rotate.py
@@ -245,6 +245,15 @@ def test_channel_alignment(device, channels):
     ), f"90-degree rotation should be exact for {channels} channels"
 
 
+@pytest.mark.parametrize("channels", [16, 48])
+def test_bilinear_rejects_non_tile_width_channels(device, channels, expect_error):
+    ttnn_input = ttnn.from_torch(
+        torch.randn(1, 32, 32, channels, dtype=torch.bfloat16), layout=ttnn.ROW_MAJOR_LAYOUT, device=device
+    )
+    with expect_error(RuntimeError, "divisible by TILE_WIDTH"):
+        ttnn.rotate(ttnn_input, angle=45.0, interpolation_mode="bilinear")
+
+
 # ============================================================================
 # Memory Configuration Tests
 # ============================================================================

--- a/tests/ttnn/unit_tests/operations/pool/test_rotate.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_rotate.py
@@ -154,6 +154,14 @@ def test_custom_fill_values(device, fill, interpolation_mode, dtype):
     ttnn_output = ttnn.rotate(ttnn_input, angle=angle, fill=fill, interpolation_mode=interpolation_mode)
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
+    # Nearest OOB fill must be tight; whole-image atol=6 hides the FLOAT32 packing bug.
+    # Bilinear interpolates near the edge, so those pixels are not exact fill.
+    if interpolation_mode == "nearest":
+        fill_mask = torch.all(torch_output_nhwc == fill, dim=-1)
+        assert torch.any(fill_mask), "45° rotation should produce out-of-bounds fill pixels"
+        fill_close = torch.allclose(ttnn_output_torch[fill_mask], torch_output_nhwc[fill_mask], atol=1e-5, rtol=0)
+        assert fill_close, f"OOB fill mismatch for fill={fill}, dtype={dtype}"
+
     atol, rtol = get_rotate_tolerances(input_shape, angle, interpolation_mode)
     comparison_passed = torch.allclose(torch_output_nhwc, ttnn_output_torch, atol=atol, rtol=rtol)
     assert comparison_passed, f"Fill value test failed for fill={fill}, mode={interpolation_mode}, dtype={dtype}"

--- a/tests/ttnn/unit_tests/operations/pool/test_rotate.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_rotate.py
@@ -130,25 +130,33 @@ def test_custom_center(device, center, interpolation_mode):
 
 
 @pytest.mark.parametrize("fill", [0.0, 1.0, -1.0, 0.5])
-@pytest.mark.parametrize("interpolation_mode", ["nearest", "bilinear"])
-def test_custom_fill_values(device, fill, interpolation_mode):
+@pytest.mark.parametrize(
+    "interpolation_mode,dtype",
+    [
+        ("nearest", ttnn.bfloat16),
+        ("nearest", ttnn.float32),
+        ("bilinear", ttnn.bfloat16),
+    ],
+)
+def test_custom_fill_values(device, fill, interpolation_mode, dtype):
     """Test different fill values for out-of-bounds pixels."""
     torch.manual_seed(0)
 
     input_shape = (1, 16, 16, 64)
     angle = 45.0
-    torch_input_nhwc = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    torch_input_nhwc = torch.randn(input_shape, dtype=torch_dtype)
 
     golden_function = ttnn.get_golden_function(ttnn.rotate)
     torch_output_nhwc = golden_function(torch_input_nhwc, angle=angle, fill=fill, interpolation_mode=interpolation_mode)
 
-    ttnn_input = ttnn.from_torch(torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    ttnn_input = ttnn.from_torch(torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=dtype)
     ttnn_output = ttnn.rotate(ttnn_input, angle=angle, fill=fill, interpolation_mode=interpolation_mode)
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
     atol, rtol = get_rotate_tolerances(input_shape, angle, interpolation_mode)
     comparison_passed = torch.allclose(torch_output_nhwc, ttnn_output_torch, atol=atol, rtol=rtol)
-    assert comparison_passed, f"Fill value test failed for fill={fill}, mode={interpolation_mode}"
+    assert comparison_passed, f"Fill value test failed for fill={fill}, mode={interpolation_mode}, dtype={dtype}"
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_nearest_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_nearest_interleaved.cpp
@@ -16,7 +16,7 @@ void kernel_main() {
     int32_t sin_angle = static_cast<int32_t>(get_arg_val<uint32_t>(4));
     int32_t center_x = static_cast<int32_t>(get_arg_val<uint32_t>(5));
     int32_t center_y = static_cast<int32_t>(get_arg_val<uint32_t>(6));
-    uint32_t fill_value_bf16 = get_arg_val<uint32_t>(7);
+    uint32_t fill_value_bits = get_arg_val<uint32_t>(7);
 
     constexpr uint32_t output_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t input_stick_nbytes = get_compile_time_arg_val(1);
@@ -29,6 +29,7 @@ void kernel_main() {
     constexpr uint32_t input_stick_nbytes_unaligned = get_compile_time_arg_val(8);
     constexpr bool fill_is_zero = get_compile_time_arg_val(9) != 0;
     constexpr uint32_t burst_size = get_compile_time_arg_val(10);
+    constexpr uint32_t element_size = input_stick_nbytes_unaligned / input_channels;
 
     constexpr auto src_args = TensorAccessorArgs<11>();
     const auto input_tensor_accessor = TensorAccessor(src_args, input_addr);
@@ -43,14 +44,21 @@ void kernel_main() {
         zero_out_page(noc, fill_dfb);
     } else {
         volatile tt_l1_ptr uint32_t* fill_ptr32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fill_stick_addr);
-        const uint32_t fill_value_packed = (fill_value_bf16 << 16) | fill_value_bf16;
-        const uint32_t num_pairs = input_channels / 2;
-        for (uint32_t c = 0; c < num_pairs; c++) {
-            fill_ptr32[c] = fill_value_packed;
-        }
-        if (input_channels & 1) {
-            volatile tt_l1_ptr uint16_t* fill_ptr16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(fill_stick_addr);
-            fill_ptr16[input_channels - 1] = static_cast<uint16_t>(fill_value_bf16);
+        if constexpr (element_size == 2) {
+            const uint32_t fill_value_packed = (fill_value_bits << 16) | fill_value_bits;
+            const uint32_t num_pairs = input_channels / 2;
+            for (uint32_t c = 0; c < num_pairs; c++) {
+                fill_ptr32[c] = fill_value_packed;
+            }
+            if (input_channels & 1) {
+                volatile tt_l1_ptr uint16_t* fill_ptr16 =
+                    reinterpret_cast<volatile tt_l1_ptr uint16_t*>(fill_stick_addr);
+                fill_ptr16[input_channels - 1] = static_cast<uint16_t>(fill_value_bits);
+            }
+        } else {
+            for (uint32_t c = 0; c < input_channels; c++) {
+                fill_ptr32[c] = fill_value_bits;
+            }
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
@@ -68,6 +68,12 @@ void RotateDeviceOperation::validate_inputs(
     if (operation_attributes.interpolation_mode == "bilinear") {
         constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
         const uint32_t input_channels = input.padded_shape()[-1];
+        TT_FATAL(
+            input_channels % tt::constants::TILE_WIDTH == 0,
+            "Input tensor last dimension must be divisible by TILE_WIDTH ({}), but got {} in padded shape {}",
+            tt::constants::TILE_WIDTH,
+            input_channels,
+            input.padded_shape());
         const uint32_t in_ntiles_c =
             static_cast<uint32_t>(std::ceil(static_cast<float>(input_channels) / tt::constants::TILE_WIDTH));
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
@@ -65,7 +65,13 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
         center_y = (static_cast<float>(input_height) - 1.0f) / 2.0f;
     }
 
-    const uint16_t fill_value_bf16 = nearest_float_to_bfloat16(operation_attributes.fill);
+    const bool is_bfloat16 = input_tensor.dtype() == DataType::BFLOAT16;
+    uint32_t fill_value_bits;
+    if (is_bfloat16) {
+        fill_value_bits = nearest_float_to_bfloat16(operation_attributes.fill);
+    } else {
+        fill_value_bits = std::bit_cast<uint32_t>(operation_attributes.fill);
+    }
     const uint32_t total_output_sticks = input_batch * input_height * input_width;
 
     const uint32_t element_size = input_tensor.element_size();
@@ -187,7 +193,7 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
         .buffer = any_sharded ? output_tensor.buffer() : nullptr,
     });
 
-    const bool fill_is_zero = (fill_value_bf16 == 0);
+    const bool fill_is_zero = (fill_value_bits == 0);
 
     const uint32_t effective_stick_nbytes = any_sharded ? effective_channels * element_size : input_stick_nbytes;
 
@@ -262,7 +268,7 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
                     static_cast<uint32_t>(fixed_point_arithmetic::float_to_fixed(sin_angle)),
                     static_cast<uint32_t>(fixed_point_arithmetic::float_to_fixed(center_x)),
                     static_cast<uint32_t>(fixed_point_arithmetic::float_to_fixed(center_y)),
-                    static_cast<uint32_t>(fill_value_bf16),
+                    fill_value_bits,
                 });
 
             writer_desc.emplace_runtime_args(
@@ -290,7 +296,7 @@ ProgramDescriptor RotateDeviceOperation::NearestProgramFactory::create_descripto
                     static_cast<uint32_t>(fixed_point_arithmetic::float_to_fixed(sin_angle)),
                     static_cast<uint32_t>(fixed_point_arithmetic::float_to_fixed(center_x)),
                     static_cast<uint32_t>(fixed_point_arithmetic::float_to_fixed(center_y)),
-                    static_cast<uint32_t>(fill_value_bf16),
+                    fill_value_bits,
                 });
 
             writer_desc.emplace_runtime_args(


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Relates to #51226 (items 2 and 3).

Nearest rotate always packed the fill stick as bfloat16 pairs. For FLOAT32, out-of-bounds sticks got bf16 bits in the first half and uninitialized L1 in the rest. Encode fill bits per dtype and branch the reader on element size. `test_custom_fill_values` now covers nearest float32.

Bilinear rotate has no `C % TILE_WIDTH == 0` check, but tilize assumes that pitch (same as `grid_sample`). Reject non-multiples with the same `TT_FATAL`.

### Notes for reviewers
Chose reject over padding the bilinear corner stride so `C=16` would run.

Wormhole:
- `pytest tests/ttnn/unit_tests/operations/pool/test_rotate.py::test_custom_fill_values -v`
- `pytest tests/ttnn/unit_tests/operations/pool/test_rotate.py::test_bilinear_rejects_non_tile_width_channels -v`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ijankowski/fix-rotate-fill-and-bilinear-c-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ijankowski/fix-rotate-fill-and-bilinear-c-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ijankowski/fix-rotate-fill-and-bilinear-c-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ijankowski/fix-rotate-fill-and-bilinear-c-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ijankowski/fix-rotate-fill-and-bilinear-c-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ijankowski/fix-rotate-fill-and-bilinear-c-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ijankowski/fix-rotate-fill-and-bilinear-c-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ijankowski/fix-rotate-fill-and-bilinear-c-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ijankowski/fix-rotate-fill-and-bilinear-c-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ijankowski/fix-rotate-fill-and-bilinear-c-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ijankowski/fix-rotate-fill-and-bilinear-c-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ijankowski/fix-rotate-fill-and-bilinear-c-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ijankowski/fix-rotate-fill-and-bilinear-c-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ijankowski/fix-rotate-fill-and-bilinear-c-guard)