### PR TITLE
[DeepSeek-V3] ff1_3 fused-op test: derive the decode shard grid from the device; run every device perf case

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -402,7 +402,7 @@ models:
     wh_llmbox: 0
   device_perf:
     wh_n150: 20
-    wh_galaxy_perf: 65
+    wh_galaxy_perf: 70
     bh_p150: 20
     bh_p300: 20
     bh_quietbox_2: 80

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -402,7 +402,7 @@ models:
     wh_llmbox: 0
   device_perf:
     wh_n150: 20
-    wh_galaxy_perf: 55
+    wh_galaxy_perf: 65
     bh_p150: 20
     bh_p300: 20
     bh_quietbox_2: 80

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py
@@ -293,7 +293,15 @@ def _build_ff1_3_inputs(
             memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             buffer_type=ttnn.BufferType.L1,
             shard_spec=ttnn.ShardSpec(
-                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
+                # One [32, 128] shard per 128 columns of the per-device slice (hidden_size split
+                # across the mesh columns by the mapper below). Derive the cores from the device
+                # grid: under COL dispatch the Galaxy compute grid is only 7 cores wide, so a
+                # hard-coded 8-wide range includes the dispatch column and fails buffer validation.
+                ttnn.num_cores_to_corerangeset(
+                    hf_config.hidden_size // mesh_device.shape[1] // 128,
+                    mesh_device.compute_with_storage_grid_size(),
+                    row_wise=True,
+                ),
                 [32, 128],
                 ttnn.ShardOrientation.ROW_MAJOR,
             ),

--- a/tests/pipeline_reorg/models_device_perf_tests.yaml
+++ b/tests/pipeline_reorg/models_device_perf_tests.yaml
@@ -174,6 +174,6 @@
   model_family: DeepSeek
   skus:
     wh_galaxy_perf:
-      timeout: 30
+      timeout: 40
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models

--- a/tests/pipeline_reorg/models_device_perf_tests.yaml
+++ b/tests/pipeline_reorg/models_device_perf_tests.yaml
@@ -136,11 +136,13 @@
     PROFILER_DIR="generated/profiler/deepseek_v3_fused_ops_device_perf"
     TRACY_TIMEOUT_PORT=5000
     TRACY_OP_SUPPORT_COUNT=10000
+    rc=0
     run_tracy_case() {
       local name="$1"
       local perf_env_var="$2"
       local test_target="$3"
       local k_expr="$4"
+      local case_rc=0
       echo "--- Case: $name | Target: $test_target | Expr: $k_expr"
       env "${perf_env_var}=1" python3 -m tracy -p -r \
         -o "$PROFILER_DIR" \
@@ -148,7 +150,11 @@
         --op-support-count "$TRACY_OP_SUPPORT_COUNT" \
         -t "$TRACY_TIMEOUT_PORT" \
         -a device_kernel_duration \
-        -m "pytest $test_target -k \"$k_expr\""
+        -m "pytest $test_target -k \"$k_expr\"" || case_rc=$?
+      if [ "$case_rc" -ne 0 ]; then
+        echo "--- Case FAILED (rc=$case_rc): $name"
+        rc=$case_rc
+      fi
       sleep 10
     }
     run_tracy_case "embedding decode seq1 + prefill seq128" "DS_EMBEDDING_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py::test_ds_embedding" "program_cache and not no_program_cache and real_weights and ((trace and decode and 1) or (eager and prefill and 128))"
@@ -163,6 +169,7 @@
     run_tracy_case "all_gather_preff1_3 decode seq1 + prefill seq128" "DS_ALL_GATHER_PREFF1_3_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py::test_ds_all_gather_preff1_3" "program_cache and not no_program_cache and ((trace and decode and 1) or (eager and prefill and 128))"
     run_tracy_case "moe decode seq1 + prefill seq128" "DS_MOE_FORWARD_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py::test_ds_moe_forward" "test_ds_moe_forward and real_weights and program_cache and not no_program_cache and ((trace and decode and 1) or (eager and prefill and 128))"
     run_tracy_case "mla decode seq1 + prefill seq128" "DS_MLA_FORWARD_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py::test_ds_mla_forward" "test_ds_mla_forward and real_weights and program_cache and not no_program_cache and ((trace and decode and 1) or (eager and prefill and 128))"
+    exit $rc
   model: deepseek-v3-tg
   model_family: DeepSeek
   skus:

--- a/tests/pipeline_reorg/models_device_perf_tests.yaml
+++ b/tests/pipeline_reorg/models_device_perf_tests.yaml
@@ -174,6 +174,6 @@
   model_family: DeepSeek
   skus:
     wh_galaxy_perf:
-      timeout: 40
+      timeout: 45
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models


### PR DESCRIPTION
### PR Category
Bug fix (test + CI config)

### Summary
`DeepSeek-V3 fused-op device perf tests (Galaxy)` in the scheduled `(Tier 1) Models Device Perf Tests` job has failed on every run since the job was created (#54616, 2026-08-28) in the `ff1_3` decode case with

```
TT_FATAL buffer.cpp:200 allocator.has_bank(bank_type, core)
```

Cause (test code, already noted in #54873): `test_ds_ff1_3.py` width-shards its decode input over a hard-coded `CoreRange((0,0),(7,6))`. The DeepSeek conftest forces `DispatchCoreAxis.COL`, and under COL dispatch every Wormhole compute grid is 7 cores wide (Galaxy `galaxy/col` is 7×10, the "70 banks" in the message), so core (7,0) is the dispatch column and buffer validation rejects it. Only 7 of the listed cores were ever used (7168 / 8 mesh columns / 128 = 7 shards), which is why this was silent until the grid validation landed on 08-20 (#53263, #53967). The model code in `mlp.py` already derives its grids from `compute_with_storage_grid_size()`. This fails on every COL-dispatch Galaxy chip; it is not a harvested-device problem.

Second defect in the same job: the twelve `run_tracy_case` calls run under `run-with-log`'s `bash -eo pipefail`, and `python3 -m tracy --check-exit-code` exits non-zero on a failing case, so the six cases after `ff1_3` (ff2, mul, reduce_scatter_post_ff2, all_gather_preff1_3, moe, mla) have never executed in this pipeline.

### Change
- `models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py`: build the decode shard core set with `ttnn.num_cores_to_corerangeset(hidden_size // mesh_columns // 128, mesh_device.compute_with_storage_grid_size(), row_wise=True)` instead of the hard-coded 8×7 range.
- `tests/pipeline_reorg/models_device_perf_tests.yaml`: `run_tracy_case` captures each case's exit code and keeps going; the script exits with the first failure at the end, so every case runs and reports. Job timeout 30 → 45 min and models `device_perf` `wh_galaxy_perf` budget 55 → 70: the job was sized when it never ran past `ff1_3`; with all twelve cases running, eleven take about 27 minutes and the first validation run's 30-minute budget killed the twelfth (mla) three and a half minutes in.

Not changed here: `tests/fused_op_unit_tests/mla/test_alltoall_deepseek.py` hard-codes an 8×8 range the same way (not in this job's case list) and will hit the same assert under COL dispatch on Galaxy.

### CI
- `(Tier 1) Models Device Perf Tests`, model=`deepseek-v3-tg`, sku=`wh_galaxy_perf (WH Galaxy perf)` (runs both DeepSeek Galaxy device perf jobs):
  - https://github.com/tenstorrent/tt-metal/actions/runs/34471041253 (grid fix + case isolation, 30-min budget; g03glx04): `DeepSeek-V3 decode device perf tests` green. In the fused-op job **`ff1_3` passed (2 passed, 2 skipped)**, the `allocator.has_bank` assert is gone, and the six cases that had never run before all passed: ff2, mul, reduce_scatter_post_ff2, all_gather_preff1_3, moe (343 s). 11 of 12 cases green in about 27 minutes; the 30-minute step budget then killed the twelfth (mla) about 3.5 minutes in, so the job is red for budget only. No `Case FAILED` line in the log.
  - https://github.com/tenstorrent/tt-metal/actions/runs/34475647610 (with the 40-min budget): the fused-op job landed on `UF-EV-A1-GWH02` and died in container setup (`ContainerId` null), no test ran; the decode-demo job passed.
  - https://github.com/tenstorrent/tt-metal/actions/runs/34478587350 (re-dispatch; 40-min budget) — **fused-op job PASSED, all 12 cases green** ([job 102879250539](https://github.com/tenstorrent/tt-metal/actions/runs/34478587350/job/102879250539), j09glx02): embedding, all_gather_embedding, lm_head, rms_norm, distributed_norm, ff1_3 (2 passed, 2 skipped), ff2, mul, reduce_scatter_post_ff2, all_gather_preff1_3, moe (339 s), mla (219 s); test step 36m58s. The decode-demo job in the same run died in container setup on `UF-EV-A1-GWH02` (it passed in the two earlier attempts; unrelated).
  - Follow-up commit `b53403b313c`: budget 40 → 45 min (models `device_perf` `wh_galaxy_perf` 65 → 70), since 37 minutes measured against 40 leaves less headroom than the 5–10 % host-to-host variance seen on the Galaxy pool today. Timeout-only change, not re-run.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/deepseek-ff1-3-derive-shard-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/deepseek-ff1-3-derive-shard-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/deepseek-ff1-3-derive-shard-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/deepseek-ff1-3-derive-shard-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/deepseek-ff1-3-derive-shard-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/deepseek-ff1-3-derive-shard-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/deepseek-ff1-3-derive-shard-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/deepseek-ff1-3-derive-shard-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/deepseek-ff1-3-derive-shard-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/deepseek-ff1-3-derive-shard-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/deepseek-ff1-3-derive-shard-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/deepseek-ff1-3-derive-shard-grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/deepseek-ff1-3-derive-shard-grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/deepseek-ff1-3-derive-shard-grid)

