### PR TITLE
Test: make the cumsum callback test assert, and drop a duplicate backward test

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
@@ -137,8 +137,10 @@ def test_moreh_cumsum_callback(input_shape, dim, device):
 
         # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
         device.clear_program_cache()
+        num_program_cache_entries_list = []
         for i in range(2):
             tt_output_cpu = ttnn.to_torch(ttnn.operations.moreh.cumsum(tt_input, dim))
+            num_program_cache_entries_list.append(device.num_program_cache_entries())
 
             logger.debug(f"torch_output.shape == {torch_output.shape}, tt_output_cpu == {tt_output_cpu.shape}")
 
@@ -148,7 +150,9 @@ def test_moreh_cumsum_callback(input_shape, dim, device):
             logger.debug(f"Output pcc={output_pcc}")
 
             assert passing
-        assert device.num_program_cache_entries() >= 1
+        logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+        assert num_program_cache_entries_list[0] > 0
+        assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
@@ -94,68 +94,6 @@ def test_moreh_cumsum_dim(input_shape, dim, device):
 @pytest.mark.parametrize(
     "input_shape",
     (
-        ([1, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1]),
-        ([4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1]),
-        ([4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1]),
-        ([8, 8, TILE_HEIGHT * 20 - 1, TILE_WIDTH * 20 - 1]),
-    ),
-    ids=[
-        "1, 1, TILE_HEIGHT-1,TILE_WIDTH - 1",
-        "4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1",
-        "4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1",
-        "8, 8, TILE_HEIGHT * 20 - 1, TILE_WIDTH * 20 - 1",
-    ],
-)
-@pytest.mark.parametrize(
-    "dim",
-    (
-        0,
-        1,
-    ),
-    ids=["0", "1"],
-)
-def test_moreh_cumsum_backward(input_shape, dim, device):
-    if (
-        input_shape
-        in (
-            [1, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1],
-            [4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1],
-        )
-        and dim == 0
-    ):
-        pytest.skip(
-            reason="Disabled by issue #44858: moreh cumsum backward TT_FATAL on nightly dim-0 tile-misaligned shapes"
-        )
-
-    output_shape = input_shape.copy()
-
-    (_, _, torch_input) = get_tensors(input_shape, output_shape, device)
-    (tt_output_grad, tt_input_grad, torch_output_grad) = get_backward_tensors(output_shape, input_shape, device)
-
-    torch_output = torch.cumsum(torch_input, dim)
-    torch_output.backward(torch_output_grad)
-
-    # Same fix pattern as #44283 applied to test_moreh_cumsum_dim: the legacy
-    # .cpu().to(ROW_MAJOR).unpad_from_tile(shape).to_torch() chain trips the
-    # hardened unpad_from_tile precondition (#43568) when input_shape's last
-    # two dims aren't tile-aligned — ttnn.to_torch handles padding correctly.
-    tt_input_grad_cpu = ttnn.to_torch(
-        ttnn.operations.moreh.cumsum_backward(tt_output_grad, dim, input_grad=tt_input_grad)
-    )
-
-    # test for equivalance
-    rtol = atol = 0.1
-    passing, output_pcc = comp_allclose_and_pcc(torch_input.grad, tt_input_grad_cpu, pcc=0.999, rtol=rtol, atol=atol)
-
-    logger.debug(f"Out passing={passing}")
-    logger.debug(f"Output pcc={output_pcc}")
-
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "input_shape",
-    (
         ([]),
         ([TILE_WIDTH - 1]),
         ([TILE_HEIGHT, TILE_WIDTH + 1]),
@@ -194,17 +132,23 @@ def test_moreh_cumsum_callback(input_shape, dim, device):
 
         torch_output = torch.cumsum(torch_input, dim)
 
-        cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-
         # test for equivalance
         rtol = atol = 0.1
 
+        # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+        device.clear_program_cache()
         for i in range(2):
             tt_output_cpu = ttnn.to_torch(ttnn.operations.moreh.cumsum(tt_input, dim))
 
             logger.debug(f"torch_output.shape == {torch_output.shape}, tt_output_cpu == {tt_output_cpu.shape}")
 
             passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
+
+            logger.debug(f"Out passing={passing}")
+            logger.debug(f"Output pcc={output_pcc}")
+
+            assert passing
+        assert device.num_program_cache_entries() >= 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### PR Category

Test Only

### Summary

Two problems in `test_moreh_cumsum.py`.

`test_moreh_cumsum_callback` never asserted. It computed `passing, output_pcc = comp_allclose_and_pcc(...)` and then ended, discarding both. It also lacked the `num_program_cache_entries` check that is the reason a `_callback` test runs the op twice at all. 18 parametrized cases were running the op and checking nothing.

`test_moreh_cumsum_backward` was defined twice, at lines 117 and 233. The two blocks are byte-identical, so Python rebinds the name at import and the first 60 lines are never collected.

The callback test now follows its sibling `test_moreh_cumsum_backward_callback`, which carries the identical shape list and the identical tolerances: clear the cache first, `assert passing` in the loop, and `assert device.num_program_cache_entries() >= 1` after. The dead `cpu_layout` local goes with it.

### Notes for reviewers

The assertion is newly meaningful rather than newly strict. That parameter list is not the 4D one used elsewhere in the file; it spans rank 1 through rank 6, so `moreh.cumsum` forward on those ranks had never actually been checked. It passes: 18 of 18 on a Blackhole p150b and on a Wormhole n150.

Evidence the test was vacuous, and now is not: adding `+ 1` to the torch reference leaves it green before this change, and fails 15 of 18 after.

Collection is unchanged by the duplicate removal, 52 tests before and after, and the whole file is 50 passed 2 skipped on both cards.
