### PR TITLE
[Bug Fix] sharded ttnn.slice maps runtime arguments by bounding box, not shard order

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -194,11 +194,58 @@ def test_slice_rm_sharded_with_program_cache(device, n, c, h, w):
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [16])
 def test_slice_rm_sharded_shard_grid_placement(device, shard_grid, n, c, h, w):
-    """A height-sharded row-major slice must give the same result whichever cores the shards live
-    on. A shard grid may be several rectangles rather than one, and it need not include core
-    (0, 0). Each parameter here is the shard grid of both the input and the output, and each is
-    checked against the same PyTorch reference, which does not depend on the shard grid."""
+    """ttnn.slice must give the same result whichever cores the shards live on, for a row-major
+    input and output that are both height sharded. A shard grid may be several rectangles rather
+    than one, and it need not include core (0, 0). Each parameter here is the shard grid of both
+    the input and the output, and each is checked against the same PyTorch reference, which does
+    not depend on the shard grid."""
     run_slice_rm_sharded(device, n, c, h, w, input_shard_grid=shard_grid, output_shard_grid=shard_grid)
+
+
+@pytest.mark.parametrize(
+    "shard_grid",
+    [
+        ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)),
+                ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 1)),
+            ]
+        ),
+        ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)),
+                ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(3, 1)),
+            ]
+        ),
+    ],
+    ids=["origin_with_gap", "origin_no_gap"],
+)
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+@pytest.mark.parametrize("n", [1])
+@pytest.mark.parametrize("c", [128])
+@pytest.mark.parametrize("h", [128])
+@pytest.mark.parametrize("w", [16])
+def test_slice_rm_sharded_shard_grid_order(device, shard_grid, orientation, n, c, h, w):
+    """Checks that ttnn.slice matches the same slice taken in PyTorch exactly, for an input and output
+    sharing one height sharded layout: rows are cut into equal blocks (shards), one per core, and the
+    cores holding them form a shard grid of two rectangles, each given by two (x, y) corner cores.
+    Shards fill the grid in its own order: rectangle by rectangle, then row by row or column by column
+    inside a rectangle, as the shard orientation selects. The test runs two grids in both orientations.
+    Row-major on {(0,0)-(1,1), (2,0)-(3,1)} puts the third shard on core (0,1), not on (2,0), where a
+    row by row scan of the enclosing rectangle (0,0)-(3,1) would put the third shard. The grid
+    {(0,0)-(1,1), (3,0)-(4,1)} skips (2,0) and (2,1), so it holds 8 of the 10 cores of its enclosing
+    rectangle (0,0)-(4,1), and a scan of that rectangle reaches two cores that hold no shard."""
+    run_slice_rm_sharded(
+        device,
+        n,
+        c,
+        h,
+        w,
+        input_shard_grid=shard_grid,
+        output_shard_grid=shard_grid,
+        input_shard_orientation=orientation,
+        output_shard_orientation=orientation,
+    )
 
 
 @pytest.mark.parametrize("input_shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
@@ -209,7 +256,7 @@ def test_slice_rm_sharded_shard_grid_placement(device, shard_grid, n, c, h, w):
 @pytest.mark.parametrize("w", [16])
 def test_slice_rm_sharded_shard_orientation(device, input_shard_orientation, output_shard_orientation, n, c, h, w):
     """A shard spec's orientation says which core holds which shard, and it belongs to one tensor.
-    The input tensor and the output tensor each carry their own orientation, so a slice must read
+    The input tensor and the output tensor each carry their own orientation, so ttnn.slice must read
     the input according to the input's orientation and write the output according to the output's
     orientation, including when the input's orientation and the output's orientation differ. The
     shard grid is the same origin-anchored rectangle in every case here, so which core holds which

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -196,9 +196,8 @@ def test_slice_rm_sharded_with_program_cache(device, n, c, h, w):
 def test_slice_rm_sharded_shard_grid_placement(device, shard_grid, n, c, h, w):
     """A height-sharded row-major slice must give the same result whichever cores the shards live
     on. A shard grid may be several rectangles rather than one, and it need not include core
-    (0, 0). The cores a shard grid leaves out are available for other work, so the slice must
-    leave them untouched. Each parameter here is the shard grid of both the input and the
-    output."""
+    (0, 0). Each parameter here is the shard grid of both the input and the output, and each is
+    checked against the same PyTorch reference, which does not depend on the shard grid."""
     run_slice_rm_sharded(device, n, c, h, w, input_shard_grid=shard_grid, output_shard_grid=shard_grid)
 
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -25,7 +25,34 @@ def random_torch_tensor(dtype, shape):
     return torch.rand(shape).bfloat16().float()
 
 
-def run_slice_rm_sharded(device, n, c, h, w):
+def height_sharded_l1_mem_config(shard_grid, num_rows, row_width, orientation=ttnn.ShardOrientation.ROW_MAJOR):
+    """Height-shard num_rows rows of row_width elements over shard_grid, one shard per core in the grid."""
+    num_cores = shard_grid.num_cores()
+    shard_h = (num_rows + num_cores - 1) // num_cores
+    shard_spec = ttnn.ShardSpec(shard_grid, (shard_h, row_width), orientation)
+    return ttnn.MemoryConfig(ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec)
+
+
+def full_grid_core_range_set(num_cores_x, num_cores_y):
+    """The single rectangle of cores from (0, 0) to (num_cores_x - 1, num_cores_y - 1)."""
+    return ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))])
+
+
+def run_slice_rm_sharded(
+    device,
+    n,
+    c,
+    h,
+    w,
+    input_shard_grid=None,
+    output_shard_grid=None,
+    input_shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    output_shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
+):
+    if input_shard_grid is None:
+        input_shard_grid = full_grid_core_range_set(8, 7)
+    if output_shard_grid is None:
+        output_shard_grid = full_grid_core_range_set(8, 7)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     n_unpadded = n
     c_unpadded = 115
@@ -40,29 +67,13 @@ def run_slice_rm_sharded(device, n, c, h, w):
     )
 
     # shard config
