### PR TITLE
[Test Only] Optimizing data movement tests by opening a single device

### DIFF
--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -175,6 +175,28 @@ class UnitMeshAnyDispatchFixture : public AnyDispatchMeshDeviceSingleCardFixture
 // Requires slow dispatch mode.
 class UnitMeshFixture : public MeshDeviceSingleCardFixture {};
 
+// Single unit-mesh fixture: always owns exactly one unit MeshDevice.
+// Requires fast dispatch mode.
+class UnitMeshFastDispatchFixture : public AnyDispatchMeshDeviceSingleCardFixture {
+protected:
+    void SetUp() override {
+        auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        // Emule has no HWCommandQueue, so TT_METAL_EMULE_MODE always enables slow
+        // dispatch. Skip only on real silicon under slow dispatch; still run on emule.
+        auto* emulated = getenv("TT_METAL_EMULE_MODE");
+        if (slow_dispatch && !emulated) {
+            GTEST_SKIP() << "Skipping Mesh-Device test suite, since it can only be run in Fast Dispatch Mode.";
+        }
+        AnyDispatchMeshDeviceSingleCardFixture::SetUp();
+    }
+
+public:
+    std::shared_ptr<distributed::MeshDevice> get_mesh_device() {
+        TT_FATAL(!devices_.empty(), "MeshDevice not initialized in {}", __FUNCTION__);
+        return devices_.front();
+    }
+};
+
 class BlackholeSingleCardFixture : public MeshDeviceSingleCardFixture {
 protected:
     void SetUp() override {

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -6,7 +6,7 @@ This test suite addresses the functionality and performance (i.e. bandwidth) of 
 This test suite includes tests using both fast dispatch (Mesh Device API) and slow dispatch modes:
 
 ### Fast Dispatch (Mesh Device API)
-Most test suites use the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. These tests use `GenericMeshDeviceFixture` and run on single-device unit meshes with fast dispatch mode for optimal performance.
+Most test suites use the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. These tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes with fast dispatch mode for optimal performance.
 
 ### Slow Dispatch
 Some test suites use slow dispatch mode for reliable program execution. These tests use `MeshDeviceFixture`. With TT-Mesh, APIs for executing programs in slow dispatch are the same as in fast dispatch, using `tt::tt_metal::distributed::EnqueueMeshWorkload`. Tests requiring slow dispatch include:
@@ -15,7 +15,7 @@ Some test suites use slow dispatch mode for reliable program execution. These te
 - **Reshard Hardcoded** (IDs 17-20)
 
 ### Quasar Simulator
-Quasar data movement tests (IDs 912-927) use `GenericMeshDeviceFixture` with `arch == ARCH::QUASAR` branches inside each test. They require `TT_METAL_SLOW_DISPATCH_MODE=1` (fast dispatch is not yet supported on the Quasar emulator). The base fixture skips gracefully if fast dispatch is attempted. Tests that require `≥2 Tensix columns` (e.g. subordinate core `{1,0}`) also skip with an informative message when run on a 1-column emulator — use `emu-quasar-2x3` or larger for those tests.
+Quasar data movement tests (IDs 912-927) use `UnitMeshFastDispatchFixture` with `arch == ARCH::QUASAR` branches inside each test. They require `TT_METAL_SLOW_DISPATCH_MODE=1` (fast dispatch is not yet supported on the Quasar emulator). The base fixture skips gracefully if fast dispatch is attempted. Tests that require `≥2 Tensix columns` (e.g. subordinate core `{1,0}`) also skip with an informative message when run on a 1-column emulator — use `emu-quasar-2x3` or larger for those tests.
 
 ## Device 2.0 API Support
 This test suite now includes tests using the new device 2.0 NOC API alongside the original implementations. These tests provide validation and performance comparison for the updated API design:
@@ -99,9 +99,9 @@ An exhaustive list of options and their descriptions can be found in `./conftest
 Follow these steps to add new tests to this test suite.
 
 1. **Choose dispatch mode:** Decide whether your test should use fast dispatch (Mesh Device API) or slow dispatch:
-    - **Fast Dispatch (recommended)**: Use `GenericMeshDeviceFixture` for new performance tests
+    - **Fast Dispatch (recommended)**: Use `UnitMeshFastDispatchFixture` for new performance tests
     - **Slow Dispatch**: Use `MeshDeviceFixture` only if fast dispatch APIs don't work for your specific test case
-    - **Quasar Simulator**: Use `GenericMeshDeviceFixture` with an `arch == ARCH::QUASAR` branch inside the test; run with `TT_METAL_SLOW_DISPATCH_MODE=1`
+    - **Quasar Simulator**: Use `UnitMeshFastDispatchFixture` with an `arch == ARCH::QUASAR` branch inside the test; run with `TT_METAL_SLOW_DISPATCH_MODE=1`
 2. Create a new directory with a descriptive name for the test.
     - **Example:** `./dram_unary`
 3. In this directory, create the c++ test file with a filename that starts with "test_".

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from all subordinate cores to all master cores.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -475,7 +475,7 @@ void grid_packet_sizes_test(
 
 /* ======== DIRECTED IDEAL ======== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     uint32_t test_case_id = 320;
@@ -494,7 +494,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllDirectedIdeal) {
 
 /* ======== PACKET SIZES ======== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllPacketSizes) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -512,7 +512,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes) {
 }
 
 /* ======== 2x2 to 1x1 ======== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From1x1DirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll2x2From1x1DirectedIdeal) {
     uint32_t test_case_id = 322;
 
     /* Parameters */
@@ -527,7 +527,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From1x1DirectedI
 }
 
 /* ======== 4x4 to 1x1 ======== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll4x4From1x1DirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll4x4From1x1DirectedIdeal) {
     uint32_t test_case_id = 323;
 
     /* Parameters */
@@ -542,7 +542,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll4x4From1x1DirectedI
 }
 
 /* ======== 1x1 to 2x2 ======== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From2x2DirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll1x1From2x2DirectedIdeal) {
     uint32_t test_case_id = 324;
 
     /* Parameters */
@@ -557,7 +557,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From2x2DirectedI
 }
 
 /* ======== 1x1 to 4x4 ======== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From4x4DirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll1x1From4x4DirectedIdeal) {
     uint32_t test_case_id = 325;
 
     /* Parameters */
@@ -572,7 +572,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From4x4DirectedI
 }
 
 /* ======== 2x2 to 2x2 ======== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From2x2DirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll2x2From2x2DirectedIdeal) {
     uint32_t test_case_id = 326;
 
     /* Parameters */
@@ -588,14 +588,14 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From2x2DirectedI
 
 /* ======== VIRTUAL CHANNELS ======== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllVirtualChannels) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 327;
 
     unit_tests::dm::all_from_all::virtual_channels_test(get_mesh_device(), test_case_id);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllCustom) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllCustom) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 328;
 
@@ -624,7 +624,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllCustom) {
         num_virtual_channels);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllPacketSizes2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
 
@@ -648,7 +648,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes2_0) {
         mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllDirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllDirectedIdeal_2_0) {
     uint32_t test_id = 330;
 
     auto mesh_device = get_mesh_device();
@@ -713,29 +713,29 @@ void all_from_all_grid_directed_ideal_2_0(
 }
 }  // namespace
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From1x1DirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll2x2From1x1DirectedIdeal_2_0) {
     all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 331, {0, 0}, {4, 4}, {2, 2}, {1, 1});
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll4x4From1x1DirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll4x4From1x1DirectedIdeal_2_0) {
     all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 332, {0, 0}, {0, 0}, {4, 4}, {1, 1});
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From2x2DirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll1x1From2x2DirectedIdeal_2_0) {
     all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 333, {0, 0}, {4, 4}, {1, 1}, {2, 2});
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From4x4DirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll1x1From4x4DirectedIdeal_2_0) {
     all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 334, {0, 0}, {0, 0}, {1, 1}, {4, 4});
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From2x2DirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll2x2From2x2DirectedIdeal_2_0) {
     all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 335, {0, 0}, {0, 0}, {2, 2}, {2, 2});
 }
 
 /* ======== GRID + PACKET SIZE SWEEP ======== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllGridSweepPacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllGridSweepPacketSizes2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
     auto grid = device->compute_with_storage_grid_size();

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from all master cores to all subordinate cores.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -483,7 +483,7 @@ void grid_packet_sizes_test(
 /* ======== DIRECTED IDEAL ======== */
 
 /* ======== All to All ======== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -502,7 +502,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllDirectedIdeal) {
 
 /* ======== PACKET SIZES ======== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllPacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllPacketSizes) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -520,7 +520,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllPacketSizes) {
 }
 
 /* ======== 2x2 to 1x1 ======== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To1x1DirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll2x2To1x1DirectedIdeal) {
     uint32_t test_case_id = 302;
 
     /* Parameters */
@@ -535,7 +535,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To1x1DirectedIdeal
 }
 
 /* ======== 4x4 to 1x1 ======== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll4x4To1x1DirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll4x4To1x1DirectedIdeal) {
     uint32_t test_case_id = 303;
 
     /* Parameters */
@@ -550,7 +550,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll4x4To1x1DirectedIdeal
 }
 
 /* ======== 1x1 to 2x2 ======== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll1x1To2x2DirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll1x1To2x2DirectedIdeal) {
     uint32_t test_case_id = 304;
 
     /* Parameters */
@@ -565,7 +565,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll1x1To2x2DirectedIdeal
 }
 
 /* ======== 1x1 to 4x4 ======== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll1x1To4x4DirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll1x1To4x4DirectedIdeal) {
     uint32_t test_case_id = 305;
 
     /* Parameters */
@@ -580,7 +580,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll1x1To4x4DirectedIdeal
 }
 
 /* ======== 2x2 to 2x2 ======== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal) {
     uint32_t test_case_id = 306;
 
     /* Parameters */
@@ -596,7 +596,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal
 
 /* ======== VIRTUAL CHANNELS ======== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllVirtualChannels) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_case_id = 307;
@@ -604,7 +604,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllVirtualChannels) {
     unit_tests::dm::all_to_all::virtual_channels_test(get_mesh_device(), test_case_id);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllCustom) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllCustom) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_case_id = 308;
@@ -618,7 +618,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllCustom) {
         get_mesh_device(), test_case_id, num_of_transactions, pages_per_transaction, num_virtual_channels);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllPacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllPacketSizes2_0) {
     uint32_t test_id = 309;
 
     auto mesh_device = get_mesh_device();
@@ -642,7 +642,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllPacketSizes2_0) {
         mesh_device, test_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllDirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllDirectedIdeal_2_0) {
     uint32_t test_id = 310;
 
     auto mesh_device = get_mesh_device();
@@ -707,29 +707,29 @@ void all_to_all_grid_directed_ideal_2_0(
 }
 }  // namespace
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To1x1DirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll2x2To1x1DirectedIdeal_2_0) {
     all_to_all_grid_directed_ideal_2_0(get_mesh_device(), 311, {0, 0}, {4, 4}, {2, 2}, {1, 1});
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll4x4To1x1DirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll4x4To1x1DirectedIdeal_2_0) {
     all_to_all_grid_directed_ideal_2_0(get_mesh_device(), 312, {0, 0}, {0, 0}, {4, 4}, {1, 1});
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll1x1To2x2DirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll1x1To2x2DirectedIdeal_2_0) {
     all_to_all_grid_directed_ideal_2_0(get_mesh_device(), 313, {0, 0}, {4, 4}, {1, 1}, {2, 2});
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll1x1To4x4DirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll1x1To4x4DirectedIdeal_2_0) {
     all_to_all_grid_directed_ideal_2_0(get_mesh_device(), 314, {0, 0}, {0, 0}, {1, 1}, {4, 4});
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal_2_0) {
     all_to_all_grid_directed_ideal_2_0(get_mesh_device(), 315, {0, 0}, {0, 0}, {2, 2}, {2, 2});
 }
 
 /* ======== GRID + PACKET SIZE SWEEP ======== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllGridSweepPacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllGridSweepPacketSizes2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
     auto grid = device->compute_with_storage_grid_size();

--- a/tests/tt_metal/tt_metal/data_movement/atomics/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/atomics/README.md
@@ -5,7 +5,7 @@ This directory contains tests for `noc_semaphore_inc` and `noc_async_atomic_barr
 **Note**: Due to how the test framework works, `Transaction Size (bytes)` in the output actually means `Increment Amount`.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 

--- a/tests/tt_metal/tt_metal/data_movement/atomics/test_atomic_semaphore_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/atomics/test_atomic_semaphore_bandwidth.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "../dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
@@ -257,7 +257,7 @@ void directed_performance_test(
 
 /* ========== TEST CASES ========== */
 
-TEST_F(GenericMeshDeviceFixture, AtomicSemaphoreAdjacentIncrementValueSweep) {
+TEST_F(UnitMeshFastDispatchFixture, AtomicSemaphoreAdjacentIncrementValueSweep) {
     uint32_t test_id = 340;
 
     unit_tests::dm::atomics::increment_value_sweep_test(
@@ -268,7 +268,7 @@ TEST_F(GenericMeshDeviceFixture, AtomicSemaphoreAdjacentIncrementValueSweep) {
     );
 }
 
-TEST_F(GenericMeshDeviceFixture, AtomicSemaphoreNonAdjacentIncrementValueSweep) {
+TEST_F(UnitMeshFastDispatchFixture, AtomicSemaphoreNonAdjacentIncrementValueSweep) {
     uint32_t test_id = 341;
 
     auto logical_grid_size = get_mesh_device()->logical_grid_size();

--- a/tests/tt_metal/tt_metal/data_movement/core_bidirectional/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/core_bidirectional/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of bidirectional data movement transactions between two Tensix cores where one core simultaneously sends and receives data.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 

--- a/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -287,7 +287,7 @@ void packet_sizes_test(
 
 // ========== Directed Ideal Tests ==========
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalDirectedIdealSameKernel) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalDirectedIdealSameKernel) {
     GTEST_SKIP() << "Skipping test";  // Timeout issue (#36428)
 
     // Test ID (Arbitrary)
@@ -301,7 +301,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalDirectedIdea
         get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalDirectedIdealDifferentKernels) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalDirectedIdealDifferentKernels) {
     GTEST_SKIP() << "Skipping test";  // Timeout issue (#36428)
 
     // Test ID (Arbitrary)
@@ -317,7 +317,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalDirectedIdea
 
 // ========== Same VC Tests ==========
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalSameVCSameKernel) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalSameVCSameKernel) {
     GTEST_SKIP() << "Skipping test";  // Timeout issue (#36428)
 
     // Test ID (Arbitrary)
@@ -330,7 +330,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalSameVCSameKe
         get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalSameVCDifferentKernels) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalSameVCDifferentKernels) {
     GTEST_SKIP() << "Skipping test";  // Timeout issue (#36428)
 
     // Test ID (Arbitrary)
@@ -345,7 +345,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalSameVCDiffer
 
 // ========== Write VC Sweep Tests ==========
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweepSameKernel) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalWriteVCSweepSameKernel) {
     GTEST_SKIP() << "Skipping test";  // Timeout issue (#36428)
 
     // Test ID base
@@ -363,7 +363,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweep
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweepDifferentKernels) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalWriteVCSweepDifferentKernels) {
     GTEST_SKIP() << "Skipping test";  // Timeout issue (#36428)
 
     // Test ID base
@@ -383,7 +383,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweep
 
 // ========== Packet Sizes Tests ==========
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesSameKernel) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalPacketSizesSameKernel) {
     // Test ID
     uint32_t test_id = 146;
     bool same_kernel = true;
@@ -394,7 +394,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesS
         get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesDifferentKernels) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalPacketSizesDifferentKernels) {
     // Test ID
     uint32_t test_id = 147;
     bool same_kernel = false;
@@ -407,7 +407,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesD
 
 // ========== Custom Test Case ==========
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalCustom) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalCustom) {
     GTEST_SKIP() << "Skipping test";  // Timeout issue (#36428)
 
     // Test ID

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-logger/tt-logger.hpp>
-#include "multi_device_fixture.hpp"
 #include "device_fixture.hpp"
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
@@ -323,7 +322,7 @@ void multicast_test(
 
 }  // namespace unit_tests::dm::direct_write
 
-TEST_F(GenericMeshDeviceFixture, TensixDirectWritePerformanceComparison) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDirectWritePerformanceComparison) {
     if (get_mesh_device()->impl().get_device(0)->arch() == ARCH::QUASAR) {
         GTEST_SKIP()
             << "Skipping on Quasar emulator: direct-write kernel executes but destination L1 remains unchanged";
@@ -332,7 +331,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDirectWritePerformanceComparison) {
     unit_tests::dm::direct_write::performance_comparison_test(get_mesh_device(), test_id);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDirectWriteAddressPatterns) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDirectWriteAddressPatterns) {
     if (get_mesh_device()->impl().get_device(0)->arch() == ARCH::QUASAR) {
         GTEST_SKIP()
             << "Skipping on Quasar emulator: direct-write kernel executes but destination L1 remains unchanged";
@@ -341,7 +340,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDirectWriteAddressPatterns) {
     unit_tests::dm::direct_write::address_pattern_test(get_mesh_device(), test_id);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDirectWriteMulticast) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDirectWriteMulticast) {
     uint32_t test_id = 507;
     unit_tests::dm::direct_write::multicast_test(get_mesh_device(), test_id);
 }

