### PR TITLE
[tt-train] gumbel_sample fused op integration

### DIFF
--- a/tt-train/sources/examples/grpo/utils/llama_completer.py
+++ b/tt-train/sources/examples/grpo/utils/llama_completer.py
@@ -21,9 +21,10 @@ from huggingface_hub import snapshot_download
 from transformers import AutoTokenizer
 
 from ttml.trainers.grpo_trainer import GRPOCompleter
+from ttml.common.sampling import positions_to_tensor
+
 from .completer_common import deallocate_tensors, async_read_to_host
 from .llama_overrides import LlamaCompositeKV
-
 
 TILE_SIZE = 32
 SAMPLE_SEED = 42
@@ -356,10 +357,12 @@ class LlamaGRPOCompleter(GRPOCompleter):
 
         return ttml.autograd.Tensor.from_numpy(mask_4d, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, self._dp_mapper)
 
-    def _build_logits_mask(self, vocab_size: int, padded_vocab_size: int) -> ttml.autograd.Tensor:
+    def _build_logits_mask(self, vocab_size: int, padded_vocab_size: int, dtype: ttnn.DataType) -> ttml.autograd.Tensor:
+        """``dtype`` should match the logits dtype -- the fused sampler typecasts a mismatched mask on
+        every call, so the caller passes the dtype of the actual logits tensor to skip that."""
         logits_mask = np.zeros((1, 1, 1, padded_vocab_size), dtype=np.float32)
         logits_mask[:, :, :, vocab_size:] = 1e4
-        return ttml.autograd.Tensor.from_numpy(logits_mask, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16)
+        return ttml.autograd.Tensor.from_numpy(logits_mask, ttnn.Layout.TILE, dtype)
 
     def _get_stop_ids(self) -> set[int]:
         tokenizer = self._ctx._tokenizer
@@ -408,7 +411,9 @@ class LlamaGRPOCompleter(GRPOCompleter):
         padded_V = round_up_to_tile(V)
 
         kv_cache = self._get_kv_cache(B_local)
