### PR TITLE
Avoid sizeof() of a constant in the asserts-disabled ASSERT macro

### DIFF
--- a/tt_metal/hw/inc/internal/debug/assert_common.h
+++ b/tt_metal/hw/inc/internal/debug/assert_common.h
@@ -35,8 +35,10 @@ FORCE_INLINE void lightweight_assert_trap() { asm("ebreak"); }
 
 #else
 
-// Avoid unused variable warnings here.
-#define ASSERT(condition, ...) (void(sizeof(not(condition))))
+// Avoid unused variable warnings here. sizeof() the condition's *type*: sizeof() of the
+// expression itself folds to an integer constant at ASSERT(0)-style call sites, which
+// clang-tidy reports as bugprone-sizeof-expression.
+#define ASSERT(condition, ...) (void(sizeof(decltype(not(condition)))))
 
 #define ASSERT_ENABLED 0
 #define LIGHTWEIGHT_ASSERT_ENABLED 0


### PR DESCRIPTION
### Problem

The weekly kernel clang-tidy report ([dashboard](https://tenstorrent.github.io/tt-metal-kernel-clang-tidy-results/), [`findings.json`](https://github.com/tenstorrent/tt-metal-kernel-clang-tidy-results/blob/gh-pages/findings.json)) has 58 HIGH-severity findings. 12 of them are `bugprone-sizeof-expression`, and all 12 come from one line rather than from the files they are reported against:

```cpp
// tt_metal/hw/inc/internal/debug/assert_common.h:39  (asserts-disabled variant)
#define ASSERT(condition, ...) (void(sizeof(not(condition))))
```

`sizeof()` is how the macro discards the condition without evaluating it, so variables used only inside an `ASSERT` don't trip unused-variable warnings. But at any call site where the condition is a constant expression — `ASSERT(0)`, `ASSERT(!dispatch_s_enabled)` with a `constexpr` template parameter, `ASSERT(local_blocked_counter == nullptr)` — `not(condition)` folds to an integer constant, and `sizeof` of an integer constant is exactly what `bugprone-sizeof-expression` looks for.

The 12 findings, all expansions of that macro:

| File | Findings | Message |
|---|---|---|
| `tt_metal/impl/dispatch/kernels/cq_dispatch.cpp` | 4 | `suspicious usage of 'sizeof(K)'; did you mean 'K'?` |
| `tt_metal/impl/dispatch/kernels/cq_prefetch.cpp` | 3 | same |
| `tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp` | 2 | same |
| `tt_metal/impl/dispatch/kernels/telemetry.hpp` | 2 | same |
| `tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h` | 1 | `suspicious usage of 'sizeof(sizeof(...))'` |

The last one is `ASSERT(std::is_unsigned_v<HopMaskType> && (sizeof(HopMaskType) == sizeof(uint16_t)))` — the macro wraps a condition that legitimately contains `sizeof`, producing `sizeof(sizeof(...))`.

### Change

One line: take `sizeof` of the condition's *type* instead of the expression.

```cpp
#define ASSERT(condition, ...) (void(sizeof(decltype(not(condition)))))
```

`decltype` is still an unevaluated context, so the condition is not executed and its side effects don't happen — identical to today. The condition still names its variables, so it still counts as a use and unused-variable warnings stay quiet. The argument to `sizeof` is now a type, so the check no longer fires.

Only the asserts-disabled branch changes; the watcher and lightweight-trap variants are untouched.

### Verification

No clang-tidy in CI for JIT kernel code outside the weekly job, so this was checked directly with clang-tidy 20.1.0 and g++ 13.3 on a test file reproducing the reported call-site shapes (`ASSERT(0)`, a `constexpr`-bound comparison, a null-pointer compare, the `fabric_common.h` `sizeof`-inside-condition case, a user-defined `operator!`, and a variable used only inside an `ASSERT`):

- `bugprone-sizeof-expression`: **2 warnings before** (one of each reported message kind), **0 after**.
- `-Wall -Wextra -Wunused-variable -Wunused-but-set-variable` at `-O0` and `-O2`: clean before and after; the assert-only variable does not warn with either macro.
- The condition stays unevaluated: the test calls an intentionally *undefined* function inside an `ASSERT` and still links at both optimization levels.

Related to #56131, which tracks working through the rest of the report.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/assert-macro-sizeof-decltype)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/assert-macro-sizeof-decltype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/assert-macro-sizeof-decltype)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/assert-macro-sizeof-decltype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/assert-macro-sizeof-decltype)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/assert-macro-sizeof-decltype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/assert-macro-sizeof-decltype)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/assert-macro-sizeof-decltype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/assert-macro-sizeof-decltype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/assert-macro-sizeof-decltype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/assert-macro-sizeof-decltype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/assert-macro-sizeof-decltype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/assert-macro-sizeof-decltype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/assert-macro-sizeof-decltype)