### PR TITLE
[Cleanup] DRAM-sharded matmul follow-ups: dead semaphore, common runtime args, activation init order

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -305,7 +305,6 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     // Semaphore IDs (manually assigned, matching CreateSemaphore sequential allocation)
     uint32_t in0_mcast_sender_semaphore_id = 0;
     uint32_t in0_mcast_receiver_semaphore_id = 1;
-    uint32_t in0_mcast_sender_valid_semaphore_id = 2;
 
     uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
     uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
@@ -320,28 +319,27 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
             num_blocks_per_shard);
     }
 
+    // Positional, and read back by index in reader_bmm_tile_layout_in0_sender_dram_sharded.cpp -
+    // the indices below are load-bearing, so keep them annotated and contiguous.
     std::vector<uint32_t> in0_sender_compile_time_args = {
-        (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
-        (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
-        (std::uint32_t)in0_last_ktile_w,                            // in0_last_ktile_w
-        (std::uint32_t)0,                                           // in0_last_ktile_h (transpose not supported)
+        (std::uint32_t)in0_block_num_tiles,                         // [0]  in0_block_num_tiles
+        (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // [1]  in0_block_size_bytes
+        (std::uint32_t)in0_last_ktile_w,                            // [2]  in0_last_ktile_w
+        (std::uint32_t)0,                                           // [3]  in0_last_ktile_h (transpose unsupported)
         // in0 mcast args
-        (std::uint32_t)in0_mcast_sender_semaphore_id,
-        (std::uint32_t)in0_mcast_receiver_semaphore_id,
-        (std::uint32_t)num_worker_cores,  // in0_mcast_num_dests
-        (std::uint32_t)num_mcast_cores,   // in0_mcast_num_cores
+        (std::uint32_t)in0_mcast_sender_semaphore_id,    // [4]
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,  // [5]
+        (std::uint32_t)num_worker_cores,                 // [6]  in0_mcast_num_dests
+        (std::uint32_t)num_mcast_cores,                  // [7]  in0_mcast_num_cores
         // block
-        (std::uint32_t)num_blocks,
+        (std::uint32_t)num_blocks,  // [8]
         // mcast noc coords
-        (std::uint32_t)start_core_noc.x,
-        (std::uint32_t)start_core_noc.y,
-        (std::uint32_t)end_core_noc.x,
-        (std::uint32_t)end_core_noc.y,
-        // semaphore valid
-        (std::uint32_t)in0_mcast_sender_valid_semaphore_id,
-        //
-        (std::uint32_t)num_blocks_per_shard,
-        (std::uint32_t)in0_block_w};
+        (std::uint32_t)start_core_noc.x,      // [9]
+        (std::uint32_t)start_core_noc.y,      // [10]
+        (std::uint32_t)end_core_noc.x,        // [11]
+        (std::uint32_t)end_core_noc.y,        // [12]
+        (std::uint32_t)num_blocks_per_shard,  // [13]
+        (std::uint32_t)in0_block_w};          // [14]
 
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
         (std::uint32_t)in1_buffer_page_size,
@@ -654,8 +652,6 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         .id = in0_mcast_sender_semaphore_id, .core_ranges = all_cores_in_rect_grid, .initial_value = INVALID});
     desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
         .id = in0_mcast_receiver_semaphore_id, .core_ranges = all_cores_in_rect_grid, .initial_value = INVALID});
-    desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-        .id = in0_mcast_sender_valid_semaphore_id, .core_ranges = all_cores_in_rect_grid, .initial_value = VALID});
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Runtime Args (per-core loop)

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -675,11 +675,22 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         in0_mcast_sender_noc_y.push_back((std::uint32_t)device->worker_core_from_logical_core(core).y);
     }
 