-    num_cores_x = 8
-    num_cores_y = 7
-    shard_h = (n * c * h + (num_cores_x * num_cores_y) - 1) // (num_cores_x * num_cores_y)
-    grid_size = ttnn.CoreGrid(y=num_cores_y, x=num_cores_x)
-    grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
-    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
-    shard_spec = ttnn.ShardSpec(shard_grid, (shard_h, w), ttnn.ShardOrientation.ROW_MAJOR)
-    sharded_mem_config = ttnn.MemoryConfig(
-        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
-    )
+    sharded_mem_config = height_sharded_l1_mem_config(input_shard_grid, n * c * h, w, input_shard_orientation)
     with device.cache_entries_counter.measure():
         tt_input_tensor = ttnn.to_memory_config(tt_input_tensor, sharded_mem_config)
 
     # output shard config
-    num_cores_x = 8
-    num_cores_y = 7
-    shard_h = (n_unpadded * c_unpadded * h_unpadded + (num_cores_x * num_cores_y) - 1) // (num_cores_x * num_cores_y)
-    grid_size = ttnn.CoreGrid(y=num_cores_y, x=num_cores_x)
-    grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
-    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
-    shard_spec = ttnn.ShardSpec(shard_grid, (shard_h, w), ttnn.ShardOrientation.ROW_MAJOR)
-    output_mem_config = ttnn.MemoryConfig(
-        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    output_mem_config = height_sharded_l1_mem_config(
+        output_shard_grid, n_unpadded * c_unpadded * h_unpadded, w, output_shard_orientation
     )
 
     with device.cache_entries_counter.measure():
@@ -162,6 +173,57 @@ def test_slice_rm_sharded_with_program_cache(device, n, c, h, w):
             memory_config=ttnn.L1_MEMORY_CONFIG,
         )
     assert device.cache_entries_counter.total == 3
+
+
+@pytest.mark.parametrize(
+    "shard_grid",
+    [
+        full_grid_core_range_set(8, 7),
+        ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(5, 6))]),
+        ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
+                ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+            ]
+        ),
+    ],
+    ids=["origin_rectangle", "offset_rectangle", "two_rectangles"],
+)
+@pytest.mark.parametrize("n", [16])
+@pytest.mark.parametrize("c", [128])
+@pytest.mark.parametrize("h", [128])
+@pytest.mark.parametrize("w", [16])
+def test_slice_rm_sharded_shard_grid_placement(device, shard_grid, n, c, h, w):
+    """A height-sharded row-major slice must give the same result whichever cores the shards live
+    on. A shard grid may be several rectangles rather than one, and it need not include core
+    (0, 0). The cores a shard grid leaves out are available for other work, so the slice must
+    leave them untouched. Each parameter here is the shard grid of both the input and the
+    output."""
+    run_slice_rm_sharded(device, n, c, h, w, input_shard_grid=shard_grid, output_shard_grid=shard_grid)
+
+
+@pytest.mark.parametrize("input_shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+@pytest.mark.parametrize("output_shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+@pytest.mark.parametrize("n", [16])
+@pytest.mark.parametrize("c", [128])
+@pytest.mark.parametrize("h", [128])
+@pytest.mark.parametrize("w", [16])
+def test_slice_rm_sharded_shard_orientation(device, input_shard_orientation, output_shard_orientation, n, c, h, w):
+    """A shard spec's orientation says which core holds which shard, and it belongs to one tensor.
+    The input tensor and the output tensor each carry their own orientation, so a slice must read
+    the input according to the input's orientation and write the output according to the output's
+    orientation, including when the input's orientation and the output's orientation differ. The
+    shard grid is the same origin-anchored rectangle in every case here, so which core holds which
+    shard is the only thing that varies."""
+    run_slice_rm_sharded(
+        device,
+        n,
+        c,
+        h,
+        w,
+        input_shard_orientation=input_shard_orientation,
+        output_shard_orientation=output_shard_orientation,
+    )
 
 
 @pytest.mark.parametrize("n", [16])

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -26,7 +26,9 @@ def random_torch_tensor(dtype, shape):
 
 
 def height_sharded_l1_mem_config(shard_grid, num_rows, row_width, orientation=ttnn.ShardOrientation.ROW_MAJOR):
-    """Height-shard num_rows rows of row_width elements over shard_grid, one shard per core in the grid."""
+    """Height-shard num_rows rows of row_width elements over shard_grid. The shard height is num_rows
+    divided by the number of cores, rounded up, so the shards together can have room for more rows than
+    num_rows and the trailing cores of the grid can end up holding none."""
     num_cores = shard_grid.num_cores()
     shard_h = (num_rows + num_cores - 1) // num_cores
     shard_spec = ttnn.ShardSpec(shard_grid, (shard_h, row_width), orientation)
@@ -246,6 +248,43 @@ def test_slice_rm_sharded_shard_grid_order(device, shard_grid, orientation, n, c
         input_shard_orientation=orientation,
         output_shard_orientation=orientation,
     )
+
+
+@pytest.mark.parametrize(
+    "input_shard_grid, output_shard_grid",
+    [
+        (
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(7, 0))]),
+        ),
+        (
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))]),
+        ),
+        (
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 1)),
+                ]
+            ),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))]),
+        ),
+    ],
+    ids=["disjoint_cores", "fewer_output_cores", "two_input_rectangles_one_output"],
+)
+@pytest.mark.parametrize("n", [1])
+@pytest.mark.parametrize("c", [128])
+@pytest.mark.parametrize("h", [128])
+@pytest.mark.parametrize("w", [16])
+def test_slice_rm_sharded_input_and_output_grids_differ(device, input_shard_grid, output_shard_grid, n, c, h, w):
+    """Checks that ttnn.slice matches the same slice taken in PyTorch exactly when the input and the
+    output are height sharded over different shard grids. The input's shard grid decides which core
+    holds each source row, and the output's shard grid decides which core each shard's work is sent to,
+    so ttnn.slice reads each core from the shard grid of its own tensor. The three cases make the
+    input's shard grid and the output's shard grid disagree in a different way: disjoint sets of cores,
+    an output on fewer cores than the input, and an input of two rectangles against an output of one."""
+    run_slice_rm_sharded(device, n, c, h, w, input_shard_grid=input_shard_grid, output_shard_grid=output_shard_grid)
 
 
 @pytest.mark.parametrize("input_shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -8,7 +8,9 @@
 
 #include <map>
 #include <optional>
+#include <vector>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program.hpp>
@@ -57,18 +59,19 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<ui
     return chunks;
 }
 
