### PR TITLE
[LLK][fuser] Enable int FPU reduce row in quasar fuser

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/golden.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/golden.py
@@ -30,6 +30,7 @@ from helpers.golden_generators import (
 from helpers.llk_params import (
     AccToDest,
     BroadcastType,
+    DataFormat,
     EltwiseBinaryReuseDestType,
     ReduceDimension,
     ReducePool,
@@ -264,7 +265,7 @@ class Golden:
         node: "FpuNode",
         block_max: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        output_format = config.sentinel.golden_math_format
+        math_format = config.sentinel.golden_math_format
         tile_shape = operation.tile_shape
         dimensions = operation.max_output_dimensions
         num_faces = tile_shape.total_num_faces()
@@ -275,7 +276,17 @@ class Golden:
         pool = torch.amax if pool_type == ReducePool.Max else torch.sum
         generate_golden = get_golden_generator(ReduceGolden)
 
-        def reduce(tensor: torch.Tensor, fold_blocks: bool) -> torch.Tensor:
+        int32_dest = (
+            config.dest_acc.value
+            and reduce_dim == ReduceDimension.Row
+            and math_format.needs_int8_math_config()
+        )
+        output_format = DataFormat.Int32 if int32_dest else math_format
+        src_input_format = math_format if int32_dest else None
+
+        def reduce(
+            tensor: torch.Tensor, fold_blocks: bool, input_format
+        ) -> torch.Tensor:
             reduced = tilize_block(
                 tensor, dimensions, output_format, num_faces, tile_dimensions=tile_dims
             ).flatten()
@@ -286,6 +297,7 @@ class Golden:
                 output_format,
                 tile_cnt=grid_y * grid_x,
                 tile_shape=tile_shape,
+                input_format=input_format,
             ).flatten()
 
             if fold_blocks:
@@ -310,8 +322,10 @@ class Golden:
                 num_faces=num_faces,
             ).flatten()
 
-        src_reduced = reduce(tensor_a, block_max or node.reduce_to_tile)
-        dest_reduced = reduce(tensor_dst, block_max)
+        src_reduced = reduce(
+            tensor_a, block_max or node.reduce_to_tile, src_input_format
+        )
+        dest_reduced = reduce(tensor_dst, block_max, None)
 
         if pool_type == ReducePool.Average:
             span = tile_dims[1] if reduce_dim == ReduceDimension.Row else tile_dims[0]

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/common.py
@@ -12,9 +12,17 @@ if TYPE_CHECKING:
     from fuser.l1_operation import L1Operation
 
 
+def _dest_format_config(dest_acc: str, math_fmt: DataFormat) -> tuple[str, str]:
+    int32_dest = dest_acc == "true" and math_fmt.needs_int8_math_config()
+    fp32_dest = dest_acc == "true" and not int32_dest
+    return str(fp32_dest).lower(), str(int32_dest).lower()
+
+
 def hw_configure_math(dest_acc: str, math_fmt: DataFormat) -> str:
+    fp32_dest, int32_dest = _dest_format_config(dest_acc, math_fmt)
+    implied_math_format = "false" if int32_dest == "true" else "true"
     return (
-        f"_llk_math_srcAB_hw_configure_<true, {dest_acc}, false>(\n"
+        f"_llk_math_srcAB_hw_configure_<{implied_math_format}, {fp32_dest}, {int32_dest}>(\n"
         f"    {math_fmt.cpp_enum_value}, {math_fmt.cpp_enum_value}\n"
         f");\n"
     )
@@ -25,8 +33,9 @@ def configure_math(
     old_math: DataFormat,
     new_math: DataFormat,
 ) -> str:
+    fp32_dest, int32_dest = _dest_format_config(dest_acc, new_math)
     return (
-        f"_llk_math_srcAB_hw_configure_<false, {dest_acc}, false>(\n"
+        f"_llk_math_srcAB_hw_configure_<false, {fp32_dest}, {int32_dest}>(\n"
         f"    {new_math.cpp_enum_value}, {new_math.cpp_enum_value}\n"
         f");\n"
     )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/reduce.py
@@ -11,7 +11,25 @@ from fuser.fpu_node import FpuNode
 from fuser.fuser_config import GlobalConfig
 from fuser.l1_operation import L1Operation
 from fuser.tile_loop import LoopTileByTile, TileLoop
-from helpers.llk_params import ReduceDimension, ReducePool
+from helpers.llk_params import DataFormat, ReduceDimension, ReducePool
+
+
+def _is_int_fpu_enabled(
+    reduce_dim: ReduceDimension, config: GlobalConfig, compute_unit: FpuNode
+) -> str:
+    int_fpu_formats = {DataFormat.Int8, DataFormat.UInt8, DataFormat.Int32}
+    return (
+        "true"
+        if (
+            config.dest_acc.value
+            and reduce_dim == ReduceDimension.Row
+            and any(
+                operand is not None and operand.data_format in int_fpu_formats
+                for operand in (compute_unit.src_a, compute_unit.src_b)
+            )
+        )
+        else "false"
+    )
 
 
 class ReduceFpu(Fpu):
