### PR TITLE
[emule] Derive runtime CB tile geometry when unpack face geometry is absent

### DIFF
--- a/tests/tt_metal/tt_metal/api/emule/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/emule/sources.cmake
@@ -22,6 +22,7 @@ list(
     ${CMAKE_CURRENT_LIST_DIR}/test_alignment_writes.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_cb_leak.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_cb_pages.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_cb_tile_geometry.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_emule_host_wait.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_host_alignment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_metadata_size.cpp

--- a/tests/tt_metal/tt_metal/api/emule/test_cb_tile_geometry.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_cb_tile_geometry.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tile.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include "device_fixture.hpp"
+#include "impl/context/metal_context.hpp"
+#include "llrt/tt_cluster.hpp"
+#include "tt_emule/device.hpp"
+#include "umd/device/chip/sw_emule_chip.hpp"
+#include "umd/device/cluster.hpp"
+
+namespace tt::tt_metal {
+
+TEST_F(UnitMeshFixture, OrdinaryShortTileInitializesRuntimeCbGeometryWithoutUnpackOverride) {
+    constexpr uint8_t cb_id = 0;
+    constexpr uint32_t page_size = 64;
+    const CoreCoord logical_core{0, 0};
+
+    Program program = CreateProgram();
+    CircularBufferConfig cb_config(page_size, {{cb_id, tt::DataFormat::Float16_b}});
+    cb_config.set_page_size(cb_id, page_size).set_tile_dims(cb_id, Tile({1, 32}));
+    ASSERT_FALSE(cb_config.unpack_face_geometry()[cb_id].has_value());
+    CreateCircularBuffer(program, logical_core, cb_config);
+
+    CreateKernelFromString(
+        program,
+        "void kernel_main() {}",
+        logical_core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+
+    auto& cluster = MetalContext::instance().get_cluster();
+    auto* emule_chip = dynamic_cast<tt::umd::SWEmuleChip*>(cluster.get_driver()->get_chip(this->device().build_id()));
+    ASSERT_NE(emule_chip, nullptr);
+    const auto physical_core = this->device().virtual_core_from_logical_core(logical_core, CoreType::WORKER);
+    auto* emule_core = emule_chip->get_core(tt_xy_pair(physical_core.x, physical_core.y));
+    ASSERT_NE(emule_core, nullptr);
+
+    const auto& cb_state = emule_core->cb_sync_array()[cb_id];
+    ASSERT_EQ(cb_state.page_size, page_size);
+    EXPECT_EQ(cb_state.face_r_dim, 1u);
+    EXPECT_EQ(cb_state.num_faces, 2u);
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -3283,13 +3283,16 @@ static void init_core_cb_sync(
             uint32_t page_size = cb_impl->page_size(idx);
             uint32_t num_pages = (page_size > 0) ? cb_impl->num_pages(idx) : 0;
             uint8_t* base = (page_size > 0) ? core->l1_ptr(cb_addr) : nullptr;
-            // Carry the faced-tile geometry silicon's pack/unpack init reads off the
-            // CB when the config sets it, else the full-tile default (16/4).
+            // Match JIT precedence: explicit unpack geometry, ordinary Tile geometry,
+            // then the full-tile default (16/4).
             uint32_t cb_face_r_dim = 16, cb_num_faces = 4;
             const auto& cb_fg = cb_impl->unpack_face_geometry(idx);
             if (cb_fg.has_value()) {
                 cb_face_r_dim = cb_fg->face_r_dim;
                 cb_num_faces = cb_fg->num_faces;
+            } else if (const auto& cb_tile = cb_impl->tile(idx); cb_tile.has_value()) {
+                cb_face_r_dim = cb_tile->get_face_shape()[0];
+                cb_num_faces = cb_tile->get_num_faces();
             }
             core->init_cb_sync(
                 idx, base, page_size, num_pages, cb_impl->globally_allocated(), cb_face_r_dim, cb_num_faces);


### PR DESCRIPTION
### Problem
In `init_core_cb_sync` (`tt_metal/impl/emulation/emulated_program_runner.cpp`), runtime CB face geometry (`face_r_dim`, `num_faces`) was derived solely from `cb_impl->unpack_face_geometry(idx)`. When that optional override was absent, the runner fell back to full-tile defaults (`face_r_dim = 16, num_faces = 4`), even when the CircularBuffer had an ordinary non-standard tile shape configured (e.g. `Tile({1, 32})`).

In the emulated backend, this caused `pack_untilize_dest` to write 2048 bytes (4 faces * 16 rows * 32 cols) into a 64-byte page allocation. In fused kernels like the DeepSeek-V4 Compressor, this out-of-bounds write silently corrupted adjacent L1 variables (such as `cur_pos`), causing missing gather notifications and deadlocks.

### Fix
Align runtime CB sync initialization with JIT compiler precedence in `jit_build_options.cpp`:
1. Explicit `unpack_face_geometry`, if present.
2. Otherwise, derive `face_r_dim = tile->get_face_shape()[0]` and `num_faces = tile->get_num_faces()` from the configured `Tile`.
3. Default to full-tile (`16/4`) only if neither is present.

### Tests
- Added `UnitMeshFixture.OrdinaryShortTileInitializesRuntimeCbGeometryWithoutUnpackOverride` under `tests/tt_metal/tt_metal/api/emule/test_cb_tile_geometry.cpp`. Confirmed RED (`16/4`) before fix and GREEN (`1/2`) after fix.
- Full LoudBox compressor stress test (400 iterations, 100 per parameter config) passed with 0 failures and 0 deadlocks.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arminale/emule-cb-tile-geometry-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arminale/emule-cb-tile-geometry-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arminale/emule-cb-tile-geometry-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arminale/emule-cb-tile-geometry-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arminale/emule-cb-tile-geometry-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arminale/emule-cb-tile-geometry-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arminale/emule-cb-tile-geometry-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arminale/emule-cb-tile-geometry-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arminale/emule-cb-tile-geometry-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arminale/emule-cb-tile-geometry-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arminale/emule-cb-tile-geometry-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arminale/emule-cb-tile-geometry-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arminale/emule-cb-tile-geometry-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arminale/emule-cb-tile-geometry-main)