### PR TITLE
Bug fix: saturate positive float-to-int32 overflow to INT32_MAX

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -210,6 +210,18 @@ inline void calculate_typecast_fp32_to_int32() {
         // LaneEnabled = true
         TTI_SFPENCC(0, 0, 0, 0);
 
+        // A positive input cannot legitimately produce a negative int32, so the only lanes this
+        // matches are the positive overflows that the INT_MIN constant above saturated the wrong
+        // way: the same constant serves both signs and the negate only fires for in < 0.
+        // Decrementing wraps INT_MIN to INT_MAX.
+        // LaneEnabled = in >= 0
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_GTE0);
+        // LaneEnabled &= result < 0
+        TTI_SFPSETCC(0, p_sfpu::LREG1, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
+        // result -= 1
+        TTI_SFPIADD(-1 & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+        // LaneEnabled = true
+        TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -223,6 +223,18 @@ inline void calculate_typecast_fp32_to_int32() {
         // LaneEnabled = true
         TTI_SFPENCC(0, 0, 0, 0);
 
+        // A positive input cannot legitimately produce a negative int32, so the only lanes this
+        // matches are the positive overflows that the INT_MIN constant above saturated the wrong
+        // way: the same constant serves both signs and the negate only fires for in < 0.
+        // Decrementing wraps INT_MIN to INT_MAX.
+        // LaneEnabled = in >= 0
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_GTE0);
+        // LaneEnabled &= result < 0
+        TTI_SFPSETCC(0, p_sfpu::LREG1, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
+        // result -= 1
+        TTI_SFPIADD(-1 & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+        // LaneEnabled = true
+        TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_2, 0);
     }
 }


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #55933. `ttnn.typecast(t, ttnn.int32)` returned `INT32_MIN` for every float at or above `2^31`, inverting the sign on the largest positive values instead of saturating.

`calculate_typecast_fp32_to_int32` keeps one saturation constant for both signs. It loads `INT_MIN`, narrows the lane mask to `exp < 31` so overflow lanes keep that constant, then negates only where `in < 0`. Since `-INT_MIN == INT_MIN`, positive overflow ends up at `INT32_MIN`.

A positive input cannot legitimately produce a negative int32, so the lanes where `in >= 0` and the result is negative are exactly the mis-saturated ones. Decrementing them wraps `INT_MIN` to `INT_MAX`. Four instructions, applied to both architectures.

### Notes for reviewers

Measured on a Blackhole p150b and a Wormhole n150, both at `502793db992`:

| input | before | after | torch |
|---|---|---|---|
| `2^31`, `3e9`, `1e38`, `+inf` | `-2147483648` | `2147483647` | saturates positive |
| `-2^31`, `-3e9`, `-1e38`, `-inf` | `-2147483648` | `-2147483648` | unchanged |
| in-range | unchanged | unchanged | matches |

Regression sweep of 875 values per card (powers of two either side of the boundary, randoms, subnormals, signed zeros, `2^31 - 129`): **0 mismatches on both cards**, and the in-range and negative paths are byte-identical to before.

Cost on Blackhole, 4M elements, median of nine after a reset: 417.8 us before, 421.8 us after, **1.010x**.

One behaviour change worth calling out: NaN went from `INT32_MIN` to `INT32_MAX`. Both differ from torch, which gives `0`, so this does not fix or worsen the NaN case the issue also mentions. `SFPSETCC` is unspecified for NaN, so pinning it would need an explicit exponent test; happy to add that here or leave it for the separate NaN discussion.
