### PR TITLE
Reduce cached runtime-argument overhead in sparse_sdpa_msa

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program.hpp>
 #include <algorithm>
+#include <array>
 #include <bit>
 
 namespace ttnn::prim {
@@ -306,53 +307,66 @@ void SparseSDPAMsaOperation::SparseSDPAMsaProgramFactory::override_runtime_argum
     const uint32_t idx_addr = t.indices.buffer()->address();
     const uint32_t out_addr = tensor_return_value.buffer()->address();
 
+    // Kernel argument grids are invariant across the cores in this dispatch.
+    auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, kReaderKernelIdx);
+    auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, kWriterKernelIdx);
+    auto& compute_args = tt::tt_metal::GetRuntimeArgs(program, kComputeKernelIdx);
+
+    // Only the work range varies by core; refresh every address and scalar each dispatch.
+    std::array<uint32_t, kReaderArgCount> reader_values{};
+    reader_values[kReaderQAddr] = q_addr;
+    reader_values[kReaderKAddr] = k_addr;
+    reader_values[kReaderVAddr] = v_addr;
+    reader_values[kReaderIdxAddr] = idx_addr;
+    reader_values[kReaderKBatchOffset] = dyn.k_batch_tile_offset;
+    reader_values[kReaderVBatchOffset] = dyn.v_batch_tile_offset;
+    reader_values[kReaderKGroupStride] = dyn.k_group_tile_stride;
+    reader_values[kReaderVGroupStride] = dyn.v_group_tile_stride;
+    reader_values[kReaderChunkStart] = dyn.chunk_start_local;
+    std::array<uint32_t, kWriterArgCount> writer_values{};
+    writer_values[kWriterOutAddr] = out_addr;
+    writer_values[kWriterKAddr] = k_addr;
+    writer_values[kWriterVAddr] = v_addr;
+    writer_values[kWriterKBatchOffset] = dyn.k_batch_tile_offset;
+    writer_values[kWriterVBatchOffset] = dyn.v_batch_tile_offset;
+    writer_values[kWriterKGroupStride] = dyn.k_group_tile_stride;
+    writer_values[kWriterVGroupStride] = dyn.v_group_tile_stride;
+    std::array<uint32_t, kComputeArgCount> compute_values{};
+
     for (uint32_t i = 0; i < dyn.num_cores; ++i) {
         const tt::tt_metal::CoreCoord core = {i % dyn.grid.x, i / dyn.grid.x};
         const uint32_t work_start = i * dyn.base_work + std::min(i, dyn.extra);
         const uint32_t work_count = dyn.base_work + (i < dyn.extra ? 1u : 0u);
 
-        auto& reader = tt::tt_metal::GetRuntimeArgs(program, kReaderKernelIdx, core);
+        auto& reader = reader_args[core.x][core.y];
         TT_FATAL(
             reader.size() == kReaderArgCount,
             "sparse_sdpa_msa reader expected {} runtime args, cached program has {}",
             static_cast<uint32_t>(kReaderArgCount),
             reader.size());
-        reader[kReaderQAddr] = q_addr;
-        reader[kReaderKAddr] = k_addr;
-        reader[kReaderVAddr] = v_addr;
-        reader[kReaderIdxAddr] = idx_addr;
-        reader[kReaderWorkStart] = work_start;
-        reader[kReaderWorkCount] = work_count;
-        reader[kReaderKBatchOffset] = dyn.k_batch_tile_offset;
-        reader[kReaderVBatchOffset] = dyn.v_batch_tile_offset;
-        reader[kReaderKGroupStride] = dyn.k_group_tile_stride;
-        reader[kReaderVGroupStride] = dyn.v_group_tile_stride;
-        reader[kReaderChunkStart] = dyn.chunk_start_local;
+        reader_values[kReaderWorkStart] = work_start;
+        reader_values[kReaderWorkCount] = work_count;
+        std::copy(reader_values.begin(), reader_values.end(), reader.data());
 
-        auto& writer = tt::tt_metal::GetRuntimeArgs(program, kWriterKernelIdx, core);
+        auto& writer = writer_args[core.x][core.y];
         TT_FATAL(
             writer.size() == kWriterArgCount,
             "sparse_sdpa_msa writer expected {} runtime args, cached program has {}",
             static_cast<uint32_t>(kWriterArgCount),
             writer.size());
-        writer[kWriterOutAddr] = out_addr;
-        writer[kWriterWorkStart] = work_start;
-        writer[kWriterWorkCount] = work_count;
-        writer[kWriterKAddr] = k_addr;
-        writer[kWriterVAddr] = v_addr;
-        writer[kWriterKBatchOffset] = dyn.k_batch_tile_offset;
-        writer[kWriterVBatchOffset] = dyn.v_batch_tile_offset;
-        writer[kWriterKGroupStride] = dyn.k_group_tile_stride;
-        writer[kWriterVGroupStride] = dyn.v_group_tile_stride;
+        writer_values[kWriterWorkStart] = work_start;
+        writer_values[kWriterWorkCount] = work_count;
+        std::copy(writer_values.begin(), writer_values.end(), writer.data());
 
-        auto& compute = tt::tt_metal::GetRuntimeArgs(program, kComputeKernelIdx, core);
+        auto& compute = compute_args[core.x][core.y];
         TT_FATAL(
             compute.size() == kComputeArgCount,
             "sparse_sdpa_msa compute expected {} runtime args, cached program has {}",
             static_cast<uint32_t>(kComputeArgCount),
             compute.size());
-        compute[kComputeWorkStart] = work_start;
-        compute[kComputeWorkCount] = work_count;
+        compute_values[kComputeWorkStart] = work_start;
+        compute_values[kComputeWorkCount] = work_count;
+        std::copy(compute_values.begin(), compute_values.end(), compute.data());
     }
 }
 


