### PR TITLE
Cleanup: remove the two matmul DRAM helpers that have no callers

### DIFF
--- a/ttnn/cpp/ttnn/operations/compute_throttle_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/compute_throttle_utils.cpp
@@ -89,17 +89,4 @@ void throttle_mm_perf(
     }
 }
 
-void add_dram_skip_defines_if_needed(
-    const tt::ARCH arch, std::map<std::string, std::string>& mm_in1_sender_writer_defines) {
-    const bool skip_in1_dram = std::getenv("TT_MM_SKIP_IN1_DRAM");
-    if (skip_in1_dram && (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE)) {
-        mm_in1_sender_writer_defines["SKIP_IN1_DRAM"] = "1";
-    }
-}
-
-bool should_sync_after_in1_dram(const tt::ARCH arch) {
-    const bool sync_in1_dram = std::getenv("TT_MM_SYNC_AFTER_IN1_DRAM");
-    return sync_in1_dram && (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE);
-}
-
 }  // namespace ttnn::operations::compute_throttle_utils

--- a/ttnn/cpp/ttnn/operations/compute_throttle_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/compute_throttle_utils.hpp
@@ -33,8 +33,6 @@ inline std::ostream& operator<<(std::ostream& os, ThrottleLevel level) {
 }
 
 void add_stagger_defines_if_needed(tt::ARCH arch, int num_cores, std::map<std::string, std::string>& mm_kernel_defines);
-void add_dram_skip_defines_if_needed(tt::ARCH arch, std::map<std::string, std::string>& mm_in1_sender_writer_defines);
-bool should_sync_after_in1_dram(tt::ARCH arch);
 
 /*
  * Optionally limit matmul compute throughput by inserting NOP instructions between MVMUL instructions of matmul kernel


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

`add_dram_skip_defines_if_needed` and `should_sync_after_in1_dram` in `compute_throttle_utils` have no callers, and the environment variables they read reach nothing.

Before this change, a repo-wide grep for `add_dram_skip_defines_if_needed|should_sync_after_in1_dram|SKIP_IN1_DRAM|TT_MM_SYNC_AFTER_IN1_DRAM|TT_MM_SKIP_IN1_DRAM` returns exactly 7 lines, all of them the two definitions and their two declarations. After it, zero.

`SKIP_IN1_DRAM` has no kernel consumer either, so wiring the helper up would still do nothing. Neither environment variable appears in any doc, script or workflow, so setting `TT_MM_SKIP_IN1_DRAM` or `TT_MM_SYNC_AFTER_IN1_DRAM` today is silently inert.

### Notes for reviewers

The header is not a reserved-API surface: its live siblings are used widely, `add_stagger_defines_if_needed` has 16 callers, and `compute_throttle_utils` is listed as an internal source in `ttnn/sources.cmake` rather than an installed public header.

Worth knowing before you queue it: the header is included by 20+ matmul and conv program factories, so a 15-line deletion still triggers a large rebuild.

Built and exercised on a Blackhole p150b and a Wormhole n150: `_ttnn.so` builds clean on both, and matmul runs and returns finite output on both.
