### PR TITLE
Cleanup: drop the retired FUSE_ACTIVATION define from both sparse matmul factories

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
@@ -403,7 +403,6 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
     std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
 
-    mm_kernel_defines["FUSE_ACTIVATION"] = "0";
     if (packer_l1_acc_en) {
         mm_kernel_defines["PACKER_L1_ACC"] = "1";
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
@@ -441,7 +441,6 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
     std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
 
-    mm_kernel_defines["FUSE_ACTIVATION"] = "0";
     if (packer_l1_acc_en) {
         mm_kernel_defines["PACKER_L1_ACC"] = "1";
     }


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Both sparse matmul factories set a define no kernel reads:

```cpp
mm_kernel_defines["FUSE_ACTIVATION"] = "0";
```

`FUSE_ACTIVATION` has exactly two occurrences in the tree, both of them these writes. The mechanism the matmul compute kernels actually gate on is `SFPU_ACTIVATION`, used at four points in `bmm_large_block_zm_fused_bias_activation.cpp`, and the non-sparse factory sets `SFPU_ACTIVATION` and `PACK_RELU` accordingly. The sparse copies kept the retired name.

The value makes it slightly worse than inert. `#ifdef` tests definedness, not the value, so a future reader of `FUSE_ACTIVATION` would see `"0"` as enabled.

Both lines sit directly above live defines (`PACKER_L1_ACC`, `FP32_DEST_ACC_EN`), which is why the leftover is easy to miss in review.

### Notes for reviewers

Removing a define changes the JIT kernel hash, so the first run after this recompiles the sparse matmul kernels once. No output changes, because nothing ever read it.

Built and tested on a Blackhole p150b and a Wormhole n150, with the kernel cache cleared: `tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py -k with_nnz` gives 6 passed on both cards before and after.