-        logits_mask_tensor = self._build_logits_mask(V, padded_V) if padded_V != V else None
+        # Built lazily on the first step: the mask should match the LOGITS dtype (a mismatch costs
+        # a typecast on every sample call), and that dtype is only knowable from an actual forward pass.
+        logits_mask_tensor = None
 
         tokens_to_complete = min(
             ctx.max_tokens_to_complete,
@@ -432,8 +437,12 @@ class LlamaGRPOCompleter(GRPOCompleter):
                 arr[:, j] = column.to_numpy(composer).reshape(B)
             return arr
 
+        prefill_positions = positions_to_tensor([N - 1] * B, B, N, self._dp_mapper)
+        decode_positions = positions_to_tensor([0] * B, B, 1, self._dp_mapper)
+
         for i in range(tokens_to_complete):
-            if kv_cache.get_cache_position() == 0:
+            is_prefill = kv_cache.get_cache_position() == 0
+            if is_prefill:
                 processed = 0
                 new_tokens = prompt_tokens_np.shape[1]
                 token_tensor = self._tokens_to_tensor(prompt_tokens_np, B)
@@ -450,21 +459,25 @@ class LlamaGRPOCompleter(GRPOCompleter):
             mask = self._create_causal_mask(processed, new_tokens, pad_lengths, B)
             logits = self._model(token_tensor, mask, kv_cache=kv_cache, new_tokens=new_tokens)
 
+            if logits_mask_tensor is None and padded_V != V:
+                logits_mask_tensor = self._build_logits_mask(V, padded_V, logits.get_value().dtype)
+
             next_token_tensor = ttml.ops.sample.sample_op(
-                logits, ctx.temperature, np.random.randint(low=1e7), logits_mask_tensor, self._seed_axes
+                logits,
+                ctx.temperature,
+                np.random.randint(low=1e7),
+                logits_mask_tensor,
+                self._seed_axes,
+                prefill_positions if is_prefill else decode_positions,
             )
 
-            last_token_column = ttnn.slice(
-                next_token_tensor.get_value(),
-                [0, 0, new_tokens - 1, 0],
-                [B_local, 1, new_tokens, 1],
-            )
+            last_token_column = next_token_tensor.get_value()
 
             generated_columns.append(last_token_column)
             chunk_columns.append(last_token_column)
             N += 1
 
-            deallocate_tensors([token_tensor, mask, logits, next_token_tensor])
+            deallocate_tensors([token_tensor, mask, logits])
 
             if (i + 1) % CHUNK == 0:
                 if pending_event is not None:
@@ -481,8 +494,7 @@ class LlamaGRPOCompleter(GRPOCompleter):
                 chunk_columns = []
 
         completions_np = to_np(generated_columns)
-        deallocate_tensors(generated_columns)
-        deallocate_tensors([logits_mask_tensor])
+        deallocate_tensors(generated_columns + [prefill_positions, decode_positions, logits_mask_tensor])
         kv_cache.reset()
 
         completions: List[List[int]] = []

--- a/tt-train/sources/examples/grpo/utils/qwen3_completer.py
+++ b/tt-train/sources/examples/grpo/utils/qwen3_completer.py
@@ -36,6 +36,8 @@ from huggingface_hub import snapshot_download
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 from ttml.trainers.grpo_trainer import GRPOCompleter
+from ttml.common.sampling import positions_to_tensor
+
 from .completer_common import deallocate_tensors, async_read_to_host
 from ttml.common.utils import build_mesh
 from ttml.models.qwen3.weights import load_weights_from_hf
@@ -356,19 +358,35 @@ class Qwen3GRPOCompleter(GRPOCompleter):
                 logits = self._model(input_tensor, prefill_mask, past_key_values=kv)
 
                 seed = int(np.random.randint(low=1, high=int(1e7)))
+
+                # The model emits logits for all Np prompt positions, but exactly ONE per row is ever
+                # read: row b's prediction comes from pred_pos[b] = len_b - 1, and the prompts have
+                # different lengths so every row wants a different position. Sampling the whole
+                # [B, 1, Np, V] therefore did Np times the necessary work.
+                #
+                # Hand the positions to the op instead. It reads only the tiles those rows live in,
+                # so prefill sampling costs one decode step's worth of work whatever the context
+                # length, and returns [B, 1, 1, 1].
+                #
                 # Seed uniquely only over the batch-sharded axes (dp/fsdp) so each device's rollout
                 # draws independent noise; a replicated (tp) axis, if any, is excluded via _seed_axes.
-                sampled = ttml.ops.sample.sample_op(logits, ctx.temperature, seed, None, self._seed_axes)
-                # Per-row prediction position: read the whole sampled column once
-                # on host and pick row b's token at pred_pos[b].
+                positions_tensor = positions_to_tensor(pred_pos, B, Np, self._dp_mapper)
+                sampled = ttml.ops.sample.sample_op(
+                    logits,
+                    ctx.temperature,
+                    seed,
+                    None,
+                    self._seed_axes,
+                    positions_tensor,
+                )
                 sampled_host = ttnn.to_torch(sampled.get_value(), mesh_composer=composer)
-                sampled_host = sampled_host.reshape(B, 1, Np, 1).to(int).numpy()
+                sampled_host = sampled_host.reshape(B).to(int).numpy()
                 for b in range(B):
-                    tok = int(sampled_host[b, 0, pred_pos[b], 0])
+                    tok = int(sampled_host[b])
                     first_tokens[b] = tok
                     if tok in stop_ids:
                         done[b] = True
-                deallocate_tensors([input_tensor, prefill_mask, logits, sampled])
+                deallocate_tensors([input_tensor, prefill_mask, logits, sampled, positions_tensor])
                 ttml.autograd.AutoContext.get_instance().reset_graph()
 
                 # --- Decode: feed one token per step. The first decode input is
@@ -386,13 +404,11 @@ class Qwen3GRPOCompleter(GRPOCompleter):
 
                     seed = int(np.random.randint(low=1, high=int(1e7)))
                     sampled = ttml.ops.sample.sample_op(logits, ctx.temperature, seed, None, self._seed_axes)
-                    # Clone so the column is independent of the deallocated sampled.
-                    last_token_column = ttnn.clone(ttnn.slice(sampled.get_value(), [0, 0, 0, 0], [B_local, 1, 1, 1]))
+
+                    last_token_column = sampled.get_value()
                     generated_columns.append(last_token_column)
                     chunk_columns.append(last_token_column)
-                    # Do NOT deallocate ``last_input``: after step 0 it wraps the
-                    # previous step's still-referenced column.
-                    deallocate_tensors([decode_mask, logits, sampled])
+                    deallocate_tensors([decode_mask, logits])
                     last_input = ttml.autograd.Tensor(last_token_column, False)
 
                     # Chunked async stop detection.

--- a/tt-train/sources/examples/qwen3/generate.py
+++ b/tt-train/sources/examples/qwen3/generate.py
@@ -76,13 +76,17 @@ def _causal_mask(seq_len, device):
 create_causal_mask_tensor = _causal_mask  # public alias used by gradients.py
 
 
-def _sample_logits_mask(orig_vocab, padded_vocab, device):
-    """Mask for padded vocabulary entries (subtractive: 0=valid, 1e4=padding)."""
+def _sample_logits_mask(orig_vocab, padded_vocab, device, dtype=ttnn.bfloat16):
+    """Mask for padded vocabulary entries (subtractive: 0=valid, 1e4=padding).
+
+    ``dtype`` should match the logits the mask is applied to -- the fused sampler typecasts a
+    mismatched mask on every call. Pass the dtype of the actual logits tensor to skip that.
+    """
     if orig_vocab >= padded_vocab:
         return None
-    mask = torch.zeros((1, 1, 1, padded_vocab), dtype=torch.bfloat16)
+    mask = torch.zeros((1, 1, 1, padded_vocab), dtype=torch.float32)
     mask[:, :, :, orig_vocab:] = 1e4
-    return _to_device_tiled(mask, device)
+    return _to_device_tiled(mask, device, dtype)
 
 
 # =====================================================================
@@ -340,8 +344,9 @@ def generate_ttml(
             )
         else:
             if step == 0:
-                # logits is post-all_gather here, so dim 3 is the full padded vocab.
-                logits_mask = _sample_logits_mask(orig_vocab, int(logits.shape()[3]), device)
+                # logits is post-all_gather here, so dim 3 is the full padded vocab, and its
+                # dtype is the one the mask should be built in.
+                logits_mask = _sample_logits_mask(orig_vocab, int(logits.shape()[3]), device, logits.get_value().dtype)
             tokens = _sample_on_device(
                 logits,
                 pred_positions,

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -540,8 +540,14 @@ void py_module(nb::module_& m) {
             nb::arg("logits"),
             nb::arg("temperature"),
             nb::arg("seed"),
-            nb::arg("logits_padding_mask") = nb::none(),
-            nb::arg("seed_axes") = nb::none());
+            nb::arg("logits_mask") = nb::none(),
+            nb::arg("seed_axes") = nb::none(),
+            // `positions` (optional): a [B, 1, 1, 1] UINT32 ROW_MAJOR tensor, one token position per
+            // batch row, sharded with the SAME mapper as the batch. Prefill should pass the index of
+            // each sequence's last real prompt token; the op then samples only those rows and
+            // returns [B, 1, 1, 1]. Passing a plain list now raises TypeError -- deliberately loud,
+            // since a silently ignored list would sample every row instead.
+            nb::arg("positions") = nb::none());
     }
 
     {

--- a/tt-train/sources/ttml/ops/sampling_op.cpp
+++ b/tt-train/sources/ttml/ops/sampling_op.cpp
@@ -15,14 +15,16 @@ autograd::TensorPtr sample_op(
     const autograd::TensorPtr& logits,
     float temperature,
     uint32_t seed,
-    const autograd::TensorPtr& logits_padding_mask,
-    std::optional<std::vector<uint32_t>> seed_axes) {
+    const autograd::TensorPtr& logits_mask,
+    std::optional<std::vector<uint32_t>> seed_axes,
+    const autograd::TensorPtr& positions) {
     auto sampled_tensor = ttnn_fixed::sample(
         logits->get_value(),
         temperature,
         seed,
-        logits_padding_mask == nullptr ? std::nullopt : std::optional<ttnn::Tensor>(logits_padding_mask->get_value()),
-        std::move(seed_axes));
+        logits_mask == nullptr ? std::nullopt : std::optional<ttnn::Tensor>(logits_mask->get_value()),
+        std::move(seed_axes),
+        positions == nullptr ? std::nullopt : std::optional<ttnn::Tensor>(positions->get_value()));
 
     auto out = autograd::create_tensor(sampled_tensor);
 
@@ -31,7 +33,7 @@ autograd::TensorPtr sample_op(
         throw std::runtime_error("Sampling operation backward pass is not implemented.");
     };
 
-    out->set_node(autograd::add_backward_node(std::move(grad), out, logits, logits_padding_mask));
+    out->set_node(autograd::add_backward_node(std::move(grad), out, logits, logits_mask));
 
     return out;
 }