--- a/tests/tt_metal/tt_metal/data_movement/dram_neighbour/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/dram_neighbour/README.md
@@ -4,7 +4,7 @@ This test suite implements tests that measure the functionality and performance 
 
 ## Mesh Device API Support
 
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 > **Note:** The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 

--- a/tests/tt_metal/tt_metal/data_movement/dram_neighbour/test_dram_neighbour.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_neighbour/test_dram_neighbour.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -418,7 +418,7 @@ using unit_tests::dm::dram_neighbour::run_bank_sweep_test;
 using unit_tests::dm::dram_neighbour::run_single_test;
 using unit_tests::dm::dram_neighbour::run_sweep_test;
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDramNeighbourDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourDirectedIdeal) {
     shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
 
     uint32_t test_id = 502;
@@ -441,7 +441,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDramNeighbourDirectedIdeal) {
         core_dram_map));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDramNeighbourNumPagesSweep) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourNumPagesSweep) {
     shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
 
     uint32_t test_id = 503;
@@ -464,7 +464,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDramNeighbourNumPagesSweep) {
         core_dram_map));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDramNeighbourNumBankSweep) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourNumBankSweep) {
     shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
 
     uint32_t test_id = 504;
@@ -478,7 +478,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDramNeighbourNumBankSweep) {
         mesh_device, test_id, max_transactions, max_num_banks, num_pages, page_size_bytes, l1_data_format));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDramNeighbourSingleRowSweep) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourSingleRowSweep) {
     shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
 
     uint32_t test_id = 505;
@@ -501,7 +501,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDramNeighbourSingleRowSweep) 
         core_dram_map));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDramNeighbourOneHopSweep) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourOneHopSweep) {
     shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto logical_grid_size = device->logical_grid_size();
@@ -529,7 +529,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDramNeighbourOneHopSweep) {
         core_dram_map));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDramNeighbourLoopBackSweep) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourLoopBackSweep) {
     shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto logical_grid_size = device->logical_grid_size();

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement reads from sharded DRAM buffer into a Tensix core using the stateful one_packet APIs.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
@@ -46,4 +46,4 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
 4. DRAM Sharded Read Trid Directed Ideal: Tests reading from DRAM sharded with transaction IDs.
 
 ## Quasar Notes
-`TensixDataMovementDRAMShardedReadDirectedIdeal` includes a Quasar-specific code path inside `GenericMeshDeviceFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1` and the Quasar simulator.
+`TensixDataMovementDRAMShardedReadDirectedIdeal` includes a Quasar-specific code path inside `UnitMeshFastDispatchFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1` and the Quasar simulator.

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
 #include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -189,7 +188,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
 }  // namespace unit_tests::dm::dram_sharded
 
 /* ========== Directed Ideal Test Case; Test id = 84 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     const uint32_t test_id = 84;
 
@@ -217,7 +216,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadDirectedIdeal)
 }
 
 /* ========== Sweep over varying number of tiles per DRAM bank; Test id = 85 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTileNumbers) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTileNumbers) {
     auto mesh_device = get_mesh_device();
 
     // Parameters
@@ -250,7 +249,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTileNumbers) {
 }
 
 /* ========== Sweep over varying number of DRAM banks; Test id = 86 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadBankNumbers) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadBankNumbers) {
     auto mesh_device = get_mesh_device();
 
     // Parameters
@@ -283,7 +282,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadBankNumbers) {
 }
 
 /* ========== Directed Ideal Test Case with Transaction IDs; Test id = 87 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTridDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTridDirectedIdeal) {
     auto mesh_device = get_mesh_device();
 
     // Parameters
@@ -311,7 +310,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTridDirectedId
     EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadDirectedIdeal2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadDirectedIdeal2_0) {
     auto mesh_device = get_mesh_device();
 
     DataFormat l1_data_format = DataFormat::Float16_b;
@@ -336,7 +335,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadDirectedIdeal2
     EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTileNumbers2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTileNumbers2_0) {
     auto mesh_device = get_mesh_device();
 
     // Parameters
@@ -372,7 +371,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTileNumbers2_0
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadBankNumbers2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadBankNumbers2_0) {
     auto mesh_device = get_mesh_device();
 
     DataFormat l1_data_format = DataFormat::Float16_b;
@@ -403,7 +402,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadBankNumbers2_0
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTridDirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTridDirectedIdeal_2_0) {
     auto mesh_device = get_mesh_device();
 
     // Parameters

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between DRAM and a single Tensix core.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
@@ -61,4 +61,4 @@ This test suite now includes tests using the new device 2.0 NOC API. These tests
 Both API versions run the same test cases but use different underlying implementations. The device 2.0 tests serve as a validation and performance comparison for the new API.
 
 ## Quasar Notes
-`TensixDataMovementDRAMDirectedIdeal` includes a Quasar-specific code path inside `GenericMeshDeviceFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1` and the Quasar simulator.
+`TensixDataMovementDRAMDirectedIdeal` includes a Quasar-specific code path inside `UnitMeshFastDispatchFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1` and the Quasar simulator.

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
 #include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
@@ -298,7 +297,7 @@ void packet_sizes_test(
 }  // namespace unit_tests::dm::dram
 
 /* ========== Test case for varying transaction numbers and sizes; Test id = 0 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMPacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMPacketSizes) {
     unit_tests::dm::dram::packet_sizes_test(
         get_mesh_device(),
         0,      // Test case ID
@@ -307,7 +306,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMPacketSizes) {
 }
 
 /* ========== Test case for varying core locations; Test id = 1 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMCoreLocations) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMCoreLocations) {
     uint32_t test_case_id = 1;
 
     auto mesh_device = get_mesh_device();
@@ -332,7 +331,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMCoreLocations) {
 // DRAM channels
 
 /* ========== Test case for varying DRAM channels; Test id = 2 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMChannels) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMChannels) {
     uint32_t test_case_id = 2;
 
     auto mesh_device = get_mesh_device();
@@ -348,7 +347,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMChannels) {
 }
 
 /* ========== Directed ideal test case; Test id = 3 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
@@ -370,7 +369,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMDirectedIdeal) {
 }
 
 /* ========== Test case for varying transaction numbers and sizes with 2.0 API; Test id = 40 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMPacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMPacketSizes2_0) {
     auto mesh_device = get_mesh_device();
     if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
         // Quasar emulator: full sweep is too slow (same as legacy
@@ -394,7 +393,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMPacketSizes2_0) {
     unit_tests::dm::dram::packet_sizes_test(mesh_device, 40, {0, 0}, 0);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMDirectedIdeal2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMDirectedIdeal2_0) {
     auto mesh_device = get_mesh_device();
     if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
@@ -415,7 +414,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMDirectedIdeal2_0) {
     unit_tests::dm::dram::directed_ideal_test(mesh_device, 41, {0, 0}, 0, 0);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMCoreLocations2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMCoreLocations2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -432,7 +431,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMCoreLocations2_0) {
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMChannels2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMChannels2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between DRAM or L1 interleaved buffers and a Tensix core using `noc_async_*_page` APIs.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -200,7 +200,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Interl
 /* ========== INTERLEAVED DRAM TESTS ========== */
 
 /* ========== Test case for varying number of pages; Test id = 61 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageNumbers) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageNumbers) {
     auto mesh_device = get_mesh_device();
 
     // Physical Constraints
@@ -241,7 +241,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageNumbers) {
 }
 
 /* ========== Test case for varying core location; Test id = 62 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageCoreLocations) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageCoreLocations) {
     GTEST_SKIP() << "Skipping test";
 
     // Parameters
@@ -274,7 +274,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageCoreLocati
 }
 
 /* ========== Test noc_async_read_page kernel only; Test id = 63 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageReadNumbers) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageReadNumbers) {
     auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
@@ -317,7 +317,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageReadNumber
 }
 
 /* ========== Test noc_async_write_page kernel only; Test id = 64 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNumbers) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageWriteNumbers) {
     auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
@@ -360,7 +360,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNumbe
 }
 
 /* ========== Directed Ideal Test Case; Test id = 65 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
@@ -388,7 +388,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageDirectedId
 }
 
 /* ========== Test noc_async_read_page kernel only with swapped noc; Test id = 72 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageReadNocSwap) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageReadNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
     auto mesh_device = get_mesh_device();
@@ -434,7 +434,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageReadNocSwa
 }
 
 /* ========== Test noc_async_write_page kernel only with swapped noc; Test id = 73 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNocSwap) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageWriteNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
     auto mesh_device = get_mesh_device();
@@ -482,7 +482,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNocSw
 /* ========== INTERLEAVED L1 TESTS ========== */
 
 /* ========== Test case for varying number of pages using interleaved L1; Test id = 66 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageNumbers) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageNumbers) {
     auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
@@ -523,7 +523,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageNumbers) {
 }
 
 /* ========== Test case for varying core location; Test id = 67 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageCoreLocations) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageCoreLocations) {
     GTEST_SKIP() << "Skipping test";
 
     // Parameters
@@ -556,7 +556,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageCoreLocation
 }
 
 /* ========== Test noc_async_read_page only; Test id = 68 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageReadNumbers) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageReadNumbers) {
     auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
@@ -598,7 +598,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageReadNumbers)
     }
 }
 /* ========== Test noc_async_write_page only; Test id = 69 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageWriteNumbers) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageWriteNumbers) {
     auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
@@ -641,7 +641,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageWriteNumbers
 }
 
 /* ========== Directed Ideal Test Case; Test id = 71 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
@@ -670,7 +670,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageDirectedIdea
 }
 
 /* ========== Test noc_async_read_page only with swapped noc; Test id = 74 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageReadNocSwap) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageReadNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
     auto mesh_device = get_mesh_device();
@@ -715,7 +715,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageReadNocSwap)
     }
 }
 /* ========== Test noc_async_write_page only; Test id = 75 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageWriteNocSwap) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageWriteNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
     auto mesh_device = get_mesh_device();

--- a/tests/tt_metal/tt_metal/data_movement/loopback/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between Tensix cores.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
@@ -41,4 +41,4 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
 2. Loopback Directed Ideal: Tests the most optimal data movement setup on the core itself that reduces the number of transactions while maximizing transaction size to minimize the effects of initialization overhead.
 
 ## Quasar Notes
-`TensixDataMovementLoopbackPacketSizes` and `TensixDataMovementLoopbackDirectedIdeal` include Quasar-specific code paths inside `GenericMeshDeviceFixture`. Run with `TT_METAL_SLOW_DISPATCH_MODE=1` and the Quasar simulator.
+`TensixDataMovementLoopbackPacketSizes` and `TensixDataMovementLoopbackDirectedIdeal` include Quasar-specific code paths inside `UnitMeshFastDispatchFixture`. Run with `TT_METAL_SLOW_DISPATCH_MODE=1` and the Quasar simulator.

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
 #include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
@@ -186,7 +185,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
 }  // namespace unit_tests::dm::core_loopback
 
 /* ========== Test case for loopback data movement; ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackPacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackPacketSizes) {
     auto mesh_device = get_mesh_device();
     auto arch_ = mesh_device->impl().get_device(0)->arch();
 
@@ -233,7 +232,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackPacketSizes) {
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto arch_ = mesh_device->impl().get_device(0)->arch();
 
@@ -264,7 +263,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackDirectedIdeal) {
 }
 
 /* ========== Metal 2.0 variants ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackPacketSizes_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackPacketSizes_2_0) {
     auto mesh_device = get_mesh_device();
     auto arch_ = mesh_device->impl().get_device(0)->arch();
 
@@ -308,7 +307,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackPacketSizes_2_0) {
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackDirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackDirectedIdeal_2_0) {
     auto mesh_device = get_mesh_device();
     auto arch_ = mesh_device->impl().get_device(0)->arch();
 

--- a/tests/tt_metal/tt_metal/data_movement/matmul/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/README.md
@@ -525,4 +525,4 @@ In the 2D variant, both in0 and in1 have separate source and multicast output re
 - For single-column grids (C = 1), the in0 kernel uses a unicast self-write instead of multicast loopback due to a known hardware limitation. Similarly, for single-row grids (R = 1) in 2D, the in1 kernel uses a unicast self-write.
 - Tests that request a grid exceeding the device's compute grid are automatically skipped (not failed).
 - Barrier synchronization uses a coordinator-based polling pattern from `barrier_sync.hpp`, shared with other data movement test suites.
-- This test suite uses the TT-Metal Mesh Device API with `GenericMeshDeviceFixture`, running on single-device unit meshes. The Mesh Device API only supports fast dispatch mode.
+- This test suite uses the TT-Metal Mesh Device API with `UnitMeshFastDispatchFixture`, running on single-device unit meshes. The Mesh Device API only supports fast dispatch mode.

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_common.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_common.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include <tt-metalium/mesh_device.hpp>
 #include <cstdint>
 #include <string>
@@ -219,13 +219,13 @@ struct MatmulTestNameGenerator {
 
 namespace tt::tt_metal {
 
-class Matmul1DParamFixture : public GenericMeshDeviceFixture,
+class Matmul1DParamFixture : public UnitMeshFastDispatchFixture,
                              public ::testing::WithParamInterface<unit_tests::dm::matmul::MatmulTestConfig> {};
 
-class Matmul1DV2ParamFixture : public GenericMeshDeviceFixture,
+class Matmul1DV2ParamFixture : public UnitMeshFastDispatchFixture,
                                public ::testing::WithParamInterface<unit_tests::dm::matmul::MatmulTestConfig> {};
 
-class Matmul2DParamFixture : public GenericMeshDeviceFixture,
+class Matmul2DParamFixture : public UnitMeshFastDispatchFixture,
                              public ::testing::WithParamInterface<unit_tests::dm::matmul::MatmulTestConfig> {};
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between DRAM interleaved buffers and multiple Tensix cores.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -405,7 +405,7 @@ void grid_packet_sizes_test(
 }  // namespace unit_tests::dm::multi_interleaved
 
 /* ========== Full grid directed ideal ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -417,7 +417,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedDirectedIdeal
 }
 
 /* ========== Full grid packet sizes sweep ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedSizes) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -429,7 +429,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedSizes) {
 }
 
 /* ========== Full grid read kernel directed ideal ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedReadDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -441,7 +441,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadDirectedI
 }
 
 /* ========== Full grid read kernel packet sizes sweep ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedReadSizes) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -453,7 +453,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadSizes) {
 }
 
 /* ========== Full grid write kernel directed ideal ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedWriteDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -465,7 +465,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteDirected
 }
 
 /* ========== Full grid write kernel packet sizes sweep ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedWriteSizes) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -478,7 +478,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteSizes) {
 
 /* ========== 2x2 CORE TESTS ========== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedDirectedIdeal) {
     uint32_t test_case_id = 116;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
@@ -486,7 +486,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedDirectedId
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedSizes) {
     uint32_t test_case_id = 117;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
@@ -494,7 +494,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedSizes) {
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedReadDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedReadDirectedIdeal) {
     uint32_t test_case_id = 118;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
@@ -502,7 +502,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedReadDirect
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedReadSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedReadSizes) {
     uint32_t test_case_id = 119;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
@@ -510,7 +510,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedReadSizes)
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedWriteDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedWriteDirectedIdeal) {
     uint32_t test_case_id = 120;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
@@ -518,7 +518,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedWriteDirec
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedWriteSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedWriteSizes) {
     uint32_t test_case_id = 121;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
@@ -528,7 +528,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedWriteSizes
 
 /* ========== 6x6 CORE TESTS ========== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedDirectedIdeal) {
     uint32_t test_case_id = 122;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
@@ -536,7 +536,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedDirectedId
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedSizes) {
     uint32_t test_case_id = 123;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
@@ -544,7 +544,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedSizes) {
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedReadDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedReadDirectedIdeal) {
     uint32_t test_case_id = 124;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
@@ -552,7 +552,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedReadDirect
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedReadSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedReadSizes) {
     uint32_t test_case_id = 125;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
@@ -560,7 +560,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedReadSizes)
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedWriteDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedWriteDirectedIdeal) {
     uint32_t test_case_id = 126;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
@@ -568,7 +568,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedWriteDirec
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedWriteSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedWriteSizes) {
     uint32_t test_case_id = 127;
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
@@ -578,17 +578,17 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedWriteSizes
 
 /* ========== GRID SWEEP TESTS ========== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedGridSweepSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedGridSweepSizes) {
     uint32_t test_case_id = 128;
     unit_tests::dm::multi_interleaved::grid_packet_sizes_test(get_mesh_device(), test_case_id, true, true);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadGridSweepSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedReadGridSweepSizes) {
     uint32_t test_case_id = 129;
     unit_tests::dm::multi_interleaved::grid_packet_sizes_test(get_mesh_device(), test_case_id, true, false);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteGridSweepSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedWriteGridSweepSizes) {
     uint32_t test_case_id = 130;
     unit_tests::dm::multi_interleaved::grid_packet_sizes_test(get_mesh_device(), test_case_id, false, true);
 }

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
@@ -8,7 +8,7 @@ The `noc_semaphore_inc_multicast` API allows a single core to atomically increme
 
 ## Mesh Device API Support
 
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 ## Device 2.0 API Support
 

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "../dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
@@ -214,7 +214,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Multic
 
 /* ========== TEST CASES ========== */
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSource) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSource) {
     uint32_t test_id = 342;
 
     auto mesh_device = get_mesh_device();
@@ -237,7 +237,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSource) {
     EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
 }
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSource) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSource) {
     uint32_t test_id = 343;
 
     auto mesh_device = get_mesh_device();
@@ -260,7 +260,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSource) {
     EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
 }
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSourceNOC1) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSourceNOC1) {
     uint32_t test_id = 344;
 
     auto mesh_device = get_mesh_device();
@@ -283,7 +283,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSourceNOC1) {
     EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
 }
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSourceNOC1) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSourceNOC1) {
     uint32_t test_id = 345;
 
     auto mesh_device = get_mesh_device();
@@ -306,7 +306,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSourceNOC1) {
     EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
 }
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrement) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrement) {
     uint32_t test_id = 346;
 
     auto mesh_device = get_mesh_device();
@@ -331,7 +331,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrement) {
     EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
 }
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrementNOC1) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrementNOC1) {
     uint32_t test_id = 347;
 
     auto mesh_device = get_mesh_device();
@@ -358,7 +358,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrementNOC1) {
 
 /* ========== NOC 2.0 API TEST CASES ========== */
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSource_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSource_2_0) {
     uint32_t test_id = 348;
 
     auto mesh_device = get_mesh_device();
@@ -382,7 +382,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSource_2_0) {
     EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
 }
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrement_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrement_2_0) {
     uint32_t test_id = 349;
 
     auto mesh_device = get_mesh_device();
@@ -408,7 +408,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrement_2_0) {
     EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
 }
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSource_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSource_2_0) {
     uint32_t test_id = 350;
 
     auto mesh_device = get_mesh_device();
@@ -432,7 +432,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSource_2_0) {
     EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
 }
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSourceNOC1_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSourceNOC1_2_0) {
     uint32_t test_id = 351;
 
     auto mesh_device = get_mesh_device();
@@ -456,7 +456,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSourceNOC1_2_0) {
     EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
 }
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSourceNOC1_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSourceNOC1_2_0) {
     uint32_t test_id = 352;
 
     auto mesh_device = get_mesh_device();
@@ -480,7 +480,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSourceNOC1_2_0) {
     EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
 }
 
-TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrementNOC1_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrementNOC1_2_0) {
     uint32_t test_id = 353;
 
     auto mesh_device = get_mesh_device();

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/README.md
@@ -3,7 +3,7 @@
 This test suite measures the issue latency (in cycles) of various NOC API calls using the experimental dataflow 2.0 API.
 
 ## Dispatch Mode
-These tests use **Fast Dispatch (Mesh Device API)** with `GenericMeshDeviceFixture` for optimal performance measurement.
+These tests use **Fast Dispatch (Mesh Device API)** with `UnitMeshFastDispatchFixture` for optimal performance measurement.
 
 ## Test Description
 

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "kernel_types.hpp"
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
@@ -228,55 +228,55 @@ void multicast_write_sweep_test(
 }  // namespace unit_tests::dm::noc_api_latency
 
 // Test definitions
-TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyUnicastWrite) {
+TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyUnicastWrite) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 700;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
-        this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_WRITE);
+        this->get_mesh_device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_WRITE);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyUnicastRead) {
+TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyUnicastRead) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 701;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
-        this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_READ);
+        this->get_mesh_device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_READ);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyStatefulWrite) {
+TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyStatefulWrite) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 702;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
-        this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_WRITE);
+        this->get_mesh_device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_WRITE);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyStatefulRead) {
+TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyStatefulRead) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 703;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
-        this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_READ);
+        this->get_mesh_device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_READ);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyMulticastWrite2x2) {
+TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyMulticastWrite2x2) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 704;
     tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
