### PR TITLE
Bug fix: give the full golden the same argument handling as zeros and ones

### DIFF
--- a/ttnn/ttnn/operations/creation.py
+++ b/ttnn/ttnn/operations/creation.py
@@ -69,10 +69,15 @@ def _golden_function(shape: ttnn.Shape, dtype=None, *_, **__):
 ttnn.attach_golden_function(ttnn.ones, golden_function=_golden_function)
 
 
-def _golden_function_full(input_shape: ttnn.Shape, fill_value: float, **_):
+def _golden_function_full(shape: ttnn.Shape, fill_value: float, dtype=None, *_, **__):
     import torch
 
-    return torch.full(input_shape, fill_value=fill_value)
+    # Same handling as the zeros and ones goldens above: TTNN accepts Shape directly and permits
+    # dtype, layout, device and memory config positionally, and defaults dtype to BFLOAT16.
+    if isinstance(shape, ttnn.Shape):
+        shape = tuple(shape)
+    torch_dtype = ttnn.ttnn_dtype_to_torch_dtype(dtype) if dtype is not None else torch.bfloat16
+    return torch.full(shape, fill_value=fill_value, dtype=torch_dtype)
 
 
 ttnn.attach_golden_function(ttnn.full, golden_function=_golden_function_full)


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

#53789 gave the `zeros` and `ones` goldens shape normalization, dtype handling and `*_` to absorb the allocation-only arguments. `full` sits between them in the same file and was not updated, so it still raises on the calls its own tests make.

Four failures against the current golden, all with callers in tree:

| call | caller | current |
|---|---|---|
| `full(shape, 7.0, bfloat16, TILE_LAYOUT, device, L1_MEMORY_CONFIG)` | `test_backward_fill.py:98`, `test_backward_pow.py:265`, `:324` | `TypeError: takes 2 positional arguments but 6 were given` |
| `full(shape=..., ...)` | `test_tensor_creation_examples.py:56`, `ops_for_profiling.py:1221` | `TypeError: missing 1 required positional argument: 'input_shape'` |
| a `ttnn.Shape` as the shape | `ops_for_profiling.py:1221` | `TypeError: full(): argument 'size' must be tuple of ints, not Shape` |
| `dtype=...` | `test_full.py:85`, `full_model_traced.py:228` | ignored; an int fill gives int64 and a float fill float32 |

The parameter is named `input_shape` while the binding calls it `shape` (`creation_nanobind.cpp:105`), which is what breaks the keyword callers.

The fix mirrors the two goldens directly above it, and defaults dtype to bfloat16 to match `dtype.value_or(DataType::BFLOAT16)` at `creation.cpp:176`.

### Notes for reviewers

Verified on an N150 by calling the golden with each of the four shapes above: all four raise before this change and pass after, and `zeros`/`ones` already pass the identical call. dtype propagates for BFLOAT16, FLOAT32, INT32 and UINT32.
