### PR TITLE
Bug fix: forward the diagonal argument to the tril and triu goldens

### DIFF
--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -360,6 +360,26 @@ def _golden_function_softplus(input_tensor, *args, beta=1.0, threshold=20.0, **k
 ttnn.attach_golden_function(ttnn.softplus, golden_function=_golden_function_softplus)
 
 
+def _golden_function_tril(input_tensor, *args, diagonal=0, **kwargs):
+    import torch
+
+    # The generic unary wrapper drops parameters, and diagonal is keyword-only on the binding.
+    return torch.tril(input_tensor, diagonal)
+
+
+ttnn.attach_golden_function(ttnn.tril, golden_function=_golden_function_tril)
+
+
+def _golden_function_triu(input_tensor, *args, diagonal=0, **kwargs):
+    import torch
+
+    # Same as tril above: forward the diagonal the generic wrapper discards.
+    return torch.triu(input_tensor, diagonal)
+
+
+ttnn.attach_golden_function(ttnn.triu, golden_function=_golden_function_triu)
+
+
 def _preprocess_inverse_trig_golden_inputs(function_args, function_kwargs):
     """Preserve block-float input identity for inverse-trigonometric goldens.
     Adds a BF8 flag used to select out-of-domain comparison behavior.


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`ttnn.tril` and `ttnn.triu` take `diagonal` as a keyword-only argument (`unary_nanobind.cpp:2063,2077` via `bind_unary_composite_int_with_default`, which emits `nb::kw_only()` before it). The generic unary golden forwards only positional arguments:

```python
return torch_function(input_tensor, *args)
```

so `diagonal` lands in `**_` and is dropped. The golden computes the main diagonal while the device uses the requested one, so comparison mode reports a mismatch on output that is correct.

Measured on a Blackhole p150b and a Wormhole n150: for `diagonal` of 2, -1 and 5, the device matches torch on every case and the golden matches on none. Only `diagonal=0` agrees.

The fix mirrors `_golden_function_softplus` a few lines above, added by #53789 with the same rationale, "The generic unary wrapper drops parameters".

### Notes for reviewers

`tril` and `triu` are the only two ops affected. They are the sole entries in the 64-entry `name_to_golden_function` map bound through a template that takes a user-facing parameter (`multigammaln` uses `bind_unary_composite_2param` but passes no parameter name).

Their map entries stay, because the `golden_keys != function_names` check requires them; `cosh`, `gelu`, `sinh`, `softplus` and `tanh` are already shadowed the same way.

Verifiable without a device: `ttnn.get_golden_function(ttnn.tril)(t, diagonal=2)` returns `torch.tril(t, 0)` before and `torch.tril(t, 2)` after.
