### PR TITLE
[skip ci] [Bug fix] Scope Copilot cloud build instructions to Copilot

### DIFF
--- a/.github/instructions/copilot-cloud.instructions.md
+++ b/.github/instructions/copilot-cloud.instructions.md
@@ -1,15 +1,20 @@
-# AGENTS.md — instructions for coding agents authoring changes
+---
+applyTo: "**"
+excludeAgent: "code-review"
+---
 
-This file is for agents **writing** changes to tt-metal (GitHub Copilot cloud
-agent and equivalents).
+# Copilot cloud agent — authoring and build instructions
+
+These instructions apply to GitHub Copilot cloud agent **writing** changes to
+tt-metal in the environment configured by `.github/workflows/copilot-setup-steps.yml`.
 
 Related instruction files:
 
 | File | Audience | Purpose |
 | --- | --- | --- |
-| `AGENTS.md` (this file) | cloud agent | how to author and **verify** a change |
+| `.github/instructions/copilot-cloud.instructions.md` (this file) | cloud agent | how to author and **verify** a change |
 | `.github/copilot-instructions.md` | code review | cross-cutting review criteria |
-| `.github/instructions/*.instructions.md` | code review | path-scoped review criteria (all carry `excludeAgent: "cloud-agent"`) |
+| Other `.github/instructions/*.instructions.md` files | code review | path-scoped review criteria (carry `excludeAgent: "cloud-agent"`) |
 
 The review files describe how to critique a PR. They are not a specification
 for your own work.

--- a/.github/scripts/copilot-build.sh
+++ b/.github/scripts/copilot-build.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
-# Build tt-metal from inside the CI build image. Intended for coding agents
-# (see AGENTS.md); harmless for humans, but you probably want build_metal.sh.
+# Build tt-metal from inside the CI build image for the Copilot cloud agent.
+# See .github/instructions/copilot-cloud.instructions.md for authoring guidance.
+# For local development, you probably want build_metal.sh.
 #
 # Why a wrapper: the Copilot cloud agent cannot run inside a job `container:` -
 # its runtime stages a git-proxy binary on the host and then looks it up at the

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,7 +1,8 @@
 name: "Copilot Setup Steps"
 
 # Environment for the GitHub Copilot cloud agent, so it can make a change and
-# verify that it compiles. Authoring guidance lives in AGENTS.md, not here.
+# verify that it compiles. Authoring guidance lives in
+# .github/instructions/copilot-cloud.instructions.md.
 #
 # Deliberately NO `container:`. The agent's runtime stages a git-proxy binary on
 # the host and then resolves it against the container-remapped RUNNER_TEMP


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The root `AGENTS.md` introduced in #54520 makes local Codex workflows inherit Copilot cloud runner assumptions, including using the Docker build wrapper and avoiding dependency installation. Move the guidance to `.github/instructions/copilot-cloud.instructions.md` with `applyTo: "**"` and `excludeAgent: "code-review"`, so Copilot cloud agent receives it without placing it in default Codex instruction discovery.

Closes #56125.

### Notes for reviewers
The authoring and build guidance is preserved from `## Your environment` onward. The introduction and instruction-file table now identify the Copilot cloud scope. References in `copilot-build.sh` and `copilot-setup-steps.yml` point to the new file; both changes are comments only.

This uses GitHub's documented [cloud-agent instruction scoping](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions#creating-path-specific-custom-instructions).

Validation: relevant pinned pre-commit hooks passed (trailing whitespace, end-of-file, YAML parsing, merge conflicts, yamllint); `bash -n .github/scripts/copilot-build.sh` and `git diff --cached --check` passed. Also verified the frontmatter, removal of the root `AGENTS.md`, preservation of the build guidance, and unchanged executable script/workflow content. No compilation was needed for instructions and comment-only changes. Copilot cloud instruction loading has not been exercised in a live session.
