### PR TITLE
Fix `#if` guards that test undefined macros in eltwise kernels

### DIFF
--- a/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_split_includes.h
@@ -4,226 +4,226 @@
 
 #pragma once
 
-#if SFPU_OP_ISINF_ISNAN_INCLUDE
+#ifdef SFPU_OP_ISINF_ISNAN_INCLUDE
 #include "api/compute/eltwise_unary/isinf_isnan.h"
 #endif
 
-#if SFPU_OP_ERF_ERFC_INCLUDE
+#ifdef SFPU_OP_ERF_ERFC_INCLUDE
 #include "api/compute/eltwise_unary/erf_erfc.h"
 #endif
 
-#if SFPU_OP_LOGICAL_NOT_INCLUDE
+#ifdef SFPU_OP_LOGICAL_NOT_INCLUDE
 #include "api/compute/eltwise_unary/logical_not.h"
 #endif
 
-#if SFPU_OP_EXP_INCLUDE
+#ifdef SFPU_OP_EXP_INCLUDE
 #include "api/compute/eltwise_unary/exp.h"
 #endif
 
-#if SFPU_OP_GELU_INCLUDE
+#ifdef SFPU_OP_GELU_INCLUDE
 #include "api/compute/eltwise_unary/gelu.h"
 #endif
 
-#if SFPU_OP_SQRT_INCLUDE
+#ifdef SFPU_OP_SQRT_INCLUDE
 #include "api/compute/eltwise_unary/sqrt.h"
 #endif
 
-#if SFPU_OP_RSQRT_INCLUDE
+#ifdef SFPU_OP_RSQRT_INCLUDE
 #include "api/compute/eltwise_unary/rsqrt.h"
 #endif
 
-#if SFPU_OP_RECIP_INCLUDE
+#ifdef SFPU_OP_RECIP_INCLUDE
 #include "api/compute/eltwise_unary/recip.h"
 #endif
 
-#if SFPU_OP_CBRT_INCLUDE
+#ifdef SFPU_OP_CBRT_INCLUDE
 #include "api/compute/eltwise_unary/cbrt.h"
 #endif
 
-#if SFPU_OP_RELU_FAMILY_INCLUDE
+#ifdef SFPU_OP_RELU_FAMILY_INCLUDE
 #include "api/compute/eltwise_unary/relu.h"
 #endif
 
-#if SFPU_OP_ELU_INCLUDE
+#ifdef SFPU_OP_ELU_INCLUDE
 #include "api/compute/eltwise_unary/elu.h"
 #endif
 
-#if SFPU_OP_I0_INCLUDE
+#ifdef SFPU_OP_I0_INCLUDE
 #include "api/compute/eltwise_unary/i0.h"
 #endif
 
-#if SFPU_OP_I1_INCLUDE
+#ifdef SFPU_OP_I1_INCLUDE
 #include "api/compute/eltwise_unary/i1.h"
 #endif
 
-#if SFPU_OP_ERFINV_INCLUDE
+#ifdef SFPU_OP_ERFINV_INCLUDE
 #include "api/compute/eltwise_unary/erfinv.h"
 #endif
 
-#if SFPU_OP_NEG_INCLUDE
+#ifdef SFPU_OP_NEG_INCLUDE
 #include "api/compute/eltwise_unary/negative.h"
 #endif
 
-#if SFPU_OP_TRIG_FAMILY_INCLUDE
+#ifdef SFPU_OP_TRIG_FAMILY_INCLUDE
 #include "api/compute/eltwise_unary/trigonometry.h"
 #endif
 
-#if SFPU_OP_RSUB_INCLUDE
+#ifdef SFPU_OP_RSUB_INCLUDE
 #include "api/compute/eltwise_unary/rsub.h"
 #endif
 
-#if SFPU_OP_IDENTITY_INCLUDE
+#ifdef SFPU_OP_IDENTITY_INCLUDE
 #include "api/compute/eltwise_unary/identity.h"
 #endif
 
-#if SFPU_OP_TYPECAST_INCLUDE
+#ifdef SFPU_OP_TYPECAST_INCLUDE
 #include "api/compute/eltwise_unary/typecast.h"
 #endif
 
