### PR TITLE
[CI] Publish the nightly's perf data to the warehouse on every run

### DIFF
--- a/.github/workflows/llk-perf.yaml
+++ b/.github/workflows/llk-perf.yaml
@@ -46,10 +46,8 @@ jobs:
       architecture: ${{ inputs.architecture || 'all' }}
       # Nightly runs always use speed-of-light; manual runs use the checkbox.
       speed-of-light: ${{ github.event_name == 'schedule' || inputs.speed-of-light }}
-      # Off for the scheduled nightly until the warehouse key is authorised. A
-      # scheduled run has no inputs, so the expression falls through to false.
-      # Turning it on for every night is this one expression -> true.
-      upload-to-warehouse: ${{ inputs.upload-to-warehouse || false }}
+      # Nightly runs always publish; manual runs use the checkbox.
+      upload-to-warehouse: ${{ github.event_name == 'schedule' || inputs.upload-to-warehouse }}
     secrets: inherit
 
   llk-perf-summary:


### PR DESCRIPTION
The upload job landed in #55331 gated off, so the secret and the SFTP path
could be proven before any scheduled run depended on them. Both are proven:
run 33743798610 merged five Wormhole shards, uploaded the result, and the rows
are queryable. 166 runs covering 2026-06-10..09-07 are now in
`TTDATASF.LLK_PERF` after a manual backfill.

Follows the `speed-of-light` line directly above rather than a bare `true`, so
a dispatch from a feature branch still has to ask for the upload.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/perf-enable-nightly-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/perf-enable-nightly-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-enable-nightly-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/perf-enable-nightly-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/perf-enable-nightly-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/perf-enable-nightly-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/perf-enable-nightly-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/perf-enable-nightly-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/perf-enable-nightly-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/perf-enable-nightly-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/perf-enable-nightly-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/perf-enable-nightly-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/perf-enable-nightly-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/perf-enable-nightly-upload)