### PR TITLE
Bug fix: fix the fabric router static_assert message to match its condition

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -129,7 +129,7 @@ constexpr bool is_intermesh_router = NAMED_CT_ARG("IS_INTERMESH_ROUTER");
 constexpr bool is_handshake_sender = NAMED_CT_ARG("IS_HANDSHAKE_SENDER") != 0;
 constexpr size_t handshake_addr = NAMED_CT_ARG("HANDSHAKE_ADDR");
 
-static_assert(fuse_receiver_flush_and_completion_ptr == 1, "fuse_receiver_flush_and_completion_ptr must be 0");
+static_assert(fuse_receiver_flush_and_completion_ptr == 1, "fuse_receiver_flush_and_completion_ptr must be 1");
 
 constexpr size_t VC0_RECEIVER_CHANNEL = 0;
 constexpr size_t VC1_RECEIVER_CHANNEL = 1;


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

The assert and its message disagree:

```cpp
static_assert(fuse_receiver_flush_and_completion_ptr == 1, "fuse_receiver_flush_and_completion_ptr must be 0");
```

The condition requires 1, the message says 0. Anyone who trips this is told to set the one value that guarantees it fires again.

One string literal. The condition is unchanged.

### Notes for reviewers

Latent today rather than blocking: the host field defaults to `true` (`erisc_datamover_builder.hpp:648`) and is written to the compile-time arg at `erisc_datamover_builder.cpp:1191`, and nothing in the tree assigns it `false`, so the assert never fires as things stand.

Worth a separate look by the fabric owners, deliberately not in this diff: because the assert pins the value to 1, the `if constexpr (!fuse_receiver_flush_and_completion_ptr)` branch in `fabric_erisc_router.cpp:1955` is unreachable.
