### PR TITLE
[Test Only] Fix LLK fmod edge goldens after SFPI 7.75

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2246,7 +2246,8 @@ class PackGolden:
 @register_golden
 class UnarySFPUGolden:
     # Ops whose NaN result carries a real sign, because the kernel moves the sign bit rather
-    # than generating a NaN: Neg flips it, Abs clears it, Identity passes it through. For every
+    # than generating a NaN: Neg flips it, Abs clears it, Identity passes it through, and
+    # Fmod copies the dividend's sign onto the remainder, including a NaN. For every
     # other op the sign of a NaN result is unspecified and torch picks it inconsistently, so
     # the golden canonicalises it and asserts the sign only where it means something.
     _NAN_SIGN_TRANSPARENT_OPS = frozenset(
@@ -2254,6 +2255,7 @@ class UnarySFPUGolden:
             MathOperation.Neg,
             MathOperation.Abs,
             MathOperation.Identity,
+            MathOperation.Fmod,
         }
     )
 
@@ -3199,9 +3201,12 @@ class UnarySFPUGolden:
         return self._torch_unary(x, lambda t: torch.pow(t, self._UNARY_POWER_EXP))
 
     def _fmod(self, x):
-        return self._torch_unary(
+        result = self._torch_unary(
             x, lambda t: torch.fmod(t, torch.tensor(self._FMOD_DIVISOR))
         )
+        # calculate_fmod applies copysgn even to inf - inf. Keep that sign when
+        # the Dest/pack path subsequently converts the NaN to a signed infinity.
+        return math.copysign(result, x)
 
     def _remainder(self, x):
         return self._torch_unary(

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_domains.py
@@ -640,6 +640,37 @@ def test_hardtanh_golden_matches_the_clamp_golden():
         )
 
 
+@pytest.mark.parametrize(
+    "output_format,dest_acc",
+    [
+        (DataFormat.Float16_b, DestAccumulation.Yes),
+        (DataFormat.Float32, DestAccumulation.No),
+        (DataFormat.Float32, DestAccumulation.Yes),
+    ],
+)
+def test_fmod_golden_preserves_dividend_sign_through_pack(output_format, dest_acc):
+    import torch
+    from helpers.golden_generators import UnarySFPUGolden
+
+    probes = torch.tensor([float("inf"), -float("inf"), 5.0, -5.0])
+    result = UnarySFPUGolden()(
+        MathOperation.Fmod,
+        probes.repeat(256),
+        output_format,
+        dest_acc,
+        DataFormat.Float32,
+        dimensions=(32, 32),
+    )
+
+    if output_format == DataFormat.Float32 and dest_acc == DestAccumulation.Yes:
+        assert torch.isnan(result[:2]).all()
+    else:
+        assert torch.equal(result[:2].float(), probes[:2])
+    assert torch.equal(torch.signbit(result[:4]), torch.signbit(probes))
+    expected = torch.fmod(probes[2:], UnarySFPUGolden._FMOD_DIVISOR)
+    assert torch.equal(result[2:4].float(), expected)
+
+
 def test_reduce_extremum_follows_the_total_order_on_floats_only():
     """Reduce MAX/MIN fold under the SFPU total order; Sum/Average stay IEEE; ints stay torch.
 

--- a/tt_metal/tt-llk/tests/sources/matmul_face_compressed_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_face_compressed_test.cpp
@@ -84,12 +84,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 
-    {
-        // Dest init also issues SETADCXY/SETADCZW. Serialize them with the
-        // unpacker's borrowed ADC writes, just like pack init and each pack below.
-        T6MutexLockGuard<true> guard(mutex::THREAD2_ADC);
-        _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
-    }
+    _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK, params.in0_face_r_dim, TILE_C_DIM, params.num_faces, true);
 

--- a/tt_metal/tt-llk/tests/sources/matmul_face_compressed_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_face_compressed_test.cpp
@@ -84,7 +84,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 
-    _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    {
+        // Dest init also issues SETADCXY/SETADCZW. Serialize them with the
+        // unpacker's borrowed ADC writes, just like pack init and each pack below.
+        T6MutexLockGuard<true> guard(mutex::THREAD2_ADC);
+        _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK, params.in0_face_r_dim, TILE_C_DIM, params.num_faces, true);
 


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Fix the two Blackhole unary `fmod` edge failures in the [September 10 LLK e2e nightly](https://github.com/tenstorrent/tt-metal/actions/runs/34424964721).

`calculate_fmod` copies the dividend's sign onto its remainder, including a NaN produced by an infinite dividend. The golden canonicalized generated NaNs to positive. For `fmod(-inf, 3)` packed through BF16, this made the expected value `+inf` while the device returned `-inf`. Preserve the dividend sign in the existing Fmod golden and exclude Fmod from NaN-sign canonicalization. Add a regression covering both failing format combinations plus FP32 output.

The golden/sign policy was introduced in #52938. These failures first appear after #55993 updated SFPI from 7.74.0 to 7.75.0, whose release changes floating-point comparisons.

### Validation
- Unchanged-main [baseline run 34461328806](https://github.com/tenstorrent/tt-metal/actions/runs/34461328806), at `d87af74bd14cda49bcbd8ecef50f59e7c5d1894a`, failed with exactly these two Fmod edge cases; the other three hardware shards passed.
- From `tt_metal/tt-llk/tests/python_tests`: `pytest --noconftest -q -o addopts= test_sfpu_domains.py -k test_fmod_golden_preserves_dividend_sign_through_pack`: **3 passed**. The same three regressions failed against the original main golden.
- Applicable repository pre-commit hooks passed, including Python formatting and lint checks. `git diff --check` passes.
- The final diff is **Python-only**: no C++ or LLK API changes, so no build is required.
- Full [LLK e2e run 34469983639](https://github.com/tenstorrent/tt-metal/actions/runs/34469983639) **passed** at final commit `e693c45366b2177f1c11479f0b9f69be36fb70d0`, based on the same main commit as the baseline. All four hardware shards, the e2e summary, and status reporting succeeded, using the default `not perf and not quasar and not accuracy` selection.
- JUnit confirms that both previously failing Blackhole Fmod edge cases, all three new golden regressions, and the reported sparse-matmul case `(8, 576, 256), ('bfp2', 'bfp0'), interleave_n=16` **passed**, without skip or xfail. The sparse case used the original, unguarded C++ kernel.

| Hardware shard | JUnit passes | Failures / errors |
| --- | ---: | ---: |
| Wormhole 1/2 | 114,105 | 0 |
| Wormhole 2/2 | 116,416 | 0 |
| Blackhole 1/2 | 116,267 | 0 |
| Blackhole 2/2 | 116,553 | 0 |

### Separate sparse-matmul flake
The nightly also reported intermittent face-compressed matmul failures that predate the SFPI update. An initialization mutex was investigated as a candidate. In [A/B run 34469316210](https://github.com/tenstorrent/tt-metal/actions/runs/34469316210), the 72 historically affected sparse/interleaved cases passed **200 device executions each both with and without that guard**. Both source hashes were checked against the intended revisions, and neither side skipped tests.

This comparison did not reproduce the flake or establish that the guard fixes it. The proposed guard has therefore been removed from this PR; the sparse-matmul root cause remains unresolved. This PR fixes the reproduced Fmod golden mismatch and does not claim to resolve that separate flake.

This tests main plus the proposed change on the draft PR branch; main itself is unchanged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilenkovic/fix-llk-e2e-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilenkovic/fix-llk-e2e-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilenkovic/fix-llk-e2e-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilenkovic/fix-llk-e2e-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/fix-llk-e2e-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/fix-llk-e2e-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilenkovic/fix-llk-e2e-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilenkovic/fix-llk-e2e-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/fix-llk-e2e-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/fix-llk-e2e-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/fix-llk-e2e-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/fix-llk-e2e-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/fix-llk-e2e-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/fix-llk-e2e-main)

