### PR TITLE
[TT-Transformers] batched prefill: fill every padded slot so the prefill trace is slot-agnostic

### DIFF
--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -1165,22 +1165,21 @@ class Attention(LightweightModule):
             fill_page_table = chunk_page_table if chunk_page_table is not None else page_table
 
         if batch_size > 1:
-            # For batched prefill, loop over VALID users only and fill each user's cache separately
+            # For batched prefill, fill every slot of the padded batch separately.
             # k_fill/v_fill have shape [padded_batch, n_kv_heads, seq_len_per_user, head_dim]
             # The paged_fill_cache kernel reads batch_idx_ptr[0] for all positions,
-            # so we must call it once per user with their specific K/V slice
+            # so we must call it once per slot with that slot's K/V slice.
             #
-            # IMPORTANT: user_id is a list of valid slot indices for batched prefill.
-            # Empty slots have page_table entries of -1, so we must skip them to avoid
-            # writing to invalid memory blocks.
+            # IMPORTANT: this loop is captured into the prefill trace, whose identity is the
+            # padded batch width, not the set of active slots. Looping over the active slots
+            # (user_id) would freeze that slot set into the trace, and a later replay for a
+            # different slot set would never write K/V for the new slots. Empty slots have
+            # page_table rows of -1, which the kernel treats as "skip" without any write, so
+            # filling all padded_batch rows is both safe and slot-agnostic.
             seq_len_per_user = k_fill.shape[2]
             page_len = fill_page_table.shape[1] * block_size
 
-            # user_id is a list of valid slot indices (e.g., [0, 1, 2, ..., N-1] for N users)
-            # Each slot index tells us which row in k_fill and page_table to use
-            valid_slots = user_id if isinstance(user_id, (list, tuple)) else list(range(batch_size))
-
-            for slot_idx in valid_slots:
+            for slot_idx in range(batch_size):
                 # Extract this slot's K/V slice: [1, n_kv_heads, seq_len_per_user, head_dim]
                 k_user = k_fill[slot_idx : slot_idx + 1, :, :, :]
                 v_user = v_fill[slot_idx : slot_idx + 1, :, :, :]


### PR DESCRIPTION
### PR Category
Bug fix (TT-Transformers generator / batched prefill)

### Summary
vLLM `Llama-3.1-8B-Instruct with sampling-tests [wh_llmbox]` fails `test_presence_penalty_is_per_request` with `Unpenalised requests in a mixed batch should agree`: 5 of 16 unpenalised rows agree on token 1 (` a`) and diverge at token 2 into lost-context text (` a month ago…`, ` a system. a system…`). This is not a penalty leak. Penalty values are rewritten per row on every decode step and `apply_penalties` is row-local; under vLLM semantics presence penalises output tokens only, so after one output token nothing could suppress the next prompt token. The rows have lost their prompt context.

Cause: traced batched prefill freezes the set of slots whose K/V gets written into the trace.
- `attention.py` fills the paged cache in batched prefill with a Python loop over the active slots (`user_id`) and a scalar `batch_idx` per `paged_fill_cache` call. `batch_idx` is a kernel runtime arg that is not refreshed on trace replay, and the loop itself is captured.
- The prefill trace key is `{seq_len}_{model_id}_{padded_batch}_{use_start_pos}` (no slot set), replay refreshes only tokens and page tables, and warmup captures batch-1 traces only, so the first real batch of a given padded width captures the trace with its own slot set.
- A later batch of the same width on other slots replays that trace: slots outside the captured set have no fill program in the trace, so their K/V is dropped. The first token is still right (the prefill kernel's own attention produces it); the first decode step reads the unwritten cache and diverges. Exactly the log: the pre-test benchmark captured the 128-token batch-32 trace with a partial slot set at 00:50:19, the failing test's 31-request batched prefill at 00:51:51 replayed it with no capture marker.

The same reason the T3K job has deselected `test_mixed_params_batch`, `TestSeedingAndVariety` and the three `*_mixed_batch` tests since 08-04: those are the full-32-request tests.

### Change
- `models/tt_transformers/tt/attention.py`: in batched prefill, loop over every slot of the padded batch instead of the active slots. Empty slots have page-table rows of `-1`, which the fill kernel treats as skip without any write (`writer_fill_cache_interleaved.cpp`, `SKIP_PAGE_TABLE_ENTRY`), so the trace is valid for any slot set of the same width.

Not done here (from the same analysis, for the owners): a single `paged_fill_cache(..., batch_idx_tensor=...)` call with the slot ids as a per-replay trace input would remove the 2 × padded_batch kernel launches; asserting on replay that the slot set matches the captured one would make any future mismatch fail loudly; a T3K test that captures a batched trace on slots `[0..k-1]` and replays it on disjoint slots would have caught this (the existing `test_w6_active15_padded16_trace_correctness` replays with identity slots only).

### CI
- `vLLM model tests`, model=`meta-llama/Llama-3.1-8B-Instruct`, sku=`wh_llmbox (T3000)`: https://github.com/tenstorrent/tt-metal/actions/runs/34471640141 — **all three Llama-8B T3K jobs green**:
  - [`Llama-3.1-8B-Instruct with sampling-tests`](https://github.com/tenstorrent/tt-metal/actions/runs/34471640141/job/102854915520) (t3k-01): structured output `correct_rate 100.0`; sampling tests **43 passed, 4 skipped, 31 deselected in 75.8 s**, including **`test_presence_penalty_is_per_request PASSED`** (the failing test of the scheduled run).
  - `Llama-3.1-8B-Instruct (chunked prefill)` and `Llama-3.1-8B-Instruct (prefix caching)`: green.
  - The run itself is marked failed only by `vllm-plugin-unit-tests` (`ModuleNotFoundError: No module named 'tests.tt'` importing `tests/test_determinism_assertions.py`), a plugin-repo test import problem that also fails on main's latest scheduled run 34420294455; unrelated to this change.
- The deselected mixed-batch tests (`test_mixed_params_batch`, `TestSeedingAndVariety`, `*_mixed_batch`) are not re-enabled by this PR; with the slot set no longer frozen into the trace they are candidates for re-enabling in a follow-up.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/batched-prefill-fill-all-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/batched-prefill-fill-all-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/batched-prefill-fill-all-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/batched-prefill-fill-all-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/batched-prefill-fill-all-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/batched-prefill-fill-all-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/batched-prefill-fill-all-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/batched-prefill-fill-all-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/batched-prefill-fill-all-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/batched-prefill-fill-all-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/batched-prefill-fill-all-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/batched-prefill-fill-all-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/batched-prefill-fill-all-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/batched-prefill-fill-all-slots)