+// input_cores lists the cores of the input tensor's shard grid in shard order, so input_cores[k] is the
+// core holding input shard k. Every core address written into an argument list comes from input_cores.
+// num_padded_sticks is how many rows the input holds, so a row id at or past num_padded_sticks has no
+// source.
 inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm_sharded(
     const Tensor& input_tensor,
     Tensor& output_tensor,
     const ttnn::Shape& output_tensor_start,
+    const std::vector<CoreCoord>& input_cores,
     uint32_t num_cores_unpadded,
-    bool row_major,
-    uint32_t num_cores_x_unpadded,
-    uint32_t num_cores_y_unpadded,
     uint32_t shard_height_unpadded,
     uint32_t shard_height_padded,
-    uint32_t num_cores_x_padded,
-    uint32_t num_cores_y_padded) {
+    uint32_t num_padded_sticks) {
     tt::tt_metal::IDevice* device = input_tensor.device();
 
     auto input_shape = input_tensor.padded_shape();
@@ -100,12 +103,6 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
     uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(input_tensor, output_tensor_start);
     for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_unpadded; i++) {
-        CoreCoord core;
-        if (row_major) {
-            core = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
-        } else {
-            core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
-        }
         uint32_t num_sticks_per_core_unpadded = shard_height_unpadded;
         uint32_t num_sticks_per_core_padded = shard_height_padded;
 
@@ -140,51 +137,54 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             }
         }
 
-        // figure out the stick id in a shard, and the core id for the stick.
-        std::map<std::pair<uint32_t, uint32_t>, std::vector<uint32_t>> core_stick_map;
+        // Group this core's source rows by the input shard holding them. Keying on the shard index puts the
+        // groups in increasing shard index order, which is what the reader needs: it fills the output shard
+        // front to back as it walks the list of cores to read from, and within each of those cores its chunk
+        // list. Row ids only grow as stick_ids_per_core is built above, so increasing shard index order is
+        // also increasing output row order.
+        std::map<uint32_t, std::vector<uint32_t>> shard_stick_map;
         for (uint32_t i = 0; i < num_sticks_per_core_unpadded; ++i) {
             uint32_t stick_id = stick_ids_per_core[i];
             uint32_t shard_id = stick_id / num_sticks_per_core_padded;
             uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_padded);
 
-            uint32_t shard_grid_inner_dim = row_major ? num_cores_x_padded : num_cores_y_padded;
-            uint32_t shard_grid_outer_dim_id = shard_id / shard_grid_inner_dim;
-            uint32_t shard_grid_inner_dim_id = shard_id - (shard_grid_outer_dim_id * shard_grid_inner_dim);
-
-            uint32_t worker_y_logical = row_major ? shard_grid_outer_dim_id : shard_grid_inner_dim_id;
-            uint32_t worker_x_logical = row_major ? shard_grid_inner_dim_id : shard_grid_outer_dim_id;
-
-            if (worker_x_logical < num_cores_x_padded and worker_y_logical < num_cores_y_padded) {
-                auto core_physical =
-                    device->worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
-                // save stick id in a shard, and core coord into a map
-                std::pair<uint32_t, uint32_t> xy_pair = row_major ? std::make_pair(core_physical.y, core_physical.x)
-                                                                  : std::make_pair(core_physical.x, core_physical.y);
-                core_stick_map[xy_pair].push_back(stick_id_in_shard);
+            // A shard height that does not divide the output evenly leaves the last output shard only
+            // partly inside the output tensor. Rows past the end of the output tensor have no source,
+            // because the stick_ids_per_core walk runs them off the end of the input. That walk only ever
+            // increases the row id, so the rows with no source are the tail of this core's list; stopping
+            // keeps every row that does have a source at its own position in the output shard.
+            if (stick_id >= num_padded_sticks) {
+                break;
             }
+            // Every input row lies in one of the input's own shards, so the row-id bound above already
+            // puts the shard index inside input_cores. A shard index outside input_cores would mean the
+            // input's shard height, shard grid and row count do not describe the same tensor.
+            TT_FATAL(
+                shard_id < input_cores.size(),
+                "SliceRmShardedProgramFactory: input row {} falls in shard {}, but the input shard grid holds "
+                "only {} shards.",
+                stick_id,
+                shard_id,
+                input_cores.size());
+            shard_stick_map[shard_id].push_back(stick_id_in_shard);
         }
 
         // reader rt args
         std::vector<uint32_t> reader_kernel_args;
-        reader_kernel_args.reserve(1 + 3 * core_stick_map.size() + 2 * num_sticks_per_core_unpadded);
-        reader_kernel_args.push_back(core_stick_map.size());  // num_cores
+        reader_kernel_args.reserve(1 + 3 * shard_stick_map.size() + 2 * num_sticks_per_core_unpadded);
+        reader_kernel_args.push_back(shard_stick_map.size());  // num_cores
 
