### PR TITLE
[skip ci] Bug fix: Give fork PRs more time for clang-tidy analysis

### DIFF
--- a/.github/workflows/clang-tidy-reusable.yaml
+++ b/.github/workflows/clang-tidy-reusable.yaml
@@ -304,7 +304,11 @@ jobs:
           done
 
       - name: 🔍 Analyze code with clang-tidy
-        timeout-minutes: 120
+        # Fork PRs run without ccache/ctcache credentials and need more time.
+        timeout-minutes: >-
+          ${{ github.event_name == 'pull_request' &&
+              github.event.pull_request.head.repo.fork &&
+              180 || 120 }}
         run: |
           # Record the exit code rather than failing here: violations fail compile
           # edges but still export, so the gate below decides pass/fail from counts.


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fork PRs skip the S3 ccache and ctcache setup because they do not have the required credentials. The [clang-tidy job for PR #55145](https://github.com/tenstorrent/tt-metal/actions/runs/34396484396/job/102892676111?pr=55145) succeeded, but its analysis step took 116m 29s against a 120-minute timeout.

Allow 180 minutes for the analysis step on fork pull requests, using the same fork flag as the cache setup. Other runs retain the 120-minute step timeout. The overall job limit remains 240 minutes to allow time for setup and reporting.

### Notes for reviewers

The change is limited to the analysis step in the reusable clang-tidy workflow. The event check keeps scheduled, manual, and merge queue runs on the existing timeout.

Validation: `check-yaml --unsafe`, `yamllint` (passed with existing line-length warnings), trailing whitespace, end-of-file and merge-conflict checks, and `git diff --check`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/clang-tidy-fork-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/clang-tidy-fork-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/clang-tidy-fork-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/clang-tidy-fork-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/clang-tidy-fork-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/clang-tidy-fork-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/clang-tidy-fork-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/clang-tidy-fork-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/clang-tidy-fork-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/clang-tidy-fork-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/clang-tidy-fork-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/clang-tidy-fork-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/clang-tidy-fork-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/clang-tidy-fork-timeout)