-#if SFPU_OP_BITWISE_INCLUDE
+#ifdef SFPU_OP_BITWISE_INCLUDE
 #include "api/compute/eltwise_unary/bitwise.h"
 #endif
 
-#if SFPU_OP_BITWISE_NOT_INCLUDE
+#ifdef SFPU_OP_BITWISE_NOT_INCLUDE
 #include "api/compute/eltwise_unary/bitwise_not.h"
 #endif
 
-#if SFPU_OP_SHIFT_INCLUDE
+#ifdef SFPU_OP_SHIFT_INCLUDE
 #include "api/compute/eltwise_unary/shift.h"
 #endif
 
-#if SFPU_OP_ROUND_FAMILY_INCLUDE
+#ifdef SFPU_OP_ROUND_FAMILY_INCLUDE
 #include "api/compute/eltwise_unary/rounding.h"
 #endif
 
-#if SFPU_OP_REMAINDER_INCLUDE
+#ifdef SFPU_OP_REMAINDER_INCLUDE
 #include "api/compute/eltwise_unary/remainder.h"
 #endif
 
-#if SFPU_OP_FMOD_INCLUDE
+#ifdef SFPU_OP_FMOD_INCLUDE
 #include "api/compute/eltwise_unary/fmod.h"
 #endif
 
-#if SFPU_OP_BINOP_WITH_SCALAR_INCLUDE
+#ifdef SFPU_OP_BINOP_WITH_SCALAR_INCLUDE
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
 #endif
 
-#if SFPU_OP_SOFTPLUS_INCLUDE
+#ifdef SFPU_OP_SOFTPLUS_INCLUDE
 #include "api/compute/eltwise_unary/softplus.h"
 #endif
 
-#if SFPU_OP_XIELU_INCLUDE
+#ifdef SFPU_OP_XIELU_INCLUDE
 #include "api/compute/eltwise_unary/xielu.h"
 #endif
 
-#if SFPU_OP_LOGSIGMOID_INCLUDE
+#ifdef SFPU_OP_LOGSIGMOID_INCLUDE
 #include "api/compute/logsigmoid.h"
 #endif
 
-#if SFPU_OP_SELU_INCLUDE
+#ifdef SFPU_OP_SELU_INCLUDE
 #include "api/compute/eltwise_unary/selu.h"
 #endif
 
-#if SFPU_OP_PRELU_INCLUDE
+#ifdef SFPU_OP_PRELU_INCLUDE
 #include "api/compute/eltwise_unary/prelu.h"
 #endif
 
-#if SFPU_OP_DROPOUT_INCLUDE
+#ifdef SFPU_OP_DROPOUT_INCLUDE
 #include "api/compute/eltwise_unary/dropout.h"
 #endif
 
-#if SFPU_OP_FILL_INCLUDE
+#ifdef SFPU_OP_FILL_INCLUDE
 #include "api/compute/eltwise_unary/fill.h"
 #endif
 
-#if SFPU_OP_LOG1P_INCLUDE
+#ifdef SFPU_OP_LOG1P_INCLUDE
 #include "api/compute/eltwise_unary/log1p.h"
 #endif
 
-#if SFPU_OP_UNARY_COMP_INCLUDE
+#ifdef SFPU_OP_UNARY_COMP_INCLUDE
 #include "api/compute/eltwise_unary/comp.h"
 #endif
 
-#if SFPU_OP_ACTIVATIONS_INCLUDE
+#ifdef SFPU_OP_ACTIVATIONS_INCLUDE
 #include "api/compute/eltwise_unary/activations.h"
 #endif
 
-#if SFPU_OP_THRESHOLD_INCLUDE
+#ifdef SFPU_OP_THRESHOLD_INCLUDE
 #include "api/compute/eltwise_unary/threshold.h"
 #endif
 
-#if SFPU_OP_WHERE_INCLUDE
+#ifdef SFPU_OP_WHERE_INCLUDE
 #include "api/compute/eltwise_unary/where.h"
 #endif
 
-#if SFPU_OP_MAC_INCLUDE
+#ifdef SFPU_OP_MAC_INCLUDE
 #include "api/compute/eltwise_unary/mac.h"
 #endif
 
