### PR TITLE
[Test Only] Keep program caching enabled for top-k metadata traces

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -186,7 +186,7 @@ def test_topk_large_indices_program_cache_separates_compute_body_modes(device):
         _assert_topk_matches_torch(fused_input, fused, k)
         _assert_topk_matches_torch(classic_input, classic, k)
     finally:
-        device.disable_and_clear_program_cache()
+        device.clear_program_cache()
 
 
 @pytest.mark.parametrize(
@@ -395,7 +395,7 @@ def test_topk_large_indices_program_cache_ignores_row_count_and_array_size(devic
         assert cache_entries[0] > 0
         assert max(cache_entries) == min(cache_entries)
     finally:
-        device.disable_and_clear_program_cache()
+        device.clear_program_cache()
 
 
 @pytest.mark.parametrize(
@@ -598,7 +598,7 @@ def test_topk_large_indices_valid_length_program_cache_reuse_while_growing(devic
         assert entries[0] > 0
         assert max(entries) == min(entries)  # no recompile as valid_length grew
     finally:
-        device.disable_and_clear_program_cache()
+        device.clear_program_cache()
 
 
 @pytest.mark.parametrize("k", [512, 1024, 2048])


### PR DESCRIPTION
### Summary

1. #55085 added metadata trace tests; L2 failed when running the full module.
2. Earlier tests disabled the shared device's program cache, so the trace warmup was not retained.
3. Clear cached programs without disabling caching in the three cleanup blocks.

### Validation

Reproduced the ordered failure on Blackhole; the same pair passes after the fix. Full top-k correctness module: **133 passed, 3 deselected**. Pre-commit passed. Python-only change.

[L2 experimental tests on Blackhole](https://github.com/tenstorrent/tt-metal/actions/runs/34595062441) queued on this branch.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/fix-topk-metadata-trace-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/fix-topk-metadata-trace-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/fix-topk-metadata-trace-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/fix-topk-metadata-trace-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/fix-topk-metadata-trace-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/fix-topk-metadata-trace-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/fix-topk-metadata-trace-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/fix-topk-metadata-trace-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/fix-topk-metadata-trace-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/fix-topk-metadata-trace-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/fix-topk-metadata-trace-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/fix-topk-metadata-trace-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/fix-topk-metadata-trace-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/fix-topk-metadata-trace-cache)