### PR TITLE
[Cleanup] Quasar binary_ng: remove ARCH_QUASAR copy_init ifdefs from the SFPU DFB kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
@@ -595,10 +595,8 @@ bool BinaryNgDeviceOperation::matches_metal_v2_slice(
         return false;
     }
 
-    // lhs and rhs must share a data format. The compute kernel switches the unpacker between the two
-    // operands without a per-operand data-format reconfig (on Quasar copy_tile_to_dst_init_short_with_dt
-    // is a no-op, so the WH/BH format reconfig it performs is absent), so a differing rhs format would be
-    // unpacked using the lhs format. Mixed-dtype lhs/rhs therefore falls to the descriptor path.
+    // Not an unpacker limitation: the compute kernel switches between the two operands with
+    // reconfig_data_format_srca + copy_init on every arch (Quasar included).
     if (a.dtype() != b.dtype()) {
         return false;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_col_bcast_dfb.cpp
@@ -139,25 +139,13 @@ ALWI void process_tile(
         BINARY_SFPU_INIT;
 #endif
         tile_regs_acquire();
-#ifdef ARCH_QUASAR
-        // Quasar's copy_tile_to_dst_init_short_with_dt is a no-op and cannot switch which operand the
-        // unpacker reads, so use copy_tile_to_dst_init_short (which reprograms the unpacker descriptor)
-        // to point at each operand before its copy_tile loop. matches_metal_v2_slice requires lhs and rhs
-        // to share a data format, so the data-format reconfig the WH/BH _with_dt path performs is not needed.
-        copy_init(dfb_post_lhs_id);
-#else
         reconfig_data_format_srca(dfb_post_rhs_id, dfb_post_lhs_id);
         copy_init(dfb_post_lhs_id);
-#endif
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(dfb_post_lhs_id, i, i * 2);
         }
-#ifdef ARCH_QUASAR
-        copy_init(dfb_post_rhs_id);
-#else
         reconfig_data_format_srca(dfb_post_lhs_id, dfb_post_rhs_id);
         copy_init(dfb_post_rhs_id);
-#endif
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(dfb_post_rhs_id, i, i * 2 + 1);
 #if HAS_ACTIVATIONS(POST)

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_no_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_no_bcast_dfb.cpp
@@ -71,24 +71,13 @@ FORCE_INLINE void process_sfpu_tiles(
 #endif
 
     tile_regs_acquire();
-#ifdef ARCH_QUASAR
-    // On Quasar the data-format reconfig is a no-op, so copy_init alone reprograms the unpacker
-    // descriptor to point at each operand before its copy_tile loop. matches_metal_v2_slice requires
-    // lhs and rhs to share a data format, so no SrcA data-format reconfig is needed here.
-    copy_init(dfb_post_lhs_id);
-#else
     reconfig_data_format_srca(dfb_post_rhs_id, dfb_post_lhs_id);
     copy_init(dfb_post_lhs_id);
-#endif
     for (uint32_t i = 0; i < n; ++i) {
         copy_tile(dfb_post_lhs_id, i, i * 2);
     }
-#ifdef ARCH_QUASAR
-    copy_init(dfb_post_rhs_id);
-#else
     reconfig_data_format_srca(dfb_post_lhs_id, dfb_post_rhs_id);
     copy_init(dfb_post_rhs_id);
-#endif
     for (uint32_t i = 0; i < n; ++i) {
         copy_tile(dfb_post_rhs_id, i, i * 2 + 1);
 #if HAS_ACTIVATIONS(POST)

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_bcast_dfb.cpp
@@ -157,25 +157,13 @@ void kernel_main() {
 #endif
 
         tile_regs_acquire();
-#ifdef ARCH_QUASAR
-        // Quasar's copy_tile_to_dst_init_short_with_dt is a no-op and cannot switch which operand the
-        // unpacker reads, so use copy_tile_to_dst_init_short (which reprograms the unpacker descriptor)
-        // to point at each operand before its copy_tile loop. matches_metal_v2_slice requires lhs and rhs
-        // to share a data format, so the data-format reconfig the WH/BH _with_dt path performs is not needed.
-        copy_init(dfb_post_lhs_id);
-#else
         reconfig_data_format_srca(dfb_post_rhs_id, dfb_post_lhs_id);
         copy_init(dfb_post_lhs_id);
-#endif
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(dfb_post_lhs_id, i, i * 2);
         }
-#ifdef ARCH_QUASAR
-        copy_init(dfb_post_rhs_id);
-#else
         reconfig_data_format_srca(dfb_post_lhs_id, dfb_post_rhs_id);
         copy_init(dfb_post_rhs_id);
-#endif
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(dfb_post_rhs_id, i, i * 2 + 1);
 #if HAS_ACTIVATIONS(POST)

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_col_bcast_dfb.cpp
@@ -142,25 +142,13 @@ ALWI void process_tile(
         BINARY_SFPU_INIT;
 #endif
         tile_regs_acquire();
-#ifdef ARCH_QUASAR
-        // Quasar's copy_tile_to_dst_init_short_with_dt is a no-op and cannot switch which operand the
-        // unpacker reads, so use copy_tile_to_dst_init_short (which reprograms the unpacker descriptor) to
-        // point at each operand before its copy_tile loop. matches_metal_v2_slice requires lhs and rhs to
-        // share a data format, so the data-format reconfig the WH/BH _with_dt path performs is not needed.
-        copy_init(dfb_post_lhs_id);
-#else
         reconfig_data_format_srca(dfb_post_rhs_id, dfb_post_lhs_id);
         copy_init(dfb_post_lhs_id);
-#endif
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(dfb_post_lhs_id, i, i * 2);
         }
-#ifdef ARCH_QUASAR
-        copy_init(dfb_post_rhs_id);
-#else
         reconfig_data_format_srca(dfb_post_lhs_id, dfb_post_rhs_id);
         copy_init(dfb_post_rhs_id);
-#endif
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(dfb_post_rhs_id, i, i * 2 + 1);
 #if HAS_ACTIVATIONS(POST)

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_bcast_dfb.cpp
@@ -141,25 +141,13 @@ ALWI void process_tile(
         BINARY_SFPU_INIT;
 #endif
         tile_regs_acquire();
-#ifdef ARCH_QUASAR
-        // Quasar's copy_tile_to_dst_init_short_with_dt is a no-op and cannot switch which operand the
-        // unpacker reads, so use copy_tile_to_dst_init_short (which reprograms the unpacker descriptor)
-        // to point at each operand before its copy_tile loop. matches_metal_v2_slice requires lhs and rhs
-        // to share a data format, so the data-format reconfig the WH/BH _with_dt path performs is not needed.
-        copy_init(dfb_post_lhs_id);
-#else
         reconfig_data_format_srca(dfb_post_rhs_id, dfb_post_lhs_id);
         copy_init(dfb_post_lhs_id);
-#endif
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(dfb_post_lhs_id, i, i * 2);
         }
-#ifdef ARCH_QUASAR
-        copy_init(dfb_post_rhs_id);
-#else
         reconfig_data_format_srca(dfb_post_lhs_id, dfb_post_rhs_id);
         copy_init(dfb_post_rhs_id);
-#endif
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(dfb_post_rhs_id, i, i * 2 + 1);
 #if HAS_ACTIVATIONS(POST)

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
@@ -74,25 +74,13 @@ FORCE_INLINE void process_sfpu_scalar_tiles(
 #endif
 
     tile_regs_acquire();
-#ifdef ARCH_QUASAR
-    // Quasar's copy_tile_to_dst_init_short_with_dt is a no-op and cannot switch which operand the
-    // unpacker reads, so use copy_tile_to_dst_init_short (which reprograms the unpacker descriptor)
-    // to point at each operand before its copy_tile loop. matches_metal_v2_slice requires lhs and rhs
-    // to share a data format, so the data-format reconfig the WH/BH _with_dt path performs is not needed.
-    copy_init(dfb_post_lhs_id);
-#else
     reconfig_data_format_srca(dfb_post_rhs_id, dfb_post_lhs_id);
     copy_init(dfb_post_lhs_id);
-#endif
     for (uint32_t i = 0; i < n; ++i) {
         copy_tile(dfb_post_lhs_id, i, i * 2);
     }
-#ifdef ARCH_QUASAR
-    copy_init(dfb_post_rhs_id);
-#else
     reconfig_data_format_srca(dfb_post_lhs_id, dfb_post_rhs_id);
     copy_init(dfb_post_rhs_id);
-#endif
     for (uint32_t i = 0; i < n; ++i) {
         copy_tile(dfb_post_rhs_id, 0, i * 2 + 1);  // Always use scalar at index 0
 #if HAS_ACTIVATIONS(POST)


### PR DESCRIPTION
### PR Category
Cleanup

### Issue
https://github.com/tenstorrent/tt-metal/issues/54329

### Summary
Doing only `copy_init` on Quasar without `reconfig_data_format_srca` would break if `a.dtype() != b.dtype()`.

initially, this code used to look like this because `copy_tile_to_dst_init_short_with_dt` was not implemented for Quasar. But even then it could have been substituted for `reconfig_data_format_srca` + `copy_tile_to_dst_init_short`.
```
#ifdef ARCH_QUASAR
        copy_tile_to_dst_init_short(dfb_post_lhs_id);
#else
        copy_tile_to_dst_init_short_with_dt(dfb_post_rhs_id, dfb_post_lhs_id);
#endif 
```

Currently it looks like this because the previously used functions are deprecated:
```
#ifdef ARCH_QUASAR
    copy_init(dfb_post_lhs_id);
#else
    reconfig_data_format_srca(dfb_post_rhs_id, dfb_post_lhs_id);
    copy_init(dfb_post_lhs_id);
#endif
```

But the arch ifdef is not needed and Quasar can just use the same path WH/BH use.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
