### PR TITLE
#51270: fix statically audited bugs in experimental quasar conv2d

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
@@ -167,11 +167,22 @@ static std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard
     // at (0,0)). Shift the activation shard grid onto that origin so the conv runs on the requested cores
     // — e.g. a 2-core sub-grid at logical y=1 on a small (emulated) device. For HEIGHT_SHARDED the output
     // parallel config == the input parallel config, so this offset propagates to the output shard (and
-    // thus the program factory's placement) automatically. No-op when core_grid is unset or starts at (0,0).
-    const CoreCoord core_grid_offset =
-        conv_config.core_grid.has_value() ? conv_config.core_grid.value().bounding_box().start_coord : CoreCoord{0, 0};
-    input_tensor_sharded_memory_config =
-        offset_sharded_mem_config_qsr(input_tensor_sharded_memory_config, core_grid_offset);
+    // thus the program factory's placement) automatically.
+    //
+    // Apply it ONLY on the path where the shared helper actually anchors at (0,0):
+    //   - Skip when override_sharding_config is set: get_conv_padded_input_shape_and_mem_config then builds
+    //     parallel_config directly from conv_config.core_grid (conv2d_utils.cpp), so the returned config is
+    //     ALREADY at the requested origin — offsetting again lands one grid-start too far (or off the device).
+    //   - Skip when !needs_shard_or_reshard: the helper returns the tensor's ACTUAL memory_config, so an
+    //     offset would describe a grid the input tensor is not on (no reshard is performed to move it).
+    // (#51270 item 1 — the offset was previously applied unconditionally, double-shifting both cases.)
+    if (needs_shard_or_reshard && !conv_config.override_sharding_config) {
+        const CoreCoord core_grid_offset = conv_config.core_grid.has_value()
+                                               ? conv_config.core_grid.value().bounding_box().start_coord
+                                               : CoreCoord{0, 0};
+        input_tensor_sharded_memory_config =
+            offset_sharded_mem_config_qsr(input_tensor_sharded_memory_config, core_grid_offset);
+    }
 
     ParallelConfig parallel_config = {
         .grid = input_tensor_sharded_memory_config.shard_spec().value().grid,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1055,6 +1055,16 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
         act_block_h_ntiles);
     uint32_t num_blocks_act_h_per_core = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
 
+    // 1D depthwise multi-height-block accumulation needs a DEDICATED read-back scratch. out_cb (the
+    // persistent borrowed sharded output) cannot double as the dest-reuse scratch when there is more
+    // than one height block: earlier blocks' finished tiles are never popped, so block N's read-back
+    // would consume block N-1's output. Mirrors the shared cb_info's depthwise_dest_reuse_scratch
+    // gate (conv2d_op_program_factory_common.cpp) and upstream conv2d_op_sharded_program_factory.cpp,
+    // and matches the compute kernel's use_partials_scratch CTA (issue #51270, items 4/5). Single
+    // height block keeps the in-place accumulate on out_cb.
+    const bool depthwise_uses_partials_scratch =
+        is_conv_1d_depthwise_conv && !coalesce_1d_depthwise_kw_reads && num_blocks_act_h_per_core > 1;
+
     // OPTION B — PROGRAM A (tilize-only, standalone). When TT_METAL_QSR_CONV_SPLIT_PROGRAM is set, this conv
     // op runs ONLY the gather+tilize half in a fresh tilize-oriented Metal program (conv_tilize_only_metal2.cpp)
     // and OUTPUTS the tilized activations — no matmul, no weights reader, no output writer. This isolates the
@@ -1528,10 +1538,14 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
     }
 
     // MATMUL_PARTIALS: self-loop accumulator (resolution #2).  Borrowed-from OUTPUT when
