### PR TITLE
[CI] bevformer unit: raise the bh_p150b_civ2 job timeout to cover the watcher overhead

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -186,7 +186,7 @@ shield:
     bh_p150: 100
     bh_p150b_civ2: 90
   unit_tier3:
-    bh_p150b_civ2: 20
+    bh_p150b_civ2: 24
     bh_p150: 2
   device_perf:
     wh_n150: 100

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1576,7 +1576,7 @@
   model_family: BEVFormer
   skus:
     bh_p150b_civ2:
-      timeout: 12
+      timeout: 16
       tier: 3
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: shield


### PR DESCRIPTION
### PR Category
Bug fix (CI config)

### Summary
`bevformer unit tests [bh_p150b_civ2]` (Tier 3 Models unit, scheduled) was killed by its 12-minute step timeout on 2026-09-09 (job 102364516975) and 2026-09-10 (job 102771438281). On 09-09 pytest reported `27 passed in 707.57s` and the step was still killed at 720 s during device teardown, so that run is a false failure. On 09-10 the suite had 26/27 passed at 696 s and the last test was killed 5.7 s in (it needs about 29 s).

Cause: #48924 (2026-07-24) prepended `TT_METAL_WATCHER=30` to every Tier 1/2/3 unit job command. It bumped the Qwen2.5-32B timeout 12 → 18 for that but left bevformer at `timeout: 12`. The watcher added about 112 s (+20 %) to this suite: green steps went from 584 s (07-23) to 664–716 s (07-26 .. 09-08) against a 720 s cap, so the job has had 4–60 s of headroom for seven weeks. The 09-08 run took 663.9 s; 08-27 passed with 3.7 s to spare. 09-09/09-10 were about 9.5 % slower than 09-08 uniformly across all 27 tests, which is within the day-to-day variance seen on the sibling panoptic-deeplab job on the same pool.

Not causes: the test count has been 27 since 07-17; the only test change since April (#55367, 09-04) made the suite about 1.6 % faster; the runner label and docker image did not change between the last green and first red run.

### Change
- `tests/pipeline_reorg/models_unit_tests.yaml`: bevformer unit `bh_p150b_civ2` timeout 12 → 16 min (960 s is +31 % over the worst observed 735 s and +41 % over the median 682 s).
- `.github/time_budget.yaml`: shield `unit_tier3` `bh_p150b_civ2` 20 → 24 (the budget was exactly full: panoptic-deeplab 8 + bevformer 12).

Owner-side alternatives noted by the analysis, not taken here: enabling kernel ccache for this pipeline, or splitting the suite (which would cost more budget than the bump).

Unrelated finding for the owners: 6 of the 7 `check_with_tolerances()` call sites under `models/experimental/bevformer/tests/pcc/` discard the returned `passed` flag, so the abs/rel/high-error tolerances are not enforced in 26 of 27 tests. `ms_deformable_attention[nuscenes_tiny-1-900]` prints `OVERALL: ❌ FAILED` on every run and still passes on PCC alone.

### CI
- `(Tier 3) Models Unit`, model=`bevformer`, sku=`bh_p150b_civ2 (P150 CIv2)`: https://github.com/tenstorrent/tt-metal/actions/runs/34469106979 — **PASSED** ([job 102846653464](https://github.com/tenstorrent/tt-metal/actions/runs/34469106979/job/102846653464), tt-ubuntu-2204-p150b-stable-xttnx-runner-2qwbw, test step 12m03s = 723 s against the new 960 s cap; the old cap was 720 s)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/bevformer-unit-job-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/bevformer-unit-job-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/bevformer-unit-job-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/bevformer-unit-job-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/bevformer-unit-job-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/bevformer-unit-job-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/bevformer-unit-job-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/bevformer-unit-job-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/bevformer-unit-job-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/bevformer-unit-job-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/bevformer-unit-job-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/bevformer-unit-job-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/bevformer-unit-job-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/bevformer-unit-job-timeout)
