### PR TITLE
[Bug fix] Avoid double-counting JIT build windows in telemetry dumps

### DIFF
--- a/tests/tt_metal/tt_metal/jit_build/test_jit_build_telemetry.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_jit_build_telemetry.cpp
@@ -219,17 +219,59 @@ protected:
         return BuildCacheTelemetry::inst().get_or_register_metric("jit_build_window").snapshot();
     }
 
-    // dump_metrics() is what collapses the window endpoints into the single sample the metric
-    // carries. Token aggregates outlive disable()/enable(), so return the span of the sample this
-    // call added rather than reading the token's absolute totals.
+    // dump_metrics() replaces the single window sample, including a snapshot left over from
+    // an earlier test's enable()/disable() cycle.
     static double dump_and_get_window_ms() {
-        const TelemetryTokenData before = window_snapshot();
         BuildCacheTelemetry::inst().dump_metrics();
         const TelemetryTokenData after = window_snapshot();
-        EXPECT_EQ(after.count, before.count + 1u) << "dump_metrics() should record exactly one window sample";
-        return after.total - before.total;
+        EXPECT_EQ(after.count, 1u) << "dump_metrics() should retain exactly one window sample";
+        EXPECT_DOUBLE_EQ(after.min_val, after.total);
+        EXPECT_DOUBLE_EQ(after.max_val, after.total);
+        return after.total;
     }
 };