-        for (const auto& core_stick_pair : core_stick_map) {
-            auto xy_pair = core_stick_pair.first;
-            if (row_major) {
-                reader_kernel_args.push_back(xy_pair.second);  // noc x
-                reader_kernel_args.push_back(xy_pair.first);   // noc y
-            } else {
-                reader_kernel_args.push_back(xy_pair.first);   // noc x
-                reader_kernel_args.push_back(xy_pair.second);  // noc y
-            }
+        for (const auto& shard_stick_pair : shard_stick_map) {
+            auto core_physical = device->worker_core_from_logical_core(input_cores[shard_stick_pair.first]);
+            reader_kernel_args.push_back(core_physical.x);  // noc x
+            reader_kernel_args.push_back(core_physical.y);  // noc y
         }
 
         // coalesce the sticks into chunks
         std::vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
-        stick_chunks_per_core.reserve(core_stick_map.size());
-        for (auto core_stick_pair : core_stick_map) {
-            auto stick_chunks = group_contiguous_values(core_stick_pair.second);
+        stick_chunks_per_core.reserve(shard_stick_map.size());
+        for (auto shard_stick_pair : shard_stick_map) {
+            auto stick_chunks = group_contiguous_values(shard_stick_pair.second);
             reader_kernel_args.push_back(stick_chunks.size());  // num_chunks for current core
 
             stick_chunks_per_core.push_back(std::move(stick_chunks));
@@ -214,7 +214,7 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
     const auto& input = tensor_args.input;
     ProgramDescriptor desc;
 
-    [[maybe_unused]] uint32_t num_padded_sticks = input.physical_volume() / input.padded_shape()[-1];
+    uint32_t num_padded_sticks = input.physical_volume() / input.padded_shape()[-1];
     [[maybe_unused]] uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
 
     uint32_t W_unpadded = output.logical_shape()[-1];
@@ -224,12 +224,16 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
     auto shard_spec_padded = input.shard_spec().value();
     uint32_t shard_height_padded = shard_spec_padded.shape[0];
 
-    [[maybe_unused]] auto& all_cores_padded = shard_spec_padded.grid;
+    auto& all_cores_padded = shard_spec_padded.grid;
     [[maybe_unused]] uint32_t num_cores_padded = shard_spec_padded.num_cores();
-    auto bbox_padded = shard_spec_padded.grid.bounding_box();
-    CoreCoord grid_size_padded = {bbox_padded.end_coord.x + 1, bbox_padded.end_coord.y + 1};
-    uint32_t num_cores_x_padded = grid_size_padded.x;
-    uint32_t num_cores_y_padded = grid_size_padded.y;
+    // Which core holds which shard follows from a tensor's shard grid and its shard orientation, and the
+    // input and the output each carry their own. The input's shard grid and orientation are read here; the
+    // output's are read further down. corerange_to_cores walks the shard grid itself instead of the bounding
+    // box around it, so a grid of several rectangles, or one placed away from core (0, 0), is listed
+    // correctly. A sharded buffer builds its page mapping with the same call, so input_cores holds the input
+    // buffer's own shard-to-core assignment.
+    const bool row_major_padded = shard_spec_padded.orientation == ShardOrientation::ROW_MAJOR;
+    const std::vector<CoreCoord> input_cores = corerange_to_cores(all_cores_padded, std::nullopt, row_major_padded);
 
     if (args.sub_core_grids.has_value()) {
         log_warning(tt::LogOp, "sub_core_grids is not used when input tensor is sharded");
@@ -243,14 +247,12 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
     // output shard spec
     auto shard_spec_unpadded = output.shard_spec().value();
     uint32_t shard_height_unpadded = shard_spec_unpadded.shape[0];
-    bool row_major = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
+    const bool row_major_unpadded = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
 
     auto& all_cores_unpadded = shard_spec_unpadded.grid;
     uint32_t num_cores_unpadded = shard_spec_unpadded.num_cores();
-    auto bbox_unpadded = all_cores_unpadded.bounding_box();
-    CoreCoord grid_size_unpadded = {bbox_unpadded.end_coord.x + 1, bbox_unpadded.end_coord.y + 1};
-    uint32_t num_cores_x_unpadded = grid_size_unpadded.x;
-    uint32_t num_cores_y_unpadded = grid_size_unpadded.y;
+    const std::vector<CoreCoord> output_cores =
+        corerange_to_cores(all_cores_unpadded, std::nullopt, row_major_unpadded);
 
     log_debug(tt::LogOp, "num_unpadded_sticks: {}", num_unpadded_sticks);
     log_debug(tt::LogOp, "shard_height_unpadded: {}", shard_height_unpadded);
@@ -313,14 +315,11 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
         input,
         output,
         args.slice_start,
+        input_cores,
         num_cores_unpadded,
-        row_major,
-        num_cores_x_unpadded,
-        num_cores_y_unpadded,
         shard_height_unpadded,
         shard_height_padded,
-        num_cores_x_padded,
-        num_cores_y_padded);
+        num_padded_sticks);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
@@ -331,15 +330,12 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
     reader_desc.compile_time_args = std::move(reader_ct_args);
     reader_desc.config = ReaderConfigDescriptor{};
 
+    // The reader runs on all_cores_unpadded, so every argument list must go to a core of that set.
+    // get_slice_runtime_args_rm_sharded builds list i for output shard i, and output_cores[i] is the core
+    // holding that shard.
     reader_desc.runtime_args.reserve(num_cores_unpadded);
     for (uint32_t i = 0; i < num_cores_unpadded; ++i) {
-        CoreCoord core;
-        if (row_major) {
-            core = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
-        } else {
-            core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
-        }
-        reader_desc.runtime_args.emplace_back(core, std::move(all_runtime_args[i].first));
+        reader_desc.runtime_args.emplace_back(output_cores[i], std::move(all_runtime_args[i].first));
     }
 
     desc.kernels.push_back(std::move(reader_desc));

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -60,9 +60,8 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<ui
 }
 
 // input_cores lists the cores of the input tensor's shard grid in shard order, so input_cores[k] is the
-// core holding input shard k. Every core address written into an argument list comes from input_cores.
-// num_padded_sticks is how many rows the input holds, so a row id at or past num_padded_sticks has no
-// source.
+// logical coordinate of the core holding input shard k. Every NOC coordinate written into an argument
+// list is converted from an input_cores entry. num_padded_sticks is how many rows the input holds.
 inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm_sharded(
     const Tensor& input_tensor,
     Tensor& output_tensor,
@@ -139,20 +138,21 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // Group this core's source rows by the input shard holding them. Keying on the shard index puts the
         // groups in increasing shard index order, which is what the reader needs: it fills the output shard
-        // front to back as it walks the list of cores to read from, and within each of those cores its chunk
-        // list. Row ids only grow as stick_ids_per_core is built above, so increasing shard index order is
-        // also increasing output row order.
+        // front to back, one source core at a time in the order listed, and within a source core the rows
+        // in the order listed. Row ids only grow as stick_ids_per_core is built above, so increasing shard
+        // index order is also increasing output row order.
         std::map<uint32_t, std::vector<uint32_t>> shard_stick_map;
         for (uint32_t i = 0; i < num_sticks_per_core_unpadded; ++i) {
             uint32_t stick_id = stick_ids_per_core[i];
             uint32_t shard_id = stick_id / num_sticks_per_core_padded;
             uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_padded);
 
-            // A shard height that does not divide the output evenly leaves the last output shard only
-            // partly inside the output tensor. Rows past the end of the output tensor have no source,
-            // because the stick_ids_per_core walk runs them off the end of the input. That walk only ever
-            // increases the row id, so the rows with no source are the tail of this core's list; stopping
-            // keeps every row that does have a source at its own position in the output shard.
+            // A core's output shard has room for shard_height_unpadded rows. When the core count does not
+            // divide the output row count, the shards together have room for more rows than the output
+            // holds, so the last slots lie past the final output row and have no source row. For those,
+            // stick_ids_per_core can return an input row id at or past num_padded_sticks. Row ids only
+            // rise, so the ids past the input's end are the tail of this core's list, and leaving them out
+            // shifts none of the rows that do have a source.
             if (stick_id >= num_padded_sticks) {
                 break;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -100,12 +100,26 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_unpadded);
 
+    // The input's shards have to cover the input's rows, so every row id inside the input maps to a shard
+    // index inside input_cores. Sharded TensorSpec construction rejects a shard height and grid that cannot
+    // cover the tensor, so a failure here means the three values passed in do not describe one tensor.
+    TT_FATAL(
+        static_cast<uint64_t>(shard_height_padded) * input_cores.size() >= num_padded_sticks,
+        "SliceRmShardedProgramFactory: the input's {} shards of {} rows cannot hold its {} rows.",
+        input_cores.size(),
+        shard_height_padded,
+        num_padded_sticks);
+
     uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(input_tensor, output_tensor_start);
     for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_unpadded; i++) {
         uint32_t num_sticks_per_core_unpadded = shard_height_unpadded;
         uint32_t num_sticks_per_core_padded = shard_height_padded;
 
-        // figure out the start read stick id for each core, and the start id for each dim
+        // Reducing num_sticks_written modulo the output dimensions gives this core's first source row,
+        // and the start id for each dimension that the walk below advances from. A core whose slots all lie
+        // past the final output row enters here with num_sticks_written already past the output row count,
+        // so the reduction wraps and its first source row lands back inside the input. Such a core copies
+        // rows into slots that lie outside the output and are never read back.
         id_per_dim[0] = num_sticks_written % num_unpadded_sticks_per_dim[0];
         uint32_t unpadded_written = num_sticks_written / num_unpadded_sticks_per_dim[0];
         uint32_t start_id = id_per_dim[0] + start_offset;
@@ -147,25 +161,18 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             uint32_t shard_id = stick_id / num_sticks_per_core_padded;
             uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_padded);
 
-            // A core's output shard has room for shard_height_unpadded rows. When the core count does not
-            // divide the output row count, the shards together have room for more rows than the output
-            // holds, so the last slots lie past the final output row and have no source row. For those,
-            // stick_ids_per_core can return an input row id at or past num_padded_sticks. Row ids only
-            // rise, so the ids past the input's end are the tail of this core's list, and leaving them out
-            // shifts none of the rows that do have a source.
+            // When the core count does not divide the output row count, the output shards together have
+            // room for more rows than the output holds, so a core that holds real rows can hold surplus
+            // slots past the final output row as well. The walk above reaches those surplus slots by
+            // running off the end of the input, returning ids at or past num_padded_sticks that name rows
+            // the input does not have. Row ids only rise, so the ids at or past num_padded_sticks are the
+            // tail of this core's list and stopping drops exactly them. The num_padded_sticks bound is
+            // what keeps the reads of a core that holds both real rows and surplus slots inside the
+            // input. A core whose slots all lie past the final output row is the separate case described
+            // where start_id is derived above.
             if (stick_id >= num_padded_sticks) {
                 break;
             }
-            // Every input row lies in one of the input's own shards, so the row-id bound above already
-            // puts the shard index inside input_cores. A shard index outside input_cores would mean the
-            // input's shard height, shard grid and row count do not describe the same tensor.
-            TT_FATAL(
-                shard_id < input_cores.size(),
-                "SliceRmShardedProgramFactory: input row {} falls in shard {}, but the input shard grid holds "
-                "only {} shards.",
-                stick_id,
-                shard_id,
-                input_cores.size());
             shard_stick_map[shard_id].push_back(stick_id_in_shard);
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
@@ -54,9 +54,8 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_values_sharded(std::v
 // positional layout the reader kernel decodes:
 //   [0] num_cores_read, then (noc_x,noc_y) pairs, then num_stick_chunks, then (start_id,len) chunk pairs.
 // input_cores lists the cores of the input tensor's shard grid in shard order, so input_cores[k] is the
-// core holding input shard k. Every core address written into a vararg vector comes from input_cores.
-// num_padded_sticks is how many rows the input holds, so a row id at or past num_padded_sticks has no
-// source.
+// logical coordinate of the core holding input shard k. Every NOC coordinate written into a vararg
+// vector is converted from an input_cores entry. num_padded_sticks is how many rows the input holds.
 inline std::vector<std::vector<uint32_t>> get_slice_runtime_varargs_rm_sharded(
     const Tensor& input_tensor,
     Tensor& output_tensor,
@@ -134,20 +133,21 @@ inline std::vector<std::vector<uint32_t>> get_slice_runtime_varargs_rm_sharded(
 
         // Group this core's source rows by the input shard holding them. Keying on the shard index puts the
         // groups in increasing shard index order, which is what the reader needs: it fills the output shard
-        // front to back as it walks the list of cores to read from, and within each of those cores its chunk
-        // list. Row ids only grow as stick_ids_per_core is built above, so increasing shard index order is
-        // also increasing output row order.
+        // front to back, one source core at a time in the order listed, and within a source core the rows
+        // in the order listed. Row ids only grow as stick_ids_per_core is built above, so increasing shard
+        // index order is also increasing output row order.
         std::map<uint32_t, std::vector<uint32_t>> shard_stick_map;
         for (uint32_t s = 0; s < num_sticks_per_core_unpadded; ++s) {
             uint32_t stick_id = stick_ids_per_core[s];
             uint32_t shard_id = stick_id / num_sticks_per_core_padded;
             uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_padded);
 
-            // A shard height that does not divide the output evenly leaves the last output shard only
-            // partly inside the output tensor. Rows past the end of the output tensor have no source,
-            // because the stick_ids_per_core walk runs them off the end of the input. That walk only ever
-            // increases the row id, so the rows with no source are the tail of this core's list; stopping
-            // keeps every row that does have a source at its own position in the output shard.
+            // A core's output shard has room for shard_height_unpadded rows. When the core count does not
+            // divide the output row count, the shards together have room for more rows than the output
+            // holds, so the last slots lie past the final output row and have no source row. For those,
+            // stick_ids_per_core can return an input row id at or past num_padded_sticks. Row ids only
+            // rise, so the ids past the input's end are the tail of this core's list, and leaving them out
+            // shifts none of the rows that do have a source.
             if (stick_id >= num_padded_sticks) {
                 break;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
@@ -52,18 +53,19 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_values_sharded(std::v
 // Builds the per-core packed work-description vararg vectors (one per unpadded core), matching the
 // positional layout the reader kernel decodes:
 //   [0] num_cores_read, then (noc_x,noc_y) pairs, then num_stick_chunks, then (start_id,len) chunk pairs.
+// input_cores lists the cores of the input tensor's shard grid in shard order, so input_cores[k] is the
+// core holding input shard k. Every core address written into a vararg vector comes from input_cores.
+// num_padded_sticks is how many rows the input holds, so a row id at or past num_padded_sticks has no
+// source.
 inline std::vector<std::vector<uint32_t>> get_slice_runtime_varargs_rm_sharded(
     const Tensor& input_tensor,
     Tensor& output_tensor,
     const ttnn::Shape& output_tensor_start,
+    const std::vector<CoreCoord>& input_cores,
     uint32_t num_cores_unpadded,
-    bool row_major,
-    [[maybe_unused]] uint32_t num_cores_x_unpadded,
-    [[maybe_unused]] uint32_t num_cores_y_unpadded,
     uint32_t shard_height_unpadded,
     uint32_t shard_height_padded,
-    uint32_t num_cores_x_padded,
-    uint32_t num_cores_y_padded) {
+    uint32_t num_padded_sticks) {
     tt::tt_metal::IDevice* device = input_tensor.device();
 
     auto input_shape = input_tensor.padded_shape();
@@ -130,52 +132,55 @@ inline std::vector<std::vector<uint32_t>> get_slice_runtime_varargs_rm_sharded(
             }
         }
 
-        // figure out the stick id in a shard, and the core id for the stick.
-        std::map<std::pair<uint32_t, uint32_t>, std::vector<uint32_t>> core_stick_map;
+        // Group this core's source rows by the input shard holding them. Keying on the shard index puts the
+        // groups in increasing shard index order, which is what the reader needs: it fills the output shard
+        // front to back as it walks the list of cores to read from, and within each of those cores its chunk
+        // list. Row ids only grow as stick_ids_per_core is built above, so increasing shard index order is
+        // also increasing output row order.
+        std::map<uint32_t, std::vector<uint32_t>> shard_stick_map;
         for (uint32_t s = 0; s < num_sticks_per_core_unpadded; ++s) {
             uint32_t stick_id = stick_ids_per_core[s];
             uint32_t shard_id = stick_id / num_sticks_per_core_padded;
             uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_padded);
 
-            uint32_t shard_grid_inner_dim = row_major ? num_cores_x_padded : num_cores_y_padded;
-            uint32_t shard_grid_outer_dim_id = shard_id / shard_grid_inner_dim;
-            uint32_t shard_grid_inner_dim_id = shard_id - (shard_grid_outer_dim_id * shard_grid_inner_dim);
-
-            uint32_t worker_y_logical = row_major ? shard_grid_outer_dim_id : shard_grid_inner_dim_id;
-            uint32_t worker_x_logical = row_major ? shard_grid_inner_dim_id : shard_grid_outer_dim_id;
-
-            if (worker_x_logical < num_cores_x_padded and worker_y_logical < num_cores_y_padded) {
-                auto core_physical =
-                    device->worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
-                // save stick id in a shard, and core coord into a map
-                std::pair<uint32_t, uint32_t> xy_pair = row_major ? std::make_pair(core_physical.y, core_physical.x)
-                                                                  : std::make_pair(core_physical.x, core_physical.y);
-                core_stick_map[xy_pair].push_back(stick_id_in_shard);
+            // A shard height that does not divide the output evenly leaves the last output shard only
+            // partly inside the output tensor. Rows past the end of the output tensor have no source,
+            // because the stick_ids_per_core walk runs them off the end of the input. That walk only ever
+            // increases the row id, so the rows with no source are the tail of this core's list; stopping
+            // keeps every row that does have a source at its own position in the output shard.
+            if (stick_id >= num_padded_sticks) {
+                break;
             }
+            // Every input row lies in one of the input's own shards, so the row-id bound above already
+            // puts the shard index inside input_cores. A shard index outside input_cores would mean the
+            // input's shard height, shard grid and row count do not describe the same tensor.
+            TT_FATAL(
+                shard_id < input_cores.size(),
+                "qsr::SliceRmShardedProgramFactory: input row {} falls in shard {}, but the input shard grid "
+                "holds only {} shards.",
+                stick_id,
+                shard_id,
+                input_cores.size());
+            shard_stick_map[shard_id].push_back(stick_id_in_shard);
         }
 
         // reader varargs
         std::vector<uint32_t> reader_varargs;
-        reader_varargs.reserve(1 + (3 * core_stick_map.size()));
-        reader_varargs.push_back(core_stick_map.size());  // num_cores
+        reader_varargs.reserve(1 + (3 * shard_stick_map.size()));
+        reader_varargs.push_back(shard_stick_map.size());  // num_cores
 
-        for (const auto& core_stick_pair : core_stick_map) {
-            auto xy_pair = core_stick_pair.first;
-            if (row_major) {
-                reader_varargs.push_back(xy_pair.second);  // noc x
-                reader_varargs.push_back(xy_pair.first);   // noc y
-            } else {
-                reader_varargs.push_back(xy_pair.first);   // noc x
-                reader_varargs.push_back(xy_pair.second);  // noc y
-            }
+        for (const auto& shard_stick_pair : shard_stick_map) {
+            auto core_physical = device->worker_core_from_logical_core(input_cores[shard_stick_pair.first]);
+            reader_varargs.push_back(core_physical.x);  // noc x
+            reader_varargs.push_back(core_physical.y);  // noc y
         }
 
         // coalesce the sticks into chunks
         std::vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
-        stick_chunks_per_core.reserve(core_stick_map.size());
+        stick_chunks_per_core.reserve(shard_stick_map.size());
         size_t num_chunks_total = 0;
-        for (auto core_stick_pair : core_stick_map) {
-            auto stick_chunks = group_contiguous_values_sharded(core_stick_pair.second);
+        for (auto shard_stick_pair : shard_stick_map) {
+            auto stick_chunks = group_contiguous_values_sharded(shard_stick_pair.second);
             num_chunks_total += stick_chunks.size();
             stick_chunks_per_core.push_back(stick_chunks);
 
@@ -221,10 +226,16 @@ ttnn::device_operation::ProgramArtifacts SliceRmShardedProgramFactory::create_pr
     auto shard_spec_padded = input.shard_spec().value();
     uint32_t shard_height_padded = shard_spec_padded.shape[0];
 
-    auto bbox_padded = shard_spec_padded.grid.bounding_box();
-    CoreCoord grid_size_padded = {bbox_padded.end_coord.x + 1, bbox_padded.end_coord.y + 1};
-    uint32_t num_cores_x_padded = grid_size_padded.x;
-    uint32_t num_cores_y_padded = grid_size_padded.y;
+    // Which core holds which shard follows from a tensor's shard grid and its shard orientation, and the
+    // input and the output each carry their own. The input's shard grid and orientation are read here; the
+    // output's are read further down. corerange_to_cores walks the shard grid itself instead of the bounding
+    // box around it, so a grid of several rectangles, or one placed away from core (0, 0), is listed
+    // correctly. A sharded buffer builds its page mapping with the same call, so input_cores holds the input
+    // buffer's own shard-to-core assignment.
+    const bool row_major_padded = shard_spec_padded.orientation == ShardOrientation::ROW_MAJOR;
+    const std::vector<CoreCoord> input_cores =
+        corerange_to_cores(shard_spec_padded.grid, std::nullopt, row_major_padded);
+    const uint32_t num_padded_sticks = input.physical_volume() / input.padded_shape()[-1];
 
     if (args.sub_core_grids.has_value()) {
         log_warning(tt::LogOp, "sub_core_grids is not used when input tensor is sharded");
@@ -233,14 +244,12 @@ ttnn::device_operation::ProgramArtifacts SliceRmShardedProgramFactory::create_pr
     // output shard spec
     auto shard_spec_unpadded = output.shard_spec().value();
     uint32_t shard_height_unpadded = shard_spec_unpadded.shape[0];
-    bool row_major = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
+    const bool row_major_unpadded = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
 
     auto& all_cores_unpadded = shard_spec_unpadded.grid;
     uint32_t num_cores_unpadded = shard_spec_unpadded.num_cores();
-    auto bbox_unpadded = all_cores_unpadded.bounding_box();
-    CoreCoord grid_size_unpadded = {bbox_unpadded.end_coord.x + 1, bbox_unpadded.end_coord.y + 1};
-    uint32_t num_cores_x_unpadded = grid_size_unpadded.x;
-    uint32_t num_cores_y_unpadded = grid_size_unpadded.y;
+    const std::vector<CoreCoord> output_cores =
+        corerange_to_cores(all_cores_unpadded, std::nullopt, row_major_unpadded);
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
@@ -262,14 +271,11 @@ ttnn::device_operation::ProgramArtifacts SliceRmShardedProgramFactory::create_pr
         input,
         output,
         args.slice_start,
+        input_cores,
         num_cores_unpadded,
-        row_major,
-        num_cores_x_unpadded,
-        num_cores_y_unpadded,
         shard_height_unpadded,
         shard_height_padded,
-        num_cores_x_padded,
-        num_cores_y_padded);
+        num_padded_sticks);
 
     // Every node must supply exactly num_runtime_varargs words — pad each core's vector to the max.
     uint32_t max_varargs = 0;
@@ -296,22 +302,15 @@ ttnn::device_operation::ProgramArtifacts SliceRmShardedProgramFactory::create_pr
     };
 
     // --- Per-core runtime args (varargs only) ---
+    // The WorkUnit targets all_cores_unpadded, and a vararg vector may only be set for a node the kernel
+    // runs on, so every destination here has to be a core of that set. get_slice_runtime_varargs_rm_sharded
+    // builds vector i for output shard i, and output_cores[i] is the core holding that shard.
     AdvancedKernelRunArgs reader_run_advanced;
     for (uint32_t i = 0; i < num_cores_unpadded; ++i) {
-        CoreCoord core;
-        if (row_major) {
-            core = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
-        } else {
-            core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
-        }
         std::vector<uint32_t> padded = std::move(all_runtime_varargs[i]);
         padded.resize(max_varargs, 0);
-        reader_run_advanced.runtime_varargs.emplace(core, std::move(padded));
+        reader_run_advanced.runtime_varargs.emplace(output_cores[i], std::move(padded));
     }
-
-    // No-op cores (in the unpadded grid bounding box but outside the shard grid) still need their
-    // vararg vector supplied. The shard grid is what kernels run on (all_cores_unpadded), and the
-    // loop above covers exactly num_cores_unpadded cores; the WorkUnit targets all_cores_unpadded.
 
     // --- TensorParameters ---
     TensorParameter input_param{.unique_id = INPUT, .spec = input.tensor_spec()};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
@@ -94,13 +94,27 @@ inline std::vector<std::vector<uint32_t>> get_slice_runtime_varargs_rm_sharded(
 
     std::vector<std::vector<uint32_t>> ret_val(num_cores_unpadded);
 
+    // The input's shards have to cover the input's rows, so every row id inside the input maps to a shard
+    // index inside input_cores. Sharded TensorSpec construction rejects a shard height and grid that cannot
+    // cover the tensor, so a failure here means the three values passed in do not describe one tensor.
+    TT_FATAL(
+        static_cast<uint64_t>(shard_height_padded) * input_cores.size() >= num_padded_sticks,
+        "qsr::SliceRmShardedProgramFactory: the input's {} shards of {} rows cannot hold its {} rows.",
+        input_cores.size(),
+        shard_height_padded,
+        num_padded_sticks);
+
     uint32_t start_offset =
         ttnn::operations::experimental::quasar::get_rm_start_offset(input_tensor, output_tensor_start);
     for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_unpadded; i++) {
         uint32_t num_sticks_per_core_unpadded = shard_height_unpadded;
         uint32_t num_sticks_per_core_padded = shard_height_padded;
 
-        // figure out the start read stick id for each core, and the start id for each dim
+        // Reducing num_sticks_written modulo the output dimensions gives this core's first source row,
+        // and the start id for each dimension that the walk below advances from. A core whose slots all lie
+        // past the final output row enters here with num_sticks_written already past the output row count,
+        // so the reduction wraps and its first source row lands back inside the input. Such a core copies
+        // rows into slots that lie outside the output and are never read back.
         id_per_dim[0] = num_sticks_written % num_unpadded_sticks_per_dim[0];
         uint32_t unpadded_written = num_sticks_written / num_unpadded_sticks_per_dim[0];
         uint32_t start_id = id_per_dim[0] + start_offset;
@@ -142,25 +156,18 @@ inline std::vector<std::vector<uint32_t>> get_slice_runtime_varargs_rm_sharded(
             uint32_t shard_id = stick_id / num_sticks_per_core_padded;
             uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_padded);
 
-            // A core's output shard has room for shard_height_unpadded rows. When the core count does not
-            // divide the output row count, the shards together have room for more rows than the output
-            // holds, so the last slots lie past the final output row and have no source row. For those,
-            // stick_ids_per_core can return an input row id at or past num_padded_sticks. Row ids only
-            // rise, so the ids past the input's end are the tail of this core's list, and leaving them out
-            // shifts none of the rows that do have a source.
+            // When the core count does not divide the output row count, the output shards together have
+            // room for more rows than the output holds, so a core that holds real rows can hold surplus
+            // slots past the final output row as well. The walk above reaches those surplus slots by
+            // running off the end of the input, returning ids at or past num_padded_sticks that name rows
+            // the input does not have. Row ids only rise, so the ids at or past num_padded_sticks are the
+            // tail of this core's list and stopping drops exactly them. The num_padded_sticks bound is
+            // what keeps the reads of a core that holds both real rows and surplus slots inside the
+            // input. A core whose slots all lie past the final output row is the separate case described
+            // where start_id is derived above.
             if (stick_id >= num_padded_sticks) {
                 break;
             }
-            // Every input row lies in one of the input's own shards, so the row-id bound above already
-            // puts the shard index inside input_cores. A shard index outside input_cores would mean the
-            // input's shard height, shard grid and row count do not describe the same tensor.
-            TT_FATAL(
-                shard_id < input_cores.size(),
-                "qsr::SliceRmShardedProgramFactory: input row {} falls in shard {}, but the input shard grid "
-                "holds only {} shards.",
-                stick_id,
-                shard_id,
-                input_cores.size());
             shard_stick_map[shard_id].push_back(stick_id_in_shard);
         }
 


### PR DESCRIPTION
### Summary
Fixes #56162.

`ttnn.slice` on a row-major sharded tensor sent each shard's work to the wrong core. The host code (`SliceRmShardedProgramFactory`) turned a shard index into a core coordinate by walking the bounding box of the shard grid from (0, 0). A sharded buffer instead puts shard i on the i-th core from `corerange_to_cores`, which lists a `CoreRangeSet` one core range at a time. Both orders follow the shard orientation, so they match for a shard grid that is a single core range starting at (0, 0) and can differ for any other grid. Where they differ, a core got the arguments belonging to a different shard, or to no shard, and the output data was wrong. Failures were silent wrong data in release builds.

The same arithmetic also chose the source core for each output row, and took the orientation for both cores from the output shard spec, so an input sharded the other way also read from wrong cores. Both cores now come from `corerange_to_cores`, each with its own tensor's orientation.

A shard height that does not divide the output height leaves unused rows at the end of the last shard. The bounding box arithmetic dropped the input reads for those rows as a side effect; `corerange_to_cores` does not, so the host now stops assigning source rows past the last input row.

Added tests that demonstrate different failure modes and proved that they fail before this PR and pass after.

### Notes for reviewers
- The Quasar copy of this factory was also fixed. The fix was verified on emulator.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fplavec/slice_core_grid_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fplavec/slice_core_grid_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fplavec/slice_core_grid_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fplavec/slice_core_grid_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fplavec/slice_core_grid_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fplavec/slice_core_grid_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fplavec/slice_core_grid_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fplavec/slice_core_grid_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fplavec/slice_core_grid_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fplavec/slice_core_grid_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fplavec/slice_core_grid_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fplavec/slice_core_grid_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fplavec/slice_core_grid_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fplavec/slice_core_grid_bug)