-        this->mesh_device_, test_case_id, {0, 1}, {1, 2}, false);
+        this->get_mesh_device(), test_case_id, {0, 1}, {1, 2}, false);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyMulticastWrite5x5) {
+TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyMulticastWrite5x5) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 705;
     tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
-        this->mesh_device_, test_case_id, {0, 1}, {4, 5}, false);
+        this->get_mesh_device(), test_case_id, {0, 1}, {4, 5}, false);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyMulticastWriteAll) {
+TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyMulticastWriteAll) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 706;
-    auto* device = this->mesh_device_->get_device(0);
+    auto* device = this->get_mesh_device()->get_device(0);
     CoreCoord grid_size = device->compute_with_storage_grid_size();
     tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
-        this->mesh_device_, test_case_id, {0, 0}, {grid_size.x - 1, grid_size.y - 1}, true);
+        this->get_mesh_device(), test_case_id, {0, 0}, {grid_size.x - 1, grid_size.y - 1}, true);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/README.md
@@ -3,7 +3,7 @@
 Comprehensive performance sweep tests designed to generate profiling data for the NoC estimator. These tests systematically exercise every major NOC communication pattern across a wide range of transaction sizes, grid configurations, and transfer mechanisms to produce the data needed for accurate latency/bandwidth prediction.
 
 ## Dispatch Mode
