### PR TITLE
[CI] ResNet-50 device perf: raise the wh_n150 job timeout to 10 min

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -119,7 +119,7 @@ ttnn:
   unit_tier3:
     wh_n150: 4
   device_perf:
-    bh_p150b_civ2: 7
+    bh_p150b_civ2: 9
     wh_n150: 10
     wh_llmbox_perf: 8
   integration:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -120,7 +120,7 @@ ttnn:
     wh_n150: 4
   device_perf:
     bh_p150b_civ2: 7
-    wh_n150: 5
+    wh_n150: 10
     wh_llmbox_perf: 8
   integration:
     wh_llmbox: 30

--- a/tests/pipeline_reorg/models_device_perf_tests.yaml
+++ b/tests/pipeline_reorg/models_device_perf_tests.yaml
@@ -91,14 +91,16 @@
 
 - name: ResNet-50 device perf tests
   cmd: |
-    pytest --timeout 540 models/demos/vision/classification/resnet50/{arch_dir}/tests/test_perf_device_resnet50.py -m models_device_performance_bare_metal
+    pytest --timeout {pytest_timeout} models/demos/vision/classification/resnet50/{arch_dir}/tests/test_perf_device_resnet50.py -m models_device_performance_bare_metal
   model: resnet50
   skus:
     bh_p150b_civ2:
-      timeout: 7
+      timeout: 9
+      pytest_timeout: 240
       arch_dir: blackhole
     wh_n150:
       timeout: 10
+      pytest_timeout: 540
       arch_dir: wormhole
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn

--- a/tests/pipeline_reorg/models_device_perf_tests.yaml
+++ b/tests/pipeline_reorg/models_device_perf_tests.yaml
@@ -91,7 +91,7 @@
 
 - name: ResNet-50 device perf tests
   cmd: |
-    pytest models/demos/vision/classification/resnet50/{arch_dir}/tests/test_perf_device_resnet50.py -m models_device_performance_bare_metal
+    pytest --timeout 540 models/demos/vision/classification/resnet50/{arch_dir}/tests/test_perf_device_resnet50.py -m models_device_performance_bare_metal
   model: resnet50
   skus:
     bh_p150b_civ2:

--- a/tests/pipeline_reorg/models_device_perf_tests.yaml
+++ b/tests/pipeline_reorg/models_device_perf_tests.yaml
@@ -98,7 +98,7 @@
       timeout: 7
       arch_dir: blackhole
     wh_n150:
-      timeout: 5
+      timeout: 10
       arch_dir: wormhole
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn


### PR DESCRIPTION
### PR Category
Bug fix (CI config)

### Summary
`ResNet-50 device perf tests [wh_n150]` in the scheduled `(Tier 1) Models Device Perf Tests` job was killed by its 5-minute step timeout on 2026-09-10 (vm-166) at 299.98 s, after the inner test had already **passed** (205 s) and while tracy post-processing was starting. Same shape on 08-27 and 08-28.

Not a hang and not a device problem. Every run compiles the same 251 kernels (the profiler build has no persistent kernel cache, `0/255` JIT hits), but on the failing days every phase, including the device-free Python startup (8.5 s on good runs, 30–50 s on bad ones), is 2–5× slower. The same runner (vm-152) is fast on some days and slow on others, so this is transient host CPU contention. A healthy run needs about 145 s of the 300 s budget, so a 2× host slowdown, which is what was observed, exceeds it. The Blackhole SKU already has 7 minutes.

### Change
- `tests/pipeline_reorg/models_device_perf_tests.yaml`: ResNet-50 device perf `wh_n150` timeout 5 → 10 min, and a per-SKU `pytest --timeout {pytest_timeout}` on the test command: `wh_n150: 540` (the first validation run showed the next cap behind the step budget: the outer `test_perf_device` is bound by `pytest.ini`'s default 300 s pytest-timeout, and on the slow host the wrapped run alone took 259 s, so the outer test was killed at 301 s during tracy post-processing), `bh_p150b_civ2: 240` with its step raised 7 → 9 min. The Blackhole numbers keep pytest reporting before the step budget even if both cases stall (23 s start-up + 2 × 240 s < 540 s); 240 s is 1.5× that leg's worst green case (158 s) and 2.2× its median (110 s). An earlier revision of this PR applied the shared 540 s to both SKUs, which sat above the Blackhole leg's 7-minute step.
- `.github/time_budget.yaml`: ttnn `device_perf` `wh_n150` 5 → 10, `bh_p150b_civ2` 7 → 9.

Follow-ups noted by the analysis, not taken here: log `nproc` and `/proc/stat` steal at step start so the contention is visible in the log; cache the JIT kernel build directory across runs for the profiler build.

### CI
- `(Tier 1) Models Device Perf Tests`, model=`resnet50`, sku=`wh_n150 (N150)`:
  - https://github.com/tenstorrent/tt-metal/actions/runs/34471008501 (step budget only): landed on vm-166 again, the same slow host as the scheduled failure. The wrapped run passed in 258.9 s (145 s on a healthy host), then the outer test hit the default 300 s pytest-timeout at 301 s during post-processing. Step time 6m14s, well inside the new 10 min, so the step budget itself is now sufficient; the pytest timeout was the remaining cap.
  - https://github.com/tenstorrent/tt-metal/actions/runs/34473148864 (with `--timeout 540`) — **PASSED** ([job 102860859013](https://github.com/tenstorrent/tt-metal/actions/runs/34473148864/job/102860859013), tt-metal-ci-vm-115): 1 passed in 98.03s; 1 passed in 119.78s; test step 2m20s = 140 s against the new 600 s step budget (old: 300 s).
  - https://github.com/tenstorrent/tt-metal/actions/runs/34605783972 (per-SKU pytest timeouts, `sku=all`): **wh_n150 PASSED**. **bh_p150b_civ2 hit the Blackhole board stall again** (pod xttnx-2vsz4: `MMIO per-op timeout: 4B load took 222336 us (budget=2 ms)`, then `terminate called`), and the new numbers did what they are for: both cases were reported by pytest-timeout at 240 s each and pytest printed `2 failed in 253.19s` inside the 540 s step. The step still ran to its 540 s cap because the orphaned profiler tail (fixed separately in #56252) is not in this branch. The wh_llmbox_perf e2e-perf leg of the `sku=all` run was cancelled as unrelated after sitting in the T3000-perf queue.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/resnet50-device-perf-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/resnet50-device-perf-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/resnet50-device-perf-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/resnet50-device-perf-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/resnet50-device-perf-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/resnet50-device-perf-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/resnet50-device-perf-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/resnet50-device-perf-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/resnet50-device-perf-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/resnet50-device-perf-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/resnet50-device-perf-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/resnet50-device-perf-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/resnet50-device-perf-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/resnet50-device-perf-n150-timeout)



