### PR TITLE
[skip ci] [Bug fix] Fix Bug Check pull_request_target event handling

### DIFF
--- a/.github/workflows/bug-check.yaml
+++ b/.github/workflows/bug-check.yaml
@@ -9,10 +9,8 @@ on:
 jobs:
   parse-comment:
     name: Resolve Target
-    # Automatic runs are skipped for PRs from forks — secrets (BUG_CHECKER_API_KEY,
-    # the PAT) are unavailable and the GITHUB_TOKEN is read-only in that context, so
-    # the scan would fail. Forks can still be checked via a maintainer's /bug-check
-    # comment, which runs in the base repo's Actions context.
+    # Automatic runs are limited to non-draft PRs from this repository.
+    # Fork PRs can still be checked via a maintainer's /bug-check comment.
     if: >-
       (
         github.event_name == 'issue_comment' &&
@@ -24,7 +22,7 @@ jobs:
         )
       ) ||
       (
-        github.event_name == 'pull_request' &&
+        github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
         github.event.pull_request.head.repo.full_name == github.repository
       )
@@ -56,7 +54,7 @@ jobs:
           ISSUE_NUM: ${{ github.event.issue.number }}
           PR_NUM_FROM_EVENT: ${{ github.event.pull_request.number }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
             # Automatic run triggered by the PR itself (not a /bug-check comment):
             # always the "run" subcommand against every matching rule.
             echo "pr-number=$PR_NUM_FROM_EVENT" >> "$GITHUB_OUTPUT"
@@ -136,7 +134,7 @@ jobs:
 
     steps:
       - name: Post running notice
-        # Automatic (pull_request-triggered) runs skip this: an "I'm running" ack
+        # Automatic (pull_request_target-triggered) runs skip this: an "I'm running" ack
         # with no findings yet is noise. Manual /bug-check comment runs keep it as
         # confirmation the command was received.
         if: github.event_name == 'issue_comment'
@@ -209,11 +207,11 @@ jobs:
           if [ "$SUBCOMMAND" = "run" ] || [ "$SUBCOMMAND" = "check-rule" ]; then
             cmd+=(--sarif .github/bug-checker-results.sarif)
           fi
-          # Automatic (pull_request-triggered) runs shouldn't post a comment when
+          # Automatic (pull_request_target-triggered) runs shouldn't post a comment when
           # there's nothing to report — that's noise without signal. Manual
           # /bug-check comment runs keep posting "no issues found" etc. as
           # confirmation the command ran.
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
             cmd+=(--quiet-if-clean)
           fi
           cmd+=(--post-comments --verbose)


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Bug Check listens for `pull_request_target`, but its job gate and shell branches still compare the event name with `pull_request`. Opening test PR #56217 produced a [skipped run](https://github.com/tenstorrent/tt-metal/actions/runs/34580250578).

Update all three comparisons so automatic runs enter Resolve Target, use the event's PR number with subcommand `run`, and pass `--quiet-if-clean`. Refresh the related comments, including the outdated explanation of the fork restriction.

### Notes for reviewers
The existing non-draft and same-repository guards remain in place. The workflow continues checking out `main` for trusted checker code. The CLI receives `--pr`, calls `fetch_pr_info()`, retrieves the PR's diff through `gh pr diff`, and sends rule-filtered diff sections to the LLM.

### Validation
- YAML parsing and the repository's check-yaml, trailing-whitespace, and end-of-file hooks passed.
- Executed the workflow's parsing and checker-command shell blocks with stubbed Python invocation: automatic PR events and manual run, dry-run, check-rule, list-rules, and help cases passed. Used GNU sed to match the Ubuntu runner.
- Checked trigger event types and retained draft/same-repository guards.
- Ran the actual `fetch_pr_info(56217)` implementation against GitHub: it retrieved the test marker file and its eight-line diff. Traced that diff through per-rule filtering into the LLM prompt.
- End-to-end automatic execution still needs verification after merging: `pull_request_target` uses the base branch workflow. No LLM scan was performed locally.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/fix-bug-check-pull-request-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/fix-bug-check-pull-request-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/fix-bug-check-pull-request-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/fix-bug-check-pull-request-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/fix-bug-check-pull-request-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/fix-bug-check-pull-request-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/fix-bug-check-pull-request-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/fix-bug-check-pull-request-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/fix-bug-check-pull-request-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/fix-bug-check-pull-request-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/fix-bug-check-pull-request-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/fix-bug-check-pull-request-target)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/fix-bug-check-pull-request-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/fix-bug-check-pull-request-target)