### PR TITLE
Fix SOFTMIN last-tile missing max subtraction in moreh_softmax h/w large kernels (#51278 items 12, 13)

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
@@ -75,8 +75,10 @@ void kernel_main() {
                     /*pop=*/1,
                     /*popm=*/0);
 #else
+                sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+
                 rexp_tile_and_mask_tile_to_cb(
-                    dfb_in0_obj,
+                    dfb_tmp_obj,
                     dfb_mask_obj,
                     dfb_exps_obj,
                     /*itile=*/0,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
@@ -78,8 +78,10 @@ void kernel_main() {
                     /*pop=*/1,
                     /*popm=*/0);
 #else
+                sub_tiles_bcast_cols_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
+
                 rexp_tile_and_mask_tile_to_cb(
-                    dfb_in0_obj,
+                    dfb_tmp_obj,
                     dfb_mask_obj,
                     dfb_exps_obj,
                     /*itile=*/0,


### PR DESCRIPTION
## Summary
Fixes items **12** and **13** of #51278 (paired copy-paste slips): in the SOFTMIN (`!SOFTMAX`) path of `moreh_softmax_h_large.cpp` / `moreh_softmax_w_large.cpp`, the **last** H/W tile exponentiated the raw input instead of `(x - max)`, while every other tile and all of step 3 subtract the row/column max first. The softmin denominator therefore mixed two different scales.

## The fix
Mirror the SOFTMAX branch (and the small-H/W kernels' behaviour): subtract the broadcast max first, then `rexp_tile_and_mask_tile_to_cb` on `(x - max)`:

```cpp
#else
    sub_tiles_bcast_rows_to_cb(dfb_in0_obj, dfb_max_obj, dfb_tmp_obj, 0, 0, /*pop0=*/1, /*pop1=*/0);
    rexp_tile_and_mask_tile_to_cb(dfb_tmp_obj, dfb_mask_obj, dfb_exps_obj, 0, 0, 1, 0);
#endif
```
(cols variant in the W kernel; 2 files, +6/-2 total, no other path touched.)

## Verification (ttsim Blackhole simulator, ttnn 0.78.0, no hardware)

Before → after, `ttnn.operations.moreh.softmax(..., strategy=LARGE_W/LARGE_H, op=SOFTMIN)`:

| case | row/col sum before | after | expected |
|---|---|---|---|
| Wt==1, LARGE_W | **7.18** (whole row scaled by e^max) | **0.992** | 1.0 |
| Wt==2, LARGE_W | **1.71** (last tile under-weighted by e^max) | **0.999** | 1.0 |
| per-tile sum error (Wt==2) | 0.366 / 0.346 | **0.0009 / 0.0003** | 0 |
| Ht==2, LARGE_H | wrong per-column scale | correct | — |
| control: SOFTMAX path | 0.989 | **0.989 (unchanged)** | ~1.0 |

Repro snippet (before fix, row sums to 7.18 instead of 1.0):
```python
x = torch.zeros(1,1,32,32); x[0,0,0,:] = torch.tensor([0.,.5,1.,1.5,2.]*6+[.25]*2)
out = ttnn.operations.moreh.softmax(ttnn.from_torch(x.bfloat16(), ...), 3,
         strategy=MorehSoftmaxOpParallelizationStrategy.LARGE_W, op=MorehSoftmaxOp.SOFTMIN)
# torch ref: torch.softmax(-x, dim=-1)
```

## Notes for reviewers
- SOFTMIN is the **default** `op` in the nanobind signature (`nb::arg("op") = MorehSoftmaxOp::SOFTMIN`), so this path is easy to reach.
- The SOFTMAX/LOGSOFTMAX branches are untouched; the control case confirms byte-identical behaviour there.
- Per #51278's instruction, items 12 & 13 are the same defect in the H and W variants — fixed together in one PR, checkboxes ticked separately.

Addresses #51278 items 12, 13 (the umbrella issue stays open for the remaining items).

