### PR TITLE
Bug fix: propagate the sqrt_custom non-finite guard to Quasar

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
@@ -15,7 +15,9 @@ template <bool APPROXIMATION_MODE>
 sfpi_inline sfpi::vFloat sfpu_sqrt_custom(sfpi::vFloat in) {
     sfpi::vFloat val = in;
     sfpi::vFloat out = val;
-    v_if(val != 0.0f) {
+    // Exclude non-finite: the +inf seed squares to a denormal, SFPMAD flushes it to +0, and
+    // 0 * -inf = NaN. Same guard as Wormhole and Blackhole, see #53757.
+    v_if(val != 0.0f && sfpi::exexp(val, sfpi::ExponentMode::Biased) != 255) {
         // Fast inverse square-root seed + two Newton-Raphson refinements.
         sfpi::vUInt magic = sfpi::as<sfpi::vUInt>(sfpi::vFloat(sfpi::sFloat16b(0x5f37)));
         sfpi::vFloat approx = sfpi::as<sfpi::vFloat>(magic - (sfpi::as<sfpi::vUInt>(val) >> 1));


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

#53757 fixed `sqrt_custom(+inf)` on Wormhole and Blackhole and left Quasar on the pre-fix kernel, which its own summary table records as `Quasar | unchanged`. This applies the same guard there so the three architectures agree.

Without it the `+inf` seed (~5.2e-20) squares to a denormal, SFPMAD flushes that to `+0`, and `0 * -inf` is NaN, so `sqrt_custom(+inf)` returns NaN and consumers inherit it. That is how the original defect surfaced, through `erfinv(±1)`.

The guard is copied verbatim from the Blackhole kernel, which is otherwise line-for-line identical to the Quasar one:

```cpp
v_if(val != 0.0f && sfpi::exexp(val, sfpi::ExponentMode::Biased) != 255) {
```

### Notes for reviewers

No behaviour change on Wormhole or Blackhole; this touches the Quasar kernel only.

The `-inf` residual is carried over deliberately rather than fixed here, matching the other two architectures: `-inf` passes through where IEEE gives NaN, because a negative-to-NaN guard would break `erfinv` on small in-domain inputs.