+    // The sender-coordinate table is the same on every node that reads it, so it goes out as common
+    // runtime args: one multicast write per kernel group, instead of a copy appended to every
+    // sender's and every receiver's unique arg list. Note this does not shrink per-core L1 - unique
+    // and common args draw on the same kernel-config budget - the saving is in the dispatch payload.
+    // The kernel reads the two blocks at get_common_arg_addr(0) and (num_storage_cores).
+    in0_sender_kernel_desc.common_runtime_args.reserve(in0_mcast_sender_noc_x.size() + in0_mcast_sender_noc_y.size());
+    in0_sender_kernel_desc.common_runtime_args.insert(
+        in0_sender_kernel_desc.common_runtime_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
+    in0_sender_kernel_desc.common_runtime_args.insert(
+        in0_sender_kernel_desc.common_runtime_args.end(), in0_mcast_sender_noc_y.begin(), in0_mcast_sender_noc_y.end());
+
     // in0 sender runtime args (mcast senders)
     uint32_t sender_id = 0;
     for (auto core : mcast_senders_coords) {
         std::vector<uint32_t> mm_in0_sender_args;
-        mm_in0_sender_args.reserve(3 + in0_mcast_sender_noc_x.size() + in0_mcast_sender_noc_y.size());
+        mm_in0_sender_args.reserve(3);
 
         uint32_t worker_core_type;
         if (find(storage_worker_common.begin(), storage_worker_common.end(), core) != storage_worker_common.end()) {
@@ -692,10 +703,6 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         mm_in0_sender_args.push_back((std::uint32_t)sender_id);
         mm_in0_sender_args.push_back(
             (std::uint32_t)((core == input_all_storage_cores_vec.back()) and (in0_last_ktile_w > 0)));
-        mm_in0_sender_args.insert(
-            mm_in0_sender_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
-        mm_in0_sender_args.insert(
-            mm_in0_sender_args.end(), in0_mcast_sender_noc_y.begin(), in0_mcast_sender_noc_y.end());
 
         in0_sender_kernel_desc.runtime_args.emplace_back(core, std::move(mm_in0_sender_args));
         sender_id++;
@@ -705,15 +712,11 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     std::vector<CoreCoord> mcast_receiver_coords = corerange_to_cores(mcast_receivers);
     for (auto core : mcast_receiver_coords) {
         std::vector<uint32_t> mm_in0_receiver_args;
-        mm_in0_receiver_args.reserve(3 + in0_mcast_sender_noc_x.size() + in0_mcast_sender_noc_y.size());
+        mm_in0_receiver_args.reserve(3);
         uint32_t worker_core_type = 3;
         mm_in0_receiver_args.push_back((std::uint32_t)worker_core_type);
         mm_in0_receiver_args.push_back((std::uint32_t)0);
         mm_in0_receiver_args.push_back((std::uint32_t)0);  // in0_last_ktile_w
-        mm_in0_receiver_args.insert(
-            mm_in0_receiver_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
-        mm_in0_receiver_args.insert(
-            mm_in0_receiver_args.end(), in0_mcast_sender_noc_y.begin(), in0_mcast_sender_noc_y.end());
 
         in0_sender_kernel_desc.runtime_args.emplace_back(core, std::move(mm_in0_receiver_args));
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -319,8 +319,6 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
             num_blocks_per_shard);
     }
 
-    // Positional, and read back by index in reader_bmm_tile_layout_in0_sender_dram_sharded.cpp -
-    // the indices below are load-bearing, so keep them annotated and contiguous.
     std::vector<uint32_t> in0_sender_compile_time_args = {
         (std::uint32_t)in0_block_num_tiles,                         // [0]  in0_block_num_tiles
         (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // [1]  in0_block_size_bytes
@@ -675,11 +673,7 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         in0_mcast_sender_noc_y.push_back((std::uint32_t)device->worker_core_from_logical_core(core).y);
     }
 
-    // The sender-coordinate table is the same on every node that reads it, so it goes out as common
-    // runtime args: one multicast write per kernel group, instead of a copy appended to every
-    // sender's and every receiver's unique arg list. Note this does not shrink per-core L1 - unique
-    // and common args draw on the same kernel-config budget - the saving is in the dispatch payload.
-    // The kernel reads the two blocks at get_common_arg_addr(0) and (num_storage_cores).
+    // The sender-coordinate table is the same on every node.
     in0_sender_kernel_desc.common_runtime_args.reserve(in0_mcast_sender_noc_x.size() + in0_mcast_sender_noc_y.size());
     in0_sender_kernel_desc.common_runtime_args.insert(
         in0_sender_kernel_desc.common_runtime_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -234,6 +234,11 @@ void kernel_main() {
 #endif
     DataflowBuffer mm_out_dfb(mm_out_dfb_id);
 
+    // Hardware startup must precede every operation-specific init, including the SFPU activation
+    // init below - keep this call above them. Mirrors the ordering already in the quasar copy of
+    // this kernel.
+    compute_kernel_hw_startup<SrcOrder::Reverse>(in0_dfb_id, in1_dfb_id, mm_partials_dfb_id);
+
     // Number of valid in1 columns in the last in1 subblock. For the DRAM-sharded variant the
     // planner may pad per_core_N_compute beyond per_core_N_in1_sender so that out_subblock_w can be
     // larger; the reader only pushes per_core_N_in1_sender tiles per block into cb_in1. To avoid
@@ -265,7 +270,6 @@ void kernel_main() {
 
     constexpr bool spill = num_blocks_inner_dim > 1;
 
-    compute_kernel_hw_startup<SrcOrder::Reverse>(in0_dfb_id, in1_dfb_id, mm_partials_dfb_id);
     matmul_block_init(in0_dfb_id, in1_dfb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
     for (uint32_t b = 0; b < batch; b++) {
         if constexpr (get_batch_from_reader) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -234,9 +234,6 @@ void kernel_main() {
 #endif
     DataflowBuffer mm_out_dfb(mm_out_dfb_id);
 
-    // Hardware startup must precede every operation-specific init, including the SFPU activation
-    // init below - keep this call above them. Mirrors the ordering already in the quasar copy of
-    // this kernel.
     compute_kernel_hw_startup<SrcOrder::Reverse>(in0_dfb_id, in1_dfb_id, mm_partials_dfb_id);
 
     // Number of valid in1 columns in the last in1 subblock. For the DRAM-sharded variant the

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -44,8 +44,10 @@ void kernel_main() {
     const uint32_t sender_id = get_arg_val<uint32_t>(1);
     const bool is_last_ktile_padded = static_cast<bool>(get_arg_val<uint32_t>(2));
 
-    tt_l1_ptr uint32_t* in0_mcast_sender_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
-    tt_l1_ptr uint32_t* in0_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(3 + num_storage_cores));
+    // Common runtime args: the sender-coordinate table is identical on every node, so the factory
+    // sends it once per kernel group rather than appending a copy to each core's unique args.
+    tt_l1_ptr uint32_t* in0_mcast_sender_noc_x = (tt_l1_ptr uint32_t*)(get_common_arg_addr(0));
+    tt_l1_ptr uint32_t* in0_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_common_arg_addr(num_storage_cores));
 
     const uint32_t sender_block_id = sender_id * num_blocks_per_shard;
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -30,8 +30,8 @@ void kernel_main() {
     constexpr uint32_t in0_mcast_dest_noc_start_y = get_compile_time_arg_val(10);
     constexpr uint32_t in0_mcast_dest_noc_end_x = get_compile_time_arg_val(11);
     constexpr uint32_t in0_mcast_dest_noc_end_y = get_compile_time_arg_val(12);
-    constexpr uint32_t num_blocks_per_shard = get_compile_time_arg_val(14);
-    constexpr uint32_t in0_block_w = get_compile_time_arg_val(15);
+    constexpr uint32_t num_blocks_per_shard = get_compile_time_arg_val(13);
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(14);
     constexpr uint32_t in0_block_h = in0_block_num_tiles / in0_block_w;
     constexpr uint32_t num_storage_cores = num_blocks / num_blocks_per_shard;
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -44,8 +44,7 @@ void kernel_main() {
     const uint32_t sender_id = get_arg_val<uint32_t>(1);
     const bool is_last_ktile_padded = static_cast<bool>(get_arg_val<uint32_t>(2));
 
-    // Common runtime args: the sender-coordinate table is identical on every node, so the factory
-    // sends it once per kernel group rather than appending a copy to each core's unique args.
+    // The sender-coordinate table is identical on every node.
     tt_l1_ptr uint32_t* in0_mcast_sender_noc_x = (tt_l1_ptr uint32_t*)(get_common_arg_addr(0));
     tt_l1_ptr uint32_t* in0_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_common_arg_addr(num_storage_cores));
 


### PR DESCRIPTION
### PR Category

Cleanup + one bug fix. Relates to #41908 (Quasar Ops/Kernels parent issue).

### Summary

Three fixes to the DRAM-sharded matmul factory and the compute kernel it shares, all deliberately kept **out** of #55961 so that port could stay a faithful translation of `main`. None of them depend on that port.

**Targeted at `main`, not stacked on #55961.** Every change here is against the legacy code, so this can land in either order; it will be rebased once #55961 lands. The one interaction to know about is noted under *Interaction with #55961* below.

| # | Change | Kind |
|---|---|---|
| 1 | Drop the dead `in0_mcast_sender_valid_semaphore_id` and close the compile-time-arg hole it left | Cleanup |
| 2 | Send the in0 sender coordinate table as common runtime args instead of replicating it per core | Cleanup / dispatch cost |
| 3 | Run `compute_kernel_hw_startup()` before the SFPU activation init | Bug fix |

One commit per item.

---

### 1. The dead in0 multicast sender-valid semaphore

The factory allocated three semaphores; the in0 sender kernel only ever constructed two. The third was passed as compile-time arg **13** and never read — the kernel reads CTAs 0–12 and then jumps to 14, so index 13 was a hole.

It is a vestige of an older kernel revision that used a dedicated always-`VALID` cell as the multicast payload source. The kernel now multicasts `VALID` out of `receiver_sem`'s own address, so nothing needs the extra cell — but a `SemaphoreDescriptor` is instantiated per target node whether or not a kernel binds it, so it still cost one L1 cell on **every core in the rect grid**.

Removes the id, the descriptor and the CTA slot, then closes the hole by renumbering the two CTAs above it (`14, 15` → `13, 14`). The in0 sender kernel has this factory as its only binder, so the renumber has exactly one consumer — verified by search; `experimental/quasar` has its *own* copy of both files and is untouched here (see *Not in scope*).

The CTA list is also annotated with its indices now. It is positional and read back by index in the kernel, which is precisely how a hole survived in it unnoticed.

### 2. The in0 sender coordinate table as common runtime args

`in0_mcast_sender_noc_x` / `_noc_y` are built once, then were appended verbatim to the unique runtime args of every multicast sender *and* every multicast receiver — the same `2 * num_storage_cores` words replicated across the grid.

Common runtime args are the mechanism for exactly this shape of data. On Tensix they go out as a single multicast write per kernel group (`dispatch.cpp` — the per-core unicast path there is ethernet-only, for cores that cannot receive multicasts), where unique args are packed and written per core.

The values qualify on every count:
- identical on every node that reads them — built once, outside the per-core loops;
- every reader is inside the kernel's `core_ranges`;
- idle cores return on `worker_core_type == 0` before touching them.

The kernel's two base pointers move from `get_arg_addr(3)` / `(3 + n)` to `get_common_arg_addr(0)` / `(n)`. The `num_storage_cores` stride between the two blocks, and the invariant that it equals the sender count, are both unchanged from `main`.

**What this does not do:** it does not shrink per-core L1. Unique and common runtime args draw on the same kernel-config budget — `SetCommonRuntimeArgs`' own documentation is explicit that they "count toward the same limit". The saving is in the dispatch payload, not in L1. This is why the item was filed as *not yet analyzed* rather than as an obvious win; the analysis is what is written above.

### 3. Hardware startup before the SFPU activation init — bug fix

Under `#ifdef SFPU_ACTIVATION`, `ActivationInitHelper<>::init()` issued its `*_tile_init_pack()` SFPU configuration **before** `compute_kernel_hw_startup()`. The startup API requires hardware startup to precede every operation-specific init, so the pair was inverted — activation setup applied first, hardware brought up around it afterwards.

**The corrected order is already shipped in this repo.** `experimental/quasar`'s copy of this same kernel places `compute_kernel_hw_startup` directly after the buffer declarations, ahead of both the activation init and `matmul_block_init`. This applies that identical arrangement to the ttnn copy, so the two agree again — it is not a newly invented ordering.

Before → after in the ttnn kernel:

```
  init()            :257          compute_kernel_hw_startup()  :240
  hw_startup()      :268    →     init()                       :262
  matmul_block_init :269          matmul_block_init            :273
```

which matches quasar's `214 → 236 → 247`.

**Honest status on this one: no reproduced failure.** The fused-bias × activation matrix passes both before and after, and `ActivationInitHelper::init()` only issues pack-thread SFPU inits, which may simply not be clobbered by the startup path. So this removes an unsupported init sequence rather than a demonstrated miscompute. It is filed as a bug fix because the ordering contract is explicit and one copy of the kernel already honours it, not because a test went from red to green.

Reported by Copilot on #55961, which correctly left it alone: the order is byte-identical on `main`, so fixing it there would have broken that PR's faithful-translation invariant.

---

### Testing

Blackhole p150b, `TT_METAL_WATCHER=10` throughout, watcher log clean across every run. **446 passed, 0 failed.**

| suite | result | covers |
|---|---|---|
| `unit_tests_ttnn --gtest_filter='*MatmulSmoke*'` | **22 passed** | the factory, incl. `DramShardedDecodeProjection` |
| nightly `test_matmul_dram_sharded.py` | **84 passed** | items 1 + 2: `has_bias` × `num_workers_per_dram_bank ∈ {1,2,3}` × dtypes, incl. `…_with_program_cache` |
| nightly `test_matmul_activations.py` (all) + `test_dram_sharded_then_1d_matmul.py` | **290 passed** | item 3 across mcast-1d, mcast-2d, optimized-reuse and DRAM-sharded configs |
| nightly `test_matmul_1d_2d.py` + `test_matmul_block_sharded_1d_grid.py` | **50 passed** | item 3 on the non-activation paths of the shared kernel |

The first two figures match #55961's pre/post-conversion baseline exactly (22 and 84).

Item 3 changes a compute kernel **six** factories share, and it moves `compute_kernel_hw_startup` unconditionally — not only under `SFPU_ACTIVATION` — so the last two rows exist specifically to exercise the other consumers rather than certifying the change on the DRAM-sharded path alone.

`./build_metal.sh --build-tests` on this branch: **0 errors, 0 warnings.**

### Interaction with #55961

#55961 ports this factory to Metal 2.0 and forks the compute kernel. On rebase:

- **Item 1** — the port already dropped the CTA hole by moving to name-keyed args, so only the orphaned `SemaphoreSpec` survives there. The rebase reduces to deleting the `SemaphoreSpecName`, the third `SemaphoreSpec` push_back, and `reserve(3)` → `reserve(2)`. The CTA renumber here has no counterpart to carry.
- **Item 2** — the port's in0 sender runtime args are name-keyed and its vararg block is separate, so this needs re-expressing in that vocabulary rather than applying as a patch.
- **Item 3** — the port created `bmm_large_block_zm_fused_bias_activation_metal2.cpp` as a fork with the same inverted order. **The fork does not track the original, and the compiler will not say so**, so this reorder has to be carried across by hand. That is the standing hazard #55961 documents for Ports 3–5, and this is a live instance of it.

### Not in scope

`experimental/quasar` carries its own copies of both the factory and the in0 sender kernel, and **its factory has the identical dead semaphore and the identical CTA-13 hole** (`…/quasar/…/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp:286, :319, :633`, kernel `:33-34`). Left untouched here to keep this PR to one tree; flagging it so the duplicate is not lost. Note the direction of the divergence is inverted between the two items — quasar is *behind* on the semaphore and *ahead* on the init order.

Also unfixed, same defect as item 3, both still inverted: `bmm_large_block_zm_fused_bias_activation_gathered.cpp` in **both** trees (ttnn `:269`/`:280`, quasar `:247`/`:258`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/mm-dram-sharded-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/mm-dram-sharded-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/mm-dram-sharded-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/mm-dram-sharded-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/mm-dram-sharded-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/mm-dram-sharded-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/mm-dram-sharded-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/mm-dram-sharded-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/mm-dram-sharded-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/mm-dram-sharded-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/mm-dram-sharded-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/mm-dram-sharded-followup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/mm-dram-sharded-followup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/mm-dram-sharded-followup)