### PR TITLE
[LLK][Quasar] Correct the p_unpacr UNPACR_NOP Nop_type values

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
@@ -62,10 +62,13 @@ struct p_unpacr
     constexpr static std::uint32_t TILE3_CFG_CONTEXT     = (0); // Config context for tile 3
     constexpr static std::uint32_t AUTO_INC_CONTEXT      = (1); // Auto increment config context (max value set through unpacker config command)
 
-    constexpr static std::uint32_t UNP_POP           = 0x0;
-    constexpr static std::uint32_t UNP_CLRSRC        = 0x1;
-    constexpr static std::uint32_t UNP_NOP           = 0x2;
-    constexpr static std::uint32_t UNP_POP_STREAM    = 0x3;
+    // UNPACR_NOP Nop_type field. The values differ from Blackhole, which numbers this
+    // field for a nine-operand instruction carrying two pop flavours as well; Quasar has
+    // no pop flavour, puts the clear at 0, and adds a set-data-valid with no clear.
+    // Src_ClrVal_Ctrl, Bank_Clr_Ctrl and Stall_Cntrl are honoured only by UNP_CLRSRC.
+    constexpr static std::uint32_t UNP_CLRSRC        = 0x0;
+    constexpr static std::uint32_t UNP_NOP           = 0x1;
+    constexpr static std::uint32_t UNP_NOP_SETDVALID = 0x2;
     constexpr static std::uint32_t UNP_CLRSRC_ZERO   = 0x0;
     constexpr static std::uint32_t UNP_CLRSRC_NEGINF = 0x1;
     constexpr static std::uint32_t UNP_CLRSRC_ONE    = 0x2;

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_AB_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_AB_reduce_runtime_custom.h
@@ -86,7 +86,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_runtime_(
         // ignores them (max(x, -inf) = x). This clear op is prepended before each face unpack (the MOP's first inner-loop op).
         constexpr std::uint32_t clr_mode = p_unpacr::UNP_CLRSRC_NEGINF;
         const std::uint32_t unpack_zero_srcA =
-            TT_OP_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0 /* clear curr bank */, clr_mode, p_unpacr::UNP_CLRSRC_ZERO /* UNP_CLR_SRC */);
+            TT_OP_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0 /* clear curr bank */, clr_mode, p_unpacr::UNP_CLRSRC);
 
         ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_zero_srcA, unpack_srcA_face);
         temp.set_last_inner_loop_instr(unpack_srcA_face_last);

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_common.h
@@ -143,5 +143,5 @@ inline void _llk_unpack_reconfig_data_format_src_(const std::uint32_t unpack_src
  */
 inline void _llk_unpack_set_srcB_dummy_valid_()
 {
-    TTI_UNPACR_NOP(p_unpacr::UNP_B, 1 /*Set_Dvalid*/, 0, 0, 0, p_unpacr::UNP_NOP);
+    TTI_UNPACR_NOP(p_unpacr::UNP_B, 1 /*Set_Dvalid*/, 0, 0, 0, p_unpacr::UNP_NOP_SETDVALID);
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
@@ -52,7 +52,7 @@ inline void _llk_unpack_reduce_mop_config_(
     {
         constexpr std::uint32_t clr_mode = (POOL_TYPE == PoolType::MAX) ? p_unpacr::UNP_CLRSRC_NEGINF : p_unpacr::UNP_CLRSRC_ZERO;
         const std::uint32_t unpack_zero_srcA =
-            TT_OP_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0 /* clear curr bank */, clr_mode, p_unpacr::UNP_CLRSRC_ZERO /* UNP_CLR_SRC */);
+            TT_OP_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0 /* clear curr bank */, clr_mode, p_unpacr::UNP_CLRSRC);
 
         ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_zero_srcA, unpack_srcA_face);
         temp.set_start_op(unpack_srcB_face);

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce_col_tilizeA_strided.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce_col_tilizeA_strided.h
@@ -94,11 +94,11 @@ inline void _llk_unpack_reduce_col_tilizeA_strided_tiny_tiles_mop_config_(const 
         [buf_desc_id_0]
         {
             // Face 0; Src_Reg_Y_Cntr_Incr = 0 resets the counter, so each face starts at row 0 of its own SrcA bank
-            TTI_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0 /* clear curr bank */, clr_mode, p_unpacr::UNP_CLRSRC_ZERO /* UNP_CLR_SRC */);
+            TTI_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0 /* clear curr bank */, clr_mode, p_unpacr::UNP_CLRSRC);
             TT_UNPACR0_STRIDE(0 /*Src_Reg_Y_Cntr_Incr*/, 0 /*inc by 1*/, 1 /*set to inc*/, 1 /*Row_Mask_Reg_Sel*/, 0, buf_desc_id_0, 1 /*Set Dvalid*/);
 
             // Face 1
-            TTI_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0 /* clear curr bank */, clr_mode, p_unpacr::UNP_CLRSRC_ZERO /* UNP_CLR_SRC */);
+            TTI_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0 /* clear curr bank */, clr_mode, p_unpacr::UNP_CLRSRC);
             TT_UNPACR0_STRIDE(0 /*Src_Reg_Y_Cntr_Incr*/, 0 /*inc by 1*/, 1 /*set to inc*/, 1 /*Row_Mask_Reg_Sel*/, 0, buf_desc_id_0, 1 /*Set Dvalid*/);
         });
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
@@ -75,8 +75,9 @@ inline void _llk_unpack_tilize_mop_config_(const std::uint32_t buf_desc_id, cons
     {
         // FP32 datacopy uses ELWADD, which requires dvalid from both SrcA and SrcB
         // Set dvalid for the opposite unpacker (if using UNP_A, set dvalid for UNP_B and vice versa)
-        constexpr std::uint32_t OPPOSITE_UNP                      = (UNP_SEL == p_unpacr::UNP_A) ? p_unpacr::UNP_B : p_unpacr::UNP_A;
-        constexpr static std::uint32_t set_opposite_dvalid_instrn = TT_OP_UNPACR_NOP(OPPOSITE_UNP, 1 /*Dvalid*/, 0, 0, 0 /*clear to 0*/, 0 /*UNP_CLR_SRC*/);
+        constexpr std::uint32_t OPPOSITE_UNP = (UNP_SEL == p_unpacr::UNP_A) ? p_unpacr::UNP_B : p_unpacr::UNP_A;
+        constexpr static std::uint32_t set_opposite_dvalid_instrn =
+            TT_OP_UNPACR_NOP(OPPOSITE_UNP, 1 /*Dvalid*/, 0, 0, p_unpacr::UNP_CLRSRC_ZERO, p_unpacr::UNP_CLRSRC);
 
         ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, set_opposite_dvalid_instrn, unpack_tile_instrn);
         temp.set_last_outer_loop_instr(reset_src_reg_instrn);
@@ -440,8 +441,9 @@ inline void _llk_unpack_tilize_strided_mop_config_small_faces_(const std::uint32
 
     if constexpr (EN_32BIT_DEST)
     {
-        constexpr std::uint32_t OPPOSITE_UNP                      = (UNP_SEL == p_unpacr::UNP_B) ? p_unpacr::UNP_A : p_unpacr::UNP_B;
-        constexpr static std::uint32_t set_opposite_dvalid_instrn = TT_OP_UNPACR_NOP(OPPOSITE_UNP, 1 /*Dvalid*/, 0, 0, 0 /*clear to 0*/, 0 /*UNP_CLR_SRC*/);
+        constexpr std::uint32_t OPPOSITE_UNP = (UNP_SEL == p_unpacr::UNP_B) ? p_unpacr::UNP_A : p_unpacr::UNP_B;
+        constexpr static std::uint32_t set_opposite_dvalid_instrn =
+            TT_OP_UNPACR_NOP(OPPOSITE_UNP, 1 /*Dvalid*/, 0, 0, p_unpacr::UNP_CLRSRC_ZERO, p_unpacr::UNP_CLRSRC);
         ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), set_opposite_dvalid_instrn);
         temp.program_bank0_sw_cntl(instrn_buffer);
     }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