--- a/tt-train/sources/ttml/ops/sampling_op.hpp
+++ b/tt-train/sources/ttml/ops/sampling_op.hpp
@@ -15,11 +15,17 @@ namespace ttml::ops {
 // `seed_axes` (optional): mesh axes across which the logits hold DISTINCT data and must be seeded
 // uniquely (e.g. dp / fsdp). Axes omitted are treated as replicated (e.g. tp) and get identical noise.
 // std::nullopt (default) => seed NO axis: every device draws the same noise (original behavior).
+// `positions` (optional): per-batch-row token position, a [B, 1, 1, 1] UINT32 ROW_MAJOR tensor
+// sharded with the SAME mapper as the batch. nullptr (default) samples every position. Supplying it
+// samples ONLY those rows and returns [B, 1, 1, 1] -- what prefill actually needs, at a fraction of
+// the work, since each sequence's prompt ends at its own position and everything else in the
+// [B, 1, tokens, V] logits is thrown away.
 autograd::TensorPtr sample_op(
     const autograd::TensorPtr& logits,
     float temperature,
     uint32_t seed,
-    const autograd::TensorPtr& logits_padding_mask = nullptr,
-    std::optional<std::vector<uint32_t>> seed_axes = std::nullopt);
+    const autograd::TensorPtr& logits_mask = nullptr,
+    std::optional<std::vector<uint32_t>> seed_axes = std::nullopt,
+    const autograd::TensorPtr& positions = nullptr);
 
 }  // namespace ttml::ops

