### PR TITLE
Bug fix: match the topk golden defaults to the binding

### DIFF
--- a/ttnn/ttnn/operations/reduction.py
+++ b/ttnn/ttnn/operations/reduction.py
@@ -27,7 +27,7 @@ def _create_golden_function(torch_function_name):
 
 
 def _create_golden_function_topk():
-    def golden_function(input_tensor: ttnn.Tensor, k: int, dim: Optional[int] = None, largest=True, sorted=True, **_):
+    def golden_function(input_tensor: ttnn.Tensor, k: int = 32, dim: int = -1, largest=True, sorted=True, **_):
         import torch
 
         return torch.topk(input_tensor, k, dim=dim, largest=largest, sorted=sorted)


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

The `ttnn.topk` golden defaults `dim` to `None`, while the binding defaults it to `-1` (`topk_nanobind.cpp:111`). Calling the op the documented way, without `dim`, hands the golden a `None` that torch rejects:

```
TypeError: topk(): argument 'dim' must be int, not NoneType
```

Comparison mode catches that and logs "Local comparison will be skipped", so the default call path is never validated.

The golden's `k` had no default either, where the binding defaults it to `32` (`topk_nanobind.cpp:110`). Both defaults now match the binding.

Measured on a Blackhole p150b and a Wormhole n150: `ttnn.get_golden_function(ttnn.topk)(x, k=8)` raises before this change and returns the expected shape after. Passing `dim` explicitly worked before and still does.

### Notes for reviewers

Distinct from #55212, which was the missing `import torch` in the same closure and is already fixed. This is the parameter defaults, and the golden raises a `TypeError` rather than that issue's `NameError`.

Verifiable without a device: call the golden with only a tensor and `k`.
