### PR TITLE
Fix moreh_adam integer-step exponent + pack-before-wait (#51278 items 1, 2)

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/moreh_adam.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/moreh_adam.cpp
@@ -220,10 +220,10 @@ void kernel_main() {
 #endif
         sqrt_tile_init();
         sqrt_tile(dst0);
-        pack_tile_with_dt(dst0, dfb_tmp1_obj);
         tile_regs_commit();
 
         tile_regs_wait();
+        pack_tile_with_dt(dst0, dfb_tmp1_obj);
         dfb_tmp1_obj.pop_front(onetile);
         dfb_tmp1_obj.push_back(onetile);
 #ifdef AMSGRAD

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/moreh_adam.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/moreh_adam.cpp
@@ -146,8 +146,8 @@ void kernel_main() {
         tile_regs_acquire();
         copy_tile_init_with_dt(dfb_scalar_args_obj);
         copy_tile(cb_scalar_args, beta2_tile, dst0);
-        power_tile_init();
-        power_tile(dst0, step);
+        power_iterative_tile_init();
+        power_iterative_tile(dst0, step);
         tile_regs_commit();
 
         tile_regs_wait();
@@ -255,8 +255,8 @@ void kernel_main() {
         dfb_tmp2_obj.reserve_back(onetile);
         copy_tile_init_with_dt(dfb_scalar_args_obj);
         copy_tile(cb_scalar_args, beta1_tile, dst0);
-        power_tile_init();
-        power_tile(dst0, step);
+        power_iterative_tile_init();
+        power_iterative_tile(dst0, step);
         tile_regs_commit();
 
         tile_regs_wait();


### PR DESCRIPTION
## Summary

Fixes items **1** and **2** of #51278 — the two independent defects in `moreh_adam.cpp`, delivered as two commits:

1. **`power_tile(dst0, step)` exponent-units mismatch** (`:150`, `:259`): `power_tile`'s `param0` is documented as *"The exponent as IEEE 754 float bits"* (`compute_kernel_api.h`), but the kernel passes the raw integer optimizer `step`. `Converter::as_float(1u)` = 1.4e-45, so `pow(beta, step)` evaluated to 1.0 **for every step value**, both bias corrections `1/(1 - pow(beta, step))` became `recip(0)` = inf, and `param_out` was garbage — bit-identical no matter which `step` the user passed. `exp_avg` / `exp_avg_sq` don't involve `power_tile` and were unaffected.

2. **pack-before-handshake in the sqrt block** (`:223`): the PACK thread issued `pack_tile_with_dt()` before `tile_regs_wait()`, reading DST without the MATH_PACK handshake. Every other block in this file and every helper in `moreh_common.hpp` packs after `tile_regs_wait()`; the PACR here executed while MATH was still writing `mul_tiles()`+`sqrt_tile()` into that DST half, so `cb_tmp1` could go stale and `param_out = param - lr * m_hat / denom` was silently wrong (timing-dependent).

## The fix

Commit 1 (item 1) — use the integer-exponent idiom that every other moreh power site uses (`moreh_common.hpp` `pow_*` helpers), both sites:

```cpp
power_iterative_tile_init();
power_iterative_tile(dst0, step);   // param0 = integer exponent
```

This was the only `power_tile` call left in the tree after #33182 changed its contract without updating this kernel; `power_iterative_tile` restores the pre-#33182 integer semantics exactly.

Commit 2 (item 2) — move the pack after the handshake, matching the sibling blocks:

```cpp
sqrt_tile(dst0);
tile_regs_commit();

tile_regs_wait();
pack_tile_with_dt(dst0, dfb_tmp1_obj);   // was issued before tile_regs_wait()
dfb_tmp1_obj.pop_front(onetile);
```

## Verification (ttsim Blackhole simulator, ttnn 0.78.0, no hardware)

`ttnn.operations.moreh.adam(param, grad, exp_avg=0, exp_avg_sq=0, step=S)` vs torch reference, shape (2,3,32,32) bf16, max |error| over `param_out`:

| build | step=1 | step=2 | step=10 |
|---|---|---|---|
| stock wheel | **3.03e16** | **3.03e16** | **3.03e16** |
| item 1 only | 2.28 | 2.26 | 2.33 |
| **items 1+2 (this PR)** | **0.0010** | **0.00074** | **0.00049** |

- The stock outputs for step=1/2/10 are **bit-identical** — direct proof of `pow(beta, step) == 1.0` regardless of step.
- "item 1 only" residual (~2.3) is item 2's stale-DST error, deterministic on ttsim; the two defects are independent but compound in `param_out`, which is why the table isolates them.
- Final errors are at bf16 rounding level; output mantissas match the torch reference exactly (e.g. got `-1.125, -1.15625, -0.25195, -0.43359` vs ref `-1.12600, -1.15725, -0.25100, -0.43259`).
- Control: `exp_avg` / `exp_avg_sq` outputs are byte-identical before/after (they don't touch `power_tile` or the sqrt block's pack ordering).
- With `fp32_dest_acc_en=True` (as the nightly test uses), all three outputs land at bf16-rounding error vs reference: 0.0010 / 0.0023 / 0.00044.

Repro (before fix):

```python
out = ttnn.operations.moreh.adam(dev(param), dev(grad), dev(zeros), dev(zeros),
                                  lr=1e-3, beta1=0.9, beta2=0.999, eps=1e-8, step=1)
# param_out max|err| = 3.03e16 vs torch Adam reference; identical for step=1/2/10
```

## Notes for reviewers

- Per #51278, items 1 & 2 are different defects in the same file — fixed as two independent commits; the checkboxes can be ticked separately.
- The amsgrad path (`AMSGRAD` define) shares both fixed blocks; its own pack sites already had the correct ordering.
- No host-side change: `step` still flows as a raw uint32 runtime arg; only the kernel's consumption changes to the integer-exponent API.

Addresses #51278 items 1, 2 (the umbrella issue stays open for the remaining items).

