### PR TITLE
ttnn.pad: bound row-major CB depth by L1 budget

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -58,24 +58,39 @@ def test_pad_rm(device, n, c, h, w, padding, torch_padding, value, dtype):
 
 
 @pytest.mark.parametrize(
-    "shape,padding,torch_padding",
+    "shape,padding,torch_padding,use_multicore",
     [
-        ((8, 1, 1, 1), ((0, 0), (0, 0), (0, 0), (0, 191)), (0, 191, 0, 0, 0, 0, 0, 0)),
-        ((1, 1, 1, 2), ((0, 0), (0, 0), (0, 0), (0, 254)), (0, 254, 0, 0, 0, 0, 0, 0)),
-        ((4, 1, 1, 4), ((0, 0), (0, 0), (0, 0), (0, 60)), (0, 60, 0, 0, 0, 0, 0, 0)),
+        ((8, 1, 1, 1), ((0, 0), (0, 0), (0, 0), (0, 191)), (0, 191, 0, 0, 0, 0, 0, 0), True),
+        ((1, 1, 1, 2), ((0, 0), (0, 0), (0, 0), (0, 254)), (0, 254, 0, 0, 0, 0, 0, 0), True),
+        ((4, 1, 1, 4), ((0, 0), (0, 0), (0, 0), (0, 60)), (0, 60, 0, 0, 0, 0, 0, 0), True),
+        ((1, 1, 1, 1985), ((0, 0), (0, 0), (0, 0), (49290, 0)), (49290, 0, 0, 0, 0, 0, 0, 0), True),
+        pytest.param(
+            (1, 1, 1, 1985),
+            ((0, 0), (0, 0), (0, 0), (49290, 0)),
+            (49290, 0, 0, 0, 0, 0, 0, 0),
+            False,
+            marks=pytest.mark.xfail(
+                raises=AssertionError,
+                strict=True,
+                reason="single-core RM pad writes the padding after the data instead of before it: "
+                "https://github.com/tenstorrent/tt-metal/issues/56323",
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize("value", [0])
-def test_pad_rm_small_to_large_width(device, shape, padding, torch_padding, value):
+def test_pad_rm_small_to_large_width(device, shape, padding, torch_padding, use_multicore, value):
     """Regression test for issue #39875: padding from very small width to large width
-    caused CB allocation to exceed L1 size due to using input width for stick batching."""
+    caused CB allocation to exceed L1 size due to using input width for stick batching,
+    and for wide padded rows whose fixed 16-row CB depth exceeded L1 on both the
+    multi-core and single-core row-major factories."""
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand(shape).bfloat16().float()
     torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, torch_padding, mode="constant", value=value)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.bfloat16)
-    output_tensor = ttnn.pad(input_tensor, padding=padding, value=value)
+    output_tensor = ttnn.pad(input_tensor, padding=padding, value=value, use_multicore=use_multicore)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -321,7 +321,16 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreDefaultProgra
     }
 
     uint32_t dfb_npages = get_num_stick_per_barrier(stick_size_padded_aligned);
-    const uint32_t buffer_reader_writer_async_factor = 16;
+    // Depth 16 is a pipelining choice; use fewer barriers when 16 would overflow L1.
+    const uint32_t barrier_bytes = dfb_npages * stick_size_padded_aligned;
+    const uint32_t l1_budget =
+        (device->l1_size_per_core() / 2) - device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    TT_FATAL(
+        barrier_bytes <= l1_budget,
+        "ttnn.pad: padded row of {} B does not fit in the per-core L1 budget ({} B)",
+        stick_size_padded_aligned,
+        l1_budget);
+    const uint32_t buffer_reader_writer_async_factor = std::clamp(l1_budget / barrier_bytes, 1u, 16u);
     dataflow_buffers.push_back(DataflowBufferSpec{
         .unique_id = RM_DEF_IN0,
         .entry_size = stick_size_padded_aligned,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -4,8 +4,10 @@
 
 #include "pad_rm_reader_writer_program_factory.hpp"
 
+#include <algorithm>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/hal_types.hpp>
 #include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
@@ -76,9 +78,17 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterProgramFactory::create
 
     const NodeCoord node{0, 0};
 
-    uint32_t dfb_npages = 16;  // multibuffering
     uint32_t dfb_pagesize =
         tt::round_up(padded_row_size_nbytes, std::max(a.buffer()->alignment(), tt::constants::TILE_WIDTH));
+    // 16 pages is a multibuffering choice; use fewer when 16 would overflow L1.
+    const uint32_t l1_budget =
+        (a.device()->l1_size_per_core() / 2) - a.device()->allocator()->get_base_allocator_addr(HalMemType::L1);
+    TT_FATAL(
+        dfb_pagesize <= l1_budget,
+        "ttnn.pad: padded row of {} B does not fit in the per-core L1 budget ({} B)",
+        dfb_pagesize,
+        l1_budget);
+    uint32_t dfb_npages = std::clamp(l1_budget / dfb_pagesize, 1u, 16u);
     tt::DataFormat in_df = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     DataflowBufferSpec in0_dfb{
         .unique_id = RM_SC_IN0,


### PR DESCRIPTION
### Ticket
- closes https://github.com/tenstorrent/tt-metal/issues/56133
- tenstorrent/tt-xla#6069

### Problem description
Row-major `ttnn.pad` fails at program creation when the padded row is wide, even for a single-row tensor:

```
TT_THROW: Statically allocated dataflow buffers on core range [0-0 - 0-0] grow to 1957760 B which is beyond max L1 size of 1572864 B
```

Both row-major pad factories size their main dataflow buffer as a fixed 16 rows of the padded width, regardless of how many rows the tensor has. For a 51275-wide bf16 row (about 100 KB) that is 1.6 MB, more than the 1.5 MB L1 of a core. The depth of 16 is only a pipelining choice; the reader and writer kernels reserve and wait `num_sticks_per_barrier` entries and do not depend on it. Front padding always takes this row-major path, since the tile kernel rejects it.

### What's changed
Bound the buffer depth by the per-core L1 budget, as `concat_program_factory.cpp` already does, in both row-major pad factories:

```diff
-    const uint32_t buffer_reader_writer_async_factor = 16;
+    const uint32_t barrier_bytes = dfb_npages * stick_size_padded_aligned;
+    const uint32_t l1_budget =
+        (device->l1_size_per_core() / 2) - device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    TT_FATAL(barrier_bytes <= l1_budget, ...);
+    const uint32_t buffer_reader_writer_async_factor = std::clamp(l1_budget / barrier_bytes, 1u, 16u);
```

Existing shapes keep depth 16; the 51275-wide row runs at depth 6. Added the failing shape to `test_pad.py::test_pad_rm_small_to_large_width` (fails before, passes after; logs attached).

### Checklist
- [x] Nightly tt-metal L2 tests - https://github.com/tenstorrent/tt-metal/actions/runs/34501780479
- [x] Sanity tests - https://github.com/tenstorrent/tt-metal/actions/runs/34501666625

### Logs

- [sep12_pad_sanity_before_fix.log](https://github.com/user-attachments/files/32139098/sep12_pad_sanity_before_fix.log)
- [sep12_pad_sanity_after_fix1.log](https://github.com/user-attachments/files/32139097/sep12_pad_sanity_after_fix1.log)



### CI

- **Sanity** ([branch](<https://github.com/tenstorrent/tt-metal/actions/runs/34501666625>) vs [main](https://github.com/tenstorrent/tt-metal/actions/runs/34504686590)): every real test failure on the branch is also present on main. The two extra red jobs on the branch are the same `fetch-ttsim` artifact-download flake, landing under a different job name than on main; they run no tests. All `data movement` groups pass with the same counts as main.
- **L2 nightly, `data_movement`** ([branch](https://github.com/tenstorrent/tt-metal/actions/runs/34501780479) vs [main](https://github.com/tenstorrent/tt-metal/actions/runs/34501780479)): identical failure set. Both Blackhole post-commit suites fail the pre-existing `test_tilize_uint8_tall_narrow_program_cache_addr_change[(1, 1, 4096, 32)]` on main too. The branch's `bh_p100` job hit the time limit on a runner about 2.5x slower than main's across every test file, with 0 failures at the cutoff. The new pad case passes on all platforms where the suite completed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kkannan/sep10-pad-rm-cb-l1-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kkannan/sep10-pad-rm-cb-l1-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kkannan/sep10-pad-rm-cb-l1-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kkannan/sep10-pad-rm-cb-l1-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kkannan/sep10-pad-rm-cb-l1-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kkannan/sep10-pad-rm-cb-l1-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kkannan/sep10-pad-rm-cb-l1-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kkannan/sep10-pad-rm-cb-l1-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kkannan/sep10-pad-rm-cb-l1-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kkannan/sep10-pad-rm-cb-l1-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kkannan/sep10-pad-rm-cb-l1-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kkannan/sep10-pad-rm-cb-l1-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kkannan/sep10-pad-rm-cb-l1-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kkannan/sep10-pad-rm-cb-l1-budget)