### PR TITLE
Cleanup: remove two golden registrations that are shadowed at import time

### DIFF
--- a/ttnn/ttnn/operations/data_movement.py
+++ b/ttnn/ttnn/operations/data_movement.py
@@ -185,21 +185,6 @@ def _golden_function(tensor, shape, **_):
 ttnn.attach_golden_function(ttnn.repeat, golden_function=_golden_function)
 
 
-def _golden_function(input_tensor: ttnn.Tensor, scale_factor: Tuple[float, float], **_):
-    import torch
-
-    input_tensor = input_tensor.permute(0, 3, 1, 2)
-    ret = torch.nn.functional.upsample(input_tensor, scale_factor=scale_factor)
-    ret = ret.permute(0, 2, 3, 1)
-    return ret
-
-
-ttnn.attach_golden_function(
-    ttnn.upsample,
-    golden_function=_golden_function,
-)
-
-
 def _golden_function(input_tensor, slice_start=None, slice_end=None, slice_step=None, *args, **kwargs):
     if slice_start is None:
         slice_start = kwargs.get("starts")

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -683,15 +683,6 @@ def _golden_function_rsub(input_tensor_a, value, *args, **kwargs):
 # Do not replace it here with the legacy unary helper after operation modules are loaded.
 
 
-def _golden_function_rdiv(input_tensor_a, value, *args, **kwargs):
-    import torch
-
-    return torch.div(torch.tensor(value, dtype=input_tensor_a.dtype), input_tensor_a)
-
-
-ttnn.attach_golden_function(ttnn.rdiv, golden_function=_golden_function_rdiv)
-
-
 def _golden_function_bitwise_left_shift(input_tensor, shift_amt, *args, **kwargs):
     import torch
 


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

`ttnn.rdiv` and `ttnn.upsample` each have their golden registered twice. `attach_golden_function` is a plain attribute assignment, so the later registration wins and the earlier one is dead code that never runs.

`rdiv` is registered twice in the same file. The dead copy at `unary.py:686` also drops `rounding_mode`, which the binding accepts (`unary_nanobind.cpp:2122`); the live copy at `:1016` takes it.

`upsample` is registered from two modules. The dead copy in `data_movement.py:188` has no `mode` parameter and calls the deprecated `torch.nn.functional.upsample`, so it is always nearest; the live `golden_upsample` in `pool.py:329` handles `mode` and normalizes a scalar `scale_factor`. `pool` wins because `ttnn/ttnn/operations/__init__.py` walks packages alphabetically. It is also the one the tests import by name, in both `tests/ttnn/unit_tests/operations/pool/test_upsample.py` and the nightly equivalent.

### Notes for reviewers

Behaviour-preserving, and checked rather than assumed. On a Blackhole p150b and a Wormhole n150, before and after the deletion:

```
rdiv     -> ttnn.operations.unary   ('input_tensor_a', 'value', 'rounding_mode', 'args')
upsample -> ttnn.operations.pool    golden_upsample
```

Identical on both cards either side of the change, and both goldens still return the expected shapes.

Distinct from #52029, which is an `rdiv` round_mode defect in the kernel and is untouched here.