### PR DESCRIPTION
MiniMax M3 uses `sparse_sdpa_msa` in 57 of its 60 layers. Its cached-program callback performs three kernel argument-grid lookups and individual scalar writes for every core. This change retrieves the grids once and builds per-dispatch scalar blocks, then updates each core's work range and copies the checked blocks into the existing argument storage.

Every dynamic buffer address, KV batch offset/group stride, and causal chunk position is still refreshed. Kernel code, attention arithmetic, cache keys, and work scheduling are unchanged. The factory already patches cached descriptors in place; this change reduces the cost of that existing path.

On a Blackhole Galaxy, three matched processes per arm at MiniMax-shaped 5k chunks and 0/25k/51k context reduced API-return time from 0.644 to 0.565 ms (12.3%) and synchronized single-call latency from 1.605 to 1.512 ms (5.8%). The 57-call queued result changed by only 0.32%. These are isolated operator measurements, not a full-model speedup. Both arms include the same selected shared-host ports and logging/SHM settings.

The full 60-layer, 56,320-token non-traced comparison (three processes per arm, ten iterations each) was effectively flat for this patch: 10,371.23 → 10,372.37 tokens/s, a 0.011% change. The separate one-shot 5,120-token comparison was also flat: 10,217.99 → 10,220.58 tokens/s, a 0.025% change (501.08 → 500.95 ms). All 24 model processes passed, with bit-identical written KV outputs within each workload. The approximately 19.1% long-prompt and 15.6% one-shot baseline-to-combined gains were almost entirely from Pavle's logging/SHM settings and are not attributed to this patch.

Validation completed: native Release build (`CMAKE_BUILD_PARALLEL_LEVEL=48 ./build_metal.sh --enable-ccache --release`), clang-format 19.1.4, and changing-address/context references on all 32 chips with program-cache reuse. Minimum sampled PCC 0.999573. Eleven existing MSA cache/slot/dtype/causal-position regressions passed on a standalone build of this patch against main `e0efbeef`. Main, the selected shared-host build, and the shared-plus-MSA build all passed the 60-layer/10,240-token golden KV gate with identical per-layer scores. The isolated fixture used the default L1-small setting; full-model checks used MiniMax's 1,152-byte reservation.

Related to #50772. This reduces eager API overhead; it does not close the ticket's historical eager-versus-traced gap. No model code or other host-factory ports are included in this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/minimax-msa-packed-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/minimax-msa-packed-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/minimax-msa-packed-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/minimax-msa-packed-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/minimax-msa-packed-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/minimax-msa-packed-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/minimax-msa-packed-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/minimax-msa-packed-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/minimax-msa-packed-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/minimax-msa-packed-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/minimax-msa-packed-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/minimax-msa-packed-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/minimax-msa-packed-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/minimax-msa-packed-args)
