### PR TITLE
[tt_metal] teardown: do not std::terminate when a dead device cannot be reset

### DIFF
--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -267,14 +267,28 @@ void RiscFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& /*ini
     auto all_devices = cluster_.all_chip_ids();
 
     if (!cluster_.is_mock_or_emulated()) {
+        // Teardown runs from ~MetalContext and from the atexit handler, both of which cannot let an
+        // exception escape (a throw from a noexcept destructor is std::terminate). When a device has
+        // already failed (for example a PCIe MMIO timeout during init), asserting its cores throws
+        // again here; log and move on so the process still exits cleanly instead of aborting under
+        // a profiler or crash handler and holding the CI step open.
         for (tt::ChipId device_id : all_devices) {
-            assert_cores(device_id);
-            cluster_.l1_barrier(device_id);
+            try {
+                assert_cores(device_id);
+                cluster_.l1_barrier(device_id);
+            } catch (const std::runtime_error& e) {
+                log_warning(
+                    tt::LogMetal, "Skipping RISC reset on device {} during teardown: {}", device_id, e.what());
+            }
         }
         // Set internal routing to false to exit active ethernet FW & go back to base FW
         // Must be last
         if (get_control_plane_) {
-            cluster_.set_internal_routing_info_for_ethernet_cores(this->get_control_plane_(), false);
+            try {
+                cluster_.set_internal_routing_info_for_ethernet_cores(this->get_control_plane_(), false);
+            } catch (const std::runtime_error& e) {
+                log_warning(tt::LogMetal, "Skipping ethernet routing reset during teardown: {}", e.what());
+            }
         }
     }
 


### PR DESCRIPTION
### PR Category
Bug fix (runtime teardown)

### Summary
When a device has already failed at init, `RiscFirmwareInitializer::teardown` throws again while asserting that device's RISC cores. Teardown runs from `~MetalContext` and from the `std::atexit` handler, so the exception escapes a `noexcept` destructor and the process aborts with `std::terminate`.

In CI that abort is what turns a 5-second failure into a job that dies at its step budget: under the tracy profiler build, Tracy's crash handler catches the abort and the process never exits; pytest-timeout then kills only the outer wrapper and the orphaned profiler holds the step's log pipe until GitHub kills the step. Observed on every Blackhole device-perf failure since 2026-08-27 (UMD `MMIO per-op timeout: 4B load took N us (budget=2 ms)` in `deassert_risc_reset`, then `Read 0xffffffff ... the board should be reset`): the `ResNet-50 device perf tests [bh_p150b_civ2]` job lost 4 of its last 16 runs this way (08-27, 09-03, 09-07, 09-11; job 103186119939 is the latest, on node f04cs02), each with the inner test erroring at device setup in about 8 s, then ~277 s of silence after `terminate called`, then the pytest-timeout and the 420 s step kill. The Llama 3.1-8B and SDXL Blackhole device-perf legs show the same chain with longer budgets.

### Change
- `tt_metal/impl/device/firmware/risc_firmware_initializer.cpp`, `teardown`: catch `std::runtime_error` (which `tt::umd::UmdException` derives from, the same idiom this file already uses around `wait_until_cores_done`) around the per-device `assert_cores` + `l1_barrier`, and around the ethernet routing reset, log a warning, and continue tearing down.

Not in scope: the Blackhole PCIe MMIO stall itself (fleet-wide since 08-27; #54764, #54765, #54874), and the tracy wrapper's orphaned children (separate PR).

### CI
- `(Tier 1) Models Device Perf Tests`, model=`resnet50`, sku=`all` (wh_n150, bh_p150b_civ2, and the wh_llmbox_perf e2e leg; exercises device open and teardown on both architectures under the profiler build): https://github.com/tenstorrent/tt-metal/actions/runs/34605821911: **`ResNet-50 device perf tests [wh_n150]` PASSED, `ResNet-50 device perf tests [bh_p150b_civ2]` PASSED** (both legs open and tear down devices normally under the profiler build). The wh_llmbox_perf e2e-perf leg of the `sku=all` run was cancelled as unrelated after sitting in the T3000-perf queue. The failure path itself only occurs on a stalled board and cannot be forced from CI; the same afternoon the stall hit the #56092 validation run again (pod xttnx-2vsz4, `MMIO per-op timeout`, `terminate called`, step burned to its cap), which is the behaviour this change removes.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/metal-context-teardown-no-terminate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/metal-context-teardown-no-terminate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/metal-context-teardown-no-terminate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/metal-context-teardown-no-terminate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/metal-context-teardown-no-terminate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/metal-context-teardown-no-terminate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/metal-context-teardown-no-terminate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/metal-context-teardown-no-terminate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/metal-context-teardown-no-terminate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/metal-context-teardown-no-terminate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/metal-context-teardown-no-terminate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/metal-context-teardown-no-terminate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/metal-context-teardown-no-terminate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/metal-context-teardown-no-terminate)
