### PR TITLE
[Bug fix] Fixing llk_pack_dummy

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
@@ -110,9 +110,10 @@ inline void llk_pack(
  * preserved for a later real pack. The strided-pack config is restored to pass-through afterwards so a
  * subsequent pack-untilize (also PACR_STRIDE) is unaffected.
  *
- * With the store suppressed the buffer descriptor is never read, so PACR_STRIDE's descriptor operand is a
- * literal 0 (a 5-bit index into the 32-entry bd_table, not a table select). This primitive needs no pack
- * init and touches neither the BFD allocator nor the DFB.
+ * Suppressing the store does not suppress the descriptor fetch: PACR_STRIDE still reads the bd_table entry
+ * it names and validates its tile size. The entry must therefore be programmed, so this primitive requires
+ * pack init (llk_pack_init, which compute_kernel_hw_startup calls) to have run on this thread; it reads the
+ * allocator's current pack-partition id rather than allocating one, and does not touch the DFB.
  *
  * @param pack_output  The output dataflow buffer whose WAIT/PUSH this orders; not used to address L1.
  */
@@ -122,9 +123,10 @@ inline void llk_pack_dummy(const std::uint32_t pack_output) {
     cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_ROW_MASK_RMW, 0xF);
 
     // Absolute src/dst index 0, no increment, Packer0, ClrDatValid=0 (must not clear DEST valids). Arg 6 is
-    // a 5-bit index into the 32-entry bd_table; a literal 0 is safe only because NO_WRITE suppresses the
-    // store so the descriptor is never read (0 otherwise falls in the unpack partition [0,16), not pack's).
-    TTI_PACR_STRIDE(0, 0, 0, 0, 0, 0 /*bd_table index*/, 0 /*Packer0*/, 0 /*ClrDatValid*/);
+    // a 5-bit index into the 32-entry bd_table. NO_WRITE suppresses the store but NOT the descriptor
+    // fetch: the entry is still read and its tile size validated, so it must be programmed. Use this
+    // thread's own pack-partition entry (llk_pack_init, via compute_kernel_hw_startup).
+    TT_PACR_STRIDE(0, 0, 0, 0, 0, ckernel::trisc::bfd_current<pack_bfd_resource>(), 0 /*Packer0*/, 0 /*ClrDatValid*/);
 
     // Restore pass-through so a later real pack-untilize (PACR_STRIDE) is unaffected.
     cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_NO_WRITE_RMW, 0);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`llk_pack_dummy` does not store or change dfb, but it does still validate the fields. Currently, it points to `bd_table` index = 0, which is actually an unpack index, and in some cases this results in an invalid format/tile size being checked. This update points to th thread's own pack-partition entry instead.

Error found & fix tested by running all DFB unit tests. Several failed, some non-deterministically, before this change. All DFB unit tests pass after making this change. DFB unit test updates will be submitted in a separate PR.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/llk_pack_dummy_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/llk_pack_dummy_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/llk_pack_dummy_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/llk_pack_dummy_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/llk_pack_dummy_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/llk_pack_dummy_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/llk_pack_dummy_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/llk_pack_dummy_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/llk_pack_dummy_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/llk_pack_dummy_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/llk_pack_dummy_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/llk_pack_dummy_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/llk_pack_dummy_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/llk_pack_dummy_fix)