### PR TITLE
graph: emit core_range_set as JSON and make L1 peaks per core

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_graph_trace_utils.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_trace_utils.py
@@ -445,14 +445,24 @@ def test_metal2_dataflow_buffers_reach_resource_usage_per_core():
 # op produces: kernel scratchpads only appear in Quasar factories today.
 
 
-def _l1_node(counter, node_type, size, **params):
-    all_params = {"size": str(size), "address": "0", "core_range_set": "{[0-0 - 0-0]}", "device_id": "0"}
+def _core_range_set(*ranges):
+    """JSON form of a CoreRangeSet as the graph processor emits it: [{start: {x, y}, end: {x, y}}, ...]."""
+    return [{"start": {"x": x0, "y": y0}, "end": {"x": x1, "y": y1}} for (x0, y0, x1, y1) in ranges]
+
+
+def _l1_node(counter, node_type, size, cores=None, **params):
+    all_params = {
+        "size": str(size),
+        "address": "0",
+        "core_range_set": _core_range_set(*(cores or [(0, 0, 0, 0)])),
+        "device_id": "0",
+    }
     all_params.update({key: str(value) for key, value in params.items()})
     return {"counter": counter, "node_type": node_type, "params": all_params, "connections": []}
 
 
-def _cb(counter, size):
-    return _l1_node(counter, "circular_buffer_allocate", size, globally_allocated=0)
+def _cb(counter, size, cores=None):
+    return _l1_node(counter, "circular_buffer_allocate", size, cores=cores, globally_allocated=0)
 
 
 def _dfb(counter, size, borrows_memory=0):
@@ -528,3 +538,18 @@ def test_extract_resource_usage_per_core_deprecated_kwarg():
     assert legacy.peak_cb == baseline.peak_cb
     assert legacy.peak_l1 == baseline.peak_l1
     assert legacy.peak_total == baseline.peak_total
+
+
+def test_peak_total_is_per_core_across_disjoint_core_sets():
+    """CBs on disjoint core sets share L1 addresses; peak_total is the busiest core, not the global sum."""
+    trace = [
+        _cb(0, 1024, cores=[(0, 0, 0, 0), (3, 0, 3, 0)]),  # cores x=0 and x=3
+        _cb(1, 2048, cores=[(1, 0, 2, 0)]),  # cores x=1..2
+        _cb(2, 512, cores=[(0, 0, 3, 0)]),  # all four cores
+    ]
+
+    usage = ttnn.graph.extract_resource_usage_per_core(trace)
+
+    # busiest core holds the 2048 CB and the shared 512 CB; the 1024 CB never shares a core with the 2048 one
+    assert usage.peak_cb == 2048 + 512
+    assert usage.peak_total == 2048 + 512

--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -23,6 +23,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_generic_op_hashing.cpp
     test_graph_add.cpp
     test_graph_basic.cpp
+    test_graph_cb_per_core.cpp
     test_levelized_graph.cpp
     test_graph_capture_arguments_morehdot.cpp
     test_graph_capture_arguments_transpose.cpp

