### PR TITLE
fix(softmax): reject sharded subblock_w above the Dest tile capacity

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -906,3 +906,36 @@ def test_softmax_large_kernel_mask_padded(device, shape, dim):
         ulp_threshold=15,
         check_ulp=True,
     )
+
+@pytest.mark.parametrize("subblock_w, should_pass", [(4, True), (16, False)])
+def test_softmax_sharded_subblock_w_capacity_guard(device, subblock_w, should_pass):
+    """
+    The sharded compute kernel keeps subblock_w tiles live in Dest simultaneously.
+    Dest holds 8 tiles by default (fp32_dest_acc_en=False).
+    • subblock_w=4:  16 % 4 == 0, 4 ≤ 8 → validation passes.
+    • subblock_w=16: 16 % 16 == 0, 16 > 8 → the new TT_FATAL fires.
+    """
+    shape = (1, 16, 256, 512)
+    input_t = torch.randn(shape, dtype=torch.bfloat16) * 0.1
+    program_config = ttnn.SoftmaxShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=(8, 8),
+        subblock_w=subblock_w,
+        block_h=2,
+        block_w=16,
+    )
+    mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
+        shard_spec=ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
+            [64, 512],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+    input_tensor = ttnn.from_torch(input_t, device=device, layout=ttnn.Layout.TILE, memory_config=mem_config)
+    if should_pass:
+        out = ttnn.softmax_in_place(input_tensor, program_config=program_config)
+        assert out is not None
+    else:
+        with pytest.raises(Exception, match="subblock_w"):
+            ttnn.softmax_in_place(input_tensor, program_config=program_config)

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -184,6 +184,17 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
             tensors_args.input_tensor.dtype() == DataType::BFLOAT8_B,
         "Input tensor must be FLOAT32, BFLOAT16, or BFLOAT8_B, got: {}",
         tensors_args.input_tensor.dtype());
+
+    // subblock_w == 0 reaches `block_w % subblock_w` in the mask branch below and `block_w / subblock_w`
+    // in the program factory, so reject it here, ahead of every divisibility check in both branches.
+    std::visit(
+        [](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<ProgramConfigType, SoftmaxShardedMultiCoreProgramConfig>) {
+                TT_FATAL(program_config.subblock_w > 0, "subblock_w must be greater than 0.");
+            }
+        },
+        attributes.program_config);
     if (tensors_args.mask.has_value()) {
         const auto& mask = tensors_args.mask.value();
         TT_FATAL(mask.storage_type() == StorageType::DEVICE, "Operands to softmax need to be on device!");
@@ -326,6 +337,22 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                     shard_shape[0],
                     shard_shape[1],
                     tensors_args.input_tensor.tensor_spec().tile().get_width());
+
+                // The sharded compute kernel keeps subblock_w tiles live in Dest at once, so a subblock_w above
+                // the Dest capacity runs to completion and silently returns wrong numbers. The capacity is 8
+                // tiles by default, 4 with fp32_dest_acc_en, and 16 with dst_full_sync_en; get_dest_reg_count
+                // reads it from the compute config rather than assuming the default.
+                const uint32_t dest_capacity = ttnn::get_dest_reg_count(
+                    attributes.compute_kernel_config,
+                    tensors_args.input_tensor.tensor_spec().tile().get_tile_shape());
+                TT_FATAL(
+                    program_config.subblock_w <= dest_capacity,
+                    "subblock_w ({}) must be at most the Dest capacity of {} tiles for this compute config "
+                    "(fp32_dest_acc_en={}, dst_full_sync_en={}).",
+                    program_config.subblock_w,
+                    dest_capacity,
+                    attributes.compute_kernel_config.fp32_dest_acc_en,
+                    attributes.compute_kernel_config.dst_full_sync_en);
 
                 const auto& a = tensors_args.input_tensor;
                 if (a.is_sharded()) {


### PR DESCRIPTION
Fixes #52040

## Summary
Sharded softmax today only validates `block_w % subblock_w == 0`. A `subblock_w` that passes
that check but is larger than the number of Dest registers the sharded compute kernel keeps
tiles live in **runs to completion and silently returns wrong numbers** — rows summing to ~47
instead of 1 in the issue's `(1,1,36864,384)` repro — with no error, no warning, no log line.

## Fix
Two guards in `SoftmaxDeviceOperation::validate_on_program_cache_miss` (both for the
`SoftmaxShardedMultiCoreProgramConfig` branch):
1. **`subblock_w > 0`** — a zero `subblock_w` would reach `block_w % subblock_w` in the mask
   branch and `block_w / subblock_w` in the program factory; reject it ahead of both.
2. **`subblock_w <= ttnn::get_dest_reg_count(compute_kernel_config, tile_shape)`** — the real
   bound. Dest holds 8 tiles by default, 4 with `fp32_dest_acc_en`, and 16 with `dst_full_sync_en`,
   so a fixed constant (8) is wrong under those configs; `get_dest_reg_count` reads the capacity
   from the compute config.

## Test
`test_softmax.py::test_softmax_sharded_subblock_w_capacity_guard` asserts a within-capacity
`subblock_w` is accepted and an over-capacity one is rejected with the new diagnostic.

## Bounty
Issue #52040 — $1,500.
Payout (Base USDC): `0xDeB7a2C40E4BAe45f2427d5AF410C56F2AC5E4DC`
