### PR TITLE
[LLK] sanitizer: keep the type model out of every TRISC build when the sanitizer is off

### DIFF
--- a/tt_metal/tt-llk/tools/include/sanitizer/api.h
+++ b/tt_metal/tt-llk/tools/include/sanitizer/api.h
@@ -6,11 +6,17 @@
 
 #include <utility>
 
-#include "sanitizer/operation.h"
 #include "sanitizer/settings.h"
-#include "sanitizer/types.h"
 
 #if defined(LLK_SAN_ENABLE)
+
+// The full type/operation model is only needed when the sanitizer is compiled in. With it off,
+// every TRISC translation unit still parsed these headers (about 1,500 lines, <bitset>, <tuple>,
+// <variant> and the State/StateStruct template instantiations) for nothing, which measurably
+// slowed first-time kernel compilation across CI; the disabled branch below keeps only what the
+// LLK API and firmware reference outside SAN_HOOK.
+#include "sanitizer/operation.h"
+#include "sanitizer/types.h"
 
 #include "sanitizer/impl.h"
 
@@ -157,10 +163,29 @@ public:
  */
 #define LLK_SAN_SILENT_ZONE() [[maybe_unused]] llk::san::SilentZone<> _silent_zone_
 
+#define SAN_HOOK(...)             \
+    do                            \
+    {                             \
+        using namespace llk::san; \
+        using llk::san::Operand;  \
+        __VA_ARGS__;              \
+    } while (false)
+
 #else
