### PR TITLE
prefill: PCC-check only the golden's last chunk, and move GLM-5.2 to the 1M trace

### DIFF
--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -13,8 +13,8 @@ MANIFEST_DIR="${TT_METAL_HOME}/models/demos/deepseek_v3_d_p/tt/runners/manifests
 MGD_DIR="${TT_METAL_HOME}/models/demos/common/prefill/runners/topology_configuration/ci"
 
 CHUNK_SIZE=5120
-GOLDEN_LEN=56320
 WARMUP_CHUNKS=10
+PCC_WINDOW_TOKENS=0
 PCC_THRESHOLD=0.85
 RUNNER_ENV=""
 PRODUCER_ENV=""
@@ -34,6 +34,7 @@ case "${MODEL}" in
     export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/prefill_runner_kv}"
     MANIFEST="${MANIFEST_DIR}/kimi27.json"
     MAX_SEQ_LEN=256000
+    GOLDEN_LEN=56320
     # Users are bounded by per-bank KV capacity, and that bound has to be bisected, not computed --
     # the arithmetic bound overshoots ~20% once weights and transients are counted. The OOM edge sits
     # just above this and wanders between ranks, so re-bisect before raising it.
@@ -51,8 +52,12 @@ case "${MODEL}" in
     TP_SHARD_KV_DEFAULT=1
     # UNTRACED, as of now
     RUNNER_ENV="export PREFILL_LAYER_ACK_D2H=1;"
+    GLM52_TRACE=/mnt/models/deepseek-prefill-cache/glm-traces/glm52-1M-last5k
+    GOLDEN_LEN=0
+    PCC_WINDOW_TOKENS=${CHUNK_SIZE}
     PRODUCER_ENV="export PREFILL_PRODUCER_MANIFEST='${MANIFEST}'; \
-        export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k;"
+        export PREFILL_TRACE_DIR=${GLM52_TRACE}; \
+        export PREFILL_PRODUCER_SLOT_TRACES=${GLM52_TRACE};"
     ;;
   *)
     echo "unknown model key '${MODEL}'" >&2
@@ -183,6 +188,7 @@ set +e
     export PREFILL_PRODUCER_CHUNKS=${REAL_CHUNKS}; \
     export PREFILL_PRODUCER_WARMUP_CHUNKS=${WARMUP_CHUNKS}; \
     export PREFILL_PCC_GOLDEN_LEN=${GOLDEN_LEN}; \
+    export PREFILL_PCC_WINDOW_TOKENS=${PCC_WINDOW_TOKENS}; \
     export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
     export PREFILL_PCC_SUMMARY_DIR='${PCC_DIR}'; \
     export PREFILL_PRODUCER_CHECK_PCC=1; \

--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -35,6 +35,7 @@ case "${MODEL}" in
     MANIFEST="${MANIFEST_DIR}/kimi27.json"
     MAX_SEQ_LEN=256000
     GOLDEN_LEN=56320
+    PCC_WINDOW_TOKENS=${CHUNK_SIZE}
     # Users are bounded by per-bank KV capacity, and that bound has to be bisected, not computed --
     # the arithmetic bound overshoots ~20% once weights and transients are counted. The OOM edge sits
     # just above this and wanders between ranks, so re-bisect before raising it.

--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -11,6 +11,7 @@ import struct
 import sys
 import time
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import NamedTuple
 
 import numpy as np
@@ -20,7 +21,11 @@ from loguru import logger
 import ttnn
 from models.demos.common.prefill.adapter import DEFAULT_MODEL, get_adapter
 from models.demos.common.prefill.runners.migration import is_per_host_storage, migration_table_path
-from models.demos.common.prefill.runners.runner_utils import load_trace_token_ids, resolve_trace_dir
+from models.demos.common.prefill.runners.runner_utils import (
+    load_trace_golden_span,
+    load_trace_token_ids,
+    resolve_trace_dir,
+)
 
 
 def _apply_manifest_env(manifest_path: str) -> dict:
@@ -498,15 +503,60 @@ def run_schedule(cfg: ProducerConfig, *, push_fn, now_fn=time.perf_counter, slee
     )
 
 