@@ -247,7 +247,7 @@ inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t
 
     // Dummy dvalid NOP for the source register filled by MOVD2A/B
     const std::uint32_t nop_op =
-        TT_OP_UNPACR_NOP(DUMMY_UNP, 0 /*Set_Dvalid*/, 0 /*Stall_Cntrl*/, 0 /*Bank_Clr_Ctrl*/, 0 /*Src_ClrVal_Ctrl*/, p_unpacr::UNP_NOP);
+        TT_OP_UNPACR_NOP(DUMMY_UNP, 0 /*Set_Dvalid*/, 0 /*Stall_Cntrl*/, 0 /*Bank_Clr_Ctrl*/, 0 /*Src_ClrVal_Ctrl*/, p_unpacr::UNP_NOP_SETDVALID);
 
     // Unpack one face from CB with auto-increment of src face index.
     // Dst_Face_Idx_Inc=0: always write to face 0 position (FPU reads from 0 after CLR_AB).


### PR DESCRIPTION
### Problem

`p_unpacr` carried **Blackhole's** numbering for the `UNPACR_NOP` flavour field.

Quasar's `UNPACR_NOP` takes six operands and its `Nop_type` field encodes
`0 = clear source`, `1 = NOP`, `2 = NOP with set-data-valid and no clear`
(`tt_llk_quasar/instructions/assembly.yaml`). Blackhole's takes nine operands and its
`Unpack_Pop` field encodes `0 = UNP_POP`, `1 = UNP_CLR_SRC`, `2 = UNP_NOP`,
`3 = UNP_POP+stream_id` (`tt_llk_blackhole/instructions/assembly.yaml`) — which is what the
Quasar header had. Quasar has no pop flavour, so the clear sits at 0 and the NOP at 1.

