### PR TITLE
[ Bug fix] DIIM-461 - Increased timeout for connectivity test.

### DIFF
--- a/tools/scaleout/exabox/TROUBLESHOOTING.md
+++ b/tools/scaleout/exabox/TROUBLESHOOTING.md
@@ -222,7 +222,7 @@ But `ip link show ens5f0np0` shows `state UP` (and `ip addr` shows a valid IP).
 **Cause**: The error message is misleading. The interface check in `utils/mpi_if_selection.sh` does **not** test whether the link is up — it runs a real MPI probe against the **first host** in `--hosts` and checks the exit code:
 
 ```bash
-timeout 3 mpirun --host "$FIRST_HOST" \
+timeout 30 mpirun --host "$FIRST_HOST" \
     --mca oob_tcp_if_include "$interface" \
     --mca btl_tcp_if_include "$interface" \
     -np 1 hostname &>/dev/null

--- a/tools/scaleout/exabox/utils/mpi_if_selection.sh
+++ b/tools/scaleout/exabox/utils/mpi_if_selection.sh
@@ -14,7 +14,7 @@ test_mpi_interface() {
     fi
 
     # MPI OOB (out-of-band) connectivity test
-    timeout 3 mpirun --host "$test_host" \
+    timeout 30 mpirun --host "$test_host" \
         --mca oob_tcp_if_include "$interface" \
         --mca btl_tcp_if_include "$interface" \
         -np 1 hostname &>/dev/null


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

- Changed timeout from 3s to 30s.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgajewskiTT/DIIM-461-recover-hosts-timeout-too-short)