### PR TITLE
[CI] T3K TT-Transformers common + sampling unit jobs: raise step timeouts to fit the measured run time

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -371,7 +371,7 @@ models:
     bh_p300: 13
     bh_quietbox_2: 42
   unit_tier1:
-    wh_llmbox: 150
+    wh_llmbox: 155
     wh_n150: 118
     wh_galaxy: 260
     wh_galaxy_perf: 65

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1702,7 +1702,7 @@
   model_family: TTTv2
   skus:
     wh_llmbox:
-      timeout: 23
+      timeout: 28
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models


### PR DESCRIPTION
### PR Category
Bug fix (CI config)

### Summary
`TT-Transformers sampling module unit tests [wh_llmbox]` and `TT-Transformers common unit tests [wh_llmbox]` (Tier 1 Models unit, scheduled) have failed with `The action has timed out` on every scheduled run since 2026-09-08 20:13 UTC, on five different T3K VMs, and the same on a PR branch based on main (run 34462930785).

These are not device hangs. In every failing log the step is killed at exactly its `timeout-minutes` budget (240 s for sampling, 1380 s for common) while the last collected device test is a few seconds into a run it used to complete:

- sampling: `test_sampling1d_logprobs_topk[1x8]` is the last test in the file and the slowest (22 s when it last completed on 09-08 04:17). Every failing run kills it 18–23 s in. The job's own `TT_METAL_OPERATION_TIMEOUT_SECONDS=5` device watchdog, armed in the same step, never fires.
- common: `test_validation_rmsnorm_host_and_device[1x1]` is the last device test collected. On 09-08 20:13 it had already **passed** (14.5 s) and the step was killed at 1380 s while pytest printed its summary. On 09-10 the budget ran out 6–10 s into the same test, during the 1x1 mesh open (`Fabric config changed`).

Both jobs were already at 93–97 % of budget before the window (sampling 224–228 s of 240 s; common 1350 s of 1380 s; the previous common bump 15 → 23 in #54608 left under 30 s of slack). The `e7c0152e390..4bec2b251fa` window (09-08 04:17 → 19:40 UTC, same docker image on both sides) then added five host-only penalty tests (#55754, about 1 s) and a 20–25 % slowdown of first-time kernel compilation. Per-test diff between the 09-08 04:17 and 09-08 20:13 logs: every test that compiles new compute kernels got 20–27 % slower (e.g. `test_log_probs_calculation` 25.0 → 30.9 s, `test_ttsampling_topk_matches_argmax` 20.3 → 24.7 s), sub-second tests are unchanged. That compile-time regression is being tracked separately; this PR only restores headroom so the jobs can report real results again.

### Change
- `tests/pipeline_reorg/models_unit_tests.yaml`: sampling module job `wh_llmbox` timeout 4 → 6 min (measured need about 250 s); common job 23 → 28 min (measured need about 1395 s).
- `.github/time_budget.yaml`: models `unit_tier1` `wh_llmbox` 150 → 155 (the tier-1 sum was 145, now 152).

Note: #55789 adds a third pytest invocation (`test_params.py`, about 5 s) to the sampling job's command. The two PRs touch different lines of the same block and both fit in the 6-minute budget.

### CI
- `(Tier 1) Models Unit Tests`, model=`tt-transformers-common`, sku=`wh_llmbox (T3000)` (runs all eight T3K module jobs): https://github.com/tenstorrent/tt-metal/actions/runs/34469889276 — **PASSED, both jobs green** (all eight T3K module jobs green).
  - [sampling module job 102849206542](https://github.com/tenstorrent/tt-metal/actions/runs/34469889276/job/102849206542): `test_penalties_1d.py` 95 passed in 71.6 s, `test_sampling_1d.py` **124 passed in 155.2 s** (`test_sampling1d_logprobs_topk[1x8]` included), test step 4m05s = 245 s: over the old 240 s cap, as predicted, under the new 360 s.
  - [common unit job 102849206508](https://github.com/tenstorrent/tt-metal/actions/runs/34469889276/job/102849206508): **3002 passed, 257 skipped, 3 deselected in 1372.7 s**, test step 23m06s = 1386 s: over the old 1380 s cap, under the new 1680 s. The `deepseek_r1_distill_qwen_14b` contract test that used to fail here did not fail in this run.

  Both jobs completed with a few seconds more than their old budget, which confirms the step-budget-kill reading: these were never device hangs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/t3k-tt-transformers-unit-job-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/t3k-tt-transformers-unit-job-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/t3k-tt-transformers-unit-job-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/t3k-tt-transformers-unit-job-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/t3k-tt-transformers-unit-job-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/t3k-tt-transformers-unit-job-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/t3k-tt-transformers-unit-job-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/t3k-tt-transformers-unit-job-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/t3k-tt-transformers-unit-job-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/t3k-tt-transformers-unit-job-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/t3k-tt-transformers-unit-job-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/t3k-tt-transformers-unit-job-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/t3k-tt-transformers-unit-job-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/t3k-tt-transformers-unit-job-timeouts)