Every value is legal in the field, so a value carried across selects a different flavour of
the instruction and still compiles.

Closes #56204.

### The bug this fixes

`llk_unpack_dummy` (`tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h`) asks for
`p_unpacr::UNP_CLRSRC`. With the wrong value that was `1` — the plain NOP — so the SrcA clear
the function documents never happened, and the `STALLWAIT` on SrcA-clear placed ahead of it
to make the clear safe was guarding nothing.

**That call site is not touched by this PR.** It already says "clear"; correcting the
constant's value is what makes it clear. Its instruction word goes
`0x43000001` → `0x43000000`.

The `WAIT`/`POP` ordering role the primitive exists for (TEN-4746 / #48552) is unaffected —
the instruction is a real unpacker TDMA in either flavour.

### Change

Keep the names, give them this architecture's values:

```
UNP_CLRSRC        0x1 -> 0x0
UNP_NOP           0x2 -> 0x1
UNP_NOP_SETDVALID        0x2   (new: the flavour Quasar adds)
UNP_POP, UNP_POP_STREAM  removed (name no Quasar flavour; no users)
```

Call sites follow only where the value would otherwise move:

- The two sites that want the set-data-valid named `UNP_NOP` for it, which *was* value 2 and
  so was already doing the right thing. They move to `UNP_NOP_SETDVALID` and keep value 2.
- The reduce and tilize clear sites were passing a `Src_ClrVal_Ctrl` constant, or a bare `0`,
  in the flavour field. They now name `UNP_CLRSRC`, which is the same value 0.

### Effect on emitted code

One word changes — the fix:

```
llk_unpack_dummy              0x43000001  ->  0x43000000
set_srcB_dummy_valid          0x43000182  ->  0x43000182
reuse_dest_dummy_nop UNP_A    0x43000002  ->  0x43000002
reuse_dest_dummy_nop UNP_B    0x43000102  ->  0x43000102
reduce_clear_srcA zero        0x43000020  ->  0x43000020
reduce_clear_srcA neginf      0x43000024  ->  0x43000024
tilize_set_opposite_dv UNP_A  0x43000080  ->  0x43000080
tilize_set_opposite_dv UNP_B  0x43000180  ->  0x43000180
```

Built from the real header, pristine vs patched, for every live call site and both branch
variants of each.

### Verification

No test was run: Quasar is pre-silicon and its LLK suite needs a simulator. The values are
checked against the instruction spec that ships beside the header, and the encoding table
above is the change's full footprint.

**The one behavioural hunk deserves an owner's eye.** Enabling the clear makes the existing
`STALLWAIT` load-bearing, which is what it was placed there for, but that is a review
judgement rather than something measured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/quasar-unpacr-nop-type-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/quasar-unpacr-nop-type-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/quasar-unpacr-nop-type-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/quasar-unpacr-nop-type-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/quasar-unpacr-nop-type-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/quasar-unpacr-nop-type-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/quasar-unpacr-nop-type-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/quasar-unpacr-nop-type-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/quasar-unpacr-nop-type-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/quasar-unpacr-nop-type-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/quasar-unpacr-nop-type-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/quasar-unpacr-nop-type-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/quasar-unpacr-nop-type-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/quasar-unpacr-nop-type-constants)