### PR TITLE
Bug fix: name the operation ordering dunder __lt__ so sorting is ascending

### DIFF
--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -1000,7 +1000,7 @@ class FastOperation:
             self._slow_operation.__post_init__()
         return self._slow_operation
 
-    def __gt__(self, other):
+    def __lt__(self, other):
         return self.python_fully_qualified_name < other.python_fully_qualified_name
 
     def __hash__(self):
@@ -1194,7 +1194,7 @@ class Operation:
     def __name__(self):
         return self.python_fully_qualified_name
 
-    def __gt__(self, other):
+    def __lt__(self, other):
         return self.python_fully_qualified_name < other.python_fully_qualified_name
 
     def __hash__(self):


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`FastOperation` and `Operation` both define `__gt__` with a less-than body (`decorators.py:1003`, `:1197`):

```python
def __gt__(self, other):
    return self.python_fully_qualified_name < other.python_fully_qualified_name
```

Neither dataclass sets `order=True`, so no `__lt__` exists. `sorted()` evaluates `a < b`, gets `NotImplemented`, and falls back to the reflected `b.__gt__(a)`, which returns `b.name < a.name`. The result is that sorting reverses and `>` answers backwards.

Measured on a Blackhole p150b and a Wormhole n150, `ttnn.query_registered_operations()`:

| | before | after |
|---|---|---|
| first five | `zeros_like, zeros, xlogy_bw, xlogy, xielu` | `abs, abs_bw, acos, acos_bw, acosh` |
| ascending | False | True |
| `ttnn.abs > ttnn.zeros_like` | `True` | `False` |

Naming the method `__lt__` gives both classes the comparison they were reaching for, with the body unchanged.

### Notes for reviewers

`ttnn.query_registered_operations()` is the only order-visible consumer. `dump_operations` re-sorts through pandas and `scripts/detect_undocumented_ttnn_ops.py` collects into a set, so neither observes the current reversed order and neither changes behaviour here.

No test asserts the ordering, so nothing depends on the reversed result.