-#if SFPU_OP_CLAMP_INCLUDE
+#ifdef SFPU_OP_CLAMP_INCLUDE
 #include "api/compute/eltwise_unary/clamp.h"
 #endif
 
-#if SFPU_OP_HARDTANH_INCLUDE
+#ifdef SFPU_OP_HARDTANH_INCLUDE
 #include "api/compute/eltwise_unary/hardtanh.h"
 #endif
 
-#if SFPU_OP_RPOW_INCLUDE
+#ifdef SFPU_OP_RPOW_INCLUDE
 #include "api/compute/eltwise_unary/rpow.h"
 #endif
 
-#if SFPU_OP_HARDMISH_INCLUDE
+#ifdef SFPU_OP_HARDMISH_INCLUDE
 #include "api/compute/eltwise_unary/hardmish.h"
 #endif
 
-#if SFPU_OP_SOFTCAP_INCLUDE
+#ifdef SFPU_OP_SOFTCAP_INCLUDE
 #include "api/compute/eltwise_unary/softcap.h"
 #endif
 
-#if SFPU_OP_LGAMMA_INCLUDE
+#ifdef SFPU_OP_LGAMMA_INCLUDE
 #include "api/compute/eltwise_unary/lgamma.h"
 #endif
 
-#if SFPU_OP_DIGAMMA_INCLUDE
+#ifdef SFPU_OP_DIGAMMA_INCLUDE
 #include "api/compute/eltwise_unary/digamma.h"
 #endif
 
-#if SFPU_OP_TANHSHRINK_INCLUDE
+#ifdef SFPU_OP_TANHSHRINK_INCLUDE
 #include "api/compute/eltwise_unary/tanhshrink.h"
 #endif
 
-#if SFPU_OP_POLYGAMMA_INCLUDE
+#ifdef SFPU_OP_POLYGAMMA_INCLUDE
 #include "api/compute/eltwise_unary/polygamma.h"
 #endif
 
-#if SFPU_OP_MISH_INCLUDE
+#ifdef SFPU_OP_MISH_INCLUDE
 #include "api/compute/eltwise_unary/mish.h"
 #endif
 
-#if SFPU_OP_COMPUTE_KERNEL_API_INCLUDE
+#ifdef SFPU_OP_COMPUTE_KERNEL_API_INCLUDE
 #include "api/compute/compute_kernel_api.h"
 #endif
 
-#if SFPU_OP_BINARY_DIV_INCLUDE
+#ifdef SFPU_OP_BINARY_DIV_INCLUDE
 #include "api/compute/eltwise_binary_sfpu.h"
 #endif
 
-#if SFPU_OP_BINARY_ATAN2_INCLUDE
+#ifdef SFPU_OP_BINARY_ATAN2_INCLUDE
 #include "api/compute/atan2.h"
 #endif
 
-#if SFPU_OP_BINARY_ADD_INT_INCLUDE
+#ifdef SFPU_OP_BINARY_ADD_INT_INCLUDE
 #include "api/compute/add_int_sfpu.h"
 #endif
 
-#if SFPU_OP_BINARY_MUL_INT_INCLUDE
+#ifdef SFPU_OP_BINARY_MUL_INT_INCLUDE
 #include "api/compute/mul_int_sfpu.h"
 #endif
 
-#if SFPU_OP_BINARY_GT_INT_INCLUDE
+#ifdef SFPU_OP_BINARY_GT_INT_INCLUDE
 #include "api/compute/binary_comp.h"
 #endif
 
