### PR TITLE
[CI] BGE-M3 unit: raise the wh_n150 job timeout to fit the 9-length benchmark

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -383,7 +383,7 @@ models:
   unit_tier2:
     wh_llmbox: 114
     wh_llmbox_perf: 191
-    wh_n150: 82
+    wh_n150: 87
     wh_n300: 30
     wh_galaxy_perf: 80
     bh_p150: 20

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1673,7 +1673,7 @@
   model: bge_m3
   skus:
     wh_n150:
-      timeout: 15
+      timeout: 20
       tier: 2
   owner_id: U082LLYBLSW # Gabriel Tobar (CODEOWNERS @gtobarTT)
   team: models


### PR DESCRIPTION
### PR Category
Bug fix (CI config)

### Summary
`BGE-M3 unit tests [wh_n150]` (Tier 2 Models unit, scheduled) was killed by its 15-minute job timeout on 2026-09-09 (vm-167) and 2026-09-10 (vm-166). In both logs the last test had started 7 s before the kill and needs about 9 s; no test failed, no pytest timeout fired, no dispatch watchdog fired. Pure slowness against the cap.

Cause: #54669 (`bc294789ec3d`, 2026-08-31) widened `SEQUENCE_LENGTHS` from 5 to 9 in `models/demos/wormhole/bge_m3/tests/test_utils.py`, taking the job from 34 to 58 tests and its test step from 567–675 s (08-24..08-31) to 853–870 s on every green run since, against a 900 s cap. It did not touch the CI entry. The e2e leg had the same omission and was fixed in #55784. The last green run (09-08, job 101906495826) took 858 s; the 09-09/09-10 runs needed an estimated 903–915 s because every wh_n150 unit job ran 5–10 % slower on those days.

Not causes: "local copy not found, so likely downloading straight from HF" and the `lm_head.layer_norm.* MISSING` lines appear in every green log too (the container runs `HF_HUB_OFFLINE=1` against the MLPerf hub cache; the load takes 3–5 s).

### Change
- `tests/pipeline_reorg/models_unit_tests.yaml`: BGE-M3 unit `wh_n150` timeout 15 → 20 min (18 is the floor for the measured step; 20 gives room for the 5–10 % day-to-day variance).
- `.github/time_budget.yaml`: models `unit_tier2` `wh_n150` 82 → 87 (the verifier was exactly full at 82/82).

Owner-side alternatives noted by the analysis, not taken here: trim the S32/S64/S256 `test_model` cases (~90 s) or module-scope the model build in the four vLLM tests (~25 s).

### CI
- `(Tier 2) Models Unit Tests`, model=`bge-m3`, sku=`wh_n150`: https://github.com/tenstorrent/tt-metal/actions/runs/34468419724 — **PASSED** ([job 102844785093](https://github.com/tenstorrent/tt-metal/actions/runs/34468419724/job/102844785093), tt-metal-ci-vm-71, test step 15m18s = 918 s against the new 1200 s cap; the old cap was 900 s)

