### PR TITLE
[Test Only] Add another worst case benchmark to the DFB init time suite

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
@@ -913,6 +913,71 @@ void run_benchmark_case_seven(DfbInitTimingBenchContext& ctx) {
     LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseSeven");
 }
 
+// BenchmarkCaseEight — the worst DFB init case the standard Metal 2.0 binding API can express.
+//
+// This case maximises total entries across DM2-7 rather than the peak on one hart.
+//
+// Shape: 12 DFBs, each bound to a 2-thread DM producer kernel and a 4-thread DM consumer kernel,
+// STRIDED both sides. P+C = 6 covers every worker DM, so each DFB puts one entry on each of them:
+//
+//   DM2=12 DM3=12 DM4=12 DM5=12 DM6=12 DM7=12   -> 72 entries, the API maximum
+void run_benchmark_case_eight(DfbInitTimingBenchContext& ctx) {
+    auto mesh_device = ctx.mesh_device;
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+
+    constexpr uint32_t ENTRY_SIZE = 64;
+    constexpr uint32_t NUM_ENTRIES = 4;  // lcm(num producers 2, num consumers 4)
+    constexpr uint32_t NUM_DFBS = 12;    // 24-id txn pool / 1 id per side
+    constexpr uint8_t NUM_PRODUCER_THREADS = 2;
+    constexpr uint8_t NUM_CONSUMER_THREADS = 4;
+
+    const experimental::KernelSpecName PROD_K{"case_eight_prod"};
+    const experimental::KernelSpecName CONS_K{"case_eight_cons"};
+    // Body only constructs accessors; the init walk is driven by the host config blob, not by what
+    // the kernel does, so no data movement is needed to measure it.
+    const char* DM_SRC = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_case8_dm.cpp";
+
+    std::vector<experimental::DataflowBufferSpec> dfb_specs;
+    std::vector<experimental::KernelSpec::DFBBinding> prod_bindings, cons_bindings;
+    for (uint32_t i = 0; i < NUM_DFBS; ++i) {
+        const experimental::DFBSpecName name{fmt::format("d{}", i)};
+        dfb_specs.push_back(MakeBenchDfbSpec(name, ENTRY_SIZE, NUM_ENTRIES));
+        prod_bindings.push_back(experimental::ProducerOf(name, fmt::format("d{}", i)));
+        // Strided, not All: AllConsumerOf caps num_consumers at 4 and scales its consumer TC count
+        // with num_producers, which drops this shape to 2 DFBs.
+        cons_bindings.push_back(experimental::StridedConsumerOf(name, fmt::format("d{}", i)));
+    }
+
+    experimental::KernelSpec prod_spec{
+        .unique_id = PROD_K,
+        .source = DM_SRC,
+        .num_threads = NUM_PRODUCER_THREADS,
+        .dfb_bindings = prod_bindings,
+        .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen2Config{}},
+    };
+    experimental::KernelSpec cons_spec{
+        .unique_id = CONS_K,
+        .source = DM_SRC,
+        .num_threads = NUM_CONSUMER_THREADS,
+        .dfb_bindings = cons_bindings,
+        .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen2Config{}},
+    };
+
+    experimental::WorkUnitSpec wu{.name = "case_eight_wu", .kernels = {PROD_K, CONS_K}, .target_nodes = core_range_set};
+    experimental::ProgramSpec spec{
+        .name = "case_eight",
+        .kernels = {prod_spec, cons_spec},
+        .dataflow_buffers = dfb_specs,
+        .work_units = {wu},
+    };
+
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    experimental::ProgramRunArgs run_args;
+    experimental::SetProgramRunArgs(program, run_args);
+
+    LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseEight");
+}
+
 // BenchmarkWorstCaseFour — exhausts all 16 one-to-many remapper slots AND exercises
 // 8 of the 48 one-to-one remapper slots simultaneously, for 24 total remapper entries.
 //
@@ -1344,11 +1409,10 @@ struct DfbInitTimingBenchCase {
 };
 
 void print_usage(const char* argv0) {
-    std::cerr
-        << "Usage: " << argv0 << " [--case NAME]\n"
-        << "  NAME: base, two, three, four, five, six, seven,\n"
-        << "        six-debug, six-debug-implicit-sync, six-debug-implicit-sync-program-spec, all\n"
-        << "\nRequires TT_METAL_SLOW_DISPATCH_MODE=1 and TT_METAL_MEASURE_DFB_INIT_TIME=1 on Quasar.\n";
+    std::cerr << "Usage: " << argv0 << " [--case NAME]\n"
+              << "  NAME: base, two, three, four, five, six, seven, eight,\n"
+              << "        six-debug, six-debug-implicit-sync, six-debug-implicit-sync-program-spec, all\n"
+              << "\nRequires TT_METAL_SLOW_DISPATCH_MODE=1 and TT_METAL_MEASURE_DFB_INIT_TIME=1 on Quasar.\n";
 }
 
 }  // namespace tt::tt_metal
@@ -1380,6 +1444,7 @@ int main(int argc, char** argv) {
         {"five", run_benchmark_case_five},
         {"six", run_benchmark_case_six},
         {"seven", run_benchmark_case_seven},
+        {"eight", run_benchmark_case_eight},
         // {"six-debug", run_benchmark_case_six_debug},
         // {"six-debug-implicit-sync", run_benchmark_case_six_debug_implicit_sync},
         // {"six-debug-implicit-sync-program-spec", run_benchmark_case_six_debug_implicit_sync_program_spec},

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_case8_dm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_case8_dm.cpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// DM kernel for BenchmarkCaseEight (issue #55788).
+//
+// Both the producer and the consumer side of case eight run this source: the case measures DFB
+// *init* time, and the init walk in setup_local_dfb_interfaces is driven entirely by the host
+// config blob, not by anything the kernel does. So the body only needs to construct the accessors
+// -- there is no data movement to perform and none is wanted, since traffic would add noise to the
+// quantity being measured.
+//
+// Only d0 and d1 are named. Case eight binds 12 DFBs (d0..d11) to each kernel; a hart initializes
+// every DFB in its participation mask whether or not the kernel ever references it, so touching
+// two is enough to keep the accessor path exercised without inflating the kernel's text.
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/kernel_thread_globals.h"
+
+void kernel_main() {
+    DataflowBuffer d0(dfb::d0);
+    DataflowBuffer d1(dfb::d1);
+    (void)d0;
+    (void)d1;
+}


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Relates to #55788 
Add another worst case benchmark to the DFB init time benchmark suite. This configuration currently takes longer time than all of the existing benchmarks. Unlike other benchmarks, this configuration uses standard metal 2.0 host API.

In this case, there are 12 DM to DM DFBs, each 2Sx4S, therefore there are 12 entries for each of DM2-7 to initialize.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=shengxiangji/dfb-init-case-8)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:shengxiangji/dfb-init-case-8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=shengxiangji/dfb-init-case-8)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:shengxiangji/dfb-init-case-8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=shengxiangji/dfb-init-case-8)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:shengxiangji/dfb-init-case-8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=shengxiangji/dfb-init-case-8)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:shengxiangji/dfb-init-case-8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=shengxiangji/dfb-init-case-8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:shengxiangji/dfb-init-case-8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=shengxiangji/dfb-init-case-8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:shengxiangji/dfb-init-case-8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=shengxiangji/dfb-init-case-8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:shengxiangji/dfb-init-case-8)