-    // partials_cb_uses_output.  1D depthwise allocates no partials CB (dest-reuse), so skip it there.
-    if (!is_conv_1d_depthwise_conv && !split_program_tilize_only) {
+    // partials_cb_uses_output.  1D depthwise normally accumulates in-place on out_cb (dest-reuse) and
+    // allocates no partials CB — EXCEPT the multi-height-block non-coalesced path, which needs a
+    // DEDICATED (never borrowed) scratch so block N doesn't read back block N-1's already-written
+    // output (#51270 item 4). The shared cb_info sizes MATMUL_PARTIALS to act_block_num_tiles for that
+    // case.
+    if ((!is_conv_1d_depthwise_conv && !split_program_tilize_only) || depthwise_uses_partials_scratch) {
         auto dfb = make_dfb(DFB_MATMUL_PARTIALS, Conv2dCb::MATMUL_PARTIALS);
-        if (partials_cb_uses_output) {
+        if (partials_cb_uses_output) {  // never true for depthwise -> depthwise scratch stays dedicated
             dfb.borrowed_from = TP_OUTPUT;
         }
         spec.dataflow_buffers.push_back(std::move(dfb));
@@ -1847,7 +1861,12 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
             // 2D writer CTA set (writer_tiled_out_2d_..._metal2).
             ctas.insert({"num_blocks_weight_h", num_blocks_act_w});
             ctas.insert({"weight_block_num_tiles", weight_block_num_tiles});
-            ctas.insert({"weight_block_height_num_outer", out_conv_c_blocks});
+            // Loop count = INPUT channel-block count (conv_act_c_blocks): the writer pushes one weights
+            // block per input channel-block that compute consumes (in0_num_blocks_w = conv_act_c_blocks *
+            // num_blocks_act_w). Using out_conv_c_blocks here under/over-pushes when the input and output
+            // shard grids differ in the channel dim -> compute's cb_in1.wait_front hangs (#51270 item 2).
+            // The tile-id stride keeps out_conv_c_blocks via weight_block_height_num_outer_in below.
+            ctas.insert({"weight_block_height_num_outer", conv_act_c_blocks});
             if (is_sender) {
                 ctas.insert({"weight_block_height_ntiles", weight_block_h_ntiles});
                 ctas.insert({"weight_block_width_ntiles", weight_block_w_ntiles});
@@ -1878,7 +1897,9 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
             ctas.insert({"num_blocks_weight_h", num_blocks_act_w});
             ctas.insert({"weight_block_num_tiles", weight_block_num_tiles});
             if (is_sender) {
-                ctas.insert({"weight_block_height_num_outer", out_conv_c_blocks});
+                // Loop count = input channel-block count (see the 2D branch above). Inert for non-block-
+                // sharded convs (both quantities are 1), fixed for consistency (#51270 item 2).
+                ctas.insert({"weight_block_height_num_outer", conv_act_c_blocks});
                 ctas.insert({"weight_block_height_ntiles", weight_block_h_ntiles});
                 ctas.insert({"weight_block_width_ntiles", weight_block_w_ntiles});
                 ctas.insert({"weight_stride_h", weight_matrix_width_ntiles});
@@ -2122,10 +2143,26 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
                 .endpoint_type = m2::DFBEndpointType::CONSUMER},
             m2::DFBBinding{
                 .dfb_spec_name = DFB_OUT, .accessor_name = "out", .endpoint_type = m2::DFBEndpointType::PRODUCER},
-            // OUT is also self-consumed (dest-reuse accumulate reads prior partial back from out_cb).
+            // OUT is also self-consumed: for a single height block the dest-reuse accumulate reads the
+            // prior partial back from out_cb (in-place). For the multi-height-block scratch path below,
+            // out_cb is only produced (last tap) and this consumer is degenerate (never popped) — the
+            // same shape the coalesced path uses.
             m2::DFBBinding{
                 .dfb_spec_name = DFB_OUT, .accessor_name = "out", .endpoint_type = m2::DFBEndpointType::CONSUMER},
         };
+        if (depthwise_uses_partials_scratch) {
+            // Dedicated read-back scratch for multi-height-block accumulation (producer + consumer
+            // self-loop). Earlier taps pack the partial here and read it back; only the last tap writes
+            // out_cb (#51270 item 4).
+            compute_dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = DFB_MATMUL_PARTIALS,
+                .accessor_name = "matmul_partials",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER});
+            compute_dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = DFB_MATMUL_PARTIALS,
+                .accessor_name = "matmul_partials",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        }
     } else {
         compute_dfb_bindings = {
             m2::DFBBinding{
@@ -2191,6 +2228,7 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
             {"in0_num_blocks_w", in0_num_blocks_w},
             {"kernel_width", filter_w},
             {"coalesce_kw_reads", (uint32_t)coalesce_1d_depthwise_kw_reads},
+            {"use_partials_scratch", (uint32_t)depthwise_uses_partials_scratch},
         };
     } else {
         compute_kernel_spec.compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -781,12 +781,20 @@ ttnn::device_operation::ProgramArtifacts Conv2dWidthShardedProgramFactory::creat
     spec.kernels.push_back(std::move(compute_kernel));
 
     // ---- Work units ----
-    // Compute + readers run on all_cores.  (Width-sharded uses one homogeneous topology; the weights
-    // reader is gated per-core by the is_active RTA rather than by node placement, mirroring legacy.)
+    // Placement must follow the legacy split, NOT the bounding box (#51270 item 3). On a non-rectangular
+    // width-sharded grid (e.g. 12 cores whose bbox is 16) the extra bbox nodes have no activation producer
+    // and no weights RTAs, so running compute/weights there hangs (compute blocks in wait_front) or fails
+    // to build (missing weights RTAs). Only the activation reader may cover the bbox — it early-returns on
+    // this_core_id >= num_mcast_cores. So: ACT on the bbox, WEIGHTS + COMPUTE on the real shard grid.
     spec.work_units.push_back(m2::WorkUnitSpec{
-        .name = "wu",
-        .kernels = {KERNEL_ACT, KERNEL_WEIGHTS, KERNEL_COMPUTE},
+        .name = "wu_act",
+        .kernels = {KERNEL_ACT},
         .target_nodes = all_reader_cores_set,
+    });
+    spec.work_units.push_back(m2::WorkUnitSpec{
+        .name = "wu_compute",
+        .kernels = {KERNEL_WEIGHTS, KERNEL_COMPUTE},
+        .target_nodes = all_cores,
     });
 
     // ============================================================================

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/compute_depthwise_conv1d_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/compute_depthwise_conv1d_metal2.cpp
@@ -22,24 +22,41 @@
 //
 // Per output tile:
 //   dst[0]  = in0 * in1                                                 (FPU mul)
-//   if idx > 0: dst[0] += prior partial loaded from out_cb              (FPU add via DST reuse)
-//   pack dst[0] -> out_cb
+//   if idx > 0: dst[0] += prior partial loaded from scratch_cb          (FPU add via DST reuse)
+//   pack dst[0] -> out_cb on the last tap, else scratch_cb
 //
-// `idx` is the kernel-tap block index (0 .. filter_h*filter_w-1). The very first call (idx == 0)
-// initializes out_cb with the tap-0 product; subsequent calls accumulate via the DST_TO_SRCB
-// dest-reuse pattern, which keeps the running partial in DST and only pulls the prior partial
-// from L1. This gives a single pack per output tile (to out_cb) and avoids the pack-format flips
-// that corrupt block-float (BFLOAT8_B/BFLOAT4_B) outputs in the round-tripped variant — while
-// still using FPU (not SFPU) for the add.
+// `idx` is the PER-HEIGHT-BLOCK kernel-tap index (0 .. num_taps-1, num_taps == filter_h*filter_w).
+// The very first tap (idx == 0) initializes the partial with the tap-0 product; subsequent taps
+// accumulate via the DST_TO_SRCB dest-reuse pattern, which keeps the running partial in DST and
+// only pulls the prior partial from L1. This gives a single pack per output tile and avoids the
+// pack-format flips that corrupt block-float (BFLOAT8_B/BFLOAT4_B) outputs in the round-tripped
+// variant — while still using FPU (not SFPU) for the add.
+//
+// The partial lives in scratch_cb; only the last tap (idx == num_taps-1) packs into out_cb. For a
+// single height block the host aliases scratch_cb == out_cb (in-place accumulate, no extra buffer).
+// For in0_num_blocks_h > 1 the host binds a DEDICATED scratch (MATMUL_PARTIALS): out_cb is the
+// persistent sharded output whose earlier height blocks are never popped, so it cannot double as
+// the read-back scratch — block N would otherwise read back block N-1's already-written output
+// (issue #51270, items 4/5).
 //
 // srcB (cfg92) tile descriptor: must match in1 for the mul, and is repopulated from DST for the
 // dest-reuse add. We force srcB back to in1's format every iteration so block-float weights are
 // decoded correctly.
 inline void mul_and_accumulate_block(
-    DataflowBuffer in0_cb, DataflowBuffer in1_cb, DataflowBuffer out_cb, uint32_t block_num_tiles, uint32_t idx) {
+    DataflowBuffer in0_cb,
+    DataflowBuffer in1_cb,
+    DataflowBuffer scratch_cb,
+    DataflowBuffer out_cb,
+    uint32_t block_num_tiles,
+    uint32_t idx,
+    uint32_t num_taps) {
     const uint32_t in0_cb_id = in0_cb.get_id();
     const uint32_t in1_cb_id = in1_cb.get_id();
-    const uint32_t out_cb_id = out_cb.get_id();
+    const uint32_t scratch_cb_id = scratch_cb.get_id();
+    // Last tap writes the finished output to out_cb; earlier taps write the partial to scratch_cb.
+    const bool is_last_tap = (idx + 1 == num_taps);
+    DataflowBuffer dst_cb = is_last_tap ? out_cb : scratch_cb;
+    const uint32_t dst_cb_id = dst_cb.get_id();
 
     for (uint32_t i = 0; i < block_num_tiles; i++) {
         in1_cb.wait_front(1);
@@ -52,24 +69,24 @@ inline void mul_and_accumulate_block(
         mul_tiles(in0_cb_id, in1_cb_id, 0, 0, 0);
 
         if (idx != 0) {
-            // dest-reuse add: dst[0] += out_cb. srcA gets out_cb (cfg52 must match out_cb fmt);
-            // srcB is filled from dst[0] by the dest-reuse path.
-            reconfig_data_format_srca(out_cb_id);
-            add_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(out_cb_id);
-            out_cb.wait_front(1);
-            add_reuse_dest_tiles<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-                out_cb_id, 0, 0);
-            out_cb.pop_front(1);
+            // dest-reuse add: dst[0] += scratch_cb (the prior tap's partial). srcA gets scratch_cb
+            // (cfg52 must match its format); srcB is filled from dst[0] by the dest-reuse path.
+            reconfig_data_format_srca(scratch_cb_id);
+            add_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(scratch_cb_id);
+            scratch_cb.wait_front(1);
+            add_reuse_dest_tiles<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(scratch_cb_id, 0, 0);
+            scratch_cb.pop_front(1);
 
             // Restore srcA to in0's format for the next iteration's mul unpack.
             reconfig_data_format_srca(in0_cb_id);
         }
         tile_regs_commit();
 
-        out_cb.reserve_back(1);
+        // scratch_cb and out_cb share the output data format, so packing to either needs no pack reconfig.
+        dst_cb.reserve_back(1);
         tile_regs_wait();
-        pack_tile(0, out_cb_id);
-        out_cb.push_back(1);
+        pack_tile(0, dst_cb_id);
+        dst_cb.push_back(1);
         tile_regs_release();
 
         in0_cb.pop_front(1);
@@ -132,6 +149,9 @@ void kernel_main() {
     constexpr uint32_t out_cb_id = dfb::out;
     constexpr uint32_t kernel_width = get_arg(args::kernel_width);
     constexpr bool coalesce_kw_reads = get_arg(args::coalesce_kw_reads) == 1;
+    // Multi-height-block non-coalesced accumulation uses a DEDICATED read-back scratch (MATMUL_PARTIALS)
+    // instead of aliasing out_cb; false for the single-block case, where scratch == out_cb (in-place).
+    constexpr bool use_partials_scratch = get_arg(args::use_partials_scratch) == 1;
 
     DataflowBuffer cb_tilized_in0(tilized_in0_cb_id);
     DataflowBuffer cb_in1(in1_cb_id);
@@ -153,9 +173,18 @@ void kernel_main() {
             if constexpr (coalesce_kw_reads) {
                 mul_and_accumulate_coalesced_block<in0_block_w, kernel_width, in0_block_num_tiles>(
                     cb_tilized_in0, cb_in1, cb_out);
+            } else if constexpr (use_partials_scratch) {
+                // Multi height block: accumulate kernel-tap in0_block_w_i of in0_num_blocks_w through a
+                // dedicated MATMUL_PARTIALS scratch, writing only the final tap to out_cb. idx is the
+                // PER-HEIGHT-BLOCK tap index (in0_block_w_i), so it restarts at 0 each height block.
+                DataflowBuffer cb_scratch(dfb::matmul_partials);
+                mul_and_accumulate_block(
+                    cb_tilized_in0, cb_in1, cb_scratch, cb_out, in0_block_num_tiles, in0_block_w_i, in0_num_blocks_w);
             } else {
-                const uint32_t idx = in0_block_h_i * in0_num_blocks_w + in0_block_w_i;
-                mul_and_accumulate_block(cb_tilized_in0, cb_in1, cb_out, in0_block_num_tiles, idx);
+                // Single height block: scratch == out_cb (in-place accumulate, no extra buffer). idx ==
+                // in0_block_w_i (in0_block_h_i is always 0 here).
+                mul_and_accumulate_block(
+                    cb_tilized_in0, cb_in1, cb_out, cb_out, in0_block_num_tiles, in0_block_w_i, in0_num_blocks_w);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/compute_depthwise_conv1d_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/compute_depthwise_conv1d_metal2.cpp
@@ -177,7 +177,12 @@ void kernel_main() {
                 // Multi height block: accumulate kernel-tap in0_block_w_i of in0_num_blocks_w through a
                 // dedicated MATMUL_PARTIALS scratch, writing only the final tap to out_cb. idx is the
                 // PER-HEIGHT-BLOCK tap index (in0_block_w_i), so it restarts at 0 each height block.
-                DataflowBuffer cb_scratch(dfb::matmul_partials);
+                //
+                // dfb::matmul_partials is emitted only when the host adds the matmul_partials binding
+                // (multi-block path). Resolve it via get_token_if_present<> so the single-block/coalesced
+                // kernel variants — where the token is absent — still name-lookup and compile: the
+                // deref is only ever reached (codegen'd) in this taken branch, which implies the binding.
+                DataflowBuffer cb_scratch(*dfb::get_token_if_present<"matmul_partials">());
                 mul_and_accumulate_block(
                     cb_tilized_in0, cb_in1, cb_scratch, cb_out, in0_block_num_tiles, in0_block_w_i, in0_num_blocks_w);
             } else {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_depthwise_conv1d.cpp
@@ -120,6 +120,8 @@ void kernel_main() {
         }
         reader_offset_idx = 0;
 
-        start_reader_idx = reader_idx;
+        // +1: advance past the last segment word to the next block's count word (the inline loop
+        // above stops on the last segment; the shared read_sticks() helper does this increment).
+        start_reader_idx = reader_idx + 1;
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_depthwise_conv1d_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_depthwise_conv1d_metal2.cpp
@@ -128,6 +128,8 @@ void kernel_main() {
         }
         reader_offset_idx = 0;
 
-        start_reader_idx = reader_idx;
+        // +1: advance past the last segment word to the next block's count word (the inline loop
+        // above stops on the last segment; the shared read_sticks() helper does this increment).
+        start_reader_idx = reader_idx + 1;
     }
 }


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #51270

Fixes the seven statically-audited defects in ttnn/experimental/quasar/conv2d from 
#51270. Three are independent host-side bugs: the activation shard-grid offset in  
conv2d.cpp was applied even when the shared helper had already anchored the grid at  
conv_config.core_grid (or when no reshard occurs), double-shifting placement onto 
wrong/out-of-range cores — now gated on needs_shard_or_reshard &&  
!override_sharding_config; the block-sharded weights-writer loop count 
weight_block_height_num_outer used the output channel-block count instead of the 
input's (conv_act_c_blocks), hanging compute when input/output shard grids differ in  
the channel dim; and the width-sharded factory placed the compute and weights kernels
on the bounding box of a non-rectangular shard grid, so the extra cores hung or  
lacked runtime args — now split so only the (early-returning) activation reader 
covers the bbox while weights+compute run on the real grid. The remaining four are 
one story in the multi-height-block depthwise-conv1d path: two off-by-one 
start_reader_idx bugs in the readers (metal2 and legacy) made every height block 
after the first re-read the previous block's activations; the compute kernel used a 
global block counter instead of the per-height-block tap index so the accumulator 
never re-initialized; and it aliased the dest-reuse read-back scratch onto the 
persistent output CB, so block N read back block N-1's finished output. The reader 
fixes add the missing +1, and the compute path is reworked to accumulate through a 
dedicated MATMUL_PARTIALS scratch (allocated/bound only for the multi-block 
non-coalesced case, in-place on out_cb otherwise) with the per-height-block tap 
index, mirroring the upstream conv2d fix.


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-51270_qsr_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-51270_qsr_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-51270_qsr_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-51270_qsr_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-51270_qsr_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-51270_qsr_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-51270_qsr_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-51270_qsr_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-51270_qsr_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-51270_qsr_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-51270_qsr_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-51270_qsr_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-51270_qsr_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-51270_qsr_conv)