### PR TITLE
[Cleanup] Convert llk API calls to compute API calls in conv, bmm, pool

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -299,7 +299,7 @@ void kernel_main() {
         for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
             if constexpr (pack_relu) {
                 // for each output block we start we relu disabled so that intermediate results are not relu'd
-                PACK((llk_pack_relu_config(ReluConfig::none())));
+                pack_relu_config(ReluConfig::none());
             }
             for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
                 const bool last_inner_dim_block = (in0_block_w_i == in0_num_blocks_w - 1);
@@ -312,7 +312,7 @@ void kernel_main() {
                         if constexpr (pack_relu && !fuse_bias) {
                             if (last_inner_dim_block) {
                                 // if last block we pack the final result with relu enabled
-                                PACK((llk_pack_relu_config(ReluConfig::none())));
+                                pack_relu_config(ReluConfig::none());
                             }
                         }
                         if constexpr (packer_l1_acc) {
@@ -343,7 +343,7 @@ void kernel_main() {
                     if constexpr (pack_relu && !fuse_bias) {
                         if (last_inner_dim_block) {
                             // if last block we pack the final result with relu enabled
-                            PACK((llk_pack_relu_config(ReluConfig::none())));
+                            pack_relu_config(ReluConfig::none());
                         }
                     }
                     if constexpr (packer_l1_acc) {
@@ -408,7 +408,7 @@ void kernel_main() {
                     if constexpr (!fuse_bias) {
                         if constexpr (pack_relu) {
                             // if last block we pack the final result with relu enabled
-                            PACK((llk_pack_relu_config(ReluConfig::zero())));
+                            pack_relu_config(ReluConfig::zero());
                         }
                     }
                 }
@@ -517,7 +517,7 @@ void kernel_main() {
             if constexpr (fuse_bias) {
                 if constexpr (pack_relu) {
                     // if last block we pack the final result with relu enabled
-                    PACK((llk_pack_relu_config(ReluConfig::zero())));
+                    pack_relu_config(ReluConfig::zero());
                 }
                 pack_reconfig_data_format(matmul_partials_cb, untilize_mode_out_cb_id);
                 if constexpr (packer_l1_acc) {
@@ -569,7 +569,7 @@ void kernel_main() {
                     pack_reconfig_l1_acc(0);
                 }
                 if constexpr (pack_relu) {
-                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                    pack_relu_config(ReluConfig::none());
                 }
                 if constexpr (!fuse_bias) {
                     reconfig_data_format_srca(in1_cb_id, matmul_partials_cb);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
@@ -291,7 +291,7 @@ void kernel_main() {
 #endif
 
                 if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
-                    PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+                    pack_reconfig_data_format(mm_partials_cb_id);
                 }
 
                 for (uint32_t block = 0; block < num_blocks_inner_dim; block++) {
@@ -307,7 +307,7 @@ void kernel_main() {
                     if constexpr (in0_transpose_tile) {
                         reconfig_data_format_srca(in1_cb_id, in0_transpose_cb_id);
                         transpose_init(in0_transpose_cb_id);
-                        PACK((pack_reconfig_data_format(in0_cb_id)));
+                        pack_reconfig_data_format(in0_cb_id);
 #ifdef PACKER_L1_ACC
                         pack_reconfig_l1_acc(0);
 #endif
@@ -315,7 +315,7 @@ void kernel_main() {
                         reconfig_data_format_srca(in0_transpose_cb_id, in1_cb_id);
                         matmul_block_init(
                             in0_cb_id, in1_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
-                        PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+                        pack_reconfig_data_format(mm_partials_cb_id);
                     }
 
                     // [DEBUG mcast2d compute stall] Which input wait does the unpacker (UPMW) block on?
@@ -385,7 +385,7 @@ void kernel_main() {
                                 tile_regs_wait();
 
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
-                                PACK((pack_reconfig_data_format(mm_out_cb_id)));
+                                pack_reconfig_data_format(mm_out_cb_id);
 #endif
 
 #ifdef PACKER_L1_ACC
@@ -479,7 +479,7 @@ void kernel_main() {
                 pack_relu_config(ReluConfig::zero());
 #endif
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
-                PACK((pack_reconfig_data_format(out_cb_id)));
+                pack_reconfig_data_format(out_cb_id);
 #endif
 #ifdef PACKER_L1_ACC
                 pack_reconfig_l1_acc(0);
@@ -550,7 +550,7 @@ void kernel_main() {
 #ifndef FUSE_BIAS
                     reconfig_data_format_srca(in1_cb_id, mm_partials_cb_id);
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
-                    PACK((pack_reconfig_data_format(out_cb_id)));
+                    pack_reconfig_data_format(out_cb_id);
 #endif
 #ifdef PACKER_L1_ACC
                     pack_reconfig_l1_acc(0);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
@@ -263,7 +263,7 @@ void kernel_main() {
                             ((in_nblocks_c - 1) * max_tiles_per_iter + partial_iter_output_tiles);
                         pre_tilize_cb.push_back(filler_stick_tiles);
                     }
-                    PACK((pack_untilize_uninit(pre_tilize_cb_id)));
+                    pack_untilize_uninit(pre_tilize_cb_id);
 
                     unpack_tilizeA_B_uninit(curr_in_cb_id);
                     pack_reconfig_data_format(out_cb_id);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -288,12 +288,12 @@ void kernel_main() {
 #ifdef PACK_RELU
                 // for each batch we start with relu disabled so that intermediate results are not relu'd
                 if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
-                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                    pack_relu_config(ReluConfig::none());
                 }
 #endif
 
                 if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
-                    PACK((pack_reconfig_data_format(mm_partials_dfb_id)));
+                    pack_reconfig_data_format(mm_partials_dfb_id);
                 }
 
                 for (uint32_t block = 0; block < num_blocks_inner_dim; block++) {
@@ -302,16 +302,16 @@ void kernel_main() {
 #if not defined FUSE_BIAS and defined PACK_RELU
                     if (last_out) {
                         // if last block we pack the final result with relu enabled
-                        PACK((llk_pack_relu_config(ReluConfig::zero())));
+                        pack_relu_config(ReluConfig::zero());
                     }
 #endif
 
                     if constexpr (in0_transpose_tile) {
                         reconfig_data_format_srca(in1_dfb_id, in0_transpose_dfb_id);
                         transpose_init(in0_transpose_dfb_id);
-                        PACK((pack_reconfig_data_format(in0_dfb_id)));
+                        pack_reconfig_data_format(in0_dfb_id);
 #ifdef PACKER_L1_ACC
-                        PACK((llk_pack_reconfig_l1_acc(0)));
+                        pack_reconfig_l1_acc(0);
 #endif
                         transpose_tile_block<in0_block_num_tiles>(in0_transpose_dfb_id, in0_dfb_id);
                         reconfig_data_format_srca(in0_transpose_dfb_id, in1_dfb_id);
@@ -322,7 +322,7 @@ void kernel_main() {
                             out_subblock_w,
                             out_subblock_h,
                             in0_block_w);
-                        PACK((pack_reconfig_data_format(mm_partials_dfb_id)));
+                        pack_reconfig_data_format(mm_partials_dfb_id);
                     }
 
                     in0_dfb.wait_front(in0_block_num_tiles);
@@ -400,18 +400,18 @@ void kernel_main() {
 #endif
 
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
-                                PACK((pack_reconfig_data_format(mm_out_dfb_id)));
+                                pack_reconfig_data_format(mm_out_dfb_id);
 #endif
 
 #ifdef PACKER_L1_ACC
 #ifdef FUSE_BIAS
                                 if (block == 0) {  // no accumulation for first iteration
-                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                    pack_reconfig_l1_acc(0);
                                 } else {
-                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                    pack_reconfig_l1_acc(1);
                                 }
 #else
-                                PACK((llk_pack_reconfig_l1_acc(0)));
+                                pack_reconfig_l1_acc(0);
 #endif
 #endif
                                 const uint32_t start_dst_index = 0;
@@ -427,11 +427,11 @@ void kernel_main() {
 
 #ifdef PACKER_L1_ACC
                                 if (block == 0) {  // no accumulation for first iteration
-                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                    pack_reconfig_l1_acc(0);
                                 } else if (block == 1 || in0_transpose_tile) {
                                     // block == 1 switches accumulation on. For later blocks, the transpose stage
                                     // disabled it again, so put it back here.
-                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                    pack_reconfig_l1_acc(1);
                                 }
 #endif
 
@@ -486,13 +486,13 @@ void kernel_main() {
 #ifdef FUSE_BIAS
 #ifdef PACK_RELU
                 // if last block we pack the final result with relu enabled
-                PACK((llk_pack_relu_config(ReluConfig::zero())));
+                pack_relu_config(ReluConfig::zero());
 #endif
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
-                PACK((pack_reconfig_data_format(out_dfb_id)));
+                pack_reconfig_data_format(out_dfb_id);
 #endif
 #ifdef PACKER_L1_ACC
-                PACK((llk_pack_reconfig_l1_acc(0)));
+                pack_reconfig_l1_acc(0);
 #endif
                 reconfig_data_format(in1_dfb_id, mm_partials_dfb_id, in0_dfb_id, bias_dfb_id);
                 if constexpr (row_broadcast_bias) {
@@ -574,15 +574,15 @@ void kernel_main() {
 #endif  // FUSE_BIAS
                 if constexpr (untilize_out) {
 #ifdef PACK_RELU
-                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                    pack_relu_config(ReluConfig::none());
 #endif  // PACK_RELU
 #ifndef FUSE_BIAS
                     reconfig_data_format_srca(in1_dfb_id, mm_partials_dfb_id);
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
-                    PACK((pack_reconfig_data_format(out_dfb_id)));
+                    pack_reconfig_data_format(out_dfb_id);
 #endif
 #ifdef PACKER_L1_ACC
-                    PACK((llk_pack_reconfig_l1_acc(0)));
+                    pack_reconfig_l1_acc(0);
 #endif
 #endif  // FUSE_BIAS
                     pack_untilize_dest_init<out_subblock_w, out_block_w>(out_dfb_id);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -205,7 +205,7 @@ void kernel_main() {
                             ((in_nblocks_c - 1) * max_tiles_per_iter + partial_iter_output_tiles);
                         pre_tilize_dfb.push_back(filler_stick_tiles);
                     }
-                    PACK((pack_untilize_uninit(pre_tilize_cb_id)));
+                    pack_untilize_uninit(pre_tilize_cb_id);
 
                     unpack_tilizeA_B_uninit(curr_in_cb_id);
                     pack_reconfig_data_format(out_cb_id);
@@ -232,21 +232,13 @@ void kernel_main() {
 
                     tilize_stick_counter = 0;
 
-                    UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
-                        in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce)));
-                    // init math for reduction again since FPU gets reprogrammed by tilize
-                    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>(
-                        in_cb_id_0, in_scalar_cb_id_0)));
-#ifdef ARCH_BLACKHOLE
-                    // need this on BH to set swizzle bit before pack untilize dest
-                    MATH((llk_math_reconfig_remap(true)));
-#endif
-
+                    tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
+                        in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce);
                     if constexpr (is_output_block_format) {
                         pack_reconfig_data_format(pre_tilize_cb_id);
                     }
-                    PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(
-                        pre_tilize_cb_id)));
+                    pack_untilize_dest_init<max_tiles_per_iter, max_tiles_per_iter, false /*narrow_row*/, TILE_C_DIM>(
+                        pre_tilize_cb_id);
                 }
             } else {
                 // ROW_MAJOR output: pack directly to output CB


### PR DESCRIPTION
### PR Category
Cleanup

### Issue
https://github.com/tenstorrent/tt-metal/issues/54329

### Summary
This PR is one in a series of PRs cleaning up experimental/quasar compute kernels and switching their llk API calls to compute API calls. It also cleans up some of the regular OPs in the same way, in order to not diverge. 

- For experimental/quasar `bmm_large_block_zm_fused_bias_activation_metal2.cpp` and `compute_pool_2d.cpp` compute API `pack_reconfig_data_format` and `pack_untilize_uninit` call were wrapped in PACK(), removes the wrapper;
- For mainline `conv_bmm_tilize.cpp` llk_pack_relu_config -> pack_relu_config;
- For mainline `bmm_large_block_zm_fused_bias_activation.cpp` removes PACK() wrap from compute API `pack_reconfig_data_format`, llk_pack_relu_config -> pack_relu_config, llk_pack_reconfig_l1_acc -> pack_reconfig_l1_acc;
- For mainline `compute_pool_2d.cpp` removes PACK() wrap from compute API `pack_untilize_uninit `, llk_unpack_tilizeA_B_init + llk_math_reduce_init -> tilizeA_B_reduce_init, llk_math_reconfig_remap + llk_pack_untilize_init -> pack_untilize_dest_init (BH specific remap is included in this compute API).

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/cleanup_v5)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/cleanup_v5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/cleanup_v5)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/cleanup_v5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/cleanup_v5)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/cleanup_v5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/cleanup_v5)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/cleanup_v5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/cleanup_v5)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/cleanup_v5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/cleanup_v5)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/cleanup_v5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/cleanup_v5)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/cleanup_v5)