-All tests use **fast dispatch** via `GenericMeshDeviceFixture`.
+All tests use **fast dispatch** via `UnitMeshFastDispatchFixture`.
 
 ## NOC API
 - **L1 kernels** use the device 2.0 NOC API (`Noc`, `UnicastEndpoint`, `MulticastEndpoint`).

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -1391,77 +1391,77 @@ static void sweep_column_to_column(const shared_ptr<distributed::MeshDevice>& me
 // ============ TEST CASES ============
 
 // ---- L1 tests (800-809) ----
-TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneToOne) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneToOne) {
     unit_tests::dm::noc_estimator::sweep_one_to_one(get_mesh_device(), 800);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneFromOne) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneFromOne) {
     unit_tests::dm::noc_estimator::sweep_one_from_one(get_mesh_device(), 801);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneToAll) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneToAll) {
     unit_tests::dm::noc_estimator::sweep_one_to_all(get_mesh_device(), 802);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneFromAll) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneFromAll) {
     unit_tests::dm::noc_estimator::sweep_one_from_all(get_mesh_device(), 803);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorL1AllToAll) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1AllToAll) {
     unit_tests::dm::noc_estimator::sweep_all_to_all(get_mesh_device(), 804);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorL1AllFromAll) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1AllFromAll) {
     unit_tests::dm::noc_estimator::sweep_all_from_all(get_mesh_device(), 805);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneToRow) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneToRow) {
     unit_tests::dm::noc_estimator::sweep_one_to_row(get_mesh_device(), 806);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorL1RowToRow) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1RowToRow) {
     unit_tests::dm::noc_estimator::sweep_row_to_row(get_mesh_device(), 807);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneToColumn) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneToColumn) {
     unit_tests::dm::noc_estimator::sweep_one_to_column(get_mesh_device(), 808);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorL1ColumnToColumn) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1ColumnToColumn) {
     unit_tests::dm::noc_estimator::sweep_column_to_column(get_mesh_device(), 809);
 }
 
 // ---- DRAM Read tests (810-813) ----
-TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMShardedOneFromOne) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMShardedOneFromOne) {
     unit_tests::dm::noc_estimator::sweep_dram_sharded_one_from_one(get_mesh_device(), 810);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMShardedAllFromAll) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMShardedAllFromAll) {
     unit_tests::dm::noc_estimator::sweep_dram_sharded_all_from_all(get_mesh_device(), 811);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMInterleavedOneFromAll) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMInterleavedOneFromAll) {
     unit_tests::dm::noc_estimator::sweep_dram_interleaved_one_from_all(get_mesh_device(), 812);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMInterleavedAllFromAll) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMInterleavedAllFromAll) {
     unit_tests::dm::noc_estimator::sweep_dram_interleaved_all_from_all(get_mesh_device(), 813);
 }
 
 // ---- DRAM Write tests (814-817) ----
-TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMShardedOneToOne) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMShardedOneToOne) {
     unit_tests::dm::noc_estimator::sweep_dram_sharded_one_to_one(get_mesh_device(), 814);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMShardedAllToAll) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMShardedAllToAll) {
     unit_tests::dm::noc_estimator::sweep_dram_sharded_all_to_all(get_mesh_device(), 815);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMInterleavedOneToAll) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMInterleavedOneToAll) {
     unit_tests::dm::noc_estimator::sweep_dram_interleaved_one_to_all(get_mesh_device(), 816);
 }
 
-TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMInterleavedAllToAll) {
+TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMInterleavedAllToAll) {
     unit_tests::dm::noc_estimator::sweep_dram_interleaved_all_to_all(get_mesh_device(), 817);
 }
 

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from all subordinate cores to one master core.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
@@ -42,4 +42,4 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
 2. **One From All Directed Ideal**: Tests the most optimal data movement setup from multiple subordinate cores to one master core that maximizes the transaction size and performs enough transactions to amortize initialization overhead. This test uses neighboring cores to minimize latency.
 
 ## Quasar Notes
-`TensixDataMovementOneFromAllPacketSizes` and `TensixDataMovementOneFromAllDirectedIdeal` include Quasar-specific code paths inside `GenericMeshDeviceFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1`, the Quasar simulator, and a grid with at least 2 columns (e.g. `emu-quasar-2x3`).
+`TensixDataMovementOneFromAllPacketSizes` and `TensixDataMovementOneFromAllDirectedIdeal` include Quasar-specific code paths inside `UnitMeshFastDispatchFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1`, the Quasar simulator, and a grid with at least 2 columns (e.g. `emu-quasar-2x3`).

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
 #include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
@@ -371,7 +370,7 @@ void custom_test(
 }  // namespace unit_tests::dm::core_from_all
 
 /* ========== Test case for one from all data movement; Test id = 15 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllPacketSizes) {
     auto mesh_device = get_mesh_device();
     if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
         // sub_grid_size {2, 1} requires at least 2 columns in the compute grid
@@ -405,7 +404,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
 }
 
 /* ========== Test case for one from all data movement; Test id = 30 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
         // sub_grid_size {2, 1} requires at least 2 columns in the compute grid
@@ -438,7 +437,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
         mesh_device, test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
 
     // Test ID (Arbitrary)
@@ -455,7 +454,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
         get_mesh_device(), test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllCustom) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllCustom) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_id = 157;
@@ -484,7 +483,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllCustom) {
 }
 
 /* ========== Metal 2.0 variants ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllPacketSizes_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto arch_ = device->arch();
@@ -547,7 +546,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes_2_0) {
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllDirectedIdeal_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto arch_ = device->arch();
@@ -599,7 +598,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal_2_0) 
     EXPECT_TRUE(unit_tests::dm::core_from_all::run_dm(mesh_device, test_config));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllVirtualChannels_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -633,7 +632,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels_2_0
         {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y});
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllCustom_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllCustom_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from one subordinate core to one master core.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
@@ -63,4 +63,4 @@ This test suite now includes tests using the new device 2.0 NOC API. These tests
 Both API versions run the same test cases but use different underlying implementations. The device 2.0 tests serve as a validation and performance comparison for the new API.
 
 ## Quasar Notes
-`TensixDataMovementOneFromOnePacketSizes` and `TensixDataMovementOneFromOneDirectedIdeal` include Quasar-specific code paths inside `GenericMeshDeviceFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1`, the Quasar simulator, and a grid with at least 2 columns (e.g. `emu-quasar-2x3`).
+`TensixDataMovementOneFromOnePacketSizes` and `TensixDataMovementOneFromOneDirectedIdeal` include Quasar-specific code paths inside `UnitMeshFastDispatchFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1`, the Quasar simulator, and a grid with at least 2 columns (e.g. `emu-quasar-2x3`).

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
 #include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
@@ -329,7 +328,7 @@ void custom_test(
 
 /* ========== TEST CASES ========== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOnePacketSizes) {
     auto mesh_device = get_mesh_device();
     if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
         // subordinate_core_coord {1, 0} requires at least 2 columns in the compute grid
@@ -357,7 +356,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
     unit_tests::dm::core_from_core::packet_sizes_test(mesh_device, test_id, master_core_coord, subordinate_core_coord);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
         // subordinate_core_coord {1, 0} requires at least 2 columns in the compute grid
@@ -386,7 +385,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneDirectedIdeal) {
         mesh_device, test_id, master_core_coord, subordinate_core_coord);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneVirtualChannels) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
     // Test ID (Arbitrary)
     uint32_t test_id = 152;
@@ -399,7 +398,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneVirtualChannels) {
     );
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneCustom) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneCustom) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_id = 153;
 
@@ -418,7 +417,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneCustom) {
         num_virtual_channels);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOnePacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOnePacketSizes2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     if (device->arch() == ARCH::QUASAR) {
@@ -451,7 +450,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOnePacketSizes2_0) {
     unit_tests::dm::core_from_core::packet_sizes_test(mesh_device, test_id, CoreCoord(0, 0), CoreCoord(1, 1));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneDirectedIdeal2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneDirectedIdeal2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     if (device->arch() == ARCH::QUASAR) {

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between a sender and a receiver Tensix core using the one_packet APIs.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
@@ -44,4 +44,4 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
 4. One Packet Write Directed Ideal: Tests the most optimal transactions for writing packets by maximizing the number of packets and packet size to amortize initialization overhead and saturate the bandwidth.
 
 ## Quasar Notes
-`TensixDataMovementOnePacketReadSizes` and `TensixDataMovementOnePacketWriteSizes` include Quasar-specific code paths inside `GenericMeshDeviceFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1`, the Quasar simulator, and a grid with at least 2 columns (e.g. `emu-quasar-2x3`).
+`TensixDataMovementOnePacketReadSizes` and `TensixDataMovementOnePacketWriteSizes` include Quasar-specific code paths inside `UnitMeshFastDispatchFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1`, the Quasar simulator, and a grid with at least 2 columns (e.g. `emu-quasar-2x3`).

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
 #include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -204,7 +203,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
 }  // namespace unit_tests::dm::one_packet
 
 /* ========== Test case for reading varying number of packets and packet sizes; Test id = 80 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadSizes) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     // Physical Constraints
@@ -259,7 +258,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadSizes) {
 }
 
 /* ========== Test case for writing varying number of packets and packet sizes; Test id = 81 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteSizes) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -314,7 +313,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteSizes) {
 }
 
 /* ========== Directed Ideal Test Case; Test id = 82 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
@@ -346,7 +345,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadDirectedIdeal) {
 }
 
 /* ========== Directed Ideal Test Case; Test id = 83 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
@@ -377,7 +376,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteDirectedIdeal) 
     EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadSizes_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadSizes_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
@@ -427,7 +426,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadSizes_2_0) {
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteSizes_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteSizes_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
@@ -477,7 +476,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteSizes_2_0) {
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadDirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadDirectedIdeal_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
@@ -521,7 +520,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadDirectedIdeal_2_
     EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(mesh_device, test_config));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteDirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteDirectedIdeal_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from one master core to all subordinate cores.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
@@ -75,4 +75,4 @@ The semaphore-based tests use additional kernels for sender-receiver synchroniza
 Both API versions run the same test cases but use different underlying implementations. The device 2.0 tests serve as a validation and performance comparison for the new API.
 
 ## Quasar Notes
-`TensixDataMovementOneToAllUnicastDirectedIdeal` includes a Quasar-specific code path inside `GenericMeshDeviceFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1`, the Quasar simulator, and a grid with at least 2 columns (e.g. `emu-quasar-2x3`).
+`TensixDataMovementOneToAllUnicastDirectedIdeal` includes a Quasar-specific code path inside `UnitMeshFastDispatchFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1`, the Quasar simulator, and a grid with at least 2 columns (e.g. `emu-quasar-2x3`).

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -159,7 +159,7 @@ void run_all_tests(
 /* =================== LOOP THROUGH SCHEMES ==================== */
 /* ============================================================= */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSchemesLoopback) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastSchemesLoopback) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_case_id = 100;
