### PR TITLE
Bug fix: drop the removed Grayskull check from the trunc sweep fixtures

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary/trunc/trunc.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/trunc/trunc.py
@@ -38,8 +38,8 @@ parameters = {
 
 def mesh_device_fixture():
     device = ttnn.open_device(device_id=0)
-    assert not ttnn.device.grayskull(device), "This op is not supported on Grayskull"
-    yield (device, "Wormhole_B0")
+    device_name = ttnn.get_arch_name()
+    yield (device, device_name)
     ttnn.close_device(device)
     del device
 

--- a/tests/sweep_framework/sweeps/eltwise/unary/trunc/trunc_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/trunc/trunc_sharded.py
@@ -41,8 +41,8 @@ parameters = {
 
 def mesh_device_fixture():
     device = ttnn.open_device(device_id=0)
-    assert not ttnn.device.grayskull(device), "This op is not supported on Grayskull"
-    yield (device, "Wormhole_B0")
+    device_name = ttnn.get_arch_name()
+    yield (device, device_name)
     ttnn.close_device(device)
     del device
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

The `trunc` and `trunc_sharded` sweep fixtures still call `ttnn.device.grayskull`, which no longer exists:

```python
assert not ttnn.device.grayskull(device), "This op is not supported on Grayskull"
```

`ttnn/ttnn/device.py` defines only `is_wormhole_b0` and `is_blackhole`, so this raises `AttributeError: module 'ttnn.device' has no attribute 'grayskull'`. Confirmed on a Blackhole p150b and a Wormhole n150.

The sweep runner does not contain it. The fixture is a generator, so the body runs at `next(cur_gen)` in `sweeps_runner.py:391`, whose handler is `except AssertionError` only. An `AttributeError` escapes and takes the worker down, after `ttnn.open_device` on the previous line has already succeeded and with the teardown never reached. Both modules are listed in `.github/workflows/ttnn-run-sweeps.yaml:408-409`.

These are the last two. Every sibling sweep was updated when Grayskull support was removed; `grep -rl "This op is not supported on Grayskull" tests/sweep_framework/sweeps/` now returns nothing.

### Notes for reviewers

The replacement matches what the already-updated siblings use, for example `binary_backward/remainder_bw/remainder_bw.py`:

```python
device_name = ttnn.get_arch_name()
yield (device, device_name)
```

That also fixes a second problem in the same two lines: the fixtures yielded a hardcoded `"Wormhole_B0"`, so results from a Blackhole run were labelled Wormhole. After the change the fixture reports `blackhole` and `wormhole_b0` on the respective cards, verified on both.