+
+#include <cstdint>
 
 namespace llk::san
 {
+
+// Mirrors types.h; only the thread tag is referenced by the disabled entry points below.
+enum class Thread : std::uint32_t
+{
+    TRISC0 = 0,
+    TRISC1 = 1,
+    TRISC2 = 2,
+    TRISC3 = 3
+};
 
 template <Thread T = Thread::TRISC0>
 static inline void thread_init()
@@ -208,12 +233,11 @@ static inline void unsupported()
     {                         \
     } while (false)
 
-#endif
-
-#define SAN_HOOK(...)             \
-    do                            \
-    {                             \
-        using namespace llk::san; \
-        using llk::san::Operand;  \
-        __VA_ARGS__;              \
+// With the sanitizer off the hook arguments are not parsed at all: they name StateVal/Operand/
+// Operation types that only exist in the enabled build.
+#define SAN_HOOK(...) \
+    do                \
+    {                 \
     } while (false)
+
+#endif


### PR DESCRIPTION
### PR Category
Performance (kernel compile time)

### Summary
Since the 2026-09-08 scheduled runs, first-time kernel compilation in CI is 20–27 % slower (#56090). Two model-tier failures are this regression measured through different gates:

- `ResNet-50 e2e tests [wh_n150]` fails its centralized `fps` target (23.79 / 24.35 / 24.45 on 09-11 / 09-10 / 09-09 vs 28.18 ± 0.44 over the 25 scheduled runs before 09-09; lower bound 24.17). That "fps" is `1600 / t(run of 100 iterations)` and iteration 0 carries the from-scratch JIT compile of every kernel, so the metric is about 95 % compile time: iteration 0 went from 53.8 ± 0.8 s to 62–64 s while iterations 1–99, the trace probe and the cached-kernel probe are unchanged. The step is between main `ce94a27c66b` (09-08) and `f7b965a4ab4` (09-09) with identical image, toolchain and host; vm-71 (today's runner) read 28.0–28.9 on 08-21, 08-27 and 09-02.
- The T3K `TT-Transformers sampling module unit tests` / `common unit tests` overran their step budgets by a few seconds from 09-08 20:13 on (widened in #56085); per-test diffs show only compile-heavy tests slowing.

Cause: `sanitizer/api.h` included `operation.h`, `settings.h` and `types.h` above the `LLK_SAN_ENABLE` guard, and the disabled `SAN_HOOK` still expanded its arguments. With the sanitizer off (the default and CI) every compute translation unit parsed the full sanitizer type model, pulled in `<bitset>`, `<tuple>` and `<variant>`, and instantiated `StateVal`/`Operand` and the `State`/`StateStruct` templates for nothing. #54467 ("[SAN] Refactor State Store", `a0a1aff94155`, in the window) grew that unguarded footprint from 930 to 1,527 lines; static include-graph resolution of the 65 commits in the ResNet window found no other change that adds per-TU work to compute kernels.

### Change
- `tt_metal/tt-llk/tools/include/sanitizer/api.h`: move `operation.h`/`types.h` (and `impl.h`) under `#if defined(LLK_SAN_ENABLE)`; keep `settings.h` (macros only) unconditional; make the disabled `SAN_HOOK(...)` a no-op that does not parse its arguments; give the disabled branch the only pieces the LLK API and `trisck.cc` reference outside hooks (the `Thread` tag, mirroring `types.h`, and the existing no-op entry points). The enabled build is unchanged.

Host check: `clang++ -std=c++17 -fsyntax-only -Wall -Werror` of a TU that includes `sanitizer/api.h` and exercises `thread_init`, `configure`, `execute<>`, `unsupported`, `LLK_SAN_FUNCTION`, `LLK_SAN_SILENT_ZONE` and a `SAN_HOOK(configure(StateVal<Operand<Exu::Fpu>::Format>(42)))` compiles with the sanitizer off; the preprocessed TU now touches 6 sanitizer lines instead of about 1,500.

No perf target is changed: the ResNet gate should return to its 28.2 steady state on its own if this is the cause, and it will say so.

### CI
- `(Tier 1) Models Unit Tests`, model=`tt-transformers-common`, sku=`wh_llmbox (T3000)`: https://github.com/tenstorrent/tt-metal/actions/runs/34606457368 — **all eight T3K module jobs green**. Sampling module job ([103290518158](https://github.com/tenstorrent/tt-metal/actions/runs/34606457368/job/103290518158), t3k-07): `test_sampling_1d.py` **124 passed in 135.1 s** (155.2 s with the regression on 09-10, 116.3 s on 09-08 04:17 before it), `test_penalties_1d.py` 67.7 s (74.9 / 66.4), test step **232 s**, back under the old 240 s cap that the regression broke. Common unit job ([103290518120](https://github.com/tenstorrent/tt-metal/actions/runs/34606457368/job/103290518120), t3k-13): 3002 passed in **1346.8 s** (1372.7 s regressed, 1337 s before), step 1361 s, back under the old 1380 s cap. Most of the compile-time delta is gone; the sampling file keeps about a third of it, which may be host spread (different T3K VM) or a second, smaller contributor.
- `(Tier 1) Models E2E Tests`, model=`resnet50`, sku=`wh_n150 (N150)` (the fps gate itself): https://github.com/tenstorrent/tt-metal/actions/runs/34606461438 — **PASSED, `FPS: 29.56`** ([job 103288303008](https://github.com/tenstorrent/tt-metal/actions/runs/34606461438/job/103288303008), vm-109; step 284 s). Main read 23.79 / 24.35 / 24.45 on 09-11 / 09-10 / 09-09 and 28.18 ± 0.44 before the regression, so the first-iteration compile is back to (slightly better than) its pre-09-09 cost.
- `(Tier 1) Models Device Perf Tests`, model=`resnet50`, sku=`bh_p150b_civ2 (P150b CIv2)` (Blackhole TRISC compile path): https://github.com/tenstorrent/tt-metal/actions/runs/34606465363 — **PASSED** ([job 103289672644](https://github.com/tenstorrent/tt-metal/actions/runs/34606465363/job/103289672644); both perf cases green on a Blackhole build with the slimmed headers).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/llk-san-disabled-path-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/llk-san-disabled-path-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/llk-san-disabled-path-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/llk-san-disabled-path-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/llk-san-disabled-path-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/llk-san-disabled-path-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/llk-san-disabled-path-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/llk-san-disabled-path-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/llk-san-disabled-path-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/llk-san-disabled-path-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/llk-san-disabled-path-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/llk-san-disabled-path-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/llk-san-disabled-path-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/llk-san-disabled-path-slim)