@@ -51,9 +69,10 @@ class ReduceFpu(Fpu):
         math_fidelity = compute_unit.math_fidelity.cpp_enum_value
         pool_type_cpp = self.reduce_pool.cpp_enum_value
         reduce_dim_cpp = self.reduce_dim.cpp_enum_value
+        is_int_fpu_en = _is_int_fpu_enabled(self.reduce_dim, config, compute_unit)
         return (
             f"// Operation {stage}: Reduce {reduce_dim_cpp} FPU\n"
-            f"_llk_math_reduce_init_<{pool_type_cpp}, {reduce_dim_cpp}, {math_fidelity}>"
+            f"_llk_math_reduce_init_<{pool_type_cpp}, {reduce_dim_cpp}, {math_fidelity}, {is_int_fpu_en}>"
             f"({compute_unit.src_a.tile_shape.cpp_value});\n"
         )
 
@@ -66,8 +85,9 @@ class ReduceFpu(Fpu):
     ) -> str:
         pool_type_cpp = self.reduce_pool.cpp_enum_value
         reduce_dim_cpp = self.reduce_dim.cpp_enum_value
+        is_int_fpu_en = _is_int_fpu_enabled(self.reduce_dim, config, compute_unit)
         return (
-            f"_llk_math_reduce_<{pool_type_cpp}, {reduce_dim_cpp}>"
+            f"_llk_math_reduce_<{pool_type_cpp}, {reduce_dim_cpp}, {is_int_fpu_en}>"
             f"({block.tile_id_block}, {compute_unit.src_a.tile_shape.cpp_value});\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/reduce.py
@@ -11,20 +11,19 @@ from fuser.fpu_node import FpuNode
 from fuser.fuser_config import GlobalConfig
 from fuser.l1_operation import L1Operation
 from fuser.tile_loop import LoopTileByTile, TileLoop
-from helpers.llk_params import DataFormat, ReduceDimension, ReducePool
+from helpers.llk_params import ReduceDimension, ReducePool
 
 
 def _is_int_fpu_enabled(
     reduce_dim: ReduceDimension, config: GlobalConfig, compute_unit: FpuNode
 ) -> str:
-    int_fpu_formats = {DataFormat.Int8, DataFormat.UInt8, DataFormat.Int32}
     return (
         "true"
         if (
             config.dest_acc.value
             and reduce_dim == ReduceDimension.Row
             and any(
-                operand is not None and operand.data_format in int_fpu_formats
+                operand is not None and operand.data_format.needs_int8_math_config()
                 for operand in (compute_unit.src_a, compute_unit.src_b)
             )
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
@@ -47,6 +47,7 @@ from fuser.validator import (
 )
 from helpers.llk_params import (
     BroadcastType,
+    DataFormat,
     MathOperation,
     ReduceDimension,
 )
@@ -90,6 +91,14 @@ _block_full_width = reject(
 _reduce_col_only = reject(
     lambda s, a, b: s.operation != "Reduce" or s.reduce_dim != ReduceDimension.Column,
     "unpacker can only be paired with a column reduce (operation: Reduce, reduce_dim: REDUCE_COL)",
+)
+
+_INT_FPU_FORMATS = {DataFormat.Int8, DataFormat.UInt8, DataFormat.Int32}
+
+_int_reduce_row_only = reject(
+    lambda s, a, b: s.reduce_dim != ReduceDimension.Row
+    and any(op is not None and op.data_format in _INT_FPU_FORMATS for op in (a, b)),
+    "integer reduce is only supported for REDUCE_ROW; REDUCE_COL/REDUCE_SCALAR have no int FPU path",
 )
 
 _eltwise_checks = [
@@ -194,6 +203,7 @@ FPU_MAP = {
             NO_REUSE_DEST,
             NO_BROADCAST,
             REDUCE_PARAMS_REQUIRED,
+            _int_reduce_row_only,
             forced_unpackers("ReduceUnpacker", "UnpackReduceTilize"),
         ],
     ),

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
@@ -47,7 +47,6 @@ from fuser.validator import (
 )
 from helpers.llk_params import (
     BroadcastType,
-    DataFormat,
     MathOperation,
     ReduceDimension,
 )
@@ -93,11 +92,11 @@ _reduce_col_only = reject(
     "unpacker can only be paired with a column reduce (operation: Reduce, reduce_dim: REDUCE_COL)",
 )
 
-_INT_FPU_FORMATS = {DataFormat.Int8, DataFormat.UInt8, DataFormat.Int32}
-
 _int_reduce_row_only = reject(
     lambda s, a, b: s.reduce_dim != ReduceDimension.Row
-    and any(op is not None and op.data_format in _INT_FPU_FORMATS for op in (a, b)),
+    and any(
+        op is not None and op.data_format.needs_int8_math_config() for op in (a, b)
+    ),
     "integer reduce is only supported for REDUCE_ROW; REDUCE_COL/REDUCE_SCALAR have no int FPU path",
 )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/fpu_reduce_row_int.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/fpu_reduce_row_int.yaml
@@ -1,0 +1,27 @@
+dest_acc: true
+
+operands:
+  - name: "input_A"
+    dims: [128, 128]
+    format: "Int8"
+  - name: "input_B"
+    dims: [128, 128]
+    format: "Int8"
+    const_value: 1.0
+  - name: "reduce_row_out"
+    dims: [128, 128]
+    format: "Int8"
+
+operations:
+  - math:
+      - type: "Fpu"
+        in0: "input_A"
+        in1: "input_B"
+        operation: "Reduce"
+        reduce_dim: "REDUCE_ROW"
+        reduce_pool: "SUM"
+        unpacker: "ReduceUnpacker"
+        math_fidelity: "HiFi4"
+    pack:
+      - output: "reduce_row_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/fpu_reduce_row_int.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/fpu_reduce_row_int.yaml
@@ -10,7 +10,7 @@ operands:
     const_value: 1.0
   - name: "reduce_row_out"
     dims: [128, 128]
-    format: "Int8"
+    format: "Int32"
 
 operations:
   - math:

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -498,6 +498,7 @@ inline void _llk_math_reduce_addrmod_(const TensorShape& tensor_shape)
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, ckernel::MathFidelity MATH_FIDELITY_TYPE, bool is_int_fpu_en = false>
 inline void _llk_math_reduce_init_(const TensorShape tensor_shape)
 {
+    static_assert(!is_int_fpu_en || REDUCE_DIMENSION == ReduceDim::REDUCE_ROW, "Integer FPU reduce is only implemented for REDUCE_ROW");
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     _llk_math_reduce_addrmod_<REDUCE_DIMENSION, MATH_FIDELITY_TYPE>(tensor_shape);
 
@@ -539,6 +540,7 @@ inline void _llk_math_reduce_init_(const TensorShape tensor_shape)
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, bool is_int_fpu_en = false>
 inline void _llk_math_reduce_(const std::uint32_t tile_idx, const TensorShape& tensor_shape)
 {
+    static_assert(!is_int_fpu_en || REDUCE_DIMENSION == ReduceDim::REDUCE_ROW, "Integer FPU reduce is only implemented for REDUCE_ROW");
     // TODO: Add SFPU reduce for INT8->Int32 Scalar SUM (https://github.com/tenstorrent/tt-metal/issues/50161)
     static_assert(
         !(is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR && POOL_TYPE == PoolType::SUM),

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -498,7 +498,6 @@ inline void _llk_math_reduce_addrmod_(const TensorShape& tensor_shape)
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, ckernel::MathFidelity MATH_FIDELITY_TYPE, bool is_int_fpu_en = false>
 inline void _llk_math_reduce_init_(const TensorShape tensor_shape)
 {
-    static_assert(!is_int_fpu_en || REDUCE_DIMENSION == ReduceDim::REDUCE_ROW, "Integer FPU reduce is only implemented for REDUCE_ROW");
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     _llk_math_reduce_addrmod_<REDUCE_DIMENSION, MATH_FIDELITY_TYPE>(tensor_shape);
 
@@ -540,7 +539,6 @@ inline void _llk_math_reduce_init_(const TensorShape tensor_shape)
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, bool is_int_fpu_en = false>
 inline void _llk_math_reduce_(const std::uint32_t tile_idx, const TensorShape& tensor_shape)
 {
-    static_assert(!is_int_fpu_en || REDUCE_DIMENSION == ReduceDim::REDUCE_ROW, "Integer FPU reduce is only implemented for REDUCE_ROW");
     // TODO: Add SFPU reduce for INT8->Int32 Scalar SUM (https://github.com/tenstorrent/tt-metal/issues/50161)
     static_assert(
         !(is_int_fpu_en && REDUCE_DIMENSION == ReduceDim::REDUCE_SCALAR && POOL_TYPE == PoolType::SUM),


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Enables the int FPU reduce row path in the Quasar fuser and adds a `fpu_reduce_row_int` test.
Add guards limiting int reduce to REDUCE_ROW.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=marko/int-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:marko/int-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=marko/int-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:marko/int-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=marko/int-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:marko/int-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=marko/int-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:marko/int-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=marko/int-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:marko/int-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=marko/int-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:marko/int-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=marko/int-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:marko/int-reduce)