### PR TITLE
[Feature] Add kernel IWYU analysis and consolidated HTML reports

### DIFF
--- a/.github/scripts/utils/render_kernel_analysis_site.py
+++ b/.github/scripts/utils/render_kernel_analysis_site.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Consolidate native IWYU output and link both kernel analyzers from one site.
+
+Usage: render_kernel_analysis_site.py <per-leg artifact directory> <site directory>
+CodeChecker's HTML must already be in <site>/clang-tidy. No third-party packages
+or browser-side data downloads are needed; the IWYU report is standalone HTML.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from html import escape
+import json
+import os
+from pathlib import Path
+import posixpath
+import re
+
+from brand_kernel_tidy_site import FAVICON
+
+HEADING = re.compile(r"^(.+) should (add|remove) these lines:$")
+WHEEL_ROOT = re.compile(r"^/opt/venv/lib/python\d+\.\d+/site-packages/ttnn/")
+DIAGNOSTIC = re.compile(r"^(.+?):(\d+):(\d+): ((?:fatal )?error:.*)$")
+
+
+def source_path(path: str) -> str:
+    """Checkout and installed wheel copies refer to the same repository file."""
+    return posixpath.normpath(WHEEL_ROOT.sub("", path.removeprefix("/work/")))
+
+
+@dataclass
+class Report:
+    # File, action, suggested source line. Groups and occurrences are discarded.
+    findings: set[tuple[str, str, str]] = field(default_factory=set)
+    errors: set[str] = field(default_factory=set)
+    reports: int = 0
+    incomplete: bool = False
+
+
+def read_output(path: Path, report: Report) -> None:
+    source = action = None
+    with path.open(errors="replace") as stream:
+        for raw in stream:
+            line = raw.rstrip("\r\n")
+            heading = HEADING.fullmatch(line)
+            diagnostic = DIAGNOSTIC.fullmatch(line)
+            if diagnostic:
+                file, row, col, message = diagnostic.groups()
+                report.errors.add(f"{source_path(file)}:{row}:{col}: {message}")
+                source = action = None
+            elif re.match(r"^(?:[\w./+-]+: )?(?:fatal )?error:", line):
+                report.errors.add(line)
+                source = action = None
+            elif heading:
+                source, action = source_path(heading[1]), heading[2]
+            elif not line or line == "---" or line.startswith("The full include-list for "):
+                source = action = None
+            elif source and action:
+                if action == "remove":
+                    if not line.startswith("- "):
+                        source = action = None
+                        continue
+                    line = line[2:]
+                # Symbol explanations and original line numbers differ between
+                # invocations but do not change the suggested include/declaration.
+                code = re.split(r"\s+//", line, maxsplit=1)[0].strip()
+                if code:
+                    report.findings.add((source, action, code))
+
+
+def collect(legs: Path) -> Report:
+    report = Report()
+    for leg in sorted(legs.glob("*/")):
+        output = leg / "iwyu.txt"
+        if output.is_file():
+            report.reports += 1
+            read_output(output, report)
+            status = leg / "iwyu-exit-code.txt"
+            if not status.is_file() or status.read_text().strip() != "0":
+                report.incomplete = True
+        else:
+            commands = leg / "compile_commands.json"
+            if commands.is_file():
+                try:
+                    report.incomplete |= bool(json.loads(commands.read_text()))
+                except (ValueError, OSError):
+                    report.incomplete = True
+    report.incomplete |= bool(report.errors)
+    return report
+
+
+STYLE = """
+:root { color-scheme: light dark; --bg: #f6f5fa; --panel: #fff; --text: #252334;
+  --muted: #625e73; --line: #ddd9e8; --accent: #5944c5; }
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--text);
+  font: 16px/1.55 system-ui, sans-serif; }
+main { max-width: 1200px; padding: 40px 24px 80px; margin: auto; }
+a { color: var(--accent); }
+h1 { font-size: 2rem; letter-spacing: -.035em; margin: 16px 0 8px; }
+h2 { font-size: 1.25rem; } h3 { font-size: 1rem; margin: 0 0 12px; }
+p { margin: 8px 0 20px; } .muted { color: var(--muted); }
+.cards, .changes { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 20px; }
+.card, details { border: 1px solid var(--line); background: var(--panel); border-radius: 10px; }
+.card { padding: 24px; } .card h2 { margin-top: 0; }
+.notice { border-left: 4px solid #c78b19; padding: 14px 18px; background: var(--panel); }
+.search { margin: 28px 0 20px; } label { display: block; font-weight: 600; margin-bottom: 8px; }
+input { width: 100%; padding: 12px; font: inherit; color: var(--text);
+  background: var(--panel); border: 1px solid var(--line); border-radius: 6px; }
+input:focus-visible, a:focus-visible, summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+details { margin-bottom: 12px; } summary { padding: 16px; cursor: pointer; overflow-wrap: anywhere; }
+summary code { font-size: .88rem; } .changes { padding: 0 20px 20px; }
+.add h3 { color: #187344; } .remove h3 { color: #af3442; }
+pre { white-space: pre-wrap; overflow-wrap: anywhere; font-size: .85rem; margin: 0; }
+.diagnostics pre { padding: 0 20px 20px; } [hidden] { display: none !important; }
+@media (max-width: 720px) { .cards, .changes { grid-template-columns: 1fr; } main { padding: 24px 16px; } }
+@media (prefers-color-scheme: dark) {
+  :root { --bg: #17151f; --panel: #211e2c; --text: #eeeaf7; --muted: #b6afc8;
+    --line: #423b53; --accent: #b6a8ff; }
+  .add h3 { color: #78d7a4; } .remove h3 { color: #ff9da8; }
+}
+"""
+
+SEARCH = """
+<script>
+const files = Array.from(document.querySelectorAll('.file')).map(element => ({
+  element, text: element.textContent.toLowerCase()
+}));
+document.querySelector('#search').addEventListener('input', event => {
+  const query = event.target.value.trim().toLowerCase();
+  let visible = 0;
+  for (const {element, text} of files) {
+    const matches = text.includes(query);
+    element.hidden = !matches;
+    element.open = Boolean(query) && matches;
+    if (matches) visible++;
+  }
+  document.querySelector('#visible').textContent = `${visible} ${visible === 1 ? 'file' : 'files'} shown`;
+  document.querySelector('#no-matches').hidden = visible !== 0;
+});
+</script>
+"""
+
+
+def page(title: str, content: str, *, parent: bool = False, script: str = "") -> str:
+    icon = "../favicon.svg" if parent else "favicon.svg"
+    nav = '<a href="../index.html">All kernel reports</a>' if parent else ""
+    return f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{escape(title)} · tt-metal</title><link rel="icon" href="{icon}">
+<style>{STYLE}</style></head>
+<body><main>{nav}<h1>{escape(title)}</h1>{content}</main>{script}</body></html>
+"""
+
+
+def render_iwyu(report: Report, enabled: bool) -> str:
+    if not enabled:
+        return page("Kernel Include What You Use", "<p>IWYU was disabled for this run.</p>", parent=True)
+    sections: dict[str, dict[str, list[str]]] = {}
+    for source, action, code in sorted(report.findings):
+        sections.setdefault(source, {"add": [], "remove": []})[action].append(code)
+    content = '<p class="muted">Consolidated include and forward-declaration recommendations.</p>'
+    if report.incomplete:
+        content += (
+            '<p class="notice"><strong>Partial analysis.</strong> Some IWYU invocations failed or '
+            "did not produce a report or exit status. Recommendations may be incomplete. "
+            "Raw output remains in the per-leg workflow artifacts.</p>"
+        )
+    if not report.reports:
+        content += "<p>No IWYU reports were collected.</p>"
+    elif not sections:
+        content += "<p>No include changes were reported in the collected output.</p>"
+    content += f"""<div class="search"><label for="search">Find a file, include, or declaration</label>
+<input id="search" type="search" placeholder="e.g. reader_unary.cpp or &lt;cstdint&gt;">
+<p id="visible" class="muted" role="status">{len(sections)} files shown</p></div>
+<p id="no-matches" hidden>No matching recommendations.</p>"""
+    for source, changes in sections.items():
+        content += f'<details class="file"><summary><code>{escape(source)}</code></summary><div class="changes">'
+        for action, title in (("add", "Add"), ("remove", "Remove")):
+            code = "\n".join(changes[action])
+            lines = f"<pre><code>{escape(code)}</code></pre>" if code else '<p class="muted">None reported.</p>'
+            content += f'<section class="{action}"><h3>{title}</h3>{lines}</section>'
+        content += "</div></details>"
+    if report.errors:
+        errors = escape("\n".join(sorted(report.errors)))
+        content += f'<details class="diagnostics"><summary>Parsing errors</summary><pre>{errors}</pre></details>'
+    return page("Kernel Include What You Use", content, parent=True, script=SEARCH)
+
+
+def render_site(legs: Path, site: Path, *, iwyu_enabled: bool = True) -> bool:
+    report = collect(legs) if iwyu_enabled else Report()
+    (site / "iwyu").mkdir(parents=True, exist_ok=True)
+    (site / "iwyu/index.html").write_text(render_iwyu(report, iwyu_enabled))
+    (site / "favicon.svg").write_text(FAVICON)
+    (site / ".nojekyll").touch()
+    tidy = site / "clang-tidy"
+    tidy_index = tidy / "index.html"
+    tidy_ready = tidy_index.is_file() and tidy_index.stat().st_size > 0 and any(tidy.glob("*.plist.html"))
+    tidy_link = (
+        '<a href="clang-tidy/index.html">Open clang-tidy report →</a>' if tidy_ready else "HTML report unavailable."
+    )
+    iwyu_status = "IWYU was disabled for this run." if not iwyu_enabled else "Include and forward-declaration changes."
+    if iwyu_enabled and report.incomplete:
+        iwyu_status = "Partial analysis; some invocations failed or produced incomplete output."
+    elif iwyu_enabled and not report.reports:
+        iwyu_status = "No IWYU reports were collected."
+    content = f"""<p class="muted">Static analysis of captured JIT kernel compilations.</p>
+<div class="cards">
+<section class="card"><h2>clang-tidy</h2><p>Code diagnostics and source details.</p>{tidy_link}</section>
+<section class="card"><h2>Include What You Use</h2><p>{iwyu_status}</p>
+<a href="iwyu/index.html">Open IWYU report →</a></section></div>"""
+    if os.environ.get("GITHUB_RUN_ID"):
+        url = (
+            f"{os.environ.get('GITHUB_SERVER_URL', 'https://github.com')}/"
+            f"{os.environ.get('GITHUB_REPOSITORY', '')}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+        )
+        content += (
+            f'<p class="muted">Commit <code>{escape(os.environ.get("GITHUB_SHA", "")[:12])}</code> · '
+            f'<a href="{escape(url, quote=True)}">Workflow run</a></p>'
+        )
+    (site / "index.html").write_text(page("Kernel analysis reports", content))
+    summary = f"IWYU: {len(report.findings)} distinct recommendations in {len({f[0] for f in report.findings})} files."
+    print(summary)
+    if os.environ.get("GITHUB_STEP_SUMMARY"):
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as stream:
+            stream.write(
+                f"\n## Consolidated kernel reports\n\n{summary}\n\nOpen `index.html` in the report-site artifact.\n"
+            )
+    return tidy_ready or bool(report.reports)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("legs", type=Path)
+    parser.add_argument("site", type=Path)
+    parser.add_argument("--skip-iwyu", action="store_true", help="show IWYU as disabled on clang-tidy-only runs")
+    args = parser.parse_args()
+    ready = render_site(args.legs, args.site, iwyu_enabled=not args.skip_iwyu)
+    if os.environ.get("GITHUB_OUTPUT"):
+        with open(os.environ["GITHUB_OUTPUT"], "a") as stream:
+            stream.write(f"found={str(ready).lower()}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/utils/render_kernel_analysis_site.py
+++ b/.github/scripts/utils/render_kernel_analysis_site.py
@@ -25,6 +25,7 @@ from brand_kernel_tidy_site import FAVICON
 HEADING = re.compile(r"^(.+) should (add|remove) these lines:$")
 WHEEL_ROOT = re.compile(r"^/opt/venv/lib/python\d+\.\d+/site-packages/ttnn/")
 DIAGNOSTIC = re.compile(r"^(.+?):(\d+):(\d+): ((?:fatal )?error:.*)$")
+REMOVAL_LINES = re.compile(r"\s+// lines (\d+)-(\d+)\s*$")
 
 
 def source_path(path: str) -> str:
@@ -34,8 +35,9 @@ def source_path(path: str) -> str:
 
 @dataclass
 class Report:
-    # File, action, suggested source line. Groups and occurrences are discarded.
-    findings: set[tuple[str, str, str]] = field(default_factory=set)
+    # Key: file, action, suggested source line. Value: reported removal ranges.
+    # Locations are retained without making duplicate findings or tracking groups.
+    findings: dict[tuple[str, str, str], set[tuple[int, int]]] = field(default_factory=dict)
     errors: set[str] = field(default_factory=set)
     reports: int = 0
     incomplete: bool = False
@@ -65,11 +67,14 @@ def read_output(path: Path, report: Report) -> None:
                         source = action = None
                         continue
                     line = line[2:]
-                # Symbol explanations and original line numbers differ between
-                # invocations but do not change the suggested include/declaration.
+                # Deduplicate the suggestion independently of its explanation
+                # and location, but retain all reported removal line ranges.
                 code = re.split(r"\s+//", line, maxsplit=1)[0].strip()
                 if code:
-                    report.findings.add((source, action, code))
+                    locations = report.findings.setdefault((source, action, code), set())
+                    location = REMOVAL_LINES.search(line) if action == "remove" else None
+                    if location:
+                        locations.add((int(location[1]), int(location[2])))
 
 
 def collect(legs: Path) -> Report:
@@ -163,7 +168,13 @@ def render_iwyu(report: Report, enabled: bool) -> str:
         return page("Kernel Include What You Use", "<p>IWYU was disabled for this run.</p>", parent=True)
     sections: dict[str, dict[str, list[str]]] = {}
     for source, action, code in sorted(report.findings):
-        sections.setdefault(source, {"add": [], "remove": []})[action].append(code)
+        suggestion = escape(code)
+        locations = sorted(report.findings[(source, action, code)])
+        if locations:
+            ranges = ", ".join(str(start) if start == end else f"{start}–{end}" for start, end in locations)
+            label = "line" if len(locations) == 1 and locations[0][0] == locations[0][1] else "lines"
+            suggestion += f' <span class="muted">// {label} {ranges}</span>'
+        sections.setdefault(source, {"add": [], "remove": []})[action].append(suggestion)
     content = '<p class="muted">Consolidated include and forward-declaration recommendations.</p>'
     if report.incomplete:
         content += (
@@ -183,7 +194,7 @@ def render_iwyu(report: Report, enabled: bool) -> str:
         content += f'<details class="file"><summary><code>{escape(source)}</code></summary><div class="changes">'
         for action, title in (("add", "Add"), ("remove", "Remove")):
             code = "\n".join(changes[action])
-            lines = f"<pre><code>{escape(code)}</code></pre>" if code else '<p class="muted">None reported.</p>'
+            lines = f"<pre><code>{code}</code></pre>" if code else '<p class="muted">None reported.</p>'
             content += f'<section class="{action}"><h3>{title}</h3>{lines}</section>'
         content += "</div></details>"
     if report.errors:

--- a/.github/scripts/utils/test_render_kernel_analysis_site.py
+++ b/.github/scripts/utils/test_render_kernel_analysis_site.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for native IWYU consolidation and static report delivery."""
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from render_kernel_analysis_site import collect, render_site
+
+
+def native_output(source: str, symbol: str = "uint32_t", line: int = 12) -> str:
+    return f"""warning: a compiler warning
+{source} should add these lines:
+#include <cstdint>  // for {symbol}
+namespace example {{ class Foo; }}
+
+{source} should remove these lines:
+- #include "old.h"  // lines {line}-{line}
+
+The full include-list for {source}:
+#include <cstdint>  // for {symbol}
+#include "already-present.h"
+namespace example {{ class Foo; }}
+---
+({source} has correct #includes/fwd-decls)
+"""
+
+
+class ReportTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.legs = self.root / "legs"
+        self.site = self.root / "site"
+
+    def leg(self, name, output=None, status="0", commands=None):
+        path = self.legs / name
+        path.mkdir(parents=True)
+        (path / "compile_commands.json").write_text(json.dumps([] if commands is None else commands))
+        if output is not None:
+            (path / "iwyu.txt").write_text(output)
+        if status is not None:
+            (path / "iwyu-exit-code.txt").write_text(status + "\n")
+        return path
+
+    def test_deduplicates_across_legs_and_roots_without_merging_actions(self):
+        self.leg("first", native_output("/work/tt_metal/header.h"))
+        self.leg(
+            "second",
+            native_output("/opt/venv/lib/python3.10/site-packages/ttnn/tt_metal/header.h", "uint64_t", 99),
+        )
+        self.leg("third", '/work/tt_metal/header.h should add these lines:\n#include "old.h"\n\n')
+        report = collect(self.legs)
+        self.assertEqual(
+            report.findings,
+            {
+                ("tt_metal/header.h", "add", "#include <cstdint>"),
+                ("tt_metal/header.h", "add", "namespace example { class Foo; }"),
+                ("tt_metal/header.h", "add", '#include "old.h"'),
+                ("tt_metal/header.h", "remove", '#include "old.h"'),
+            },
+        )
+        self.assertFalse(report.incomplete)
+
+    def test_unknown_paths_remain_distinct(self):
+        self.leg("first", native_output("/cache/a/header.h") + native_output("/cache/b/header.h"))
+        self.assertEqual({f[0] for f in collect(self.legs).findings}, {"/cache/a/header.h", "/cache/b/header.h"})
+
+    def test_errors_are_separate_and_deduplicated(self):
+        error = "/work/tt_metal/header.h:4:2: error: ambiguous conversion\n"
+        self.leg("first", error + native_output("/work/tt_metal/header.h"), "1")
+        self.leg("second", error + "error: unknown target\n", "1")
+        report = collect(self.legs)
+        self.assertTrue(report.incomplete)
+        self.assertEqual(report.errors, {"tt_metal/header.h:4:2: error: ambiguous conversion", "error: unknown target"})
+        self.assertEqual(len(report.findings), 3)
+        render_site(self.legs, self.site)
+        html = (self.site / "iwyu/index.html").read_text()
+        self.assertIn("Partial analysis.", html)
+        self.assertIn("Parsing errors", html)
+
+    def test_missing_output_or_exit_status_marks_partial_analysis(self):
+        self.leg("empty-capture")
+        self.assertFalse(collect(self.legs).incomplete)
+        self.leg("no-status", native_output("/work/a.h"), status=None)
+        self.assertTrue(collect(self.legs).incomplete)
+        (self.legs / "no-status/iwyu-exit-code.txt").write_text("0\n")
+        self.assertFalse(collect(self.legs).incomplete)
+        self.leg("missing-output", commands=[{"file": "kernel.cc"}])
+        self.assertTrue(collect(self.legs).incomplete)
+
+    def test_html_escapes_tool_output_and_preserves_codechecker_pages(self):
+        source = '/work/ttnn/<script>alert("file")</script>.h'
+        self.leg("first", native_output(source))
+        tidy = self.site / "clang-tidy"
+        tidy.mkdir(parents=True)
+        (tidy / "index.html").write_text("CodeChecker index")
+        (tidy / "sample.plist.html").write_text("CodeChecker finding")
+        self.assertTrue(render_site(self.legs, self.site))
+        html = (self.site / "iwyu/index.html").read_text()
+        self.assertNotIn('<script>alert("file")</script>', html)
+        self.assertIn("#include &lt;cstdint&gt;", html)
+        self.assertIn("&lt;script&gt;", html)
+        self.assertIn('href="../index.html"', html)
+        index = (self.site / "index.html").read_text()
+        self.assertIn('href="clang-tidy/index.html"', index)
+        self.assertIn('href="iwyu/index.html"', index)
+        self.assertEqual((tidy / "index.html").read_text(), "CodeChecker index")
+        self.assertFalse(list(self.site.rglob("*.json")))
+        before = html
+        render_site(self.legs, self.site)
+        self.assertEqual((self.site / "iwyu/index.html").read_text(), before)
+
+    def test_empty_disabled_and_failed_runs_do_not_look_clean(self):
+        self.assertFalse(render_site(self.legs, self.site))
+        self.assertIn("No IWYU reports were collected.", (self.site / "iwyu/index.html").read_text())
+        self.leg("failed", "error: cannot parse input\n", "1")
+        # Partial output can still be published even when CodeChecker has no HTML.
+        self.assertTrue(render_site(self.legs, self.site))
+        self.assertIn("Partial analysis.", (self.site / "iwyu/index.html").read_text())
+        self.assertFalse(render_site(self.legs, self.site, iwyu_enabled=False))
+        self.assertIn("IWYU was disabled", (self.site / "iwyu/index.html").read_text())
+        tidy = self.site / "clang-tidy"
+        tidy.mkdir()
+        (tidy / "index.html").write_text("An index alone does not mean CodeChecker rendered any findings")
+        self.assertFalse(render_site(self.legs, self.site, iwyu_enabled=False))
+        (tidy / "sample.plist.html").write_text("CodeChecker finding")
+        self.assertTrue(render_site(self.legs, self.site, iwyu_enabled=False))
+        (tidy / "index.html").write_text("")
+        self.assertFalse(render_site(self.legs, self.site, iwyu_enabled=False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/utils/test_render_kernel_analysis_site.py
+++ b/.github/scripts/utils/test_render_kernel_analysis_site.py
@@ -57,7 +57,7 @@ class ReportTests(unittest.TestCase):
         self.leg("third", '/work/tt_metal/header.h should add these lines:\n#include "old.h"\n\n')
         report = collect(self.legs)
         self.assertEqual(
-            report.findings,
+            set(report.findings),
             {
                 ("tt_metal/header.h", "add", "#include <cstdint>"),
                 ("tt_metal/header.h", "add", "namespace example { class Foo; }"),
@@ -65,7 +65,38 @@ class ReportTests(unittest.TestCase):
                 ("tt_metal/header.h", "remove", '#include "old.h"'),
             },
         )
+        self.assertEqual(report.findings[("tt_metal/header.h", "remove", '#include "old.h"')], {(12, 12), (99, 99)})
         self.assertFalse(report.incomplete)
+
+    def test_removal_locations_survive_deduplication_and_rendering(self):
+        source = "/work/tt_metal/header.h"
+        output = (
+            native_output(source)
+            + f"""{source} should remove these lines:
+- struct Entry;  // lines 30-31
+- #include "unlocated.h"
+
+"""
+        )
+        self.leg("first", output)
+        self.leg("duplicate", output)
+        self.leg("another-location", native_output(source, line=99))
+        report = collect(self.legs)
+        self.assertEqual(len(report.findings), 5)
+        self.assertEqual(report.findings[("tt_metal/header.h", "remove", "struct Entry;")], {(30, 31)})
+        self.assertEqual(report.findings[("tt_metal/header.h", "remove", '#include "unlocated.h"')], set())
+        self.assertEqual(report.findings[("tt_metal/header.h", "add", "#include <cstdint>")], set())
+        render_site(self.legs, self.site)
+        html = (self.site / "iwyu/index.html").read_text()
+        self.assertEqual(html.count('&quot;old.h&quot; <span class="muted">// lines 12, 99</span>'), 1)
+        self.assertIn('struct Entry; <span class="muted">// lines 30–31</span>', html)
+        self.assertNotIn("&quot;unlocated.h&quot; <span", html)
+        self.assertNotIn("#include &lt;cstdint&gt; <span", html)
+        self.leg("single-line", native_output("/work/another.h", line=7))
+        render_site(self.legs, self.site)
+        self.assertIn(
+            '&quot;old.h&quot; <span class="muted">// line 7</span>', (self.site / "iwyu/index.html").read_text()
+        )
 
     def test_unknown_paths_remain_distinct(self):
         self.leg("first", native_output("/cache/a/header.h") + native_output("/cache/b/header.h"))

--- a/.github/workflows/kernel-clang-tidy.yaml
+++ b/.github/workflows/kernel-clang-tidy.yaml
@@ -1,10 +1,11 @@
-name: "Kernel clang-tidy"
+name: "Kernel clang-tidy and IWYU"
 
-# Post-hoc clang-tidy on runtime-JIT-compiled kernel code.
+# Post-hoc clang-tidy and Include What You Use on runtime-JIT-compiled kernel code.
 # Runs the ttnn sanity suite on hardware with kernel clang-tidy enabled on every
 # leg: each leg captures its own JIT kernel compiles, lints them via CodeChecker
-# and uploads the raw plists. A final job merges those, renders one deduplicated
-# CodeChecker report and publishes it to GitHub Pages.
+# and IWYU, and uploads the raw plists and include recommendations. A final job
+# merges the plists, renders one deduplicated CodeChecker report and publishes
+# it to GitHub Pages. IWYU recommendations remain in the per-leg artifacts.
 # See tech_reports/code-indexing/kernel-clang-tidy.md.
 
 on:
@@ -24,6 +25,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable-iwyu:
+        description: "Run Include What You Use on the captured kernels (reports in per-leg artifacts)"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   check-harbor:
@@ -55,6 +61,7 @@ jobs:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-kernel-clang-tidy: true
+      enable-kernel-iwyu: ${{ github.event_name == 'schedule' || inputs.enable-iwyu }}
 
   consolidate-report:
     name: "Consolidate & publish report"

--- a/.github/workflows/kernel-clang-tidy.yaml
+++ b/.github/workflows/kernel-clang-tidy.yaml
@@ -4,8 +4,8 @@ name: "Kernel clang-tidy and IWYU"
 # Runs the ttnn sanity suite on hardware with kernel clang-tidy enabled on every
 # leg: each leg captures its own JIT kernel compiles, lints them via CodeChecker
 # and IWYU, and uploads the raw plists and include recommendations. A final job
-# merges the plists, renders one deduplicated CodeChecker report and publishes
-# it to GitHub Pages. IWYU recommendations remain in the per-leg artifacts.
+# deduplicates both analyzers' findings and publishes their HTML reports to
+# GitHub Pages, with a shared index linking clang-tidy and IWYU.
 # See tech_reports/code-indexing/kernel-clang-tidy.md.
 
 on:
@@ -26,7 +26,7 @@ on:
         type: boolean
         default: false
       enable-iwyu:
-        description: "Run Include What You Use on the captured kernels (reports in per-leg artifacts)"
+        description: "Run Include What You Use on the captured kernels and consolidate its HTML report"
         required: false
         type: boolean
         default: true
@@ -202,25 +202,36 @@ jobs:
         timeout-minutes: 100
         continue-on-error: true
         run: |
-          CodeChecker parse /work/merged --export html --output /work/site || true
+          mkdir -p /work/site/clang-tidy
+          CodeChecker parse /work/merged --export html --output /work/site/clang-tidy || true
           # index.html alone is not success: CodeChecker writes it even when it
           # skipped every plist for missing sources.
-          pages=$(ls /work/site/*.plist.html 2>/dev/null | wc -l)
+          pages=$(ls /work/site/clang-tidy/*.plist.html 2>/dev/null | wc -l)
           echo "finding pages rendered: $pages"
-          if [ -s /work/site/index.html ] && [ "$pages" -gt 0 ]; then
-            touch /work/site/.nojekyll
+          if [ -s /work/site/clang-tidy/index.html ] && [ "$pages" -gt 0 ]; then
             # CodeChecker titles every page "Plist HTML Viewer" and ships no icon.
-            python3 .github/scripts/utils/brand_kernel_tidy_site.py /work/site
+            python3 .github/scripts/utils/brand_kernel_tidy_site.py /work/site/clang-tidy
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::render produced no finding pages; not publishing."
+            echo "::warning::clang-tidy render produced no finding pages."
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Not gated on the render: reports.json is the complete finding set and
-      # is worth keeping even if only the HTML rendering ran long.
+      # IWYU uses its native text, independently of CodeChecker's plists/render.
+      - name: Render consolidated IWYU report and shared index
+        id: reports
+        if: ${{ !cancelled() }}
+        timeout-minutes: 10
+        run: |
+          args=()
+          if [ "${{ github.event_name == 'schedule' || inputs.enable-iwyu }}" != 'true' ]; then
+            args+=(--skip-iwyu)
+          fi
+          python3 .github/scripts/utils/render_kernel_analysis_site.py /work/legs /work/site "${args[@]}"
+
+      # Preserve both reports and the JSON export even if a render failed.
       - name: Upload consolidated report
-        if: ${{ !cancelled() && steps.merge.outputs.merged != '0' }}
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: kernel-tidy-report-site
@@ -230,7 +241,7 @@ jobs:
       - name: Publish to tenstorrent/tt-metal-kernel-clang-tidy-results (gh-pages)
         # The weekly run is on main, so it publishes; a dispatch has to ask.
         if: >-
-          ${{ steps.site.outputs.found == 'true' &&
+          ${{ !cancelled() && steps.reports.outputs.found == 'true' &&
               (inputs.publish-html || github.ref == 'refs/heads/main') }}
         uses: peaceiris/actions-gh-pages@v4
         with:
@@ -242,4 +253,4 @@ jobs:
           # CodeChecker's raw export exceeds GitHub's 100 MB per-file limit and
           # is only in the artifact; findings.json is the published database.
           exclude_assets: ".github,reports.json"
-          commit_message: "kernel clang-tidy report from tt-metal @ ${{ github.sha }}"
+          commit_message: "kernel analysis reports from tt-metal @ ${{ github.sha }}"

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -83,6 +83,14 @@ on:
           On every HW leg, capture that leg's runtime JIT kernel compiles and run clang-tidy on them post-hoc
           via CodeChecker, uploading one capture artifact per leg. Non-blocking. The capture defeats all
           kernel-compile caches, so legs run slower. Default off, no overhead when disabled.
+      enable-kernel-iwyu:
+        required: false
+        type: boolean
+        default: false
+        description: >-
+          On every HW leg, run Include What You Use on captured runtime JIT kernel compiles.
+          Shares capture with kernel clang-tidy, but can run independently. Non-blocking;
+          recommendations are uploaded in the per-leg capture artifact. Defeats kernel-compile caches.
     outputs:
       matrix:
         description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
@@ -412,9 +420,9 @@ jobs:
             # The JIT build logs each kernel compile command into this leg's
             # run log; every kernel-compile cache layer is defeated so each
             # compile, and its logged command, actually happens.
-            KERNEL_TIDY_THIS="${{ inputs.enable-kernel-clang-tidy }}"
+            KERNEL_TIDY_THIS="${{ inputs.enable-kernel-clang-tidy || inputs.enable-kernel-iwyu }}"
             if [ "$KERNEL_TIDY_THIS" = "true" ]; then
-              echo "kernel clang-tidy capture ENABLED for '$TEST_GROUP_NAME'"
+              echo "kernel analysis capture ENABLED for '$TEST_GROUP_NAME'"
               export TT_METAL_LOG_KERNELS_COMPILE_COMMANDS=1
               export TT_LOGGER_LEVEL=info
               export TT_METAL_FORCE_JIT_COMPILE=1
@@ -477,18 +485,21 @@ jobs:
                 exit 1
               '
 
-      # Translate the captured SFPI-GCC compile commands for clang and run
-      # clang-tidy through CodeChecker, exporting an HTML report. Non-blocking.
-      - name: Run clang-tidy via CodeChecker on captured JIT kernel compiles (kernel clang-tidy)
-        if: ${{ !cancelled() && inputs.enable-kernel-clang-tidy && !startsWith(matrix.test-group.sku, 'sim_') }}
+      # Both analyzers need the same real wrapper TUs, role defines and generated
+      # headers. Translate once, independently of either analyzer's success.
+      - name: Translate captured JIT kernel compiles
+        id: kernel-commands
+        if: >-
+          ${{ !cancelled() && (inputs.enable-kernel-clang-tidy || inputs.enable-kernel-iwyu) &&
+              !startsWith(matrix.test-group.sku, 'sim_') }}
         continue-on-error: true
-        timeout-minutes: 45
+        timeout-minutes: 10
         env:
           KERNEL_TIDY_GROUP: ${{ matrix.test-group.name }}
         run: |
           RUN_LOG="generated/test_logs/${KERNEL_TIDY_GROUP}.log"
           if [ ! -s "$RUN_LOG" ]; then
-            echo "::warning::run log '$RUN_LOG' missing/empty; skipping clang-tidy."
+            echo "::warning::run log '$RUN_LOG' missing/empty; skipping kernel analysis."
             exit 0
           fi
           mkdir -p /work/kernel_tidy
@@ -497,11 +508,53 @@ jobs:
             --output-dir /work/kernel_tidy | tee /work/kernel_tidy/summary.txt
           # An empty capture is '[]', which is non-empty as a file.
           n_entries=$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))))' \
-            /work/kernel_tidy/compile_commands.json 2>/dev/null || echo 0)
+            /work/kernel_tidy/compile_commands.json)
+          echo "entries=$n_entries" >> "$GITHUB_OUTPUT"
           if [ "$n_entries" -eq 0 ]; then
-            echo "::warning::no kernel compile commands captured; skipping clang-tidy."
-            exit 0
+            echo "::warning::no kernel compile commands captured; skipping kernel analysis."
           fi
+
+      - name: Run Include What You Use on captured JIT kernel compiles
+        if: ${{ !cancelled() && inputs.enable-kernel-iwyu && steps.kernel-commands.outputs.entries > 0 }}
+        continue-on-error: true
+        timeout-minutes: 45
+        run: |
+          # The ci-test image ships IWYU 0.24 with Clang 20. Its driver replays
+          # every database entry in its own cwd, including repeated wrapper paths.
+          # --check_also reaches the #included kernel sources and project headers;
+          # --keep preserves the JIT's deliberate implementation-file includes.
+          # Default exit status is zero for recommendations, nonzero for errors.
+          include-what-you-use --version > /work/kernel_tidy/iwyu-version.txt
+          status=0
+          iwyu_tool.py -p /work/kernel_tidy -j 8 -- \
+            -Xiwyu "--check_also=$PWD/*" \
+            -Xiwyu '--check_also=*/tt_metal/*' \
+            -Xiwyu '--check_also=*/ttnn/*' \
+            -Xiwyu '--check_also=*/tt-metal-cache/*' \
+            -Xiwyu '--keep=*.cpp' \
+            -Xiwyu '--keep=*.cc' \
+            > /work/kernel_tidy/iwyu.txt 2>&1 || status=$?
+          echo "$status" > /work/kernel_tidy/iwyu-exit-code.txt
+          {
+            echo '### Kernel Include What You Use (non-blocking)'
+            echo ''
+            cat /work/kernel_tidy/iwyu-version.txt
+            echo ''
+            echo "Analyzer exit code: $status (0 means analysis completed, not that includes are clean)."
+            echo 'Recommendations and parse errors: `iwyu.txt` in the per-leg kernel-clang-tidy artifact.'
+            echo 'Advice is per captured configuration; review across roles before applying changes.'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::IWYU reported analysis failures; see iwyu.txt in the capture artifact."
+          fi
+          exit "$status"
+
+      # Non-blocking and independent of IWYU, including when IWYU timed out.
+      - name: Run clang-tidy via CodeChecker on captured JIT kernel compiles (kernel clang-tidy)
+        if: ${{ !cancelled() && inputs.enable-kernel-clang-tidy && steps.kernel-commands.outputs.entries > 0 }}
+        continue-on-error: true
+        timeout-minutes: 45
+        run: |
           # Checkers, check options and scoping all come from codechecker.json.
           CodeChecker analyze /work/kernel_tidy/compile_commands.json \
             --config tt_metal/jit_build/kernel_clang_tidy/codechecker.json \
@@ -550,8 +603,10 @@ jobs:
             echo '</details>'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload kernel clang-tidy capture (kernel clang-tidy)
-        if: ${{ !cancelled() && inputs.enable-kernel-clang-tidy && !startsWith(matrix.test-group.sku, 'sim_') }}
+      - name: Upload kernel analysis capture
+        if: >-
+          ${{ !cancelled() && (inputs.enable-kernel-clang-tidy || inputs.enable-kernel-iwyu) &&
+              !startsWith(matrix.test-group.sku, 'sim_') }}
         continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/tech_reports/code-indexing/kernel-clang-tidy.md
+++ b/tech_reports/code-indexing/kernel-clang-tidy.md
@@ -127,7 +127,7 @@ with the first-captured config. Pass `--dedupe none` to lint every configuration
 `.github/workflows/kernel-clang-tidy.yaml` is the entry point: build → run the
 ttnn sanity suite on hardware via `ttnn-sanity-tests-impl.yaml` with
 `enable-kernel-clang-tidy: true` and `enable-kernel-iwyu: true` → a `consolidate-report` job that merges every
-leg's findings into one report and publishes it to
+leg's findings into consolidated HTML reports and publishes them to
 `tenstorrent/tt-metal-kernel-clang-tidy-results` gh-pages. It runs weekly on
 Saturdays at noon PST, and on dispatch. The weekly run publishes because it is
 on main; a dispatch publishes only with `publish-html: true`.
@@ -158,9 +158,10 @@ When IWYU is enabled, the same artifact also contains `iwyu.txt`,
 CodeChecker have separate non-blocking steps and 45-minute limits, so an IWYU
 failure does not prevent clang-tidy or artifact upload. A timed-out IWYU run
 can leave partial output without an exit-code file. The job summary records
-IWYU's status and points to the artifact. IWYU's native recommendations are
-kept per leg; they are not CodeChecker plists and are not part of the merged
-CodeChecker HTML site. Coverage and configuration limits apply to both tools.
+IWYU's status and points to the artifact. The consolidation job reads the
+native recommendations from every leg and renders one deduplicated IWYU HTML
+report alongside CodeChecker's report. Coverage and configuration limits apply
+to both tools.
 
 CodeChecker's compilation-database parser consults `ClangSA.analyzer_binary()`
 unconditionally, so a `clang` binary must be resolvable even though only
@@ -169,8 +170,33 @@ clang-tidy runs. Both jobs install `update-alternatives` symlinks for `clang`,
 
 ### The consolidated report
 
+The published site's `index.html` links to `clang-tidy/index.html` and
+`iwyu/index.html`. The same layout is available in the `kernel-tidy-report-site`
+workflow artifact: download it, unzip it, and open `index.html` locally.
+Both reports use the existing GitHub Pages repository and publication controls.
+
+`.github/scripts/utils/render_kernel_analysis_site.py` reads each leg's native
+`iwyu.txt` and deduplicates by source file, addition/removal, and suggested
+include or forward declaration. It strips explanatory comments and line-number
+annotations, and treats `/work/` and the installed wheel's `ttnn/` root as
+copies of the repository. Other paths are preserved. The report lists Add and
+Remove suggestions per file with a search box. It assumes a consistent kernel
+configuration across test groups; it does not track group provenance, count
+occurrences, or reconcile configuration differences. No include fixes are applied.
+
+IWYU failures and missing exit statuses produce a partial-analysis notice;
+deduplicated parsing errors appear separately. Empty captures and disabled IWYU
+runs are identified explicitly. The report has no external assets or JSON fetches,
+so it works directly from disk. Native output stays in the per-leg artifacts.
+To regenerate it from downloaded captures, with optional CodeChecker HTML already
+in `<site>/clang-tidy`:
+
+```sh
+python3 .github/scripts/utils/render_kernel_analysis_site.py <legs> <site>
+```
+
 `consolidate-report` merges every leg's plists and runs `CodeChecker parse
---export html` once, so the published site is a genuine CodeChecker report: a
+--export html` once, so the clang-tidy section is a genuine CodeChecker report: a
 sortable Severity / Checker / File / Message table plus its own checker- and
 severity-statistics pages. Leg provenance is dropped deliberately — the same
 kernel code is analyzed on many legs and only the finding matters.
@@ -201,7 +227,8 @@ referenced sources in its artifact and the consolidate job restores them.
 
 **The JSON export runs before the render and uploads unconditionally.** It is
 the machine-readable form of the same data and the thing to point an agent at.
-`findings.json` is a slimmed projection of it; CodeChecker's own export carries
+`findings.json` is a slimmed projection of it; both JSON files remain at the site
+root while the CodeChecker HTML lives under `clang-tidy/`. CodeChecker's own export carries
 bug paths and macro expansions and runs to ~124 MB, over GitHub's 100 MB
 per-file limit, so it stays in the artifact and is excluded from the published
 site.

--- a/tech_reports/code-indexing/kernel-clang-tidy.md
+++ b/tech_reports/code-indexing/kernel-clang-tidy.md
@@ -1,10 +1,10 @@
-# Post-hoc clang-tidy on JIT-compiled kernel code
+# Post-hoc clang-tidy and IWYU on JIT-compiled kernel code
 
 Device kernels are compiled at runtime by `tt_metal/jit_build/` with the SFPI
 cross-compiler, so the host build's static analysis never sees them. This flow
 lints them after the fact: run any workload with the JIT build's compile-command
 logging enabled, parse the logged compiler invocations, translate them for
-clang, and run clang-tidy.
+clang, and run clang-tidy and Include What You Use (IWYU).
 
 Nothing is synthesized — no stub headers, no enumerated kernel configs. The
 runtime already produced the real compile-time args, defines and generated
@@ -72,6 +72,40 @@ bear 3.0.x's intercept channel is a gRPC server on loopback, and gRPC routes
 loopback through `http_proxy` unless `no_proxy` covers it — which is why it
 fails outright in containers that set a proxy, CI's included.
 
+### Include What You Use
+
+The same translated database also works with IWYU. The ci-test image includes
+IWYU 0.24 and its `iwyu_tool.py` driver, matched to Clang 20. After step 5 above
+(omit `--run` if only IWYU is wanted), run this from the repository root while
+the generated JIT sources and wheel-installed headers still exist:
+
+```bash
+iwyu_tool.py -p /tmp/kernel_tidy -j 8 -- \
+    -Xiwyu "--check_also=$PWD/*" \
+    -Xiwyu '--check_also=*/tt_metal/*' \
+    -Xiwyu '--check_also=*/ttnn/*' \
+    -Xiwyu '--check_also=*/tt-metal-cache/*' \
+    -Xiwyu '--keep=*.cpp' \
+    -Xiwyu '--keep=*.cc' \
+    > /tmp/kernel_tidy/iwyu.txt 2>&1
+```
+
+`iwyu_tool.py` replays every database entry with its own working directory and
+arguments, preserving the real wrapper TU and UNPACK/MATH/PACK context. IWYU
+normally reports only on the main source and its associated headers;
+`--check_also` also selects the included kernel sources, checkout headers,
+wheel-installed device headers, and generated files in the default kernel cache.
+For a custom cache outside these paths, add a `--check_also` glob for that path.
+The `--keep` globs preserve intentional `.cpp`/`.cc` includes used by JIT glue.
+
+The report contains native IWYU add/remove recommendations and parse errors.
+Recommendations return zero; a nonzero exit status signals analysis failures.
+No fixes are applied. A recommendation describes the captured configuration:
+review other roles and compile-time arguments before changing shared headers.
+The default `--dedupe kernel-role` capture still samples one configuration per
+kernel and RISC target; use `--dedupe none` when investigating configuration
+differences.
+
 ## What the translation does
 
 See the docstring of `scripts/build_kernel_clang_tidy_commands.py` for the full
@@ -92,11 +126,14 @@ with the first-captured config. Pass `--dedupe none` to lint every configuration
 
 `.github/workflows/kernel-clang-tidy.yaml` is the entry point: build → run the
 ttnn sanity suite on hardware via `ttnn-sanity-tests-impl.yaml` with
-`enable-kernel-clang-tidy: true` → a `consolidate-report` job that merges every
+`enable-kernel-clang-tidy: true` and `enable-kernel-iwyu: true` → a `consolidate-report` job that merges every
 leg's findings into one report and publishes it to
 `tenstorrent/tt-metal-kernel-clang-tidy-results` gh-pages. It runs weekly on
 Saturdays at noon PST, and on dispatch. The weekly run publishes because it is
 on main; a dispatch publishes only with `publish-html: true`.
+IWYU runs on the weekly schedule and defaults on for dispatches; set
+`enable-iwyu=false` on a dispatch to run clang-tidy alone. The reusable sanity
+workflow defaults both analyzers off and permits either one independently.
 
 ```sh
 gh workflow run kernel-clang-tidy.yaml --ref <branch> \
@@ -115,6 +152,15 @@ tt_metal/jit_build/kernel_clang_tidy/codechecker.json` — the same tooling
 finding counts, and the generated JIT sources those plists reference.
 CodeChecker's `reports/fixit` suggestions are deleted first: 304 MB of an 880 MB
 artifact, and nothing downstream reads them.
+
+When IWYU is enabled, the same artifact also contains `iwyu.txt`,
+`iwyu-version.txt`, and `iwyu-exit-code.txt`. Translation runs once; IWYU and
+CodeChecker have separate non-blocking steps and 45-minute limits, so an IWYU
+failure does not prevent clang-tidy or artifact upload. A timed-out IWYU run
+can leave partial output without an exit-code file. The job summary records
+IWYU's status and points to the artifact. IWYU's native recommendations are
+kept per leg; they are not CodeChecker plists and are not part of the merged
+CodeChecker HTML site. Coverage and configuration limits apply to both tools.
 
 CodeChecker's compilation-database parser consults `ClangSA.analyzer_binary()`
 unconditionally, so a `clang` binary must be resolvable even though only

--- a/tech_reports/code-indexing/kernel-clang-tidy.md
+++ b/tech_reports/code-indexing/kernel-clang-tidy.md
@@ -177,8 +177,10 @@ Both reports use the existing GitHub Pages repository and publication controls.
 
 `.github/scripts/utils/render_kernel_analysis_site.py` reads each leg's native
 `iwyu.txt` and deduplicates by source file, addition/removal, and suggested
-include or forward declaration. It strips explanatory comments and line-number
-annotations, and treats `/work/` and the installed wheel's `ttnn/` root as
+include or forward declaration. It strips explanatory comments while retaining
+IWYU's removal line ranges beside each suggestion. Repeated locations are merged
+without duplicating the finding. IWYU does not provide insertion line numbers
+for additions. It treats `/work/` and the installed wheel's `ttnn/` root as
 copies of the repository. Other paths are preserved. The report lists Add and
 Remove suggestions per file with a search box. It assumes a consistent kernel
 configuration across test groups; it does not track group provenance, count


### PR DESCRIPTION
### PR Category

Feature

### Summary

Run Include What You Use on the real JIT kernel compilations already captured by the kernel clang-tidy workflow. Use the existing IWYU 0.24 / Clang 20 installation and translated compilation database, preserving each wrapper's working directory, compiler arguments, and UNPACK/MATH/PACK context. IWYU defaults on for scheduled and manual runs, with an `enable-iwyu` toggle; the reusable sanity workflow can enable either analyzer independently.

Consolidate native IWYU output into a searchable HTML report of additions/removals per file. Deduplicate by source file, action, and suggested include or forward declaration, discarding repeated explanatory comments while retaining IWYU’s original removal line ranges. Locations are merged without duplicating the finding; IWYU does not supply insertion line numbers for additions. A shared `index.html` links `clang-tidy/index.html` and `iwyu/index.html`, published together through the existing GitHub Pages repository and included in the report-site artifact.

### Notes for reviewers

- `--check_also` reaches included kernel sources and project headers; `--keep` preserves intentional `.cpp`/`.cc` includes used by JIT glue. No include fixes are applied.
- Translation is shared; analysis steps have separate non-blocking 45-minute limits. Each leg retains native IWYU output, version, and exit status. The HTML report identifies partial analysis and lists deduplicated parsing errors separately.
- Consolidation assumes consistent kernel configurations across test groups. It does not track group provenance, count occurrences, reconcile conflicting advice, or add an IWYU JSON export.
- The report generator uses Python's standard library. The IWYU HTML embeds its content and search script, so it also works from disk. Existing clang-tidy JSON exports stay at the site root; CodeChecker's HTML moves under `clang-tidy/` with its relative links intact.
- Applicable repository pre-commit hooks, command-translation self-tests, shell syntax checks, and upstream-driver replay smoke checks passed. The reporting update has seven regression tests for deduplication, path normalization, parsing failures, missing/disabled output, HTML escaping, report availability, and preservation of removal line attribution.

### Hardware validation of IWYU execution

[Run 34591354394](https://github.com/tenstorrent/tt-metal/actions/runs/34591354394) completed successfully on commit `0ea3cb216cc10d6e092046e4b79050c409b50c59`, using `wh_n300_civ2`, `enable-iwyu=true`, and `publish-html=false`. This run predates the HTML consolidation update; its artifacts were reused to validate that update below.

- The build and all 17 hardware test legs passed. All capture artifacts uploaded. The indexer-score leg captured zero compile commands and correctly skipped both analyzers.
- IWYU 0.24 / Clang 20.1.8 ran on the 16 nonempty captures, replaying 1,965 compile entries across the legs (including repeated kernels and role/configuration variants). Native recommendations reached 922 distinct file paths, including 427 kernel `.cpp`/`.cc` paths. These counts describe observed output, not complete kernel coverage.
- The IWYU steps took 3–48 seconds per leg with eight workers. Every nonempty artifact contains recommendations, the tool version, and the native exit status.
- **All 16 IWYU invocations returned exit code 1, so analysis is partial.** Every compiler error matched a clang-tidy diagnostic from the same capture by exact path, line, column, and message: 32 distinct errors across the run, including narrowing diagnostics and ambiguous SFPI conversions. No unmatched IWYU errors or crash markers were found. The workflow's non-blocking behavior retained these failures and reports while allowing the run to complete.
- Consolidation and HTML rendering succeeded. The uploaded `kernel-tidy-report-site` artifact contains a valid HTML index and parseable findings/report JSON. HTML publication was skipped as requested; native IWYU recommendations remain in the per-leg capture artifacts.

This validates actual execution, included-kernel reporting, failure recording, and artifact delivery on Wormhole. It does not establish clean parsing, correctness of every include recommendation, or Blackhole coverage. Recommendations still require review for the captured role/configuration; no fixes were applied.

### HTML consolidation validation

Validated commit `73da0a3784bd3025d82a17b700bd51f9102741d6` against all 16 nonempty captures from the hardware run above:

- 532,992 native suggestions consolidate to **7,052 distinct recommendations in 913 normalized source paths**: 5,374 additions and 1,678 removals. An independent scan of complete native sections produced the identical recommendation set.
- The generated IWYU HTML is approximately 634 KB and retains all 32 distinct parsing errors with a partial-analysis notice.
- All six regression tests and applicable pre-commit hooks passed. The actual workflow renderer shell step was exercised locally with IWYU enabled and disabled, including its publication-availability output; all consolidation shell steps passed syntax checks.
- Browser checks passed for both landing-page links, IWYU search and empty results, Add/Remove display, parsing errors, return navigation, and an existing CodeChecker finding page under its new directory. No browser errors were observed for the IWYU report.

This reporting-only update reused the existing hardware artifacts. No new hardware run or GitHub Pages deployment was performed.

### Removal line attribution

Commit `84f67350b5106eb5825755e65ad86e21bf05db04` restores native removal line ranges in the HTML while retaining the same deduplication key. Repeated locations are merged and sorted; include suggestions remain a single entry. Additions have no fabricated insertion locations.

All seven regression tests and applicable pre-commit hooks passed. Re-rendering the 16 saved captures preserves all 7,052 distinct recommendations, with native line ranges on all 1,678 removal recommendations. Browser verification confirms `api/compute/common_globals.h` is marked `// line 7` for `tt_metal/hw/inc/api/compute/eltwise_unary/where.h`.

The preceding HTML version was successfully published by [run 34637534336](https://github.com/tenstorrent/tt-metal/actions/runs/34637534336) from `73da0a3784bd3025d82a17b700bd51f9102741d6`. This attribution follow-up has been tested locally against saved artifacts and requires a new publishing run to update the live site.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=codex/kernel-iwyu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:codex/kernel-iwyu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=codex/kernel-iwyu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:codex/kernel-iwyu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=codex/kernel-iwyu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:codex/kernel-iwyu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=codex/kernel-iwyu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:codex/kernel-iwyu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=codex/kernel-iwyu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:codex/kernel-iwyu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=codex/kernel-iwyu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:codex/kernel-iwyu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=codex/kernel-iwyu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:codex/kernel-iwyu)

