### PR TITLE
[SDXL] re-centre the vae_encode_512x512 device perf target on the observed mean

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -136,7 +136,7 @@ DEVICE_PERF_EXPECTATIONS = {
         "blackhole": 141_175_333,
     },
     "vae_encode_512x512": {
-        "wormhole": 81_841_969,
+        "wormhole": 82_600_000,
         "blackhole": None,  # Only 1024x1024 tested on Blackhole
     },
     "clip_encoder_1": {


### PR DESCRIPTION
### PR Category
Bug fix (perf target)

### Summary
`test_sdxl_perf_device[...vae_encode_512x512...]` in the scheduled `(Tier 1) Models Device Perf Tests` job on `wh_n150` failed on 2026-09-10 with `AVG DEVICE KERNEL DURATION [ns] 83070302 is outside of expected range (80614339.465, 83069598.535)`: 704 ns over the upper bound.

The target is mis-centred, not the kernel regressed. The wormhole value `81_841_969` (set in #50930 on 2026-08-11 without a stated derivation) sits 0.9 % below the steady state measured by this job. Twenty scheduled runs from 2026-08-24 to 2026-09-10 average 82,615,152 ns (sigma 0.42 %, range 81.99 M to 83.07 M), so the 1.5 % band left about 0.6 % of headroom above the mean. The two other 09-10 runs on the same commit read 82.60 M and 82.73 M, inside the band.

### Change
- `models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py`: `DEVICE_PERF_EXPECTATIONS["vae_encode_512x512"]["wormhole"]` 81_841_969 → 82_600_000 (band 81.36 M to 83.84 M at 1.5 %; every observed value fits with at least 0.9 % of headroom).

Not changed here:
- `clip_encoder_1` / `clip_encoder_2` failed in the same job on 09-10 (+2 % in one op class on every host built with SFPI 7.75.0, #55993). Today's scheduled run on main (09-11, vm-171, with SFPI 7.75.1 #56128 in the head) reads them back at 23,774,585 / 88,990,038 ns and passes, so the CLIP targets are left untouched; details in #56086.
- `unet_1024x1024` (`191_201_442`) is 1.0 % below its 16-run mean of 193,151,226 under a 1.5 % band and has not failed yet; left for the owners to decide.

### CI
- `(Tier 1) Models Device Perf Tests`, model=`sdxl`, sku=`wh_n150 (N150)`:
  - https://github.com/tenstorrent/tt-metal/actions/runs/34470238338 (first head, vm-14): **`vae_encode_512x512` PASSED** with the new target (82,598,700 ns measured); every other gate passed except the two CLIP gates (24,197,911 / 90,594,188 ns), which were the SFPI 7.75.0 regression of #56086, not this change.
  - https://github.com/tenstorrent/tt-metal/actions/runs/34586787442 (rebased onto main `89da15081de`, which includes SFPI 7.75.1; dispatched 2026-09-11; result pending). Expected: whole job green.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/sdxl-vae-encode-512-device-perf-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/sdxl-vae-encode-512-device-perf-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/sdxl-vae-encode-512-device-perf-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/sdxl-vae-encode-512-device-perf-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/sdxl-vae-encode-512-device-perf-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/sdxl-vae-encode-512-device-perf-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/sdxl-vae-encode-512-device-perf-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/sdxl-vae-encode-512-device-perf-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/sdxl-vae-encode-512-device-perf-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/sdxl-vae-encode-512-device-perf-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/sdxl-vae-encode-512-device-perf-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/sdxl-vae-encode-512-device-perf-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/sdxl-vae-encode-512-device-perf-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/sdxl-vae-encode-512-device-perf-target)


