### PR TITLE
[TTNN] strided reduce-scatter: drain window-credit atomics before the reader exits

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
@@ -462,6 +462,16 @@ void kernel_main() {
 #endif
     }
 
+#ifdef FUSE_MM_OP_SIGNALER
+    if constexpr (mm_window_blocks > 0) {
+        // The window credits above are non-posted atomics. Wait for their acks before exiting: the
+        // firmware asserts that no non-posted atomics are outstanding at kernel end (watcher trips
+        // "NCRISC detected an inter-kernel data race" otherwise), and an ack landing after the next
+        // program starts could corrupt a freshly zeroed credit counter.
+        noc_obj.async_atomic_barrier();
+    }
+#endif
+
     // Explicit cleanup: guarantee the semaphore is 0 when this kernel exits
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }


### PR DESCRIPTION
### PR Category
Bug fix (TTNN op kernel)

### Summary
`TT-DiT Wan2.2-I2V-A14B unit tests [wh_galaxy]` (Tier 1 Models unit, scheduled) fails with a watcher-tripped assert during `test_pipeline_inference[...480p-4x8sp1tp0nl4_ring_is_fsdp1-True]` (job 102746509741, 2026-09-10, OM1-01A03-STGWH01, and the same assert on the same core in every scheduled run that reached this op under the watcher):

```
Device 0 worker core(x= 1,y= 7) virtual(x=19,y=25): NCRISC detected an inter-kernel data race due to kernel completing with pending NOC transactions (missing NOC non-posted atomics flushed barrier). Current kernel: ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
```

Cause: with the fused-matmul rolling L1 window enabled (`mm_window_blocks > 0`), the strided reduce-scatter reader fires one non-posted `noc_semaphore_inc` per matmul core after every M block (the window credit, `reader.cpp` around line 452) and then returns from `kernel_main` with no atomic barrier. The writer and both matmul data-movement kernels end with `async_atomic_barrier()`; the reader does not. On this shape (M=4096, K=3456, N=5120 on the 8x9 WH Galaxy grid, ring size 4) the fallback `FusedMMRSConfig` puts 56 matmul cores in the window, so 56 acks are still in flight when NCRISC reaches the end-of-kernel check in `ncrisck.cc`. The assert parks the core in `assert_and_hang`, the program never completes, the 5 s dispatch watchdog fires, and the watcher poll turns the assert into a `TT_THROW` in the watcher thread (SIGABRT, exit 134).

Without the watcher this is a latent race: a late credit ack can land after the next matmul has zeroed its credit counters and let a window slot recycle one block early.

Not the cause: the `get_fused_mmrs_config ... fell back to the default` warning in the log. That is a perf warning; a swept table entry would not remove the missing barrier.

### Change
- `minimal_ring_strided_reduce_scatter_async_reader.cpp`: add `noc_obj.async_atomic_barrier()` at kernel end, under the existing `FUSE_MM_OP_SIGNALER` / `mm_window_blocks > 0` guard so the non-fused path is unchanged.

Separate follow-ups for the owners, not in this PR: register swept `fused_mmrs_configs` entries for `(4096, 3456, 5120)` and `(9472, 3456, 5120)` under `CoreCoord(8, 9)`; upload `generated/watcher/watcher.log` as a job artifact on failure so the assert text does not depend on the watcher poll landing before the process dies.

### CI
- `(Tier 1) Models Unit Tests`, model=`wan-2.2-i2v`, sku=`wh_galaxy (WH Galaxy)`:
  - https://github.com/tenstorrent/tt-metal/actions/runs/34469602070: infra, no test ran. Container setup on `UF-EV-A1-GWH02` died with `Value cannot be null. (Parameter 'ContainerId')` / `Could not find a part of the path '/proc/1/cgroup'`, the same runner failure that has been taking out Galaxy jobs in the scheduled runs this week.
  - Re-dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/34470540517 — **PASSED** ([job](https://github.com/tenstorrent/tt-metal/actions/runs/34470540517/job/102849942690) on `OM1-01A03-STGWH01`, the same host that tripped the assert in the 09-10 scheduled run): `2 passed, 4 skipped, 6 deselected in 2873.77s` (both `is_fsdp1` pipeline cases, 480p and 720p), zero `inter-kernel data race` / `tripped assert` lines in the log, test step 48 min against the 60-min budget. First green run of this job since the fused-op window was enabled by default (#54239, 08-27).