+
+TEST_F(JitBuildWindowTest, RepeatedDumpsDoNotAccumulateTheSameWindow) {
+    using namespace std::chrono_literals;
+    auto& tel = BuildCacheTelemetry::inst();
+    const auto t0 = std::chrono::steady_clock::now();
+    tel.note_build_window(t0, t0 + 50ms);
+
+    EXPECT_DOUBLE_EQ(dump_and_get_window_ms(), 50.0);
+    EXPECT_DOUBLE_EQ(dump_and_get_window_ms(), 50.0);
+    // A final dump, as performed by the singleton destructor, must also be observational.
+    EXPECT_DOUBLE_EQ(dump_and_get_window_ms(), 50.0);
+}
+
+TEST_F(JitBuildWindowTest, LaterBuildsReplaceThePreviouslyDumpedSpan) {
+    using namespace std::chrono_literals;
+    auto& tel = BuildCacheTelemetry::inst();
+    const auto t0 = std::chrono::steady_clock::now();
+    tel.note_build_window(t0, t0 + 50ms);
+    EXPECT_DOUBLE_EQ(dump_and_get_window_ms(), 50.0);
+
+    // Widen both endpoints after the first dump. The new extent replaces the old sample;
+    // it must not be added to it, nor should dumping reset the original endpoints.
+    tel.note_build_window(t0 - 10ms, t0 + 80ms);
+    EXPECT_DOUBLE_EQ(dump_and_get_window_ms(), 90.0);
+    EXPECT_DOUBLE_EQ(dump_and_get_window_ms(), 90.0);
+}
+
+TEST_F(JitBuildWindowTest, ConcurrentDumpsRetainOneWindowSample) {
+    using namespace std::chrono_literals;
+    auto& tel = BuildCacheTelemetry::inst();
+    const auto t0 = std::chrono::steady_clock::now();
+    tel.note_build_window(t0, t0 + 50ms);
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 16; ++i) {
+        threads.emplace_back([&] { tel.dump_metrics(); });
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    EXPECT_DOUBLE_EQ(dump_and_get_window_ms(), 50.0);
+}
 
 TEST_F(JitBuildWindowTest, WindowMeasuresBuildSpanNotProcessLifetime) {
     using namespace std::chrono_literals;

--- a/tt_metal/jit_build/build_cache_telemetry.cpp
+++ b/tt_metal/jit_build/build_cache_telemetry.cpp
@@ -45,6 +45,14 @@ TelemetryTokenData TelemetryToken::snapshot() const {
     return data_;
 }
 
+void TelemetryToken::set_single_sample(double value) {
+    if (!recording_enabled_.load(std::memory_order_relaxed)) {
+        return;
+    }
+    std::lock_guard lk(data_mutex_);
+    data_ = {.count = 1, .total = value, .min_val = value, .max_val = value};
+}
+
 // --- BuildCacheTelemetry ---
 
 struct BuildCacheTelemetryImpl {
@@ -304,16 +312,16 @@ void BuildCacheTelemetry::dump_metrics() const {
 
     log_compile_summary();
 
-    // Collapse the window endpoints into the one sample the metric carries. Done here rather than
-    // per build so the value is the whole span, not a running maximum, and so the token is
-    // populated before the loop below reads it.
+    // Serialize dumps before reading the endpoints so an older snapshot cannot overwrite a
+    // newer one. Replace the single window sample: appending it would count the same build
+    // activity again on each explicit dump and once more at process exit.
+    std::lock_guard lk(impl_->token_registry_mutex);
     const int64_t first_ns = impl_->build_window_first_ns.load(std::memory_order_relaxed);
     const int64_t last_ns = impl_->build_window_last_ns.load(std::memory_order_relaxed);
     if (build_window_token_ != nullptr && last_ns >= first_ns) {
-        build_window_token_->record(static_cast<double>(last_ns - first_ns) / 1e6);
+        build_window_token_->set_single_sample(static_cast<double>(last_ns - first_ns) / 1e6);
     }
 
-    std::lock_guard lk(impl_->token_registry_mutex);
     log_info(tt::LogBuildKernels, "JIT telemetry: {} registered TelemetryTokens", impl_->registered_tokens.size());
 
     // One info line per token, and the per-target metrics register dozens of them, so every

--- a/tt_metal/jit_build/build_cache_telemetry.hpp
+++ b/tt_metal/jit_build/build_cache_telemetry.hpp
@@ -49,6 +49,8 @@ public:
 private:
     friend class BuildCacheTelemetry;
     void set_recording_enabled(bool enabled);
+    // Replace a cumulative window's snapshot instead of appending overlapping samples.
+    void set_single_sample(double value);
 
     std::string name_;
     std::string unit_{"ms"};
@@ -95,9 +97,10 @@ public:
     uint32_t get_jit_once_dedup_count() const;
 
     // Extend the process-wide JIT build window with [start, end]. The window is the wall-clock
-    // span from the earliest build entry to the latest build exit, recorded as a single sample
-    // into the "jit_build_window" metric by dump_metrics(). It is the parallelism-aware companion
-    // to the per-call build metrics: summing those over-counts when builds run on the thread pool,
+    // span from the earliest build entry to the latest build exit. dump_metrics() replaces the
+    // single sample in "jit_build_window", so repeated dumps do not accumulate overlapping spans.
+    // It is the parallelism-aware companion to the per-call build metrics: summing those
+    // over-counts when builds run on the thread pool,
     // whereas the window is what a wall clock next to the process would show. A workload that
     // compiles lazily in bursts folds the idle gaps between bursts into the span.
     void note_build_window(std::chrono::steady_clock::time_point start, std::chrono::steady_clock::time_point end);
@@ -144,8 +147,7 @@ private:
 // The delta is recorded even when the scope is left by an exception.
 class ScopedTelemetryTimer {
 public:
-    explicit ScopedTelemetryTimer(TelemetryToken& token) :
-        token_(token), start_(std::chrono::steady_clock::now()) {}
+    explicit ScopedTelemetryTimer(TelemetryToken& token) : token_(token), start_(std::chrono::steady_clock::now()) {}
 
     ~ScopedTelemetryTimer() {
         token_.record(std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start_).count());


### PR DESCRIPTION
Fixes the repeated-dump accounting issue raised in https://github.com/tenstorrent/tt-metal/pull/55398#discussion_r3984498406. This PR targets `nsexton/jit-telemetry-token-log-info` so it can be merged directly into #55398.

A 50 ms build window currently becomes `count=2, total=100 ms` after two calls to `dump_metrics()`, even without another build. The exit-time dump adds the same span again.

Keep the window as one replaceable sample: repeated dumps retain `count=1, total=50 ms`, while later builds update that sample to the wider earliest-start/latest-end span. Serialize dumps before reading the endpoints so an older concurrent dump cannot overwrite a newer snapshot. Ordinary per-call metrics continue to accumulate normally.

Adds regression coverage for repeated dumps, a widened window after an earlier dump, and concurrent dumps; updates the existing window assertions to check the single-sample contract.

### Validation

- All three new regression tests fail against the original telemetry implementation and pass with this fix.
- All 22 tests in `test_jit_build_telemetry.cpp` pass in standalone C++20 builds under AddressSanitizer/UndefinedBehaviorSanitizer and ThreadSanitizer, with shuffled test order.
- `clang-format --dry-run --Werror` and `git diff --check` pass.

The standalone tests used GoogleTest 1.17.0 and a no-op logger stub on macOS, compiling the actual telemetry and JIT cache implementation files. Full project builds and hardware tests were not run.