--- a/tt-train/sources/ttml/ttml/common/generate.py
+++ b/tt-train/sources/ttml/ttml/common/generate.py
@@ -104,11 +104,11 @@ def generate(
     generated_tokens = prompt_tokens.copy()
     prompt_len = len(prompt_tokens)
 
+    # Built lazily on the first step: the mask should match the LOGITS dtype (a mismatch costs a
+    # typecast on every sample call), and the logits dtype is only knowable from an actual forward pass.
     logits_mask_tensor = None
     vocab_size = transformer_config.vocab_size
     padded_vocab_size = round_up_to_tile(vocab_size)
-    if padded_vocab_size != vocab_size:
-        logits_mask_tensor = build_logits_mask(vocab_size, padded_vocab_size)
 
     # Generate tokens one by one
     for step in range(max_seq_len - prompt_len):
@@ -132,6 +132,9 @@ def generate(
         mask = create_causal_mask_kv_cache(len(input_tokens), processed_tokens)
         new_tokens = len(input_tokens)
         logits = model(token_tensor, mask, kv_cache=kv_cache, new_tokens=new_tokens)
+
+        if logits_mask_tensor is None and padded_vocab_size != vocab_size:
+            logits_mask_tensor = build_logits_mask(vocab_size, padded_vocab_size, logits.get_value().dtype)
 
         # Sample next token
         # The logits tensor has shape [1, 1, seq_len, vocab_size] where seq_len may be padded

--- a/tt-train/sources/ttml/ttml/common/sampling.py
+++ b/tt-train/sources/ttml/ttml/common/sampling.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-side helpers for ``ttml.ops.sample.sample_op``.
+
+This lives in the ttml package (rather than in an example) so that every caller of the
+sampler -- not just the GRPO completers -- can build a validated positions tensor.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
+
+import numpy as np
+import ttnn
+
+import ttml
+
+
+def positions_to_tensor(
+    positions: Sequence[int], B: int, tokens: int, dp_mapper: Any, num_shards: Optional[int] = None
+) -> ttml.autograd.Tensor:
+    """Per-row sample positions for ``sample_op`` as [B, 1, 1, 1] UINT32.
+
+    ``dp_mapper`` must be the SAME mapper the batch was sharded with (``None`` when the batch is
+    replicated). That is what makes the shard landing on each device BE that device's rows -- true by
+    construction, rather than by two separately-written mapper configs happening to agree.
+
+    Validate here, while the values are still on the host: once they land in device memory the op
+    cannot range-check them on the dispatch path (reading them back would be a blocking sync). The
+    device kernels clamp out-of-range positions to the last real token (and assert under watcher),
+    so a bad value can no longer silently sample a padding row -- but the clamp is a containment
+    measure, not a diagnosis. This assert is the loud, early check that names the offending rows.
+    """
+    positions = [int(p) for p in positions]
+    assert len(positions) == B, f"expected {B} positions, got {len(positions)}"
+    bad = [(b, p) for b, p in enumerate(positions) if not 0 <= p < tokens]
+    assert not bad, f"positions outside [0, {tokens}): {bad[:8]}"
+    if dp_mapper is not None:
+        # A 1D shard mapper that receives fewer rows than it has shard slots SHRINKS the tensor's
+        # distribution shape to the actual chunk count (distributed_tensor.cpp, "If the distribution
+        # shape is 1D and we have less shards than devices"). The op then rejects the tensor for not
+        # matching the logits' topology -- a true but unhelpful message. Catch the real cause here:
+        # an uneven batch, typically the tail of a dataset whose prompt count does not divide the
+        # rollout batch size.
+        #
+        # The divisor is the number of batch shards THE MAPPER produces, which is a property of the
+        # mapper and not of axis semantics: shard_tensor_to_mesh_mapper(device, dim) without a
+        # cluster_axis -- the only batch mapper ttml builds today -- flattens the WHOLE mesh and
+        # shards across every device, so the default is the full device count of the AutoContext
+        # mesh (the only mesh a ttml mapper can target, and where this tensor is about to land).
+        # A mapper that shards across a subset of the mesh (e.g. a cluster_axis batch mapper
+        # that replicates across tp) produces fewer shards; the mapper object is opaque from Python,
+        # so such callers must pass their shard count via ``num_shards``.
+        if num_shards is None:
+            num_shards = ttml.autograd.AutoContext.get_instance().get_device().get_num_devices()
+        assert B % num_shards == 0, (
+            f"batch of {B} rows does not divide across {num_shards} batch shards; a sharded "
+            f"positions tensor requires a divisible batch (pad or drop the tail batch before "
+            f"sampling)"
+        )
+    return ttml.autograd.Tensor.from_numpy(
+        np.asarray(positions, dtype=np.uint32).reshape(B, 1, 1, 1),
+        ttnn.Layout.ROW_MAJOR,
+        ttnn.DataType.UINT32,
+        dp_mapper,
+    )

--- a/tt-train/sources/ttml/ttml/common/sampling.py
+++ b/tt-train/sources/ttml/ttml/common/sampling.py
@@ -34,9 +34,11 @@ def positions_to_tensor(
     measure, not a diagnosis. This assert is the loud, early check that names the offending rows.
     """
     positions = [int(p) for p in positions]
-    assert len(positions) == B, f"expected {B} positions, got {len(positions)}"
+    if len(positions) != B:
+        raise ValueError(f"expected {B} positions, got {len(positions)}")
     bad = [(b, p) for b, p in enumerate(positions) if not 0 <= p < tokens]
-    assert not bad, f"positions outside [0, {tokens}): {bad[:8]}"
+    if bad:
+        raise ValueError(f"positions outside [0, {tokens}): {bad[:8]}")
     if dp_mapper is not None:
         # A 1D shard mapper that receives fewer rows than it has shard slots SHRINKS the tensor's
         # distribution shape to the actual chunk count (distributed_tensor.cpp, "If the distribution
@@ -55,11 +57,11 @@ def positions_to_tensor(
         # so such callers must pass their shard count via ``num_shards``.
         if num_shards is None:
             num_shards = ttml.autograd.AutoContext.get_instance().get_device().get_num_devices()
-        assert B % num_shards == 0, (
-            f"batch of {B} rows does not divide across {num_shards} batch shards; a sharded "
-            f"positions tensor requires a divisible batch (pad or drop the tail batch before "
-            f"sampling)"
-        )
+        if B % num_shards != 0:
+            raise ValueError(
+                f"batch of {B} rows does not divide across {num_shards} batch shards; a sharded "
+                "positions tensor requires a divisible batch (pad or drop the tail batch before sampling)"
+            )
     return ttml.autograd.Tensor.from_numpy(
         np.asarray(positions, dtype=np.uint32).reshape(B, 1, 1, 1),
         ttnn.Layout.ROW_MAJOR,

--- a/tt-train/sources/ttml/ttml/common/utils.py
+++ b/tt-train/sources/ttml/ttml/common/utils.py
@@ -211,10 +211,19 @@ def get_loss_over_devices(loss):
     return loss_numpy.mean()
 
 
-def build_logits_mask(vocab_size: int, padded_vocab_size: int) -> ttml.autograd.Tensor:
+def build_logits_mask(
+    vocab_size: int, padded_vocab_size: int, dtype: ttnn.DataType = ttnn.DataType.BFLOAT16
+) -> ttml.autograd.Tensor:
+    """Subtractive vocab-padding mask ``[1, 1, 1, padded_vocab_size]``: 0 = real token, 1e4 = padding.
+
+    ``dtype`` should match the LOGITS dtype the mask will be subtracted from: the fused sampler stages
+    mask tiles into a circular buffer whose data format is derived from the logits, so a mismatched
+    mask is typecast on EVERY sample call -- one extra op per generated token. Pass the dtype of the
+    actual logits (``logits.get_value().dtype`` after the first forward pass) instead of assuming bfloat16.
+    """
     logits_mask = np.zeros((1, 1, 1, padded_vocab_size), dtype=np.float32)
     logits_mask[:, :, :, vocab_size:] = 1e4
-    return ttml.autograd.Tensor.from_numpy(logits_mask, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16)  # [1,1,1,T], bfloat16
+    return ttml.autograd.Tensor.from_numpy(logits_mask, ttnn.Layout.TILE, dtype)
 
 
 def build_causal_mask(T: int, device: bool = False):

--- a/tt-train/tests/python/test_sample_seeding.py
+++ b/tt-train/tests/python/test_sample_seeding.py
@@ -36,6 +36,13 @@ axis. The opened shape is controlled by ``SAMPLE_SEEDING_MESH`` (e.g. "8,4"),
 letting a galaxy run cover the 2D cases; set ``TT_MESH_GRAPH_DESC_PATH`` to a
 descriptor matching that shape (the fixture only auto-fills a bundled MGD when
 the env var is unset, so your value always wins).
+
+The per-row ``positions`` tests live here too (rather than in the single-device
+gtest suite) because what they check only EXISTS on a mesh: that a positions
+tensor sharded with the batch mapper hands each device its own rows, and that
+the op's topology equality check actually fires on a mismatch. On the default
+single mesh both sides of that comparison are the trivial replicated topology,
+so a single-device test of the check is vacuous.
 """
 
 from __future__ import annotations
@@ -50,7 +57,6 @@ import torch
 
 import ttnn
 import ttml
-
 
 pytestmark = pytest.mark.requires_device
 
@@ -262,3 +268,164 @@ def test_sample_seeding(seeding_mesh, name, seed_axes, need_unseeded_nontrivial)
 
     per_device = _run_sample(seed_axes)
     _assert_seeding(per_device, shape, seed_axes)
+
+
+# --- Per-row positions on a mesh. Greedy (temperature 0) so the result is a pure
+#     function of the logits and positions: no noise, no seed sensitivity.
+
+
+def _positions_winners(B_total: int, T_pos: int, V_pos: int):
+    """Distinct winner per (row, token position) so a wrong row or wrong device shard
+    lands on a DIFFERENT id rather than coincidentally matching."""
+    logits_np = np.full((B_total, 1, T_pos, V_pos), -1.0, dtype=np.float32)
+    winner = np.zeros((B_total, T_pos), dtype=np.int64)
+    for b in range(B_total):
+        for t in range(T_pos):
+            w = ((b * T_pos + t) * 7) % V_pos
+            logits_np[b, 0, t, w] = -0.5
+            winner[b, t] = w
+    return logits_np, winner
+
+
+def test_sample_positions_sharded_selects_each_devices_rows(seeding_mesh):
+    """Sharded logits + positions sharded with the SAME mapper: every global row must be
+    sampled at ITS OWN position. This is the one configuration production uses and the one
+    no single-device test can exercise -- it covers the per-device row slice, the op's
+    positions/logits topology equality on real Shard{0} topologies (non-vacuous only on a
+    mesh), and the [B, 1, 1, 1] output composing back in batch order."""
+    from ttml.common.sampling import positions_to_tensor
+
+    shape = seeding_mesh
+    n = math.prod(shape)
+    if n <= 1:
+        pytest.skip("positions sharding needs a multi-device mesh")
+
+    device = ttml.autograd.AutoContext.get_instance().get_device()
+    dp_mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(device, 0)
+    composer = ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
+
+    B_total, T_pos, V_pos = 4 * n, 64, 64  # T spans two tile rows so positions cross a tile boundary
+    logits_np, winner = _positions_winners(B_total, T_pos, V_pos)
+    # Positions differ per row and cover first/last tile rows, so a stale or mis-sliced
+    # device shard cannot pass by luck.
+    positions = [(b * 13) % T_pos for b in range(B_total)]
+
+    logits = ttml.autograd.Tensor.from_numpy(logits_np, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, dp_mapper)
+    positions_tt = positions_to_tensor(positions, B_total, T_pos, dp_mapper)
+
+    sampled = ttml.ops.sample.sample_op(logits, 0.0, SEED, None, [0], positions_tt)
+    got = ttnn.to_torch(sampled.get_value(), mesh_composer=composer).flatten().to(torch.int64).cpu().numpy()
+    ttml.autograd.AutoContext.get_instance().reset_graph()
+
+    assert got.size == B_total, f"expected one token per global row, got {got.size}"
+    expected = np.array([winner[b, positions[b]] for b in range(B_total)], dtype=np.int64)
+    np.testing.assert_array_equal(
+        got,
+        expected,
+        err_msg="a row sampled at another row's position -- the positions shard does not match the batch shard",
+    )
+
+
+def test_sample_positions_topology_mismatch_rejected(seeding_mesh, expect_error):
+    """REPLICATED positions against SHARDED logits must be rejected loudly. On a mesh the
+    two topologies genuinely differ, so this is the first configuration in which the op's
+    topology equality check can fire at all; if it silently passed, page e of the replicated
+    tensor would be read as device-local row e -- valid-looking tokens for the wrong rows."""
+    shape = seeding_mesh
+    n = math.prod(shape)
+    if n <= 1:
+        pytest.skip("topologies coincide on a single-device mesh; the check is vacuous")
+
+    device = ttml.autograd.AutoContext.get_instance().get_device()
+    dp_mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(device, 0)
+    replicate = ttml.core.distributed.replicate_tensor_to_mesh_mapper(device)
+
+    B_total, T_pos, V_pos = 4 * n, 64, 64
+    logits_np, _ = _positions_winners(B_total, T_pos, V_pos)
+    logits = ttml.autograd.Tensor.from_numpy(logits_np, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, dp_mapper)
+
+    # Deliberately the WRONG mapper: replicated [B_local, 1, 1, 1] per device (B_local rows so
+    # the shape check passes and the failure is attributable to the topology check alone).
+    B_local = B_total // n
+    bad_np = np.zeros((B_local, 1, 1, 1), dtype=np.uint32)
+    bad_positions = ttml.autograd.Tensor.from_numpy(bad_np, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32, replicate)
+
+    with expect_error(RuntimeError, "distributed across the mesh exactly as the logits"):
+        ttml.ops.sample.sample_op(logits, 0.0, SEED, None, [0], bad_positions)
+    ttml.autograd.AutoContext.get_instance().reset_graph()
+
+
+def test_sample_per_row_mask_topology_mismatch_rejected(seeding_mesh, expect_error):
+    """A per-row [B, 1, 1, V] logits_mask is per-device-row data exactly like positions: page e must
+    be the bias for the logits' local entry e. A REPLICATED per-row mask against SHARDED logits must
+    be rejected loudly -- on a mesh the topologies genuinely differ, which no single-device test can
+    exercise. (A shared [1, 1, 1, V] mask stays exempt: one row for everyone is distribution-free.)"""
+    shape = seeding_mesh
+    n = math.prod(shape)
+    if n <= 1:
+        pytest.skip("topologies coincide on a single-device mesh; the check is vacuous")
+
+    device = ttml.autograd.AutoContext.get_instance().get_device()
+    dp_mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(device, 0)
+    replicate = ttml.core.distributed.replicate_tensor_to_mesh_mapper(device)
+
+    B_total, T_pos, V_pos = 4 * n, 64, 64
+    logits_np, _ = _positions_winners(B_total, T_pos, V_pos)
+    logits = ttml.autograd.Tensor.from_numpy(logits_np, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, dp_mapper)
+
+    # Wrong mapper on purpose: replicated, sized to the LOCAL batch so the shape check passes and
+    # the failure is attributable to the topology check alone.
+    B_local = B_total // n
+    bad_np = np.zeros((B_local, 1, 1, V_pos), dtype=np.float32)
+    bad_mask = ttml.autograd.Tensor.from_numpy(bad_np, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, replicate)
+
+    with expect_error(RuntimeError, "mask must be distributed across the mesh exactly as the logits"):
+        ttml.ops.sample.sample_op(logits, 0.0, SEED, bad_mask, [0])
+    ttml.autograd.AutoContext.get_instance().reset_graph()
+
+
+def test_sample_per_row_mask_sharded_applies_each_rows_bias(seeding_mesh):
+    """The ACCEPTANCE path for a per-row mask on a mesh: a [B, 1, 1, V] mask sharded with the SAME
+    mapper as the logits must hand every device its own rows' bias. Greedy (temperature 0) so the
+    result is a pure function of logits and mask. Every global row b has a UNIQUE winner w(b) and
+    its mask row bans exactly w(b): the correct outcome is the shared runner-up (column 0) for every
+    row, while a device that received another device's mask shard leaves its own rows' winners
+    un-banned -- w(b) is injective across the GLOBAL batch, so any shard swap or offset surfaces as
+    a non-zero token. This is the configuration the single-device gtests structurally cannot reach."""
+    shape = seeding_mesh
+    n = math.prod(shape)
+    if n <= 1:
+        pytest.skip("mask sharding needs a multi-device mesh")
+
+    device = ttml.autograd.AutoContext.get_instance().get_device()
+    dp_mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(device, 0)
+    composer = ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
+
+    B_total, T_tok, V_tok = 2 * n, 32, 96  # w(b) = 1 + b must stay injective within the vocab
+    assert B_total + 1 < V_tok
+    logits_np = np.full((B_total, 1, T_tok, V_tok), -1.0, dtype=np.float32)
+    mask_np = np.zeros((B_total, 1, 1, V_tok), dtype=np.float32)
+    for b in range(B_total):
+        logits_np[b, 0, :, 1 + b] = -0.25  # unique winner per global row
+        logits_np[b, 0, :, 0] = -0.5  # shared runner-up
+        mask_np[b, 0, 0, 1 + b] = 1e4  # ban exactly this row's winner
+
+    logits = ttml.autograd.Tensor.from_numpy(logits_np, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, dp_mapper)
+    mask = ttml.autograd.Tensor.from_numpy(mask_np, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, dp_mapper)
+
+    # Sanity without the mask: each row's own winner (also proves the winners are distinguishable).
+    unmasked = ttml.ops.sample.sample_op(logits, 0.0, SEED, None, [0])
+    got = ttnn.to_torch(unmasked.get_value(), mesh_composer=composer).flatten().to(torch.int64).cpu().numpy()
+    got = got.reshape(B_total, T_tok)
+    for b in range(B_total):
+        assert np.all(got[b] == 1 + b), f"unmasked winner wrong for row {b}: {got[b][:4]}"
+
+    masked = ttml.ops.sample.sample_op(logits, 0.0, SEED, mask, [0])
+    got = ttnn.to_torch(masked.get_value(), mesh_composer=composer).flatten().to(torch.int64).cpu().numpy()
+    got = got.reshape(B_total, T_tok)
+    ttml.autograd.AutoContext.get_instance().reset_graph()
+    for b in range(B_total):
+        assert np.all(got[b] == 0), (
+            f"row {b} sampled {got[b][:4]} -- its own winner {1 + b} was not banned, so this device "
+            f"applied another row's mask shard"
+        )

--- a/tt-train/tests/python/test_sample_seeding.py
+++ b/tt-train/tests/python/test_sample_seeding.py
@@ -275,13 +275,16 @@ def test_sample_seeding(seeding_mesh, name, seed_axes, need_unseeded_nontrivial)
 
 
 def _positions_winners(B_total: int, T_pos: int, V_pos: int):
-    """Distinct winner per (row, token position) so a wrong row or wrong device shard
-    lands on a DIFFERENT id rather than coincidentally matching."""
+    """Row-tagged winners w(b, t) = (2*b + t) % V_pos, injective in BOTH directions once
+    V_pos >= 2*T_pos >= 2*B_total: for a fixed row, every position picks a different id (a row
+    read at ANOTHER ROW'S POSITION lands elsewhere), and for a fixed position, every row picks a
+    different id (a row fed ANOTHER ROW'S LOGITS shard lands elsewhere). Callers that only need
+    valid greedy logits (not the injectivity) may pass any tile-aligned T_pos == V_pos."""
     logits_np = np.full((B_total, 1, T_pos, V_pos), -1.0, dtype=np.float32)
     winner = np.zeros((B_total, T_pos), dtype=np.int64)
     for b in range(B_total):
         for t in range(T_pos):
-            w = ((b * T_pos + t) * 7) % V_pos
+            w = (2 * b + t) % V_pos
             logits_np[b, 0, t, w] = -0.5
             winner[b, t] = w
     return logits_np, winner
@@ -304,7 +307,13 @@ def test_sample_positions_sharded_selects_each_devices_rows(seeding_mesh):
     dp_mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(device, 0)
     composer = ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
 
-    B_total, T_pos, V_pos = 4 * n, 64, 64  # T spans two tile rows so positions cross a tile boundary
+    # T_pos >= B_total keeps 13*b % T_pos distinct for EVERY global row (a 32-device galaxy has
+    # B_total = 128 > 64, where rows b and b + 64 would otherwise share a position and a d <-> d+16
+    # positions-shard swap would go unnoticed). T spans at least two tile rows so positions cross
+    # a tile boundary; V_pos = 2 * T_pos gives _positions_winners room to tag each row's winner.
+    B_total = 4 * n
+    T_pos = max(64, B_total)
+    V_pos = 2 * T_pos
     logits_np, winner = _positions_winners(B_total, T_pos, V_pos)
     # Positions differ per row and cover first/last tile rows, so a stale or mis-sliced
     # device shard cannot pass by luck.


### PR DESCRIPTION
## Summary

Stacked on #52973 (the fused `gumbel_sample` kernel PR). **Base branch: `awliu/ttml_sample_fix`.** This PR is the integration half of the split requested in review: it exposes the kernel's `positions` and per-row mask to Python and moves the callers onto them. Nothing under `metal/` changes here.

- **nanobind / C++ autograd op** — `ttml.ops.sample.sample_op` gains `positions=` (a `[B, 1, 1, 1]` UINT32 ROW_MAJOR tensor sharded with the same mapper as the batch; passing a plain list raises `TypeError`). The `logits_padding_mask` kwarg is renamed `logits_mask`, since the mask is now general per-row logit bias (`[1, 1, 1, V]` or `[B, 1, 1, V]`), not only vocab padding. `ttml::ops::sample_op` gains the same `positions` parameter; nanobind binds one `nb::arg` per parameter, which is why the C++ op moves with this PR.
- **`ttml.common.sampling.positions_to_tensor`** — host-side builder for the positions tensor that validates the values while they are still on the host (range, count, and batch divisibility across the batch mapper's shard count).
- **`build_logits_mask(vocab, padded_vocab, dtype=BFLOAT16)`** — the mask dtype is now selectable. The kernel PR typecasts a mismatched mask on every call, so callers pass the logits dtype to skip that per-token op.
- **GRPO completers (llama, qwen3)** — prefill samples only each row's last prompt position via `positions` (one decode step's worth of work instead of `Np`×), decode passes position 0; the `ttnn.slice`/`ttnn.clone` of the sampled column goes away because the op now returns `[B, 1, 1, 1]` directly; the logits mask is built lazily in the logits dtype after the first forward.
- **`examples/qwen3/generate.py`, `ttml.common.generate`** — build the mask in the logits dtype after the first forward pass.
- **Mesh pytest tests (`tests/python/test_sample_seeding.py`)** — sharded positions select each device's own rows; a replicated positions tensor or per-row mask against sharded logits is rejected by the topology check; a per-row mask sharded with the batch applies each row's bias. These live here rather than in the gtest suite because the checks are vacuous on a single-device mesh.

## Test plan

Not run in this environment (no device attached).

- [ ] `pytest tt-train/tests/python/test_sample_seeding.py` on a multi-device mesh (T3K; galaxy with `SAMPLE_SEEDING_MESH=8,4`)
- [ ] GRPO rollout smoke run with the llama and qwen3 completers (prefill positions path)
- [ ] `tt-train/sources/examples/qwen3/generate.py` end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/ttml_sample_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/ttml_sample_integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=awliu/ttml_sample_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:awliu/ttml_sample_integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/ttml_sample_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/ttml_sample_integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=awliu/ttml_sample_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:awliu/ttml_sample_integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/ttml_sample_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/ttml_sample_integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/ttml_sample_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/ttml_sample_integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/ttml_sample_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/ttml_sample_integration)