--- a/tests/ttnn/unit_tests/gtests/test_graph_cb_per_core.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_cb_per_core.cpp
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <set>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+#include "gtest/gtest.h"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/graph_tracking.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt_stl/reflection.hpp>
+#include "ttnn/graph/graph_consts.hpp"
+#include "ttnn/graph/graph_processor.hpp"
+#include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn_test_fixtures.hpp"
+
+namespace ttnn::graph::test {
+
+using tt::tt_metal::CoreCoord;
+using tt::tt_metal::CoreRange;
+using tt::tt_metal::CoreRangeSet;
+
+class CBPerCoreGraphTestFixture : public TTNNFixtureWithSuiteDevice<CBPerCoreGraphTestFixture> {};
+
+// A program placing circular buffers on DISJOINT core sets. No single core holds all of them, so the
+// per-core L1 peak must be the busiest core's total, not the sum over every CB in the program.
+TEST_F(CBPerCoreGraphTestFixture, PeakTotalIsPerCoreAcrossDisjointCoreRangeSets) {
+    constexpr uint32_t kTile = 32 * 32 * 2;
+    constexpr uint32_t kSizeOuter = 4 * kTile;   // cores x=0 and x=3
+    constexpr uint32_t kSizeInner = 8 * kTile;   // cores x=1..2
+    constexpr uint32_t kSizeShared = 2 * kTile;  // all four cores
+
+    const CoreRangeSet all_cores(CoreRange({0, 0}, {3, 0}));
+    const CoreRangeSet outer_cores(std::set<CoreRange>{CoreRange({0, 0}, {0, 0}), CoreRange({3, 0}, {3, 0})});
+    const CoreRangeSet inner_cores(CoreRange({1, 0}, {2, 0}));
+
+    auto make_cb = [](uint32_t index, uint32_t size) {
+        return tt::tt_metal::CircularBufferConfig(size, {{index, tt::DataFormat::Float16_b}})
+            .set_page_size(index, kTile);
+    };
+
+    auto program = tt::tt_metal::CreateProgram();
+    tt::tt_metal::CreateCircularBuffer(program, outer_cores, make_cb(0, kSizeOuter));
+    tt::tt_metal::CreateCircularBuffer(program, inner_cores, make_cb(1, kSizeInner));
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, make_cb(2, kSizeShared));
+    tt::tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/blank.cpp",
+        all_cores,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = tt::tt_metal::NOC::RISCV_0_default});
+
+    tt::tt_metal::distributed::MeshWorkload workload;
+    workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange(device_->shape()), std::move(program));
+
+    GraphProcessor::begin_graph_capture(tt::tt_metal::IGraphProcessor::RunMode::NORMAL);
+    tt::tt_metal::distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), workload, /*blocking=*/true);
+    tt::tt_metal::distributed::Finish(device_->mesh_command_queue());
+    const auto trace = GraphProcessor::end_graph_capture();
+
+    // The trace carries each CB's core_range_set as structured JSON that round-trips through the
+    // CoreRangeSet (de)serializer.
+    uint32_t cb_nodes = 0;
+    for (const auto& node : trace) {
+        if (node.at(kNodeType) != kNodeCBAllocate) {
+            continue;
+        }
+        cb_nodes++;
+        const auto& core_range_set_json = node.at(kParams).at(kCoreRangeSet);
+        ASSERT_TRUE(core_range_set_json.is_array()) << core_range_set_json.dump();
+        const auto core_range_set = ttsl::json::from_json<CoreRangeSet>(core_range_set_json);
+        const auto size = node.at(kParams).at(kSize).get<uint32_t>();
+        if (size == kSizeOuter) {
+            EXPECT_EQ(core_range_set, outer_cores);
+        } else if (size == kSizeInner) {
+            EXPECT_EQ(core_range_set, inner_cores);
+        } else {
+            EXPECT_EQ(size, kSizeShared);
+            EXPECT_EQ(core_range_set, all_cores);
+        }
+    }
+    EXPECT_EQ(cb_nodes, 3u);
+
+    // The busiest core (x=1 or x=2) holds the inner CB and the shared CB; the outer CB never shares a
+    // core with the inner one, so it must not be added on top.
+    const auto usage = extract_resource_usage_per_core(trace);
+    EXPECT_EQ(usage.peak_cb, kSizeInner + kSizeShared);
+    EXPECT_EQ(usage.peak_total, kSizeInner + kSizeShared);
+    EXPECT_EQ(usage.peak_l1, 0u);
+}
+
+}  // namespace ttnn::graph::test

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -73,12 +73,18 @@ nlohmann::json to_json(const ttnn::graph::GraphProcessor::Vertex& data) {
     static const std::unordered_set<std::string> boolean_params = {
         ttnn::graph::kProgramCacheHit,
     };
+    // Params stored as serialized JSON (see ttsl::json::to_json); emitted as structured JSON, not a string.
+    static const std::unordered_set<std::string> json_params = {
+        ttnn::graph::kCoreRangeSet,
+    };
     nlohmann::json params_json;
     for (const auto& [key, value] : data.params) {
         if (integer_params.contains(key)) {
             params_json[key] = std::stoll(value);
         } else if (boolean_params.contains(key)) {
             params_json[key] = from_bool_param(value);
+        } else if (json_params.contains(key)) {
+            params_json[key] = nlohmann::json::parse(value);
         } else {
             params_json[key] = value;
         }
@@ -351,7 +357,7 @@ void GraphProcessor::track_allocate_cb(
     std::unordered_map<std::string, std::string> params = {
         {kSize, std::to_string(size)},
         {kAddress, std::to_string(addr)},
-        {kCoreRangeSet, core_range_set.str()},
+        {kCoreRangeSet, ttsl::json::to_json(core_range_set).dump()},
         {kGloballyAllocated, std::to_string(is_globally_allocated)},
         {kDeviceId, std::to_string(device->id())}};
     node_id counter = graph.size();
@@ -381,7 +387,7 @@ void GraphProcessor::track_allocate_dataflow_buffer(
     std::unordered_map<std::string, std::string> params = {
         {kSize, std::to_string(size)},
         {kAddress, std::to_string(addr)},
-        {kCoreRangeSet, core_range_set.str()},
+        {kCoreRangeSet, ttsl::json::to_json(core_range_set).dump()},
         {kBorrowsMemory, std::to_string(borrows_memory)},
         {kDeviceId, std::to_string(device->id())}};
     node_id counter = graph.size();
@@ -410,7 +416,7 @@ void GraphProcessor::track_allocate_scratchpad(
     std::unordered_map<std::string, std::string> params = {
         {kSize, std::to_string(size)},
         {kAddress, std::to_string(addr)},
-        {kCoreRangeSet, core_range_set.str()},
+        {kCoreRangeSet, ttsl::json::to_json(core_range_set).dump()},
         {kDeviceId, std::to_string(device->id())}};
     node_id counter = graph.size();
     int stacking_level = static_cast<int>(current_op_id.size()) - 1;

--- a/ttnn/core/graph/graph_trace_utils.cpp
+++ b/ttnn/core/graph/graph_trace_utils.cpp
@@ -4,11 +4,15 @@
 
 #include "ttnn/graph/graph_trace_utils.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>  // std::strtoul
+#include <map>
 #include <string>
 
 #include <nlohmann/json.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt_stl/reflection.hpp>
 
 #include "ttnn/graph/graph_consts.hpp"
 #include "ttnn/graph/graph_processor.hpp"
@@ -306,12 +310,47 @@ uint32_t extract_peak_memory_usage(const nlohmann::json& trace) {
 }
 
 PeakMemoryUsagePerCore extract_resource_usage_per_core(const nlohmann::json& trace) {
-    size_t current_cb = 0, peak_cb = 0;
-    size_t current_l1 = 0, peak_l1 = 0;
-    // Program-scope L1 of a Metal 2.0 program, tracked per kind. Released together with the CBs.
-    size_t current_dfb = 0, peak_dfb = 0;
-    size_t current_scratchpad = 0, peak_scratchpad = 0;
-    size_t current_total = 0, peak_total = 0;
+    // Program-scope L1 (CBs, dataflow buffers, scratchpads) is placed per core: each allocation names the
+    // exact cores it occupies (core_range_set), and allocations on disjoint core sets share addresses.
+    // Summing them program-wide over-counts, so every kind is tracked per core and each peak is the
+    // busiest core's total. L1 tensor buffers are different: the L1 allocator is lockstep across all
+    // banks, so a buffer's per-bank size is reserved on every core regardless of which cores hold its
+    // shards. They are summed globally and form a base resident on every core.
+    struct ProgramL1 {
+        size_t cb = 0;
+        size_t dfb = 0;
+        size_t scratchpad = 0;
+        size_t total() const { return cb + dfb + scratchpad; }
+    };
+    std::map<tt::tt_metal::CoreCoord, ProgramL1> per_core;
+    size_t current_l1 = 0;
+
+    size_t peak_cb = 0, peak_dfb = 0, peak_scratchpad = 0, peak_l1 = 0, peak_total = 0;
+
+    auto add_program_l1 = [&](const nlohmann::json& node, size_t ProgramL1::* kind) {
+        const size_t alloc_size = json_to_int(node.at(kParams).at(kSize));
+        const auto core_range_set =
+            ttsl::json::from_json<tt::tt_metal::CoreRangeSet>(node.at(kParams).at(kCoreRangeSet));
+        for (const auto& range : core_range_set.ranges()) {
+            for (const auto& core : range) {
+                per_core[core].*kind += alloc_size;
+            }
+        }
+    };
+    auto update_peaks = [&]() {
+        size_t max_cb = 0, max_dfb = 0, max_scratchpad = 0, max_program = 0;
+        for (const auto& [core, l1] : per_core) {
+            max_cb = std::max(max_cb, l1.cb);
+            max_dfb = std::max(max_dfb, l1.dfb);
+            max_scratchpad = std::max(max_scratchpad, l1.scratchpad);
+            max_program = std::max(max_program, l1.total());
+        }
+        peak_cb = std::max(peak_cb, max_cb);
+        peak_dfb = std::max(peak_dfb, max_dfb);
+        peak_scratchpad = std::max(peak_scratchpad, max_scratchpad);
+        peak_l1 = std::max(peak_l1, current_l1);
+        peak_total = std::max(peak_total, current_l1 + max_program);
+    };
 
     size_t counter_expected = 0;
     for (const auto& node : trace) {
@@ -323,35 +362,23 @@ PeakMemoryUsagePerCore extract_resource_usage_per_core(const nlohmann::json& tra
         }
 
         if (node.at(kNodeType) == kNodeCBAllocate) {
-            bool is_globally_allocated = json_to_int(node.at(kParams).at(kGloballyAllocated)) == 1;
-            if (!is_globally_allocated) {
-                uint32_t alloc_size = json_to_int(node.at(kParams).at(kSize));
-                current_cb += alloc_size;
-                peak_cb = std::max(peak_cb, current_cb);
-                current_total += alloc_size;
-                peak_total = std::max(peak_total, current_total);
+            // A globally allocated CB is a view onto a tensor's L1, which the tensor already reports.
+            if (json_to_int(node.at(kParams).at(kGloballyAllocated)) != 1) {
+                add_program_l1(node, &ProgramL1::cb);
+                update_peaks();
             }
         } else if (node.at(kNodeType) == kNodeDataflowBufferAllocate) {
             // A borrowed buffer is a view onto a tensor's L1, which the tensor already reports.
-            bool borrows_memory = json_to_int(node.at(kParams).at(kBorrowsMemory)) == 1;
-            if (!borrows_memory) {
-                uint32_t alloc_size = json_to_int(node.at(kParams).at(kSize));
-                current_dfb += alloc_size;
-                peak_dfb = std::max(peak_dfb, current_dfb);
-                current_total += alloc_size;
-                peak_total = std::max(peak_total, current_total);
+            if (json_to_int(node.at(kParams).at(kBorrowsMemory)) != 1) {
+                add_program_l1(node, &ProgramL1::dfb);
+                update_peaks();
             }
         } else if (node.at(kNodeType) == kNodeScratchpadAllocate) {
-            uint32_t alloc_size = json_to_int(node.at(kParams).at(kSize));
-            current_scratchpad += alloc_size;
-            peak_scratchpad = std::max(peak_scratchpad, current_scratchpad);
-            current_total += alloc_size;
-            peak_total = std::max(peak_total, current_total);
+            add_program_l1(node, &ProgramL1::scratchpad);
+            update_peaks();
         } else if (node.at(kNodeType) == kNodeCBDeallocateAll) {
-            current_total -= current_cb + current_dfb + current_scratchpad;
-            current_cb = 0;
-            current_dfb = 0;
-            current_scratchpad = 0;
+            // Program-scope L1 of every kind is released together.
+            per_core.clear();
         } else if (node.at(kNodeType) == kNodeBufferAllocate || node.at(kNodeType) == kNodeBufferDeallocate) {
             if (node.at(kParams).at(kType) == "DRAM") {
                 continue;
@@ -359,12 +386,9 @@ PeakMemoryUsagePerCore extract_resource_usage_per_core(const nlohmann::json& tra
             size_t alloc_size = calculate_buffer_allocation_size(node);
             if (node.at(kNodeType) == kNodeBufferAllocate) {
                 current_l1 += alloc_size;
-                peak_l1 = std::max(peak_l1, current_l1);
-                current_total += alloc_size;
-                peak_total = std::max(peak_total, current_total);
+                update_peaks();
             } else {  // kNodeBufferDeallocate
                 current_l1 -= alloc_size;
-                current_total -= alloc_size;
             }
         }
     }


### PR DESCRIPTION
## Problem

`extract_resource_usage_per_core(trace).peak_total` over-counts whenever a program allocates CBs / dataflow buffers / scratchpads on different core range sets.

The accounting sums every allocation into one global total, ignoring each allocation's `core_range_set`. Two CBs on disjoint core sets are added together even though no core holds both, so the reported per-core peak is the program-wide sum rather than the busiest core's actual footprint. Any op that splits work across core classes gets an inflated number; in extreme cases it exceeds physical L1.

## Fix

1. **Graph processor** emits `core_range_set` as structured JSON via the existing `ttsl::json::to_json<CoreRangeSet>` instead of the human-readable `CoreRangeSet::str()`.
2. **Trace utils** deserializes it with `ttsl::json::from_json<CoreRangeSet>` and tracks program-scope L1 (CB, dataflow buffer, scratchpad) **per core**. `peak_cb`, `peak_dataflow_buffer`, `peak_scratchpad` and `peak_total` are each the busiest core's total.

`peak_l1` (L1 tensor buffers) deliberately stays a global sum: the L1 allocator is lockstep across all banks, so a buffer's per-bank size is reserved on every core regardless of which cores hold its shards (two tensors sharded to cores (0,0) and (0,1) get disjoint address ranges). It is added as a base resident on every core in `peak_total`.

## Trace format change

`circular_buffer_allocate` / `dataflow_buffer_allocate` / `scratchpad_allocate` nodes, before:

```json
"core_range_set": "{[0-0 - 10-9]}"
```

after:

```json
"core_range_set": [
  { "start": { "x": 0, "y": 0 }, "end": { "x": 10, "y": 9 } }
]
```

A disjoint set (`{[0-0 - 0-0], [3-1 - 6-2]}`) becomes:

```json
"core_range_set": [
  { "start": { "x": 0, "y": 0 }, "end": { "x": 0, "y": 0 } },
  { "start": { "x": 3, "y": 1 }, "end": { "x": 6, "y": 2 } }
]
```

## Tests

- **`test_graph_cb_per_core.cpp`** (new gtest): builds a raw program with a blank kernel and three CBs on `{x=0, x=3}`, `{x=1..2}` and all four cores, runs it under graph capture, checks that every CB node's `core_range_set` round-trips through `from_json<CoreRangeSet>`, and asserts `peak_cb` and `peak_total` are the busiest core's total, not the program-wide sum. Independent of any op implementation.
- `test_graph_trace_utils.py`: hand-built traces updated to the JSON form; added a disjoint-core-set case.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/graph-l1-peak-percore-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/graph-l1-peak-percore-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/graph-l1-peak-percore-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/graph-l1-peak-percore-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/graph-l1-peak-percore-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/graph-l1-peak-percore-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/graph-l1-peak-percore-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/graph-l1-peak-percore-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/graph-l1-peak-percore-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/graph-l1-peak-percore-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/graph-l1-peak-percore-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/graph-l1-peak-percore-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/graph-l1-peak-percore-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/graph-l1-peak-percore-main)