### PR TITLE
Avoid deprecated all_gather arguments in offset_cumsum

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.cpp
@@ -14,29 +14,18 @@ namespace ttnn::operations::experimental::deepseek_prefill::offset_cumsum {
 std::array<ttnn::Tensor, 3> offset_cumsum(
     const ttnn::Tensor& input_tensor,
     uint32_t cluster_axis,
-    uint32_t num_links,
+    uint32_t /*num_links*/,
     uint32_t experts_per_chip,
     const ttnn::MemoryConfig& memory_config,
-    bool use_l1_small_for_semaphores) {
+    bool /*use_l1_small_for_semaphores*/) {
     const auto& shape = input_tensor.logical_shape();
     uint32_t n_routed_experts = shape[-1];
 
     auto reshaped = ttnn::reshape(input_tensor, ttnn::Shape({1, n_routed_experts}));
 
-    auto gathered = ttnn::all_gather(
-        reshaped,
-        /*dim=*/0,
-        /*cluster_axis=*/cluster_axis,
-        /*memory_config=*/memory_config,
-        /*persistent_output_tensor=*/std::nullopt,
-        /*subdevice_id=*/std::nullopt,
-        /*sub_core_grid=*/std::nullopt,
-        /*num_links=*/num_links,
-        /*topology=*/std::nullopt,
-        /*chunks_per_sync=*/std::nullopt,
-        /*num_workers_per_link=*/std::nullopt,
-        /*num_buffers_per_channel=*/std::nullopt,
-        /*use_l1_small_for_semaphores=*/use_l1_small_for_semaphores);
+    // all_gather no longer consumes the legacy link/semaphore options. Keep them
+    // in offset_cumsum's API for compatibility, without a warning on every call.
+    auto gathered = ttnn::all_gather(reshaped, /*dim=*/0, /*cluster_axis=*/cluster_axis, memory_config);
 
     auto row_major = ttnn::to_layout(gathered, tt::tt_metal::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.hpp
@@ -11,10 +11,8 @@
 
 namespace ttnn::operations::experimental::deepseek_prefill::offset_cumsum {
 
-// `use_l1_small_for_semaphores`: route the internal cross-device all-gather's global semaphores to the
-// L1_SMALL region instead of main L1. The all-gather creates its sync semaphores internally and keeps
-// them resident; in main L1 they pin the L1 floor and clash with the next layer's MLA static CBs. Routing
-// them to L1_SMALL keeps them off the main-L1 floor. Requires the device opened with l1_small_size > 0.
+// `num_links` and `use_l1_small_for_semaphores` are retained for API compatibility.
+// The current internal all_gather implementation ignores these legacy options.
 std::array<ttnn::Tensor, 3> offset_cumsum(
     const ttnn::Tensor& input_tensor,
     uint32_t cluster_axis,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.cpp
@@ -38,12 +38,11 @@ void bind_experimental_offset_cumsum_operation(nb::module_& mod) {
             Args:
                 * :attr:`input_tensor`: 1D UINT32 tensor of expert counts [n_routed_experts].
                 * :attr:`cluster_axis`: Axis along which to all_gather across devices.
-                * :attr:`num_links`: Number of links for all_gather.
+                * :attr:`num_links`: Retained for compatibility; the internal all_gather ignores it.
                 * :attr:`experts_per_chip`: Number of experts per chip (for expert region grouping).
                 * :attr:`memory_config`: Memory configuration for intermediate and output tensors.
-                * :attr:`use_l1_small_for_semaphores`: If True, route the internal all_gather's
-                  global semaphores to the reserved L1_SMALL region instead of the main L1 floor.
-                  Defaults to False.
+                * :attr:`use_l1_small_for_semaphores`: Retained for compatibility; the internal
+                  all_gather ignores it. Defaults to False.
 
         )doc",
         &offset_cumsum,


### PR DESCRIPTION
`offset_cumsum` forwards legacy link and semaphore options to `all_gather`, which already ignores them and emits a deprecation warning. MiniMax M3 invokes this wrapper 57 times per prefill chunk, producing repeated warnings even with `LOGURU_LEVEL=ERROR` because the C++ logger is separate.

Call the current `all_gather` interface without those ignored options. Preserve `offset_cumsum`'s public parameters for compatibility and correct their stale documentation. This changes neither the collective algorithm nor its current semaphore placement.

Validation on a Blackhole Galaxy 8×4:

- Standalone native Release build against main `e0efbeef`: `CMAKE_BUILD_PARALLEL_LEVEL=48 ./build_metal.sh --enable-ccache --release`; clang-format 19.1.4 passed.
- Three fresh processes per arm passed exact UINT32 results on all 32 chips, both cluster axes, independent histograms/changing buffer addresses, program-cache reuse, both legacy option combinations, and trace replay after zeroing captured outputs and running a fresh invocation.
- Standalone timings were mixed: queued median 0.199203 → 0.190667 ms per call (4.29% lower), API return 1.93% lower, synchronized call 7.87% higher. No process was excluded. This is a warning/API cleanup, with no claim of a consistent standalone speedup.

A separate experiment stacking this cleanup on Pavle's routing program grouping reduced isolated queued time another 12.36%; that grouping is not included in this PR and is not attributed to this change. A separate full 60-layer, 5,120-token comparison (three fresh processes per arm, ten iterations each) was effectively flat: control 10,223.52, grouping 10,221.02, grouping plus cleanup 10,224.62 tokens/s. All nine runs passed with matching inputs/weight inventory and bit-identical written KV hashes. This cleanup changed throughput by +0.035% against grouping; that is not a meaningful model speedup. A model-log audit confirmed 57 internal deprecation warnings per chunk became zero.

Related to #50772. The three-file diff contains no MSA changes, model changes, or Pavle factory ports.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/offset-cumsum-gather-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/offset-cumsum-gather-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/offset-cumsum-gather-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/offset-cumsum-gather-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/offset-cumsum-gather-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/offset-cumsum-gather-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/offset-cumsum-gather-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/offset-cumsum-gather-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/offset-cumsum-gather-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/offset-cumsum-gather-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/offset-cumsum-gather-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/offset-cumsum-gather-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/offset-cumsum-gather-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/offset-cumsum-gather-args)