-#if SFPU_OP_BINARY_MAX_MIN_INCLUDE
+#ifdef SFPU_OP_BINARY_MAX_MIN_INCLUDE
 #include "api/compute/binary_max_min.h"
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -81,7 +81,7 @@ ALWI void process_tile(
 #if HAS_ACTIVATIONS(POST)
             BINARY_SFPU_INIT
 #endif
-#if ISCLOSE_OP
+#ifdef ISCLOSE_OP
             BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
 #else
             BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -64,7 +64,7 @@ FORCE_INLINE void process_sfpu_tiles(
 #if HAS_ACTIVATIONS(POST)
         BINARY_SFPU_INIT;
 #endif
-#if ISCLOSE_OP
+#ifdef ISCLOSE_OP
         BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
 #else
         BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -58,7 +58,7 @@ FORCE_INLINE void process_sfpu_scalar_tiles(
 #if HAS_ACTIVATIONS(POST)
         BINARY_SFPU_INIT;
 #endif
-#if ISCLOSE_OP
+#ifdef ISCLOSE_OP
         BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
 #else
         BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
@@ -119,7 +119,7 @@ ALWI void process_tile(
 #if HAS_ACTIVATIONS(POST)
             BINARY_SFPU_INIT
 #endif
-#if ISCLOSE_OP
+#ifdef ISCLOSE_OP
             BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
 #else
             BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -118,7 +118,7 @@ void kernel_main() {
 #if HAS_ACTIVATIONS(POST)
             BINARY_SFPU_INIT
 #endif
-#if ISCLOSE_OP
+#ifdef ISCLOSE_OP
             BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
 #else
             BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -112,7 +112,7 @@ ALWI void process_tile(
 #if HAS_ACTIVATIONS(POST)
             BINARY_SFPU_INIT
 #endif
-#if ISCLOSE_OP
+#ifdef ISCLOSE_OP
             BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
 #else
             BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
@@ -119,7 +119,7 @@ ALWI void process_tile(
 #if HAS_ACTIVATIONS(POST)
             BINARY_SFPU_INIT
 #endif
-#if ISCLOSE_OP
+#ifdef ISCLOSE_OP
             BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
 #else
             BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_bcast.cpp
@@ -10,6 +10,13 @@
 #include "api/tensor/noc_traits.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
+// BCAST_LLK is only emitted by the host for the TTT variant; TTS/TST always take the
+// software fill path. Default it here so the guards below do not rely on an undefined
+// macro evaluating to 0.
+#ifndef BCAST_LLK
+#define BCAST_LLK 0
+#endif
+
 void kernel_main() {
     // Standard first 5 arguments
     const uint32_t src0_addr = get_arg_val<uint32_t>(0);  // predicate address


### PR DESCRIPTION
### Ticket
n/a — cleanup driven by the kernel clang-tidy dashboard (`tenstorrent/tt-metal-kernel-clang-tidy-results`, report generated from tt-metal @ `526ffcb1e5f6197eb7061eb22a7a96871bf9b888`).

### Problem description
The kernel clang-tidy job reports **101 `clang-diagnostic-undef` findings** — `#if SOME_MACRO` where `SOME_MACRO` is never defined in that translation unit. The preprocessor silently substitutes `0`, so the guard takes the `#else` branch and nothing warns.

**64 of the 101 are in eltwise code.** This PR fixes all 64. The remaining 37 belong to softmax, matmul, dispatch and firmware and are left to their owners (see below).

The interesting one is `sfpu_split_includes.h`: 56 gates of the form

```cpp
#if SFPU_OP_EXP_INCLUDE
#include "api/compute/eltwise_unary/exp.h"
#endif
```

one per unary SFPU op, where the host defines only the ops a given kernel needs. A typo in any of those 56 macro names silently drops the `#include`. If that op's header happens to be reachable transitively the kernel still compiles — which is exactly how the missing `<cstdlib>` in #56051 survived until #55820 removed the transitive path.

### What's changed

**1. `tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_split_includes.h` — 56 gates, `#if X` → `#ifdef X`**

Verified equivalent before changing: every producer of an `SFPU_OP_*_INCLUDE` macro in the repo assigns the string `"1"`, and none assigns `"0"`.

- `ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp:1172` — `defines[get_macro_definition(op_type)] = "1";` (unconditional, covers all 56 via the `get_macro_definition` switch)
- 32 further literal assignments across `binary/common`, `quasar/binary/common` and the tt_metal/ttnn unit tests — all `= "1"`
- no `#define SFPU_OP_*_INCLUDE` in kernel sources, and nothing in CMake

So the preprocessor result is identical for every existing build.

To be precise about what this buys: `#ifdef` does not by itself detect a misspelled gate name — it is silently false either way. The point is that `#if <optional macro>` makes `-Wundef` unusable here, because 55 of the 56 gates are *legitimately* absent from any given compute kernel, so the diagnostic fires ~55 times per TU as pure noise. Moving the optional gates to `#ifdef` is what makes it possible to enable `-Wundef` at all — and once it is on, it catches undefined macros in the guards that are supposed to always be defined (which is exactly the ternary `BCAST_LLK` case below).

**2. binary_ng SFPU compute kernels — 7 × `#if ISCLOSE_OP` → `#ifdef ISCLOSE_OP`**

These files were already inconsistent with themselves. `eltwise_binary_sfpu.cpp` reads the isclose rtol/atol runtime args under `#ifdef ISCLOSE_OP` (line 109) and then consumes them under `#if ISCLOSE_OP` (line 84); `eltwise_utils_common.hpp:40` defines `ISCLOSE_RT_ARG_PARAMS`/`ISCLOSE_RT_ARG_FWD` under `#ifdef` too. `ISCLOSE_OP` is only ever set to `"1"` (`binary_ng_program_factory.cpp:936`), so unifying on `#ifdef` is a no-op today and removes the possibility of the two spellings disagreeing.

**3. `tts_tst_reader_row_bcast.cpp` — explicit `BCAST_LLK` default**

`ternary_program_factory.cpp:1256-1258` only emits `BCAST_LLK` when `variant == TernaryVariant::TTT`. This reader is the TTS/TST one (`ternary_op_utils.cpp:374`), so the macro is genuinely absent and `#if SRC_BCAST_A && !BCAST_LLK` works only because an undefined macro evaluates to 0. That is the intended behaviour for TTS/TST — they always take the software fill path — so this adds

```cpp
#ifndef BCAST_LLK
#define BCAST_LLK 0
#endif
```

rather than changing the guard, making the contract explicit instead of accidental.

### Not in this PR (other owners)

| Macro | Findings | Location | Note |
|---|---|---|---|
| `FUSED_SCALE_MASK` | 28 | softmax attention kernels | only ever `"1"` — `#ifdef` is safe |
| `CAUSAL_MASK` | 1 | softmax attention kernels | only ever `"1"` |
| `MM_STAGGER_TYPE` | 3 | `llk_io_unpack.h` | value is a token, not 0/1 (`compute_throttle_utils.cpp:28`) — needs `#if defined(...)` |
| `OUT_SHARDED` | 2 | matmul in1 reader/writer | only ever `"1"` |
| `DEVICE_PRINT_DISPATCH_ENABLED` | 1 | `cq_common.hpp` | ⚠️ **can legitimately be `"0"`** (`dispatch_s.cpp:339`, `value_or(0)`) — `#ifdef` here would be a behaviour change; needs `#if defined(X) && X` or an unconditional define |
| `PHYSICAL_AERISC_ID` | 1 | `dataflow_cmd_bufs.h` | not a string define; source not identified |
| `MaxDMProcessorsPerCoreType` | 1 | `dev_mem_map.h` | not a string define; source not identified |

The quasar `binary_ng` kernels carry the same `#if ISCLOSE_OP` / `#if !BCAST_LLK` pattern but are not flagged (those TUs aren't compiled by the tidy job) and are owned by `metalium-developers-mmfusedreduce`, so they're left out to keep this to two CODEOWNERS groups.

### Checklist
- [Sanity tests nightly debug run](https://github.com/tenstorrent/tt-metal/actions/runs/34459697083)
- [Nightly tt-metal L2 tests — `additional_test_categories=eltwise`](https://github.com/tenstorrent/tt-metal/actions/runs/34459700680)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-kernel-undef-macro-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-kernel-undef-macro-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-kernel-undef-macro-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/fix-kernel-undef-macro-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-kernel-undef-macro-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-kernel-undef-macro-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/fix-kernel-undef-macro-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/fix-kernel-undef-macro-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-kernel-undef-macro-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-kernel-undef-macro-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-kernel-undef-macro-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-kernel-undef-macro-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-kernel-undef-macro-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-kernel-undef-macro-guards)