### PR TITLE
[moe_gpt] bug fix: single consumer for the tilize total_chunks page

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_compute.cpp
@@ -9,7 +9,7 @@
 #include "api/dataflow/circular_buffer.h"
 
 // Compute kernel for tilizing incoming tokens from the reader.
-// Waits for writer to pass total_chunks via CB, then processes each chunk:
+// Waits for the reader to pass total_chunks via CB, then processes each chunk:
 // - Wait for reader to push tokens_per_chunk tokens
 // - Tilize the block
 // - Push tilized output to writer
@@ -36,7 +36,7 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_tilize_input.get_cb_id(), cb_tilize_output.get_cb_id());
     fast_tilize_init(cb_tilize_input.get_cb_id(), tiles_per_local_chunk, cb_tilize_output.get_cb_id());
 
-    // Wait for writer to push total_chunks via CB
+    // Wait for the reader to push total_chunks via CB
     cb_total_chunks.wait_front(one_page);
 
     // Read total_chunks from the CB

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
@@ -855,7 +855,7 @@ void kernel_main() {
             num_activated_tokens_per_expert[e] = per_expert_counts[e];
         }
 
-        // Push per_expert_total_tokens_cb and total_chunks_cb so writer can read them
+        // Push per_expert_total_tokens_cb (read by the writer) and total_chunks_cb (read by the tilize compute kernel)
         // (drain core already pushed, non-drain cores need to mark as available)
         cb_per_expert_total_tokens.reserve_back(1);
         cb_per_expert_total_tokens.push_back(1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_writer.cpp
@@ -69,7 +69,6 @@ void kernel_main() {
     // CBs
     constexpr uint32_t tilize_output_cb_id = get_named_compile_time_arg_val("tilize_output_cb_id");
     constexpr uint32_t per_expert_total_tokens_cb_id = get_named_compile_time_arg_val("per_expert_total_tokens_cb_id");
-    constexpr uint32_t total_chunks_cb_id = get_named_compile_time_arg_val("total_chunks_cb_id");
     constexpr uint32_t indices_tensor_cb_id = get_named_compile_time_arg_val("indices_tensor_cb_id");
     constexpr uint32_t scores_tensor_cb_id = get_named_compile_time_arg_val("scores_tensor_cb_id");
     constexpr uint32_t mapping_tensor_cb_id = get_named_compile_time_arg_val("mapping_tensor_cb_id");
@@ -168,7 +167,6 @@ void kernel_main() {
     // CB typed wrappers
     CircularBuffer cb_tilize_output(tilize_output_cb_id);
     CircularBuffer cb_per_expert_total_tokens(per_expert_total_tokens_cb_id);
-    CircularBuffer cb_total_chunks(total_chunks_cb_id);
     CircularBuffer cb_indices_tensor(indices_tensor_cb_id);
     CircularBuffer cb_scores_tensor(scores_tensor_cb_id);
     CircularBuffer cb_mapping_tensor(mapping_tensor_cb_id);
@@ -397,11 +395,6 @@ void kernel_main() {
         num_tokens_per_expert[e] = per_expert_counts[e];
     }
 
-    // Wait for reader to push total_chunks
-    cb_total_chunks.wait_front(one_page);
-    [[maybe_unused]] uint32_t total_chunks =
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_total_chunks.get_read_ptr());
-
     /************************************************************************/
     /* Synchronization setup for signalling between tilize and matmul cores */
     /************************************************************************/
@@ -608,9 +601,8 @@ void kernel_main() {
         }
     }
 
-    // Pop the per-expert counts and total_chunks (cleanup)
+    // Pop the per-expert counts (cleanup).
     cb_per_expert_total_tokens.pop_front(one_page);
-    cb_total_chunks.pop_front(one_page);
 
     noc_obj.async_write_barrier();
     noc_obj.async_atomic_barrier();


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Relates to #55996 (the moe_compute instance of the same structure; fixed in #55997).

In `moe_gpt` the tilize reader pushes one `total_chunks` page and both the tilize compute kernel and the tilize writer waited on it and popped it. The CB has one page and one producer; the dataflow-side wait samples the shared acked counter once, so on a device whose experts received no tokens the compute kernel's immediate pop can starve the writer's wait and hang the op. The writer never used the value: its chunk loop already comes from the per-expert token counts.

The writer no longer references `total_chunks` (compile-time arg, CB wrapper, wait and pop removed), leaving the reader as the single producer and the compute kernel as the single consumer. The compute kernel's comments that called the page a writer-to-compute hand-off now name the reader.

**Test**

No new test: the empty-device routing needs a mesh with at least two devices on the expert axis, and the moe_gpt e2e test (`tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_gpt_e2e.py`) is the suite to run as the regression gate for the unchanged busy-device path.

### Notes for reviewers

- Mechanical twin of #55997; -9/+1 in the writer plus two comments. No data path or numerics change.
- The host still passes `total_chunks_cb_id` in the named compile-time args shared by the reader and the writer; the writer ignores it.
- Not run on hardware by me: the moe_compute version of this change has been in a Blackhole 1x4 production runtime since 2026-08-30 and its mechanism is identical here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjett/moe-gpt-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjett/moe-gpt-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sjett/moe-gpt-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sjett/moe-gpt-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjett/moe-gpt-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjett/moe-gpt-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjett/moe-gpt-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjett/moe-gpt-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sjett/moe-gpt-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sjett/moe-gpt-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sjett/moe-gpt-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sjett/moe-gpt-total-chunks-single-consumer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sjett/moe-gpt-total-chunks-single-consumer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sjett/moe-gpt-total-chunks-single-consumer)