### PR TITLE
[Tracy] kill the workload process group when the profiler wrapper is interrupted

### DIFF
--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -397,7 +397,22 @@ def main():
                 proc = subprocess.Popen([testCommand], shell=True, env=env, preexec_fn=os.setsid)
                 proc_holder["p"] = proc
                 logger.info("Test process started")
-                proc.communicate()
+                # TRACY_WORKLOAD_TIMEOUT (seconds) bounds the wait; on timeout or any interruption the
+                # workload's whole process group is killed so nothing outlives this wrapper.
+                workload_timeout = os.environ.get("TRACY_WORKLOAD_TIMEOUT")
+                try:
+                    proc.communicate(timeout=float(workload_timeout) if workload_timeout else None)
+                except subprocess.TimeoutExpired:
+                    logger.error(f"{testCommand} exceeded TRACY_WORKLOAD_TIMEOUT={workload_timeout}s; killing it")
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                    proc.communicate()
+                    sys.exit(4)
+                except BaseException:
+                    try:
+                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    raise
                 if options.check_exit_code and proc.returncode != 0:
                     logger.error(f"{testCommand} exited with a non-zero return code")
                     sys.exit(4)

--- a/tools/tracy/process_model_log.py
+++ b/tools/tracy/process_model_log.py
@@ -4,6 +4,7 @@
 
 import os
 import shlex
+import signal
 import subprocess
 from pathlib import Path
 import pandas as pd
@@ -189,6 +190,18 @@ def run_multi_pass(
         merge_pass_csv(pass1_csv, pass2_csv)
 
 
+def _kill_process_group(proc):
+    """Best-effort SIGKILL of the whole session started for `proc`."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+    try:
+        proc.wait(timeout=5)
+    except Exception:
+        pass
+
+
 def run_device_profiler(
     command,
     output_logs_subdir,
@@ -227,7 +240,18 @@ def run_device_profiler(
             is_command_binary_exe,
         )
         logger.info(profiler_cmd)
-        subprocess.run([profiler_cmd], shell=True, check=True)
+        # Run the profiler in its own session so that when the caller is interrupted (typically
+        # pytest-timeout raising inside wait()) the whole tree dies with it. Otherwise only the
+        # `sh -c` wrapper is killed and the orphaned `python -m tracy` plus its captured test keep
+        # the job's stdout pipe open until the CI step budget runs out.
+        proc = subprocess.Popen([profiler_cmd], shell=True, start_new_session=True)
+        try:
+            returncode = proc.wait()
+        except BaseException:
+            _kill_process_group(proc)
+            raise
+        if returncode != 0:
+            raise subprocess.CalledProcessError(returncode, profiler_cmd)
 
 
 def get_samples_per_s(time_ns, num_samples):


### PR DESCRIPTION
### PR Category
Bug fix (profiler tooling)

### Summary
`tracy.process_model_log.run_device_profiler` ran `python -m tracy ... -m "pytest ..."` through `subprocess.run(shell=True)` with no timeout and no process group. When pytest-timeout fires inside that wait, it kills only the `sh -c` wrapper; the orphaned `python -m tracy`, its shell and the captured test keep the job's stdout open, so `run-with-log`'s `tee` waits for EOF and the CI step stays alive until its budget kills it.

Every Blackhole device-perf failure since 2026-08-27 paid for this: the `ResNet-50 device perf tests [bh_p150b_civ2]` job spent 81–86 s after pytest had already printed its summary before the 420 s step budget ended it (08-27, 09-03, 09-07, 09-11; latest job 103186119939), and the Llama 3.1-8B and SDXL Blackhole legs spent their whole remaining 20/60-minute budgets the same way. On wh_n150 the orphaned tracy of a killed run kept post-processing for 45 s after the kill on 09-10 (job 102853484606).

### Change
- `tools/tracy/process_model_log.py`: start the profiler in its own session (`Popen(..., start_new_session=True)`), wait on it, and on any interruption (`BaseException`, which includes pytest-timeout's `Failed`) SIGKILL the whole group before re-raising. Non-zero exit still raises `CalledProcessError` as before.
- `tools/tracy/__main__.py`, `run_workload`: on `TimeoutExpired` or any other interruption kill the workload's process group (the existing SIGINT/SIGTERM handler already does this, but cannot run when the wrapper itself is SIGKILLed or when an exception propagates). Optional `TRACY_WORKLOAD_TIMEOUT` (seconds) bounds the wait; unset by default, so behaviour is unchanged unless a caller opts in.

Not in scope: the `std::terminate` from `~MetalContext` on a dead device that makes the inner process hang in the first place (separate PR), and the Blackhole MMIO stall itself.

### CI
- `(Tier 1) Models Device Perf Tests`, model=`resnet50`, sku=`all` (every ResNet-50 leg goes through `run_device_profiler`): https://github.com/tenstorrent/tt-metal/actions/runs/34605854188: **`bh_p150b_civ2` PASSED**; `wh_n150` landed on vm-167 (one of this week's slow N150 VMs) and was killed at the 300 s step budget while the inner test was still compiling kernels, i.e. the pre-#56092 budget problem, not the wrapper (no wrapper exception in the log; pytest never reached its timeout). Re-dispatched for wh_n150 only: https://github.com/tenstorrent/tt-metal/actions/runs/34615312222 — **PASSED** ([job 103319111767](https://github.com/tenstorrent/tt-metal/actions/runs/34615312222/job/103319111767), tt-metal-ci-vm-171 step=147s). Both SKUs green with the new wrapper. The wh_llmbox_perf e2e-perf leg of the `sku=all` run was cancelled as unrelated after sitting in the T3000-perf queue. Checks the normal path; the orphan path only appears when a case is killed mid-run.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/tracy-wrapper-kill-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/tracy-wrapper-kill-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/tracy-wrapper-kill-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/tracy-wrapper-kill-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/tracy-wrapper-kill-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/tracy-wrapper-kill-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/tracy-wrapper-kill-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/tracy-wrapper-kill-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/tracy-wrapper-kill-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/tracy-wrapper-kill-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/tracy-wrapper-kill-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/tracy-wrapper-kill-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/tracy-wrapper-kill-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/tracy-wrapper-kill-process-group)