-def _read_slot_kv_and_check_pcc(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
+@lru_cache(maxsize=None)
+def _golden_span(trace_dir) -> tuple[int, int]:
+    """``load_trace_golden_span`` memoized: every slot asks for the same trace, and the metadata a
+    million-token golden carries is tens of megabytes of JSON."""
+    return load_trace_golden_span(trace_dir)
+
+
+def _resolve_pcc_window(real_len: int, trace_dir) -> tuple[int, int]:
+    """Absolute prompt positions ``[start, end)`` to PCC for a slot that ran ``real_len`` tokens.
+
+    The end is the deepest position both the run and the golden reach. ``PREFILL_PCC_WINDOW_TOKENS``
+    then keeps only that many positions before it, which is what makes a full-length prefill
+    checkable against a golden that covers only its tail. Zero (the default) keeps the whole span.
+
+    A prefix golden shortens to whatever the run filled. A windowed one cannot: its rows are pinned
+    to absolute positions, so a run that stops short of the window has nothing to compare and says
+    so instead of sliding the golden onto the wrong tokens.
+    """
+    golden_start, golden_end = _golden_span(trace_dir)
     golden_cap = int(os.environ.get("PREFILL_PCC_GOLDEN_LEN", "0"))
     if golden_cap:
-        real_len = min(real_len, golden_cap)
-    if ADAPTER.name == "minimax_m3":
-        return _read_slot_kv_and_check_pcc_m3(table, device_map, slot_id, real_len, trace_dir)
-    if ADAPTER.name == "gpt_oss_d_p":
-        return _read_slot_kv_and_check_pcc_gpt_oss(table, device_map, slot_id, real_len, trace_dir)
-    return _read_slot_kv_and_check_pcc_mla(table, device_map, slot_id, real_len, trace_dir)
+        if golden_start:
+            raise RuntimeError(
+                f"PREFILL_PCC_GOLDEN_LEN={golden_cap} counts rows from position 0, but {trace_dir} is a "
+                f"windowed golden over [{golden_start},{golden_end}). Unset it and bound the compare with "
+                f"PREFILL_PCC_WINDOW_TOKENS."
+            )
+        golden_end = min(golden_end, golden_cap)
+    if golden_end > real_len:
+        if golden_start:
+            raise RuntimeError(
+                f"golden covers [{golden_start},{golden_end}) but the run filled only {real_len} "
+                f"tokens: the window was never written. Raise the pushed chunk count."
+            )
+        golden_end = real_len
+    window_tokens = int(os.environ.get("PREFILL_PCC_WINDOW_TOKENS", "0"))
+    start = max(golden_start, golden_end - window_tokens) if window_tokens else golden_start
+    if start >= golden_end:
+        raise RuntimeError(f"empty PCC window [{start},{golden_end}) for golden {trace_dir}")
+    return start, golden_end
+
+
+def _read_slot_kv_and_check_pcc(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
+    win_start, win_end = _resolve_pcc_window(real_len, trace_dir)
+    if ADAPTER.name in ("minimax_m3", "gpt_oss_d_p"):
+        if win_start != 0:
+            raise RuntimeError(
+                f"{ADAPTER.name} KV PCC reads from position 0 only; window [{win_start},{win_end}) "
+                f"needs the offset read the MLA path has"
+            )
+        if ADAPTER.name == "minimax_m3":
+            return _read_slot_kv_and_check_pcc_m3(table, device_map, slot_id, win_end, trace_dir)
+        return _read_slot_kv_and_check_pcc_gpt_oss(table, device_map, slot_id, win_end, trace_dir)
+    return _read_slot_kv_and_check_pcc_mla(table, device_map, slot_id, win_start, win_end, trace_dir)
 
 
 def _config_names(table) -> list:
@@ -680,7 +730,7 @@ def _full_indexer_layer_indices(num_layers: int):
     return [layer for layer in range(num_layers) if not indexer_layer_is_reused(hf_config, layer)]
 
 
-def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
+def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, win_start: int, win_end: int, trace_dir):
     from models.demos.deepseek_v3_d_p.tt.mla.indexer import normalized_hadamard_matrix
     from models.demos.deepseek_v3_d_p.tt.runners.prefill_kv_validation import (
         _load_golden_index_k,
@@ -693,26 +743,30 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
     KV_LORA = ADAPTER.model_config.KV_LORA_RANK
     HEAD_DIM = KV_LORA + ADAPTER.model_config.QK_ROPE_HEAD_DIM
     tokens_per_block = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
-    read_len = ((real_len + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
+    read_start = (win_start // tokens_per_block) * tokens_per_block
+    read_end = ((win_end + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
+    lo = win_start - read_start
+    win_len = win_end - win_start
+    golden_lo = win_start - _golden_span(trace_dir)[0]
 
     min_pcc = 1.0
     checked = 0
     for layer in range(NUM_LAYERS):
-        loc0 = table.lookup(layer, 0, slot_id)
+        loc0 = table.lookup(layer, read_start, slot_id)
         try:
             _resolve_unique_id(table.get_device_group(loc0.device_group_index).fabric_node_ids, device_map)
         except KeyError:
             continue
 
         decoded_rows = []
-        for pos in range(0, read_len, tokens_per_block):
+        for pos in range(read_start, read_end, tokens_per_block):
             loc = table.lookup(layer, pos, slot_id)
             unique_id = _resolve_unique_id(table.get_device_group(loc.device_group_index).fabric_node_ids, device_map)
             raw = ttnn.experimental.disaggregation.read_dram_umd(unique_id, loc.noc_addr, loc.size_bytes)
             decoded_rows.append(_decode_kv_chunk(raw, HEAD_DIM))
-        device_kv = torch.cat(decoded_rows, dim=0)[:real_len]
+        device_kv = torch.cat(decoded_rows, dim=0)[lo : lo + win_len]
 
-        golden = _load_golden_kv_post(trace_dir, layer, real_len)
+        golden = _load_golden_kv_post(trace_dir, layer, golden_lo + win_len, golden_lo)
         _, pcc_nope = comp_pcc(golden[:, :KV_LORA], device_kv[:, :KV_LORA])
 
         golden_pe = golden[:, KV_LORA:]
@@ -725,8 +779,8 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
         logger.info(f"[producer] slot {slot_id} layer {layer:>2} KV PCC: nope={pcc_nope:.5f} pe={pcc_pe:.5f}")
 
     logger.info(
-        f"[producer] slot {slot_id} KV PCC over [0,{real_len}) across {checked}/{NUM_LAYERS} local layers -> "
-        f"{min_pcc:.6f}"
+        f"[producer] slot {slot_id} KV PCC over [{win_start},{win_end}) across {checked}/{NUM_LAYERS} "
+        f"local layers -> {min_pcc:.6f}"
     )
     if checked == 0:
         raise RuntimeError(f"slot {slot_id}: no local layers resolved against the device map (nothing verified)")
@@ -753,23 +807,23 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
         min_index = 1.0
         checked_index = 0
         for layer in index_rows:
-            loc0 = table.lookup(layer, 0, slot_id, 1)
+            loc0 = table.lookup(layer, read_start, slot_id, 1)
             try:
                 _resolve_unique_id(table.get_device_group(loc0.device_group_index).fabric_node_ids, device_map)
             except KeyError:
                 continue
 
             decoded_rows = []
-            for pos in range(0, read_len, tokens_per_block):
+            for pos in range(read_start, read_end, tokens_per_block):
                 loc = table.lookup(layer, pos, slot_id, 1)
                 unique_id = _resolve_unique_id(
                     table.get_device_group(loc.device_group_index).fabric_node_ids, device_map
                 )
                 raw = ttnn.experimental.disaggregation.read_dram_umd(unique_id, loc.noc_addr, loc.size_bytes)
                 decoded_rows.append(_decode_kv_chunk(raw, index_head_dim))
-            dev_ik = torch.cat(decoded_rows, dim=0)[:real_len]
+            dev_ik = torch.cat(decoded_rows, dim=0)[lo : lo + win_len]
 
-            golden_ik = _load_golden_index_k(trace_dir, layer, real_len)
+            golden_ik = _load_golden_index_k(trace_dir, layer, golden_lo + win_len, golden_lo)
             dev_ik = (dev_ik.float() @ index_hadamard).to(torch.bfloat16)
             _, pcc_index = comp_pcc(golden_ik, dev_ik)
             min_index = min(min_index, pcc_index)
@@ -777,7 +831,7 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
             logger.info(f"[producer] slot {slot_id} layer {layer:>2} index PCC: {pcc_index:.5f}")
 
         logger.info(
-            f"[producer] slot {slot_id} index PCC over [0,{real_len}) across "
+            f"[producer] slot {slot_id} index PCC over [{win_start},{win_end}) across "
             f"{checked_index}/{len(index_rows)} local layers -> {min_index:.6f}"
         )
         mins["index"] = min_index

--- a/models/demos/common/prefill/runners/runner_utils.py
+++ b/models/demos/common/prefill/runners/runner_utils.py
@@ -126,6 +126,24 @@ def load_trace_token_ids(trace_dir, total_len=None) -> list:
     return tids[:total_len] if total_len is not None else tids
 
 
+def load_trace_golden_span(trace_dir) -> tuple[int, int]:
+    """Absolute prompt positions ``[start, end)`` that a trace's per-token streams describe.
+
+    ``capture_rows`` marks a trace that covers a window of a longer prefill: its streams are stored
+    from row 0 while row ``r`` stands for position ``start + r``, so a reader that ignores the window
+    compares the right row count against the wrong tokens. Without it the streams start at position
+    0 and row index and position coincide.
+    """
+    import json
+
+    with open(Path(trace_dir) / "metadata.json") as f:
+        md = json.load(f)
+    rows = md.get("capture_rows")
+    if rows is not None:
+        return int(rows[0]), int(rows[1])
+    return 0, int(md.get("n_prompt_tokens") or len(md["token_ids"]))
+
+
 def _snap_counts_to_starts(counts, valid_starts, num_layers):
     valid = sorted(valid_starts)
     boundaries, s = [], 0

--- a/models/demos/deepseek_v3_d_p/tests/test_chunked_trace_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_chunked_trace_helpers.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Host-only coverage for the chunked-prefill trace plumbing the standalone runner depends on:
-resolve_trace_dir (descend into the vllm run-hash subdir), load_trace_token_ids, and the
-format-aware golden loader (_load_golden_kv_post) that reassembles both the DeepSeek single-file
-golden and the Kimi vllm row-sharded layout into one [seq, 576] tensor.
+resolve_trace_dir (descend into the vllm run-hash subdir), load_trace_token_ids, the format-aware
+golden loader (_load_golden_kv_post) that reassembles both the DeepSeek single-file golden and the
+Kimi vllm row-sharded layout into one [seq, 576] tensor, and the position window a golden implies.
 
 Device-level chunked correctness (full transformer, both variants) is covered by the standalone
 runner's KV-cache PCC; this only guards the trace-format handling so a layout change is caught in CI."""
@@ -13,7 +13,11 @@ from pathlib import Path
 import pytest
 
 from models.demos.common.prefill.adapter import get_adapter
-from models.demos.common.prefill.runners.runner_utils import load_trace_token_ids, resolve_trace_dir
+from models.demos.common.prefill.runners.runner_utils import (
+    load_trace_golden_span,
+    load_trace_token_ids,
+    resolve_trace_dir,
+)
 from models.demos.deepseek_v3_d_p.tt.runners.prefill_kv_validation import _load_golden_kv_post
 from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 
@@ -65,3 +69,60 @@ def test_golden_row_shard_concat_is_contiguous():
     short = _load_golden_kv_post(trace, 0, 4096)
     long = _load_golden_kv_post(trace, 0, 8192)
     assert torch.equal(short, long[:4096])
+
+
+def _windowed_trace(tmp_path: Path, start: int, end: int) -> Path:
+    """A minimal trace whose streams cover prompt positions [start, end): rows stored from 0, one
+    kv_cache shard, and the capture_rows that say where those rows actually sit."""
+    import json
+
+    import torch
+    from safetensors.torch import save_file
+
+    rows = end - start
+    trace = tmp_path / "windowed"
+    (trace / "kv_cache" / "layer_0").mkdir(parents=True)
+    with open(trace / "metadata.json", "w") as f:
+        json.dump({"token_ids": list(range(rows)), "n_prompt_tokens": rows, "capture_rows": [start, end]}, f)
+    payload = torch.arange(rows, dtype=torch.float32).unsqueeze(1).expand(rows, KVPE_DIM).contiguous()
+    save_file(
+        {"kv_post_transform_layer_0": payload},
+        trace / "kv_cache" / "layer_0" / f"rows_{0:08d}_{rows:08d}.safetensors",
+    )
+    return trace
+
+
+@pytest.mark.parametrize("variant_name", ["deepseek_v3_d_p", "kimi_k2_6", "kimi_k2_7"])
+def test_golden_span_of_prefix_trace(variant_name):
+    """A trace without capture_rows spans [0, n_prompt_tokens): row index is prompt position."""
+    trace = _trace_or_skip(variant_name)
+    assert load_trace_golden_span(trace) == (0, len(load_trace_token_ids(trace)))
+
+
+def test_golden_span_of_windowed_trace(tmp_path):
+    """capture_rows makes the span absolute, so the loader's rows and the run's positions differ."""
+    trace = _windowed_trace(tmp_path, 1043456, 1048576)
+    assert load_trace_golden_span(trace) == (1043456, 1048576)
+
+
+def test_golden_windowed_rows_are_stored_from_zero(tmp_path):
+    """The window's first position is the golden's row 0, not row 1043456."""
+    import torch
+
+    trace = _windowed_trace(tmp_path, 1043456, 1048576)
+    g = _load_golden_kv_post(trace, 0, 5120)
+    assert g.shape == (5120, KVPE_DIM), g.shape
+    assert torch.equal(g[:, 0], torch.arange(5120, dtype=torch.float32))
+
+
+@pytest.mark.parametrize("variant_name", ["deepseek_v3_d_p", "kimi_k2_7"])
+def test_golden_row_start_slices_the_tail(variant_name):
+    """row_start skips rows without shifting them: the tail load matches the full load's tail."""
+    import torch
+
+    trace = _trace_or_skip(variant_name)
+    total_len, row_start = 10240, 5120
+    tail = _load_golden_kv_post(trace, 0, total_len, row_start)
+    full = _load_golden_kv_post(trace, 0, total_len)
+    assert tail.shape == (total_len - row_start, KVPE_DIM), tail.shape
+    assert torch.equal(tail, full[row_start:])

--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_kv_validation.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_kv_validation.py
@@ -62,10 +62,33 @@ def _load_kv_pt_trace(pt_path: str) -> dict:
     return cached
 
 
-def _load_golden_kv_post(trace_dir, layer_idx: int, total_len: int) -> "torch.Tensor":
-    """[total_len, 576] golden kv_post_transform for one layer, format-agnostic:
+def _load_sharded_golden_rows(layer_dir: Path, key: str, row_start: int, row_end: int) -> "torch.Tensor":
+    """Rows ``[row_start, row_end)`` of one ``rows_<start>_<end>.safetensors`` stream, in row order.
+
+    Shard names carry the row span they hold, so only the shards overlapping the request are read.
+    """
+    import torch
+    from safetensors import safe_open
+
+    rows = []
+    for shard in sorted(layer_dir.glob("rows_*.safetensors"), key=lambda p: int(p.stem.split("_")[1])):
+        start, end = (int(x) for x in shard.stem.split("_")[1:3])
+        if end <= row_start or start >= row_end:
+            continue
+        with safe_open(shard, framework="pt") as f:
+            t = f.get_tensor(key)
+        rows.append(t[max(row_start - start, 0) : min(row_end - start, t.shape[0])])
+    if not rows:
+        raise FileNotFoundError(f"{layer_dir} has no shard covering rows [{row_start},{row_end})")
+    return torch.cat(rows, dim=0)
+
+
+def _load_golden_kv_post(trace_dir, layer_idx: int, total_len: int, row_start: int = 0) -> "torch.Tensor":
+    """[total_len - row_start, 576] golden kv_post_transform rows for one layer, format-agnostic:
     - DeepSeek: a single kv_cache/layer_N.safetensors holding the full tensor.
     - Kimi (vllm): kv_cache/layer_N/rows_<start>_<end>.safetensors shards, concatenated by start row.
+
+    Rows are trace-relative; a windowed trace's row 0 is not prompt position 0.
     """
     import torch
     from safetensors import safe_open
@@ -74,18 +97,9 @@ def _load_golden_kv_post(trace_dir, layer_idx: int, total_len: int) -> "torch.Te
     single = Path(trace_dir) / "kv_cache" / f"layer_{layer_idx}.safetensors"
     if single.exists():
         with safe_open(single, framework="pt") as f:
-            return f.get_slice(key)[:total_len].to(torch.float32)
+            return f.get_slice(key)[row_start:total_len].to(torch.float32)
     layer_dir = Path(trace_dir) / "kv_cache" / f"layer_{layer_idx}"
-    shards = sorted(layer_dir.glob("rows_*.safetensors"), key=lambda p: int(p.stem.split("_")[1]))
-    rows, have = [], 0
-    for shard in shards:
-        with safe_open(shard, framework="pt") as f:
-            t = f.get_tensor(key)
-        rows.append(t)
-        have += t.shape[0]
-        if have >= total_len:
-            break
-    return torch.cat(rows, dim=0)[:total_len].to(torch.float32)
+    return _load_sharded_golden_rows(layer_dir, key, row_start, total_len).to(torch.float32)
 
 
 def index_golden_present(trace_dir) -> bool:
@@ -93,34 +107,19 @@ def index_golden_present(trace_dir) -> bool:
 
     Some vLLM dumps store only ``dsa/dsa_topk_indices_layer_*``, so a trace can hold a valid KVPE golden
     and no indexer key at all. Callers use this to skip index-cache validation instead of failing on the
-    empty ``torch.cat([])`` the loader would hit. Lives next to the loader so the ``dsa/indexer_k_layer_*``
+    missing-shard error the loader would raise. Lives next to the loader so the ``dsa/indexer_k_layer_*``
     layout stays encoded in exactly one place."""
-    from pathlib import Path
-
     dsa_dir = Path(trace_dir) / "dsa"
     return dsa_dir.is_dir() and any(dsa_dir.glob("indexer_k_layer_*"))
 
 
-def _load_golden_index_k(trace_dir, layer_idx: int, total_len: int) -> "torch.Tensor":
-    """[total_len, index_head_dim] golden indexer key for one layer, from the vLLM trace's row-sharded
-    dsa/indexer_k_layer_N/rows_<start>_<end>.safetensors shards (concatenated by start row). Mirrors
+def _load_golden_index_k(trace_dir, layer_idx: int, total_len: int, row_start: int = 0) -> "torch.Tensor":
+    """[total_len - row_start, index_head_dim] golden indexer key rows for one layer, from the vLLM
+    trace's row-sharded dsa/indexer_k_layer_N/rows_<start>_<end>.safetensors shards. Mirrors
     _load_golden_kv_post but reads the dsa/ subdir and the indexer_k_layer_N key."""
-    from pathlib import Path
-
-    from safetensors import safe_open
-
     key = f"indexer_k_layer_{layer_idx}"
     layer_dir = Path(trace_dir) / "dsa" / key
-    shards = sorted(layer_dir.glob("rows_*.safetensors"), key=lambda p: int(p.stem.split("_")[1]))
-    rows, have = [], 0
-    for shard in shards:
-        with safe_open(shard, framework="pt") as f:
-            t = f.get_tensor(key)
-        rows.append(t)
-        have += t.shape[0]
-        if have >= total_len:
-            break
-    return torch.cat(rows, dim=0)[:total_len].to(torch.float32)
+    return _load_sharded_golden_rows(layer_dir, key, row_start, total_len).to(torch.float32)
 
 
 def kv_cache_pcc_check(


### PR DESCRIPTION


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/1m_trace_runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/1m_trace_runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/1m_trace_runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/1m_trace_runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/1m_trace_runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/1m_trace_runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/1m_trace_runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/1m_trace_runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/1m_trace_runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/1m_trace_runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/1m_trace_runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/1m_trace_runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/1m_trace_runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/1m_trace_runner)