### PR TITLE
Fix moreh_sgd tile-unit mismatch: use padded_shape() for H/W (#51278 item 11)

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_program_factory.cpp
@@ -43,7 +43,7 @@ ProgramDescriptor MorehSgdOperation::create_descriptor(
 
     auto compute_kernel_config = operation_attributes.compute_kernel_config;
 
-    auto shape = param_in.logical_shape();
+    auto shape = param_in.padded_shape();
     auto H = shape[-2];
     auto W = shape[-1];
     auto num = param_in.physical_volume() / H / W;


### PR DESCRIPTION
## Summary

Fixes **item 11** of #51278: `moreh_sgd` derived its tile counts from `logical_shape()` while the work volume came from `physical_volume()` (padded), so for any TILE-layout param whose logical H/W are not tile multiples the op processed too few tiles — or zero tiles — and silently left part of `param_out` (and `momentum_buffer_out`) unwritten.

## The fix

One line in `ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_program_factory.cpp`:

```diff
-    auto shape = param_in.logical_shape();
+    auto shape = param_in.padded_shape();
```

With padded H/W, `num = physical_volume() / H / W`, `Ht`, `Wt` are all in the same (padded) units, so `units_to_divide = num * Ht * Wt` equals the true number of physical tiles — exactly what the reader/writer kernels need, since they index whole tiles by page id. This matches every sibling moreh factory that uses the same `physical_volume() / H / W` idiom: `moreh_softmax_{h,w,c}_large.cpp`, `moreh_abs_pow_program_factory.cpp`, `moreh_nll_loss_backward_program_factory.cpp`. For tile-aligned shapes `logical_shape() == padded_shape()`, so the change is a no-op on the aligned paths.

## How it fails (before the fix)

- logical `[1,1,32,40]` bf16 TILE → padded `[1,1,32,64]`, `physical_volume() = 2048` (2 tiles). Buggy math: `H=32, W=40`, `num = 2048/32/40 = 1`, `Ht = 1`, `Wt = 40/32 = 1` → `units_to_divide = 1`: only page 0 is processed, and real (logical) columns 32..39 that live in page 1 are **never written** — `param_out` keeps whatever was in that DRAM page.
- logical `[1,1,30,32]` → `Ht = 30/32 = 0` → `units_to_divide = 0`: `split_work_to_cores` gets zero work and the output is **never written at all**.

## Verification (ttsim — Blackhole simulator, no hardware needed; stock ttnn 0.78.0 wheel)

The program factory is **host-side** code compiled into the wheel (it is not a JIT-compiled device kernel), so the post-fix program it emits for logical `[1,1,32,40]` (padded `[1,1,32,64]`: `num=1, Ht=1, Wt=2, units=2`) is *identical* to the program the same factory emits for an aligned `[1,1,32,64]` tensor. Running that program on the manually padded tensor and comparing the logical region therefore reproduces the exact post-fix device behavior ("after" column below), on the unmodified stock wheel.

| case | before (stock wheel) | after (simulated, see above) | reference |
|---|---|---|---|
| `[1,1,32,40]` wrong elements (atol 0.05) | **242/1280** — logical cols 32..39 never written | **0/1280** | `param − 0.1·grad`, fp32 |
| `[1,1,30,32]` wrong elements | **917/960** — zero work units, output never written | **0/960** | `param − 0.1·grad`, fp32 |
| `[1,1,32,64]` aligned control | 0/2048 | 0/2048 | `param − 0.1·grad`, fp32 |

Repro (before / after-simulation):

```python
import torch, ttnn
device = ttnn.open_device(device_id=0)
def dev(t): return ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
def run(p, g):  # stock wheel
    out = ttnn.operations.moreh.sgd(dev(p), dev(g), None, None, None,
        lr=0.1, momentum=0.0, dampening=0.0, weight_decay=0.0,
        nesterov=False, momentum_initialized=True)
    return ttnn.to_torch(out[0]).float()

# BEFORE: logical [1,1,32,40] — tail columns 32..39 keep stale memory
p, g = torch.randn(1,1,32,40).bfloat16(), torch.randn(1,1,32,40).bfloat16()
bad = ((run(p, g) - (p.float() - 0.1 * g.float())).abs() > 0.05).sum()  # -> 242/1280

# AFTER (simulated): fix makes the factory emit the padded program,
# i.e. the one it already emits for the aligned shape:
pp, gp = torch.zeros(1,1,32,64).bfloat16(), torch.zeros(1,1,32,64).bfloat16()
pp[..., :, :40] = p; gp[..., :, :40] = g
got = run(pp, gp)[..., :, :40]
bad = ((got - (p.float() - 0.1 * g.float())).abs() > 0.05).sum()  # -> 0
```

## Notes for reviewers

- No device kernel is touched: all kernel defines, CBs, compile-time and runtime args are unchanged — only the host-side unit math.
- The existing nightly test (`tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sgd.py`) only exercises tile-aligned shapes (`[32,32]`, `[12,6,64,64]`), which is why this never surfaced. Happy to add an unaligned regression shape to that parametrize list if you'd like it in this PR.