@@ -168,7 +168,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSchemesLoopb
     unit_tests::dm::core_to_all::multicast_schemes::run_all_tests(get_mesh_device(), test_case_id, loopback);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSchemesNoLoopback) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastSchemesNoLoopback) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_case_id = 101;
@@ -177,7 +177,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSchemesNoLoo
     unit_tests::dm::core_to_all::multicast_schemes::run_all_tests(get_mesh_device(), test_case_id, loopback);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSchemesNoLoopback2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastSchemesNoLoopback2_0) {
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 10;
     bool loopback = false;
 
@@ -205,7 +205,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSchemesNoLoo
         10. Sender out grid ending not row not column
 */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSchemeSingle) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastSchemeSingle) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_case_id = 102;

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -5,7 +5,6 @@
 // Note: The sender kernels in One To All write the same transaction_size_bytes amount of data to the same location
 // num_of_transactions times
 
-#include "multi_device_fixture.hpp"
 #include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
@@ -623,7 +622,7 @@ void custom_test(
 /* ========== UNICAST ========== */
 
 /* ========== 2x2 ========== */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllUnicast2x2PacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllUnicast2x2PacketSizes) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 0;
 
@@ -640,7 +639,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllUnicast2x2Pac
 }
 
 /* ========== 5x5 ========== */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllUnicast5x5PacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllUnicast5x5PacketSizes) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 1;
 
@@ -657,7 +656,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllUnicast5x5Pac
 }
 
 /* ========== All ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastPacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastPacketSizes) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 2;
 
@@ -678,7 +677,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastPacketSizes) {
 /* ========== MULTICAST ========== */
 
 /* ========== 2x2 ========== */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticast2x2PacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast2x2PacketSizes) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 3;
 
@@ -696,7 +695,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticast2x2P
 }
 
 /* ========== 5x5 ========== */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticast5x5PacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast5x5PacketSizes) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 4;
 
@@ -714,7 +713,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticast5x5P
 }
 
 /* ========== All ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastPacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastPacketSizes) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 5;
 
@@ -735,7 +734,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastPacketSizes)
 /* ========== MULTICAST LINKED ========== */
 
 /* ========== 2x2 ========= */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLinked2x2PacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLinked2x2PacketSizes) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 6;
 
@@ -753,7 +752,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLink
 }
 
 /* ========== 5x5 ========== */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLinked5x5PacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLinked5x5PacketSizes) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 7;
 
@@ -771,7 +770,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLink
 }
 
 /* ========== 11x10 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedPacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedPacketSizes) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 8;
 
@@ -791,7 +790,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedPacket
 
 /* ========== MULTICAST LINKED WITH SEMAPHORE ========== */
 /* ========== 2x2 ========= */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphore2x2PacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSemaphore2x2PacketSizes) {
     GTEST_SKIP() << "Skipping test because CI timeout issue (#35788)";
 
     // Parameters
@@ -821,7 +820,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaph
 }
 
 /* ========== 5x5 ========= */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphore5x5PacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSemaphore5x5PacketSizes) {
     GTEST_SKIP() << "Skipping test because CI timeout issue (#35788)";
 
     // Parameters
@@ -851,7 +850,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaph
 }
 
 /* ========== All ========= */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphorePacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSemaphorePacketSizes) {
     GTEST_SKIP() << "Skipping test because CI timeout issue (#35788)";
 
     // Parameters
@@ -884,7 +883,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaph
 /* ========== DIRECTED IDEAL ========== */
 
 /* ========== UNICAST ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -938,7 +937,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastDirectedIdeal)
 }
 
 /* ========== MULTICAST ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastDirectedIdeal) {
     // Parameters
     uint32_t test_case_id = 53;  // Arbitrary test id
 
@@ -969,7 +968,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastDirectedIdea
 }
 
 /* ========== MULTICAST LINKED ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedDirectedIdeal) {
     // Parameters
     uint32_t test_case_id = 54;  // Arbitrary test id
 
@@ -1000,7 +999,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirect
 }
 
 /* ========== MULTICAST LINKED WITH SEMAPHORE ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphoreDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSemaphoreDirectedIdeal) {
     // Parameters
     uint32_t test_case_id = 56;  // Arbitrary test id
 
@@ -1035,7 +1034,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaph
 }
 
 /* ========== VIRTUAL CHANNELS ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastVirtualChannels) {  // Expose loopback here?
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastVirtualChannels) {  // Expose loopback here?
     GTEST_SKIP() << "Skipping test";
 
     // Parameters
@@ -1067,7 +1066,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastVirtualChannel
         loopback);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastCustom) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastCustom) {
     GTEST_SKIP() << "Skipping test";
 
     // Parameters
@@ -1108,7 +1107,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastCustom) {
 /* ========== UNICAST 2.0 ========== */
 
 /* ========== 2x2 ========== */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllUnicast2x2PacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllUnicast2x2PacketSizes2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 0;
 
@@ -1125,7 +1124,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllUnicast2x2Pac
 }
 
 /* ========== 5x5 ========== */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllUnicast5x5PacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllUnicast5x5PacketSizes2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 1;
 
@@ -1142,7 +1141,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllUnicast5x5Pac
 }
 
 /* ========== All ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastPacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastPacketSizes2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 2;
 
@@ -1189,7 +1188,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastPacketSizes2_0
 /* ========== MULTICAST 2.0 ========== */
 
 /* ========== 2x2 ========== */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticast2x2PacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast2x2PacketSizes2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 3;
 
@@ -1207,7 +1206,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticast2x2P
 }
 
 /* ========== 5x5 ========== */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticast5x5PacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast5x5PacketSizes2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 4;
 
@@ -1225,7 +1224,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticast5x5P
 }
 
 /* ========== All ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastPacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastPacketSizes2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 5;
 
@@ -1272,7 +1271,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastPacketSizes2
 /* ========== MULTICAST LINKED ========== */
 
 /* ========== 2x2 ========= */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLinked2x2PacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLinked2x2PacketSizes2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 6;
 
@@ -1290,7 +1289,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLink
 }
 
 /* ========== 5x5 ========== */
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLinked5x5PacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLinked5x5PacketSizes2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 7;
 
@@ -1308,7 +1307,7 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLink
 }
 
 /* ========== 11x10 ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedPacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedPacketSizes2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 8;
 
@@ -1353,7 +1352,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedPacket
 }
 
 /* ========== MULTICAST LINKED WITH LOOPBACK ========== */
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirectedIdeal2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedDirectedIdeal2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 9;
 
@@ -1383,7 +1382,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirect
         0);  // multicast_scheme_type (not used here)
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastDirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastDirectedIdeal_2_0) {
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 11;
 
     auto mesh_device = get_mesh_device();
@@ -1433,7 +1432,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastDirectedIdeal_
         0);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastDirectedIdeal_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastDirectedIdeal_2_0) {
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 12;
 
     auto mesh_device = get_mesh_device();

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between two Tensix cores.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
@@ -64,4 +64,4 @@ This test suite now includes tests using the new device 2.0 NOC API. These tests
 Both API versions run the same test cases but use different underlying implementations. The device 2.0 tests serve as a validation and performance comparison for the new API.
 
 ## Quasar Notes
-`TensixDataMovementOneToOnePacketSizes` and `TensixDataMovementOneToOneDirectedIdeal` include Quasar-specific code paths inside `GenericMeshDeviceFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1`, the Quasar simulator, and a grid with at least 2 columns (e.g. `emu-quasar-2x3`).
+`TensixDataMovementOneToOnePacketSizes` and `TensixDataMovementOneToOneDirectedIdeal` include Quasar-specific code paths inside `UnitMeshFastDispatchFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1`, the Quasar simulator, and a grid with at least 2 columns (e.g. `emu-quasar-2x3`).

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
 #include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -341,7 +340,7 @@ void custom_test(
 
 /* ========== TEST CASES ========== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOnePacketSizes) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOnePacketSizes) {
     auto mesh_device = get_mesh_device();
     if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
         // subordinate_core_coord {1, 0} requires at least 2 columns in the compute grid
@@ -375,7 +374,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOnePacketSizes) {
         3. Core locations with minimal number of hops
 */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneDirectedIdeal) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
         // subordinate_core_coord {1, 0} requires at least 2 columns in the compute grid
