### PR TITLE
[Bug fix] div: don't let the fp32 residual refinement destroy a/inf

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -87,8 +87,21 @@ def test_mul_fp32(device, ttnn_function):
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=nan; in fp32  tile
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=0; in chained (mul * recip) div op
 def test_div_fp32(device, ttnn_function):
-    x_torch = torch.tensor([[1.00030171126, -3, 16, -5, 14, -12, 0, 0, 1, 15, 0.0, float("inf")]], dtype=torch.float32)
-    y_torch = torch.tensor([[2, 3, -4, -5, 0, 0, 0, 1, 0, 10, 0.0, float("inf")]], dtype=torch.float32)
+    inf = float("inf")
+    nan = float("nan")
+    # The sweeps elsewhere in this file draw operands from [-100, 100] and never
+    # generate infinities, and the pairs below previously covered only inf / inf.
+    # The trailing pairs add finite / +-inf, which IEEE-754 and the registered
+    # torch.div golden both define as a signed zero, and +-1 / nan, which must
+    # stay nan.
+    x_torch = torch.tensor(
+        [[1.00030171126, -3, 16, -5, 14, -12, 0, 0, 1, 15, 0.0, inf, 1, -3, 0, 1, 1, -1]],
+        dtype=torch.float32,
+    )
+    y_torch = torch.tensor(
+        [[2, 3, -4, -5, 0, 0, 0, 1, 0, 10, 0.0, inf, inf, inf, inf, -inf, nan, nan]],
+        dtype=torch.float32,
+    )
     # torch out in ttnn TorchTensor([[ 0.500150859355927, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,                inf,
     #            1.500000000000000]])
     # tt out in torch TorchTensor([[ 0.500150859355927, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,                inf,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -181,15 +181,29 @@ inline void calculate_sfpu_binary_div(
         sfpi::vFloat r = sfpu_reciprocal_iter<2>(in1);
         sfpi::vFloat result = in0 * r;
         if constexpr (is_fp32_dest_acc_en) {
-            // Skip quotient refinement when in0*r is already non-finite (biased exponent == 255).
-            // If in0*r = +/-inf, then the residual e = in0 - (+/-inf)*in1 = -/+inf and
-            // result + e*r = inf + (-inf) = NaN, which would corrupt IEEE overflow behavior.
-            v_if(sfpi::exexp(result, sfpi::ExponentMode::Biased) != 255) {
+            // Skip quotient refinement in the two cases where in0*r is already the IEEE
+            // result and the residual would destroy it:
+            //   - in0*r is non-finite (biased exponent == 255). If in0*r = +/-inf, then the
+            //     residual e = in0 - (+/-inf)*in1 = -/+inf and result + e*r = inf + (-inf) =
+            //     NaN, which would corrupt IEEE overflow behavior.
+            //   - in1 is non-finite. For in1 = +/-inf, r = 1/in1 = +/-0 and result = in0*r is
+            //     already the required signed zero, but e = in0 - result*in1 evaluates
+            //     0*inf = NaN.
+            v_if(
+                sfpi::exexp(result, sfpi::ExponentMode::Biased) != 255 &&
+                sfpi::exexp(in1, sfpi::ExponentMode::Biased) != 255) {
                 // Residual (Markstein) refinement removes the double-rounding of in0 * round(1/in1).
                 // The residual subtraction is exact under Sterbenz's lemma.
                 sfpi::vFloat e = in0 - result * in1;
                 result = result + e * r;
             }
+            v_endif;
+
+            // The guard above also excludes a NaN denominator, so set that result explicitly.
+            // sfpu_reciprocal_iter returns 0 rather than NaN for a NaN input, which leaves
+            // result = in0*0 = 0; before this the refinement happened to restore the NaN via
+            // e = in0 - 0*NaN. Stating it directly does not depend on the reciprocal.
+            v_if(sfpi::is_nan(in1)) { result = std::numeric_limits<float>::quiet_NaN(); }
             v_endif;
         }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -180,15 +180,29 @@ inline void calculate_sfpu_binary_div(
         sfpi::vFloat r = sfpu_reciprocal_iter<2>(in1);
         sfpi::vFloat result = in0 * r;
         if constexpr (is_fp32_dest_acc_en) {
-            // Skip quotient refinement when in0*r is already non-finite (biased exponent == 255).
-            // If in0*r = +/-inf, then the residual e = in0 - (+/-inf)*in1 = -/+inf and
-            // result + e*r = inf + (-inf) = NaN, which would corrupt IEEE overflow behavior.
-            v_if(sfpi::exexp(result, sfpi::ExponentMode::Biased) != 255) {
+            // Skip quotient refinement in the two cases where in0*r is already the IEEE
+            // result and the residual would destroy it:
+            //   - in0*r is non-finite (biased exponent == 255). If in0*r = +/-inf, then the
+            //     residual e = in0 - (+/-inf)*in1 = -/+inf and result + e*r = inf + (-inf) =
+            //     NaN, which would corrupt IEEE overflow behavior.
+            //   - in1 is non-finite. For in1 = +/-inf, r = 1/in1 = +/-0 and result = in0*r is
+            //     already the required signed zero, but e = in0 - result*in1 evaluates
+            //     0*inf = NaN.
+            v_if(
+                sfpi::exexp(result, sfpi::ExponentMode::Biased) != 255 &&
+                sfpi::exexp(in1, sfpi::ExponentMode::Biased) != 255) {
                 // Residual (Markstein) refinement removes the double-rounding of in0 * round(1/in1).
                 // The residual subtraction is exact under Sterbenz's lemma.
                 sfpi::vFloat e = in0 - result * in1;
                 result = result + e * r;
             }
+            v_endif;
+
+            // The guard above also excludes a NaN denominator, so set that result explicitly.
+            // sfpu_reciprocal_iter returns 0 rather than NaN for a NaN input, which leaves
+            // result = in0*0 = 0; before this the refinement happened to restore the NaN via
+            // e = in0 - 0*NaN. Stating it directly does not depend on the reciprocal.
+            v_if(sfpi::is_nan(in1)) { result = std::numeric_limits<float>::quiet_NaN(); }
             v_endif;
         }
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #52114.

With fp32 DEST accumulation enabled, `ttnn.div(a, inf)` returns `NaN` for every finite `a`. IEEE-754 and the registered `torch.div` golden both give a signed zero.

There is no divide instruction, so `calculate_sfpu_binary_div` evaluates `a / b` as `a * (1/b)`. For `b = ±inf` the reciprocal is `±0`, so the product is already the answer. The fp32 residual (Markstein) refinement then runs anyway and destroys it:

```
r      = 1/inf         = +0
result = a * 0         = 0      <- already correct
guard  : exponent of 0 is 0, not 255, so the guard passes
e      = a - (0 * inf) = NaN
result = 0 + NaN * 0   = NaN
```

The guard tests whether the *quotient* is non-finite, which is the right check for `a / tiny -> inf`. It does not consider a non-finite *denominator*, where the quotient is an ordinary zero and the gate opens. So a precision step overwrites a result the hardware had already computed correctly.

This extends the guard to the denominator, and sets the NaN case explicitly for the reason below. Applied to both `blackhole` and `wormhole_b0`.

### Notes for reviewers

**Widening the guard alone is not sufficient.** The issue suggests skipping refinement whenever the denominator is non-finite. I tried that first. A biased exponent of 255 tags NaN as well as infinity, so it regresses `a / NaN`:

| case | torch | before | guard widened alone | this PR |
|---|---|---|---|---|
| `a / inf` | `0` | `NaN` | `0` | `0` |
| `a / NaN` | `NaN` | `NaN` | `0` | `NaN` |

`sfpu_reciprocal_iter` returns `0` rather than `NaN` for a NaN input, so `result = a * 0 = 0`, and it was the residual `e = a - 0 * NaN = NaN` that restored the NaN. NaN division was only correct as a side effect of the same step that breaks `a / inf`. Setting it explicitly also removes that dependency on the reciprocal's behaviour. The issue's other suggestion, skipping when `r == 0`, is not equivalent either: sfpi's `!=` does not treat `-0` and `+0` the way IEEE
does, so it misfires on `-inf`.

**Why two conditionals rather than one `!is_inf(in1)`.** That is the natural spelling and was my first attempt. It crashes the pinned SFPI 7.74.0 toolchain when the div kernel is JIT-compiled:

```
during GIMPLE pass: rvtt_expand
internal compiler error: Segmentation fault
0x9fbdab update_ssa(unsigned int)
gcc (tenstorrent/sfpi:7.74.0[897]) 15.1.0
```

Every three-predicate form reproduced it, including
`exexp(in1) != 255 || exman(in1) != 0`. Two predicates compile, and unmodified `main` compiles fine on the same toolchain. Happy to file that against tenstorrent/sfpi, and equally happy to switch if someone knows a spelling that
survives.

**Testing.** Blackhole simulator, cold kernel cache per run.

| check | result |
|---|---|
| new test on the parent commit | fails, `Tensors are not finite at the same positions` |
| new test against the widened-guard version | fails on `a / NaN` |
| new test with this change | passes |
| `test_binary_fp32.py` + `test_binaryng_fp32.py` | 107 passed, 1 skipped |

The NaN pairs in the test are the regression guard for the first note above, not decoration. `test_div_fp32` previously covered only `inf / inf`, which passes even when broken because that quotient is already non-finite, and the sweeps
elsewhere in the file draw from `[-100, 100]` and never generate non-finite values.

**Limits I'd rather state than have found.** Simulator, not silicon. The
`wormhole_b0` copy was never executed, since that simulator rejects these fp32 tests for an unrelated reason (`tensix_unpacr: unpack_to_dst=0 in_data_format=0 out_data_format=0`) including tests this change does not touch. And the *sign* of the zero is reasoned rather than measured, because `assert_with_ulp` treats `-0`
and `+0` as equal and the simulator does not preserve the sign of zero through an fp32 multiply.

**Found nearby, deliberately not fixed here.** `a / NaN` also returns `0` on the bfloat16 path, from the same `reciprocal(NaN) -> 0` behaviour; that path has no refinement so it never had the accidental rescue. And `1.0 / 1e38` returns `0` where torch gives `1e-38`, which is the separate underflow issue #52094. Happy to file the first.
