### PR TITLE
Bug fix: accept LossReductionMode in the l1_loss and mse_loss goldens

### DIFF
--- a/ttnn/ttnn/operations/losses.py
+++ b/ttnn/ttnn/operations/losses.py
@@ -9,20 +9,30 @@ __all__ = []
 LossReductionMode = ttnn._ttnn.operations.loss.LossReductionMode
 
 
-def _golden_function_l1_loss(ref_tensor: ttnn.Tensor, pred_tensor: ttnn.Tensor, *args, reduction="none", **kwargs):
+def _torch_reduction(reduction):
+    # The binding defaults reduction to LossReductionMode, while torch takes the lowercase name.
+    # Strings stay accepted so existing callers keep working.
+    return reduction.name.lower() if isinstance(reduction, LossReductionMode) else reduction
+
+
+def _golden_function_l1_loss(
+    input_reference: ttnn.Tensor, input_prediction: ttnn.Tensor, *args, reduction=LossReductionMode.NONE, **kwargs
+):
     import torch
 
-    output_tensor = torch.nn.L1Loss(reduction=reduction)(ref_tensor, pred_tensor)
+    output_tensor = torch.nn.L1Loss(reduction=_torch_reduction(reduction))(input_reference, input_prediction)
     return output_tensor
 
 
 ttnn.attach_golden_function(ttnn.l1_loss, golden_function=_golden_function_l1_loss)
 
 
-def _golden_function_mse_loss(ref_tensor: ttnn.Tensor, pred_tensor: ttnn.Tensor, *args, reduction="none", **kwargs):
+def _golden_function_mse_loss(
+    input_reference: ttnn.Tensor, input_prediction: ttnn.Tensor, *args, reduction=LossReductionMode.NONE, **kwargs
+):
     import torch
 
-    output_tensor = torch.nn.MSELoss(reduction=reduction)(ref_tensor, pred_tensor)
+    output_tensor = torch.nn.MSELoss(reduction=_torch_reduction(reduction))(input_reference, input_prediction)
     return output_tensor
 
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`ttnn.l1_loss` and `ttnn.mse_loss` take `reduction` as a `LossReductionMode` and default it to `LossReductionMode::NONE` (`loss_nanobind.cpp:51,81`). Their goldens take a torch string, so passing the op's own enum raises:

```
ValueError: LossReductionMode.MEAN is not a valid value for reduction
```

Comparison mode catches that and logs "Local comparison will be skipped", so validation is silently disabled rather than failing loudly. Measured on a Blackhole p150b and a Wormhole n150: all six combinations of the two ops and the three modes raise before this change and pass after.

Two places in the tree already work around it by carrying a parallel string next to the enum, purely to feed the golden:

- `tests/ttnn/nightly/unit_tests/operations/eltwise/test_losses.py:26-31` parametrizes `["none", ttnn.LossReductionMode.NONE]` pairs and hands index 0 to the golden and index 1 to the op
- `tests/sweep_framework/sweeps/losses/l1_loss.py:71-79` keeps `reduction_0` and `reduction_1` side by side

Strings are still accepted, so those callers keep working and can be simplified separately.

### Notes for reviewers

The parameters are also renamed to `input_reference` and `input_prediction` to match the binding. Nothing calls them by their old names: `grep -rn "ref_tensor=\|pred_tensor=" --include=*.py .` returns zero hits.

The device op itself is correct; `loss.cpp` maps the enum properly. This is a golden-side fix only.

Verifiable without a device: `ttnn.get_golden_function(ttnn.l1_loss)(a, b, reduction=ttnn.LossReductionMode.MEAN)` raises today and returns the scalar mean after.