@@ -407,7 +406,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneDirectedIdeal) {
     );
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneVirtualChannels) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
     // Test ID (Arbitrary)
     uint32_t test_id = 150;
@@ -420,7 +419,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneVirtualChannels) {
     );
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneCustom) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneCustom) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_id = 151;
 
@@ -439,7 +438,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneCustom) {
         num_virtual_channels);
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOnePacketSizes2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOnePacketSizes2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     if (device->arch() == ARCH::QUASAR) {
@@ -473,7 +472,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOnePacketSizes2_0) {
     unit_tests::dm::core_to_core::packet_sizes_test(mesh_device, test_id, CoreCoord(0, 0), CoreCoord(1, 1));
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneDirectedIdeal2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneDirectedIdeal2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     if (device->arch() == ARCH::QUASAR) {

--- a/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/README.md
@@ -3,7 +3,7 @@
 This test suite implements a test that measures the functionality and performance (i.e. bandwidth) of data movement transactions from Host(PCIe memory) to L1 memory on a single Tensix core.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 

--- a/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/test_pcie_read_bw.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/test_pcie_read_bw.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
@@ -128,7 +128,7 @@ void pcie_read_bw_test(
 
 }  // namespace unit_tests::dm::pcie_read_bw
 
-TEST_F(GenericMeshDeviceFixture, PCIeReadBandwidth) {
+TEST_F(UnitMeshFastDispatchFixture, PCIeReadBandwidth) {
     uint32_t test_id = 603;
     CoreCoord master_core_coord = {0, 0};
 
@@ -136,7 +136,7 @@ TEST_F(GenericMeshDeviceFixture, PCIeReadBandwidth) {
 }
 
 /* ========== Sweep 1M transactions with varying transaction sizes; Test id = 605 ========== */
-TEST_F(GenericMeshDeviceFixture, PCIeReadBandwidthSweep) {
+TEST_F(UnitMeshFastDispatchFixture, PCIeReadBandwidthSweep) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -172,7 +172,7 @@ TEST_F(GenericMeshDeviceFixture, PCIeReadBandwidthSweep) {
 }
 
 /* ========== Host-side D2H (ReadShard) bandwidth sweep; Test id = 607 ========== */
-TEST_F(GenericMeshDeviceFixture, PCIeHostReadBandwidthSweep) {
+TEST_F(UnitMeshFastDispatchFixture, PCIeHostReadBandwidthSweep) {
     // Remove GTEST_SKIP to run the test
     GTEST_SKIP() << "Skipping: CLI timeout with large iteration count";
     auto mesh_device = get_mesh_device();

--- a/tests/tt_metal/tt_metal/data_movement/pcie_write_bw/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_write_bw/README.md
@@ -3,7 +3,7 @@
 This test suite measures the bandwidth of data movement transactions from L1 memory on a single Tensix core to Host (PCIe memory).
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 

--- a/tests/tt_metal/tt_metal/data_movement/pcie_write_bw/test_pcie_write_bw.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_write_bw/test_pcie_write_bw.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
@@ -108,7 +108,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const PCIeWr
 }  // namespace unit_tests::dm::pcie_write_bw
 
 /* ========== Sweep 1M transactions with varying transaction sizes; Test id = 604 ========== */
-TEST_F(GenericMeshDeviceFixture, PCIeWriteBandwidthSweep) {
+TEST_F(UnitMeshFastDispatchFixture, PCIeWriteBandwidthSweep) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -141,7 +141,7 @@ TEST_F(GenericMeshDeviceFixture, PCIeWriteBandwidthSweep) {
 }
 
 /* ========== Host-side H2D (WriteShard) bandwidth sweep; Test id = 606 ========== */
-TEST_F(GenericMeshDeviceFixture, PCIeHostWriteBandwidthSweep) {
+TEST_F(UnitMeshFastDispatchFixture, PCIeHostWriteBandwidthSweep) {
     // Remove GTEST_SKIP to run the test
     GTEST_SKIP() << "Skipping: CLI timeout with large iteration count";
     auto mesh_device = get_mesh_device();

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance of NOC transaction ID (TRID) mechanisms during NOC transactions between multiple Tensix cores.
 
 ## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `UnitMeshFastDispatchFixture` and run on single-device unit meshes.
 
 **Note**: The Mesh Device API enables only fast dispatch mode by default. This provides optimal performance for data movement operations.
 
@@ -74,4 +74,4 @@ The test uses five different kernel implementations:
 All kernels implement the same read-after-write or write-after-read pattern but with different NOC API optimizations suited for different transaction size ranges and performance requirements.
 
 ## Quasar Notes
-`TensixDataMovementTransactionIdReadAfterWrite` includes a Quasar-specific code path inside `GenericMeshDeviceFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1` and the Quasar simulator. Skipped at runtime when the emulator grid has fewer than 3 cores.
+`TensixDataMovementTransactionIdReadAfterWrite` includes a Quasar-specific code path inside `UnitMeshFastDispatchFixture`. Requires `TT_METAL_SLOW_DISPATCH_MODE=1` and the Quasar simulator. Skipped at runtime when the emulator grid has fewer than 3 cores.

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
 #include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -228,7 +227,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Transa
 
 /* ========== TEST CASES ========== */
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWrite) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrite) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
@@ -295,7 +294,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWrite) 
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOnePacket) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWriteOnePacket) {
     // Test ID
     uint32_t test_id = 601;
 
@@ -342,7 +341,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOn
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOnePacketStateful) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWriteOnePacketStateful) {
     // Test ID
     uint32_t test_id = 602;
 
@@ -390,7 +389,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOn
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterRead) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRead) {
     // Test ID
     uint32_t test_id = 610;
 
@@ -439,7 +438,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterRead) 
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterReadOnePacketStateful) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterReadOnePacketStateful) {
     // Test ID
     uint32_t test_id = 611;
 
@@ -498,7 +497,7 @@ inline bool quasar_grid_ok(IDevice* device) {
 }
 }  // namespace unit_tests::dm::transaction_id
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWrite_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrite_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto arch_ = device->arch();
@@ -552,7 +551,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWrite_2
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOnePacket_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWriteOnePacket_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto arch_ = device->arch();
@@ -606,7 +605,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOn
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOnePacketStateful_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWriteOnePacketStateful_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto arch_ = device->arch();
@@ -662,7 +661,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOn
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterRead_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRead_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto arch_ = device->arch();
@@ -716,7 +715,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterRead_2
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterReadOnePacketStateful_2_0) {
+TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterReadOnePacketStateful_2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
     auto arch_ = device->arch();


### PR DESCRIPTION
### PR Category
Test Only

### Summary

Data-movement tests that only ever programmed one device were still opening the full SystemMesh via `GenericMeshDeviceFixture`.

This PR adds `UnitMeshFastDispatchFixture` (one MMIO unit mesh, same fast-dispatch skip as `MeshDeviceFixtureBase`, including the emule exemption) and switches those suites to it so they match how they actually run. READMEs are updated to match.

Locally, when running tests using the following command
```
./build/test/tt_metal/unit_tests_data_movement --gtest_filter='-*NIGHTLY_*:*NocEstimator*'
```
I see speedup **from 539244 ms to 131262 ms (9 min to 2.2 min)**, mostly thanks to avoiding `EnqueueWriteMeshBuffer` and `EnqueueMeshWorkload` across the whole SystemMesh while checking the result on this single device:
```c++
IDevice* device = mesh_device->impl().get_device(0);
```

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-dm-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-dm-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-dm-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-dm-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-dm-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-dm-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-dm-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-dm-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-dm-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-dm-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-dm-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-dm-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-dm-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-dm-fixture)