### PR TITLE
[Feature] #56453 - Nomic Embed Text v2 MoE: ttnn operator mapping and testing

### DIFF
--- a/models/experimental/nomic_embed_text_v2_moe/README.md
+++ b/models/experimental/nomic_embed_text_v2_moe/README.md
@@ -61,6 +61,7 @@ similarity = float(embeddings[0] @ embeddings[1])
 README.md                     this file: layout, setup, test commands
 common.py                     pinned revisions, contracts, checkpoint resolution, test helpers
 docs/ARCHITECTURE.md          what the model is; see Documentation below
+docs/OPERATOR_MAPPING.md      how each aten op maps onto TTNN, and its measured PCC
 reference/
   modeling_nomic_moe.py       golden PyTorch reference
   configuration_nomic_moe.py  config projected from the pinned config.json snapshot
@@ -74,14 +75,21 @@ reference/
 tests/
   conftest.py                 session-scoped checkpoint, model and tokenizer fixtures
   pcc/                        correctness tests
-tt/                           TTNN implementation (Phase 1)
+tt/
+  model_config.py             dtypes, layout and compute kernel configs, bound to a device
+  common.py                   weight reorientation, rotary tables, attention mask, reshapes
 ```
 
 ## Documentation
 
 [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) describes the model: dimensions, pinned
-revisions, checkpoint contract, operator inventory and embedding pipeline. Hand-written, and
-every number in it was measured against the pinned checkpoint.
+revisions, checkpoint contract, operator inventory and embedding pipeline.
+
+[`docs/OPERATOR_MAPPING.md`](docs/OPERATOR_MAPPING.md) maps that inventory onto TTNN: the
+operator each aten call becomes, the PCC it reaches, the API and shape differences, and the
+negative controls for the ways an operator can be wrong without failing.
+
+Both are hand-written, and every number in them was measured.
 
 ## Setup
 
@@ -96,24 +104,26 @@ Weights resolve from the Hugging Face cache at a pinned revision. Pre-fetch (1.8
 python -c "from models.experimental.nomic_embed_text_v2_moe.common import resolve_checkpoint; print(resolve_checkpoint())"
 ```
 
-Tests needing the checkpoint skip rather than fail when it is absent.
-
 ## Tests
 
 ```bash
 pytest models/experimental/nomic_embed_text_v2_moe/tests/pcc/ -v
 ```
 
-Every test needs the checkpoint and a warm HF cache or network; they skip rather than fail when
-the checkpoint is absent.
+Tests skip rather than fail when what they need is absent: the checkpoint, the network, or a
+Blackhole device.
 
-| File | Covers | Needs weights |
+| File | Covers | Needs |
 |---|---|---|
-| `test_checkpoint_contract.py` | 148 keys/shapes/dtypes generated from the config, absence assertions, strict load | yes |
-| `test_reference_vs_hf_e2e.py` | end to end vs upstream: per-layer parity, tokenizer, prefixes, model-card similarity, Matryoshka, ragged batches | yes, plus network |
+| `test_checkpoint_contract.py` | 148 keys/shapes/dtypes generated from the config, absence assertions, strict load | weights |
+| `test_reference_vs_hf_e2e.py` | end to end vs upstream: per-layer parity, tokenizer, prefixes, model-card similarity, Matryoshka, ragged batches | weights, network |
+| `test_ttnn_operators.py` | embedding, layer norm, the four projections, GELU, typecast, reshape, pooling, Matryoshka, L2 normalize | device, weights for the embedding and projections |
+| `test_ttnn_operators_attention.py` | QKV head split, rotary, SDPA masked, unmasked and causal, head concat | device |
+| `test_ttnn_operators_moe.py` | router linear, softmax, topk, scatter, both expert matmuls, gate multiply, expert reduce, shared bias | device, weights for the expert tensors |
 
-Phase 0 is CPU-only. Do not set `TT_VISIBLE_DEVICES`; on a p300c it fails with
-`Custom fabric mesh graph descriptor path must be specified for CUSTOM cluster type`.
+The three TTNN files need a Blackhole device and skip elsewhere. Do not set
+`TT_VISIBLE_DEVICES`; on a p300c it fails with `Custom fabric mesh graph descriptor path must
+be specified for CUSTOM cluster type`.
 
 ### Quick test
 

--- a/models/experimental/nomic_embed_text_v2_moe/docs/ARCHITECTURE.md
+++ b/models/experimental/nomic_embed_text_v2_moe/docs/ARCHITECTURE.md
@@ -142,6 +142,9 @@ make this list a property of the host rather than of the model.
 | `aten._to_copy.default` | `[2, 1, 1, 16]` | `[2, 1, 1, 16]` |
 | `aten.rsub.Scalar` | `[2, 1, 1, 16]` | `[2, 1, 1, 16]` |
 
+[`OPERATOR_MAPPING.md`](OPERATOR_MAPPING.md) maps every operator below onto TTNN and records
+the PCC each one reaches.
+
 `aten.nonzero`, `aten.index`, `aten.index_add_` and `aten._local_scalar_dense` come from
 upstream's ragged expert loop, which gathers each expert's tokens by value. Being
 data-dependent, the model is not `torch.fx`-traceable.

--- a/models/experimental/nomic_embed_text_v2_moe/docs/OPERATOR_MAPPING.md
+++ b/models/experimental/nomic_embed_text_v2_moe/docs/OPERATOR_MAPPING.md
@@ -1,0 +1,178 @@
+# Nomic Embed Text v2 MoE: aten to TTNN
+
+Maps the operator inventory in [`ARCHITECTURE.md` section 4](ARCHITECTURE.md#4-operator-inventory)
+onto TTNN, with the settings each operator runs under and the PCC it reaches.
+
+Measured on a Blackhole p300c, bfloat16 unless stated, weights read from the pinned
+checkpoint. Section 1 is uniformly at `B=2, S=512` (`T=1024`); section 5 states its own shapes,
+since several controls only bite off-tile. The tests gate these rather than print them:
+
+```bash
+pytest models/experimental/nomic_embed_text_v2_moe/tests/pcc/test_ttnn_operators.py \
+       models/experimental/nomic_embed_text_v2_moe/tests/pcc/test_ttnn_operators_attention.py \
+       models/experimental/nomic_embed_text_v2_moe/tests/pcc/test_ttnn_operators_moe.py -v
+```
+
+Settings live in [`../tt/model_config.py`](../tt/model_config.py): one compute kernel config
+throughout, HiFi4 with fp32 destination accumulation, with the measurements behind each half in
+its module docstring. Tensor preparation is in [`../tt/common.py`](../tt/common.py).
+
+## 1. Mapping
+
+Gate is PCC >= 0.999 per operator. SDPA sits closest at 0.99976; everything else clears
+0.99999.
+
+### Embeddings and normalization
+
+| aten | TTNN | PCC | max-abs |
+|---|---|---|---|
+| `embedding` | `ttnn.embedding` | 0.999999 | 1.95e-03 |
+| `native_layer_norm` | `ttnn.layer_norm` | 0.999996 | 7.01e-02 |
+| `add` + `native_layer_norm` | `ttnn.layer_norm(residual_input_tensor=)` | 0.999996 | 6.22e-02 |
+| `_to_copy` | `ttnn.typecast`, fp32 to bf16 | 0.999999 | 1.54e-02 |
+| `view`, `_unsafe_view` | `ttnn.reshape` | exact | 0 |
+
+### Projections
+
+`aten.t` is folded into weight preparation by `transpose_linear_weight`: the checkpoint stores
+`[out, in]` and `ttnn.linear` wants `[in, out]`. The router is the one bias-free projection, so
+it lowers from `mm` rather than `addmm`.
+
+| aten | TTNN | PCC | max-abs |
+|---|---|---|---|
+| `addmm` | `ttnn.linear`, `attn.Wqkv` 768 to 2304 | 0.999996 | 5.85e-02 |
+| `addmm` | `ttnn.linear`, `attn.out_proj` 768 to 768 | 0.999996 | 7.91e-02 |
+| `addmm` | `ttnn.linear`, `mlp.fc1` 768 to 3072 | 0.999996 | 8.53e-02 |
+| `addmm` | `ttnn.linear`, `mlp.fc2` 3072 to 768 | 0.999996 | 9.75e-02 |
+| `mm` | `ttnn.linear`, `mlp.router.layer` 768 to 8, fp32, no bias | 1.000000 | 4.30e-03 |
+
+### Attention
+
+| aten | TTNN | PCC | max-abs |
+|---|---|---|---|
+| `view` + `select` + `permute` | `ttnn.experimental.nlp_create_qkv_heads` | 0.999999 | 1.48e-02 |
+| `cat` + `neg` + `split` + `mul` | `ttnn.experimental.rotary_embedding_hf` | 0.999994 | 4.29e-02 |
+| `bmm` + `mul` + `_safe_softmax` + `bmm` | `ttnn.transformer.scaled_dot_product_attention` | 0.999758 | 1.73e-02 |
+| same, 25% padding, kept rows | same, additive mask | 0.999756 | 2.02e-02 |
+| `permute` + `reshape` | `ttnn.experimental.nlp_concat_heads` | 0.999999 | 1.53e-02 |
+
+### Dense FFN
+
+| aten | TTNN | PCC | max-abs |
+|---|---|---|---|
+| `gelu` | `ttnn.gelu`, accurate | 0.999996 | 1.61e-02 |
+
+### Router
+
+| aten | TTNN | PCC | max-abs |
+|---|---|---|---|
+| `_softmax` | `ttnn.softmax`, HiFi4 + fp32 dest acc | 1.000000 | 1.53e-03 |
+| `topk` | `ttnn.topk`, k=2 over 8, fp32 | exact indices | 0 |
+| dense routing weights | `ttnn.zeros_like` + `ttnn.scatter` | 0.999998 | 1.95e-03 |
+
+The last row has no aten counterpart: it implements `NomicRouter.dense_weights`, which the trace
+never reached because that forward took the ragged path. The inventory's own `zeros_like` and
+`scatter_` belong to that path and are eliminated (section 2).
+
+### Experts
+
+Cumulative: each row consumes the previous row's device output, so the last figure is the whole
+dense-all-experts chain. The tests isolate each operator instead.
+
+| aten | TTNN | PCC | max-abs |
+|---|---|---|---|
+| `matmul` | `ttnn.matmul`, `[1,1,T,768] x [1,8,768,3072]` | 0.999996 | 7.65e-02 |
+| `gelu` | `ttnn.gelu`, `[1,8,T,3072]` | 0.999993 | 7.50e-02 |
+| `matmul` | `ttnn.matmul`, `[1,8,T,3072] x [1,8,3072,768]` | 0.999994 | 4.94e-01 |
+| `mul` | `ttnn.multiply`, gate `[1,8,T,1]` broadcast | 0.999991 | 2.61e-01 |
+| `sum` over experts | `ttnn.experimental.fast_reduce_nc(dims=[1])` | 0.999992 | 2.88e-01 |
+| `add` | `ttnn.add`, shared bias, once after the sum | 0.999991 | 2.95e-01 |
+
+### Pooling and output
+
+Not in the aten inventory, which covers the backbone only. From
+[`ARCHITECTURE.md` section 5](ARCHITECTURE.md#5-embedding-pipeline).
+
+| stage | TTNN | PCC | max-abs |
+|---|---|---|---|
+| mask-weighted mean pool | `ttnn.multiply` + `ttnn.sum` + `ttnn.divide` | 0.999997 | 5.85e-04 |
+| Matryoshka truncation | `ttnn.slice` on the feature axis | 1.000000 | 0 |
+| L2 normalize | `ttnn.multiply` + `ttnn.sum` + `ttnn.rsqrt` | 0.999995 | 8.30e-04 |
+
+## 2. Operators with no TTNN equivalent
+
+None require a fallback. Each is eliminated by a change of formulation, folded into host-side
+preparation, absorbed into a fused device op, or a no-op on this path.
+
+| aten | Disposition |
+|---|---|
+| `nonzero`, `index`, `index_add_`, `_local_scalar_dense`, `max`, `min`, `unbind`, `zeros_like`, `scatter_` | Eliminated. From upstream's ragged expert loop, which gathers each expert's tokens by value. `NomicExperts.dense_forward` replaces them with two broadcast-batch matmuls, a multiply and a reduce; `test_dense_forward_matches_the_ragged_loop` proves the two agree. |
+| `t` | Host. `transpose_linear_weight` reorients each `nn.Linear` weight once at load. |
+| `arange`, `cos`, `sin`, `slice` | Host. The rotary tables are built once by `rotary_tables`, already trimmed to seqlen, so the reference's `cos[:seqlen]` has nothing to do on device. |
+| `rsub`, `mul`, `unsqueeze` on the mask | Host. `additive_attention_mask` turns the (B, S) keep-mask into the additive `(B, 1, S, S)` form. |
+| `stack`, `split`, `neg`, `cat` | Absorbed into `rotary_embedding_hf`. |
+| `mul.Scalar`, `transpose`, `_safe_softmax` | Absorbed into SDPA, which applies its own `1/sqrt(head_dim)` scale. |
+| `alias`, `clone`, `expand` | No-ops on this path. |
+| `zeros` | Folded away. The `token_type_ids` default, `torch.zeros(S)`. `type_vocab_size` is 1, so the lookup returns one constant row per token and collapses into a bias on the word embedding. |
+
+All 42 inventory rows are accounted for by this table and section 1, over 41 distinct names:
+`mul` appears as both `mul.Tensor` and `mul.Scalar`.
+
+## 3. API differences
+
+| Operator | Difference |
+|---|---|
+| `ttnn.linear` | Wants `[in, out]`; torch stores `[out, in]` and applies `x @ w.T`. Forgetting the transpose raises on four of the five projections, but `attn.out_proj` is 768x768, so it typechecks and returns noise (PCC 0.001 to 0.004). |
+| `ttnn.layer_norm` | `residual_input_tensor=` fuses the post-norm residual add. All 24 encoder norms use it. |
+| `ttnn.embedding` | Index tensor must be `uint32` in `ROW_MAJOR`; `layout=` selects the output layout. `padding_idx=` does not zero the row on this path, so it is neither a hazard nor a safeguard. |
+| `ttnn.transformer.scaled_dot_product_attention` | `is_causal` defaults to `True`; torch's defaults to `False`. Omitting it on this encoder applies a decoder mask and drops PCC to 0.44. |
+| `ttnn.topk` | Returns `(values, indices)`; index dtype follows the input, `uint32` from fp32 and `uint16` from bf16. Both feed `ttnn.scatter` directly. |
+| `ttnn.experimental.fast_reduce_nc` | Replaces `sum` over dim 0, 1 or both, keeping the reduced dim at size 1. Returns the **tile-padded** row count: `T=74` gives 96 rows, the trailing 22 zero, so slice back to `T`. `ttnn.sum` reaches the same PCC without the quirk. |
+| `ttnn.experimental.rotary_embedding_hf` | Prefill mode needs a leading batch of 1, so `(B, A, S, D)` is folded to `(1, B*A, S, D)`. cos/sin are `(1, 1, S, D)` and broadcast over heads. |
+| `ttnn.experimental.nlp_create_qkv_heads` | Takes `(B, 1, S, 3H)` and returns all three heads at once. `transpose_k_heads=False`, since SDPA wants K as `(B, A, S, D)`. |
+
+## 4. Shape, dtype and layout constraints
+
+- Tiles are 32x32 only. TinyTile is broken on Blackhole (#31385).
+- Canonical activation layout is `(1, 1, B*S, H)`. Attention and pooling need `(B, 1, S, H)`:
+  attention mixes tokens along S, pooling reduces along it, and both would cross the batch
+  boundary if it were flattened away. The reshape between the two is exact, and free only when
+  B is 1 or S is a multiple of 32.
+- `rotary_embedding_hf` requires a padded head_dim of 32 or a multiple of 64. This model's 64
+  qualifies.
+- **SDPA rejects a `(B, 1, 1, S)` mask** with `mask_shape[2] == q_shape[2]`. Torch broadcasts
+  that shape over queries; ttnn does not. Only the head axis may stay singleton, so
+  `additive_attention_mask` materialises `(B, 1, S, S)`. At `B=2, S=512` that is 1 MB.
+- **The mask's tile padding must be dtype-min, not the 0 a TILE conversion defaults to.** S
+  rounds up to a multiple of 32 and 0 means "attend here", so SDPA counts the pad columns in
+  the softmax denominator. At `S=37` that took the output norm to 0.69x. Build the mask in
+  ROW_MAJOR and convert with `ttnn.to_layout(..., pad_value=finfo.min)`.
+- `ttnn.scatter` rejects fp32 in both TILE and ROW_MAJOR
+  (`!(input_dtype == DataType::FLOAT32 && input_layout == Layout::TILE)`). Only the destination
+  and the scattered values need casting; the index does not.
+- `ttnn.topk` accepts fp32, bf16 and `bfloat8_b`, but is only correct on the first two.
+- The MoE transient is `(1, E, T, F)`, about 50 MB at `T=1024` in bf16. It scales with batch
+  times sequence length, not sequence length alone.
+
+## 5. Negative controls
+
+Nine ways to get an operator wrong that produce finite, plausible output. Each has a test.
+
+| Control | Measured | Test |
+|---|---|---|
+| `ttnn.softmax` without the full config | max-abs 2.7e-02 to 3.0e-02 stock, 5.4e-03 to 6.8e-03 with HiFi4 alone, 1.4e-03 to 1.9e-03 with both. Budget is 5e-03, so HiFi4 on its own does not reach it, though only just. `numeric_stable=True` measures identically to stock. | `test_softmax_needs_both_hifi4_and_fp32_accumulation` |
+| `ttnn.gelu(fast_and_approximate_mode=True)` | max-abs 2.34e-02 in fp32 vs 1.19e-06 accurate. Above the bf16 noise floor of 1.6e-02, so it is not swamped by it. The repo's BERT idiom `fused_activation=(ttnn.UnaryOpType.GELU, True)` selects this LUT. | `test_gelu_fast_mode_is_worse_than_the_bfloat16_noise_floor` |
+| Head-major Wqkv view | PCC 0.082 | `test_head_major_qkv_view_is_decorrelated` |
+| Attention mask left with 0 tile padding | Norm 0.69x at `S=37`, 0.96x at `S=513`. PCC is near-blind to it, moving 0.9998 to 0.9974 at `S=37` and not at all at `S=513`, so this is gated on the norm. | `test_all_ones_mask_matches_no_mask` |
+| SDPA left at its default `is_causal=True` | PCC 0.44. Keeps more correlation than the layout controls, since it averages a subset of the same values rather than the wrong ones. | `test_causal_attention_is_decorrelated` |
+| Interleaved (GPT-J) rotary tables | PCC 0.209 | `test_interleaved_rotary_tables_are_decorrelated` |
+| Rounding router probabilities to bf16 before `topk` | Reroutes 0.34% to 0.59% of tokens. bf16 quantizes an 8-wide row coarsely enough to turn near-ties into exact ties, which torch and ttnn order differently. | `test_rounding_probabilities_to_bfloat16_before_topk_flips_routing` |
+| `ttnn.topk` on `bfloat8_b` | Accepted, 1010/1024 rows wrong. A tile-wide shared exponent flattens an 8-wide probability row. | `test_topk_on_bfloat8_b_is_silently_wrong` |
+| Shared expert bias added inside the loop | PCC 0.9999+, so only max-abs sees it. | `test_shared_bias_must_be_added_after_the_weighted_sum` |
+
+Two more raise instead, and are asserted as such:
+
+| Control | Error | Test |
+|---|---|---|
+| `w2` viewed `(E, H, F)` | `a_shape[-1] == b_shape[-2]`. In torch this view succeeds and computes noise, because `E*F*H` is symmetric in F and H. Packing to `(1, E, F, H)` moves the mistake into the matmul's inner-dimension check. | `test_transposed_expert_weights_are_a_shape_error` |
+| `ttnn.scatter` on fp32 | `!(input_dtype == DataType::FLOAT32 && input_layout == Layout::TILE)` | `test_scatter_rejects_float32` |

--- a/models/experimental/nomic_embed_text_v2_moe/tests/conftest.py
+++ b/models/experimental/nomic_embed_text_v2_moe/tests/conftest.py
@@ -16,6 +16,7 @@ from models.experimental.nomic_embed_text_v2_moe.reference.loader import (
     load_pretrained_reference_model,
     load_state_dict_from_safetensors,
 )
+from models.experimental.nomic_embed_text_v2_moe.tt.model_config import TtModelConfig
 
 
 def pytest_configure(config):
@@ -71,6 +72,16 @@ def tokenizer():
         return load_tokenizer()
     except Exception as exc:
         pytest.skip(f"could not load the tokenizer: {type(exc).__name__}: {exc}")
+
+
+@pytest.fixture
+def tt_config(device):
+    """TTNN dtypes, layout and the compute kernel config bound to the test device.
+
+    Function-scoped and cheap: it only reads the grid and architecture off an already-open
+    device. Requesting it is what makes a test device-bound.
+    """
+    return TtModelConfig.from_device(device)
 
 
 @pytest.fixture(autouse=True)

--- a/models/experimental/nomic_embed_text_v2_moe/tests/pcc/test_ttnn_operators.py
+++ b/models/experimental/nomic_embed_text_v2_moe/tests/pcc/test_ttnn_operators.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-operator PCC validation for everything outside attention and the MoE FFN.
+
+Each test exercises one TTNN operator at this model's shapes, under the settings
+tt/model_config.py will run it with, against the torch operator the reference uses. Clearing
+these first means a later module failure is a composition bug, not a kernel surprise.
+
+Weight operands come from the real checkpoint wherever dynamic range matters, since a bf16
+matmul's error tracks the operand distribution and randn(0, 1) is not that distribution.
+Activation-only operators use seeded random tensors and need no checkpoint.
+
+Measured results are tabulated in docs/OPERATOR_MAPPING.md.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+from models.common.metrics import compute_max_abs_error
+from models.common.utility_functions import run_for_blackhole
+from models.experimental.nomic_embed_text_v2_moe.common import TOKENIZER
+from models.experimental.nomic_embed_text_v2_moe.reference.postprocessing import l2_normalize, mean_pool
+from models.experimental.nomic_embed_text_v2_moe.tt.common import (
+    flatten_tokens,
+    to_device,
+    transpose_linear_weight,
+    unflatten_tokens,
+)
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+pytestmark = [run_for_blackhole(), pytest.mark.use_module_device]
+
+# Every operator in this file clears this at model shapes in bfloat16, all of them at 0.99999
+# or better. SDPA, in the attention file, is the only one that comes close at 0.9998. Dropping
+# the gate to accommodate a regression would hide the class of bug these tests exist to catch.
+OPERATOR_PCC = 0.999
+
+# (batch, seqlen). 37 is deliberately off-tile: padding bugs only surface when S is not a
+# multiple of 32, and S is the batch's longest tokenized sequence, so that is the common case.
+TOKEN_SHAPES = [(1, 128), (2, 512), (2, 37)]
+
+
+def ids_tensor(batch: int, seqlen: int, device) -> tuple[torch.Tensor, ttnn.Tensor]:
+    """Random token ids, as torch and as the uint32 ROW_MAJOR tensor ttnn.embedding indexes with."""
+    ids = torch.randint(0, TOKENIZER.length, (batch, seqlen), dtype=torch.int64)
+    return ids, ttnn.from_torch(ids.to(torch.uint32), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+
+# Embeddings.
+
+
+@pytest.mark.needs_weights
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_embedding(device, tt_config, state_dict, batch, seqlen):
+    """aten.embedding -> ttnn.embedding, against the real 250048 x 768 table."""
+    table = state_dict["embeddings.word_embeddings.weight"]
+    ids, ids_tt = ids_tensor(batch, seqlen, device)
+
+    out = ttnn.embedding(
+        ids_tt,
+        to_device(table, device, dtype=tt_config.weight_dtype, layout=ttnn.ROW_MAJOR_LAYOUT),
+        layout=tt_config.layout,
+        dtype=tt_config.activation_dtype,
+    )
+
+    assert_with_pcc(torch.nn.functional.embedding(ids, table), out, OPERATOR_PCC)
+
+
+@pytest.mark.needs_weights
+def test_embedding_reproduces_the_trained_pad_row(device, tt_config, config, state_dict):
+    """The <pad> row is trained and non-zero, so it must survive the lookup.
+
+    nn.Embedding(padding_idx=...) zeroes it at init only; loading the checkpoint overwrites it.
+    Zeroing it here would silently change every padded batch.
+    """
+    table = state_dict["embeddings.word_embeddings.weight"]
+    pad_ids = ttnn.from_torch(
+        torch.full((1, ttnn.TILE_SIZE), config.pad_token_id, dtype=torch.uint32),
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+
+    out = ttnn.to_torch(
+        ttnn.embedding(
+            pad_ids,
+            to_device(table, device, dtype=tt_config.weight_dtype, layout=ttnn.ROW_MAJOR_LAYOUT),
+            layout=tt_config.layout,
+            dtype=tt_config.activation_dtype,
+        )
+    ).float()
+
+    assert table[config.pad_token_id].abs().max() > 0
+    assert compute_max_abs_error(out, table[config.pad_token_id].expand_as(out)) < 1e-3
+
+
+# Normalization.
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_layer_norm(device, tt_config, config, batch, seqlen):
+    """aten.native_layer_norm -> ttnn.layer_norm."""
+    hidden = config.hidden_size
+    x = torch.randn(1, 1, batch * seqlen, hidden)
+    weight, bias = torch.randn(hidden), torch.randn(hidden)
+
+    out = ttnn.layer_norm(
+        to_device(x, device),
+        weight=to_device(weight, device),
+        bias=to_device(bias, device),
+        epsilon=config.layer_norm_epsilon,
+        compute_kernel_config=tt_config.compute_kernel_config,
+    )
+
+    ref = torch.nn.functional.layer_norm(x, (hidden,), weight, bias, eps=config.layer_norm_epsilon)
+    assert_with_pcc(ref, out, OPERATOR_PCC)
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_layer_norm_fuses_the_post_norm_residual(device, tt_config, config, batch, seqlen):
+    """aten.add + aten.native_layer_norm -> one ttnn.layer_norm(residual_input_tensor=...).
+
+    Every block is post-norm, norm(sub_block(x) + x), so this fused form is what all 24 norms
+    in the encoder use.
+    """
+    hidden = config.hidden_size
+    x = torch.randn(1, 1, batch * seqlen, hidden)
+    residual = torch.randn(1, 1, batch * seqlen, hidden)
+    weight, bias = torch.randn(hidden), torch.randn(hidden)
+
+    out = ttnn.layer_norm(
+        to_device(x, device),
+        residual_input_tensor=to_device(residual, device),
+        weight=to_device(weight, device),
+        bias=to_device(bias, device),
+        epsilon=config.layer_norm_epsilon,
+        compute_kernel_config=tt_config.compute_kernel_config,
+    )
+
+    ref = torch.nn.functional.layer_norm(x + residual, (hidden,), weight, bias, eps=config.layer_norm_epsilon)
+    assert_with_pcc(ref, out, OPERATOR_PCC)
+
+
+# Projections.
+
+
+@pytest.mark.needs_weights
+@pytest.mark.parametrize(
+    "key, in_dim_is_ffn",
+    [
+        ("encoder.layers.0.attn.Wqkv", False),
+        ("encoder.layers.0.attn.out_proj", False),
+        ("encoder.layers.0.mlp.fc1", False),
+        ("encoder.layers.0.mlp.fc2", True),
+    ],
+)
+def test_linear(device, tt_config, config, state_dict, key, in_dim_is_ffn):
+    """aten.addmm -> ttnn.linear, at each of the four biased projection widths."""
+    weight, bias = state_dict[key + ".weight"], state_dict[key + ".bias"]
+    in_dim = config.intermediate_size if in_dim_is_ffn else config.hidden_size
+    x = torch.randn(1, 1, 512, in_dim)
+
+    out = ttnn.linear(
+        to_device(x, device),
+        to_device(transpose_linear_weight(weight), device, dtype=tt_config.weight_dtype),
+        bias=to_device(bias, device, dtype=tt_config.weight_dtype),
+        compute_kernel_config=tt_config.compute_kernel_config,
+    )
+
+    assert_with_pcc(torch.nn.functional.linear(x, weight, bias), out, OPERATOR_PCC)
+
+
+# Activation.
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_gelu(device, config, batch, seqlen):
+    """aten.gelu -> ttnn.gelu, exact erf, at the dense FFN's intermediate width."""
+    x = torch.randn(1, 1, batch * seqlen, config.intermediate_size)
+
+    out = ttnn.gelu(to_device(x, device))
+
+    assert_with_pcc(torch.nn.functional.gelu(x, approximate="none"), out, OPERATOR_PCC)
+
+
+def test_gelu_fast_mode_is_worse_than_the_bfloat16_noise_floor(device, config):
+    """Negative control: the LUT variant's error is not swamped by bf16 rounding.
+
+    Run in fp32, where the two are separable at all. The repo's BERT idiom
+    fused_activation=(ttnn.UnaryOpType.GELU, True) selects the LUT, which is why the port does
+    not copy it.
+    """
+    x = torch.randn(1, 1, 512, config.intermediate_size)
+    ref = torch.nn.functional.gelu(x, approximate="none")
+    x_tt = to_device(x, device, dtype=ttnn.float32)
+
+    accurate = compute_max_abs_error(ttnn.to_torch(ttnn.gelu(x_tt)).float(), ref)
+    approximate = compute_max_abs_error(ttnn.to_torch(ttnn.gelu(x_tt, fast_and_approximate_mode=True)).float(), ref)
+
+    assert accurate < 1e-5, f"expected the accurate variant to be exact to 1e-5 in fp32, got {accurate:.3e}"
+    assert approximate > 1e-2, f"expected the LUT to be visibly worse, got {approximate:.3e}"
+
+
+# Layout.
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_token_axis_reshape_round_trip_is_exact(device, config, batch, seqlen):
+    """aten.view -> ttnn.reshape, between the two activation layouts.
+
+    Exactness matters because this runs twice per block; a lossy reshape would compound over 12
+    blocks in a way a per-operator PCC gate would not catch.
+    """
+    x = to_device(torch.randn(batch, 1, seqlen, config.hidden_size), device)
+
+    flat = flatten_tokens(x)
+    assert tuple(flat.shape) == (1, 1, batch * seqlen, config.hidden_size)
+    assert torch.equal(ttnn.to_torch(unflatten_tokens(flat, batch, seqlen)), ttnn.to_torch(x))
+
+
+def test_typecast(device, config):
+    """aten._to_copy -> ttnn.typecast, the fp32-to-bf16 step the router needs before scatter."""
+    x = torch.randn(1, 1, 512, config.hidden_size)
+
+    out = ttnn.typecast(to_device(x, device, dtype=ttnn.float32), ttnn.bfloat16)
+
+    assert out.dtype == ttnn.bfloat16
+    assert_with_pcc(x, out, OPERATOR_PCC)
+
+
+# Pooling and output, the tensor half of reference/postprocessing.py.
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_mean_pool_excludes_padding(device, config, batch, seqlen):
+    """Mask-weighted mean over the sequence axis: ttnn.mul, ttnn.sum, ttnn.div.
+
+    Padding has to be excluded because the <pad> embedding is non-zero, so counting it would
+    make a text's embedding depend on its batch-mates.
+    """
+    hidden = config.hidden_size
+    x = torch.randn(batch, 1, seqlen, hidden)
+    mask = torch.ones(batch, seqlen, dtype=torch.long)
+    mask[0, (seqlen * 3) // 4 :] = 0
+
+    x_tt = to_device(x, device)
+    mask_tt = to_device(mask.reshape(batch, 1, seqlen, 1).float(), device)
+    pooled = ttnn.divide(
+        ttnn.sum(ttnn.multiply(x_tt, mask_tt), dim=2, keepdim=True), ttnn.sum(mask_tt, dim=2, keepdim=True)
+    )
+
+    ref = mean_pool(x.squeeze(1), mask).reshape(batch, 1, 1, hidden)
+    assert_with_pcc(ref, pooled, OPERATOR_PCC)
+
+
+@pytest.mark.parametrize("dim", [768, 512, 256, 128])
+def test_matryoshka_truncate(device, config, dim):
+    """aten.slice -> ttnn.slice, on the feature axis.
+
+    Upstream's matryoshka_dim slices the sequence axis instead, which is a different operation
+    and not what the published embeddings use.
+    """
+    batch = 2
+    x = torch.randn(batch, 1, 1, config.hidden_size)
+
+    out = ttnn.slice(to_device(x, device), [0, 0, 0, 0], [batch, 1, 1, dim])
+
+    assert tuple(out.shape) == (batch, 1, 1, dim)
+    assert_with_pcc(x[..., :dim], out, OPERATOR_PCC)
+
+
+@pytest.mark.parametrize("batch", [1, 2])
+def test_l2_normalize(device, config, batch):
+    """Unit-norm the pooled embedding: ttnn.mul, ttnn.sum, ttnn.rsqrt.
+
+    Runs after pooling, so the sequence axis is already gone and only batch varies.
+    """
+    x = torch.randn(batch, 1, 1, config.hidden_size)
+
+    x_tt = to_device(x, device)
+    out = ttnn.multiply(x_tt, ttnn.rsqrt(ttnn.sum(ttnn.multiply(x_tt, x_tt), dim=-1, keepdim=True)))
+
+    assert_with_pcc(l2_normalize(x), out, OPERATOR_PCC)
+
+
+# Device configuration.
+
+
+def test_core_grid_is_read_from_the_device(device, tt_config):
+    """The grid must come from the device, not a constant copied out of another model.
+
+    models/tt_transformers/tt/model_config.py implies (8, 10); this p300c reports 11x10, and a
+    program config sized for the smaller grid would silently leave cores idle.
+    """
+    grid = device.compute_with_storage_grid_size()
+
+    assert (tt_config.core_grid.x, tt_config.core_grid.y) == (grid.x, grid.y)

--- a/models/experimental/nomic_embed_text_v2_moe/tests/pcc/test_ttnn_operators_attention.py
+++ b/models/experimental/nomic_embed_text_v2_moe/tests/pcc/test_ttnn_operators_attention.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-operator PCC validation for the attention sub-block.
+
+Four device operators stand in for the reference's whole attention path. Three of them encode
+a convention that the wrong choice satisfies just as well:
+
+  nlp_create_qkv_heads   three-major [q | k | v], not head-major
+  rotary_embedding_hf    NeoX half-split with concat-widened tables, not GPT-J interleaved
+  SDPA                   bidirectional, not causal
+
+Each produces finite, plausible output taken the other way, so each carries a negative control
+alongside its PCC test. The causal one is the easiest to hit by accident: ttnn's is_causal
+defaults to True where torch's defaults to False.
+
+Activations only, so no checkpoint is needed. Measured results are in docs/OPERATOR_MAPPING.md.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+from models.common.metrics import compute_pcc
+from models.common.utility_functions import run_for_blackhole
+from models.experimental.nomic_embed_text_v2_moe.reference.modeling_nomic_moe import (
+    NomicBertRotaryEmbedding,
+    apply_rotary_emb,
+    build_extended_attention_mask,
+)
+from models.experimental.nomic_embed_text_v2_moe.tt.common import additive_attention_mask, rotary_tables, to_device
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+pytestmark = [run_for_blackhole(), pytest.mark.use_module_device]
+
+# SDPA is the tightest operator in the model at 0.9998, accumulating over the full key axis in
+# bf16; everything else here reaches 0.99999.
+OPERATOR_PCC = 0.999
+
+# A wrong layout does not lose precision, it decorrelates: the two layout controls measure 0.08
+# (head-major) and 0.21 (interleaved rotary). Anything under this is the wrong tensor.
+DECORRELATED_PCC = 0.5
+
+# (batch, seqlen). 37 is deliberately off-tile: padding bugs only surface when S is not a
+# multiple of 32, and S is the batch's longest tokenized sequence, so that is the common case.
+TOKEN_SHAPES = [(1, 128), (2, 512), (2, 37)]
+
+
+def reference_cos_sin(config, seqlen: int):
+    """Half-width cos/sin tables as NomicBertRotaryEmbedding caches them, (S, D // 2)."""
+    rotary = NomicBertRotaryEmbedding(dim=config.rotary_dim, base=config.rotary_emb_base)
+    rotary._update_cos_sin_cache(seqlen, device=torch.device("cpu"), dtype=torch.float32)
+    return rotary._cos_cached, rotary._sin_cached
+
+
+def fold_batch_into_heads(x: torch.Tensor) -> torch.Tensor:
+    """(B, A, S, D) -> (1, B*A, S, D), the prefill layout rotary_embedding_hf takes.
+
+    The op's prefill mode wants a leading batch of 1. cos/sin are (1, 1, S, D) and broadcast
+    over the head axis, so folding batch into heads applies the same table to every row.
+    """
+    batch, heads, seqlen, head_dim = x.shape
+    return x.reshape(1, batch * heads, seqlen, head_dim)
+
+
+# Head splitting.
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+@pytest.mark.parametrize("index", [pytest.param(0, id="query"), pytest.param(1, id="key"), pytest.param(2, id="value")])
+def test_nlp_create_qkv_heads(device, config, batch, seqlen, index):
+    """aten.view + aten.select + aten.permute -> ttnn.experimental.nlp_create_qkv_heads.
+
+    Wqkv is three-major: q, k and v are contiguous blocks of hidden_size with heads contiguous
+    inside each.
+    """
+    heads, head_dim = config.num_attention_heads, config.head_dim
+    qkv = torch.randn(batch, 1, seqlen, config.qkv_dim)
+
+    parts = ttnn.experimental.nlp_create_qkv_heads(
+        to_device(qkv, device), num_heads=heads, num_kv_heads=heads, transpose_k_heads=False
+    )
+
+    ref = qkv.view(batch, seqlen, 3, heads, head_dim)[:, :, index].permute(0, 2, 1, 3)
+    assert_with_pcc(ref, parts[index], OPERATOR_PCC)
+
+
+def test_head_major_qkv_view_is_decorrelated(device, config):
+    """Negative control: reading Wqkv head-major strides across the q/k/v boundaries.
+
+    The element count is the same either way, so the reshape succeeds and every downstream op
+    typechecks.
+    """
+    batch, seqlen = 2, 128
+    heads, head_dim = config.num_attention_heads, config.head_dim
+    qkv = torch.randn(batch, 1, seqlen, config.qkv_dim)
+
+    query, _, _ = ttnn.experimental.nlp_create_qkv_heads(
+        to_device(qkv, device), num_heads=heads, num_kv_heads=heads, transpose_k_heads=False
+    )
+
+    got = ttnn.to_torch(query).float()
+    three_major = qkv.view(batch, seqlen, 3, heads, head_dim)[:, :, 0].permute(0, 2, 1, 3)
+    head_major = qkv.view(batch, seqlen, heads, 3, head_dim)[:, :, :, 0].permute(0, 2, 1, 3)
+
+    # Guards against a vacuous pass: compute_pcc returns 0.0 on a broken comparison.
+    assert compute_pcc(got, three_major) > OPERATOR_PCC
+    assert compute_pcc(got, head_major) < DECORRELATED_PCC
+
+
+# Rotary.
+
+
+@pytest.mark.parametrize("seqlen", [128, 512])
+def test_rotary_tables_match_the_reference(device, config, seqlen):
+    """The tables come from tt_transformers' get_rot_mats_hf; this is the guard on that reuse.
+
+    Its unscaled path computes the same inv_freq, outer product and concat widening the
+    reference does, so the two are bit-exact in fp32. If a change upstream ever breaks that,
+    this fails before any rotated tensor does.
+    """
+    cos_tt, sin_tt = rotary_tables(device, config, seqlen, dtype=ttnn.float32)
+    cos_ref, sin_ref = reference_cos_sin(config, seqlen)
+
+    assert torch.equal(ttnn.to_torch(cos_tt), torch.cat((cos_ref, cos_ref), dim=-1)[None, None])
+    assert torch.equal(ttnn.to_torch(sin_tt), torch.cat((sin_ref, sin_ref), dim=-1)[None, None])
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_rotary_embedding_hf(device, config, batch, seqlen):
+    """aten.cos + sin + cat + neg + split + mul -> ttnn.experimental.rotary_embedding_hf."""
+    heads, head_dim = config.num_attention_heads, config.head_dim
+    x = torch.randn(batch, seqlen, heads, head_dim)
+    cos_ref, sin_ref = reference_cos_sin(config, seqlen)
+    cos_tt, sin_tt = rotary_tables(device, config, seqlen)
+
+    x_tt = to_device(fold_batch_into_heads(x.permute(0, 2, 1, 3)), device)
+    out = ttnn.experimental.rotary_embedding_hf(x_tt, cos_tt, sin_tt, is_decode_mode=False)
+
+    ref = apply_rotary_emb(x, cos_ref, sin_ref).permute(0, 2, 1, 3)
+    assert_with_pcc(ref, ttnn.to_torch(out).reshape(batch, heads, seqlen, head_dim), OPERATOR_PCC)
+
+
+def test_rotary_at_position_zero_is_the_identity(device, config):
+    """Analytic anchor: position 0 has cos 1 and sin 0, so the rotation must leave x alone.
+
+    A PCC test against a reference that shares the port's own convention cannot catch a
+    convention that is wrong on both sides. This one does not depend on the reference at all.
+    """
+    heads, head_dim = config.num_attention_heads, config.head_dim
+    x = torch.randn(1, heads, ttnn.TILE_SIZE, head_dim)
+    cos_tt, sin_tt = rotary_tables(device, config, ttnn.TILE_SIZE)
+
+    out = ttnn.to_torch(
+        ttnn.experimental.rotary_embedding_hf(to_device(x, device), cos_tt, sin_tt, is_decode_mode=False)
+    ).float()
+
+    assert_with_pcc(x[:, :, 0], out[:, :, 0], 0.9999)
+
+
+def test_interleaved_rotary_tables_are_decorrelated(device, config):
+    """Negative control: GPT-J lane pairing under the kernel's NeoX rotate-half.
+
+    repeat_interleave instead of concat is the other plausible way to widen the half-dim
+    tables. Combined with half-split rotation it is not a rotation and does not preserve the
+    per-plane norm, but it runs and produces finite output.
+    """
+    batch, seqlen = 2, 128
+    heads, head_dim = config.num_attention_heads, config.head_dim
+    x = torch.randn(batch, seqlen, heads, head_dim)
+    cos_ref, sin_ref = reference_cos_sin(config, seqlen)
+
+    x_tt = to_device(fold_batch_into_heads(x.permute(0, 2, 1, 3)), device)
+    out = ttnn.experimental.rotary_embedding_hf(
+        x_tt,
+        to_device(torch.repeat_interleave(cos_ref, 2, dim=-1)[None, None], device),
+        to_device(torch.repeat_interleave(sin_ref, 2, dim=-1)[None, None], device),
+        is_decode_mode=False,
+    )
+
+    correct = ttnn.experimental.rotary_embedding_hf(x_tt, *rotary_tables(device, config, seqlen), is_decode_mode=False)
+    ref = apply_rotary_emb(x, cos_ref, sin_ref).permute(0, 2, 1, 3)
+    shape = (batch, heads, seqlen, head_dim)
+
+    # Guards against a vacuous pass: compute_pcc returns 0.0 on a broken comparison.
+    assert compute_pcc(ttnn.to_torch(correct).reshape(shape).float(), ref) > OPERATOR_PCC
+    assert compute_pcc(ttnn.to_torch(out).reshape(shape).float(), ref) < DECORRELATED_PCC
+
+
+# Attention proper.
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_sdpa_unmasked(device, tt_config, config, batch, seqlen):
+    """aten.bmm + aten.mul + aten._safe_softmax + aten.bmm -> one SDPA call.
+
+    is_causal is always passed explicitly: ttnn defaults it to True, torch to False, and this
+    is an encoder.
+    """
+    heads, head_dim = config.num_attention_heads, config.head_dim
+    query, key, value = (torch.randn(batch, heads, seqlen, head_dim) for _ in range(3))
+
+    out = ttnn.transformer.scaled_dot_product_attention(
+        to_device(query, device),
+        to_device(key, device),
+        to_device(value, device),
+        is_causal=False,
+        compute_kernel_config=tt_config.compute_kernel_config,
+    )
+
+    ref = torch.nn.functional.scaled_dot_product_attention(query, key, value, is_causal=False)
+    assert_with_pcc(ref, out, OPERATOR_PCC)
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_sdpa_with_ragged_padding(device, tt_config, config, batch, seqlen):
+    """The same call with a 25%-padded additive mask, compared on kept positions.
+
+    The mask carries dtype-min at padded keys. Nothing here is fully masked, so no row
+    degenerates, but the output is still checked for finiteness because a saturating fill value
+    is the way that would show up.
+    """
+    heads, head_dim = config.num_attention_heads, config.head_dim
+    keep = (seqlen * 3) // 4
+    mask = torch.ones(batch, seqlen, dtype=torch.long)
+    mask[:, keep:] = 0
+    query, key, value = (torch.randn(batch, heads, seqlen, head_dim) for _ in range(3))
+
+    out = ttnn.transformer.scaled_dot_product_attention(
+        to_device(query, device),
+        to_device(key, device),
+        to_device(value, device),
+        attn_mask=additive_attention_mask(mask, device),
+        is_causal=False,
+        compute_kernel_config=tt_config.compute_kernel_config,
+    )
+
+    ref = torch.nn.functional.scaled_dot_product_attention(
+        query, key, value, attn_mask=build_extended_attention_mask(mask, torch.float32), is_causal=False
+    )
+    got = ttnn.to_torch(out).float()
+    assert torch.isfinite(got).all(), "dtype-min in the mask saturated somewhere"
+    assert_with_pcc(ref[:, :, :keep], got[:, :, :keep], OPERATOR_PCC)
+
+
+def test_causal_attention_is_decorrelated(device, tt_config, config):
+    """Negative control: this is an encoder, and ttnn's is_causal defaults to True.
+
+    Omitting the flag silently applies a decoder mask. Every token still gets a finite output,
+    just one computed from its prefix alone. Causal keeps more correlation than the layout
+    controls do, since it averages a subset of the same values rather than the wrong ones.
+    """
+    batch, seqlen = 2, 512
+    heads, head_dim = config.num_attention_heads, config.head_dim
+    query, key, value = (torch.randn(batch, heads, seqlen, head_dim) for _ in range(3))
+    operands = [to_device(t, device) for t in (query, key, value)]
+    ref = torch.nn.functional.scaled_dot_product_attention(query, key, value, is_causal=False)
+
+    def pcc(is_causal):
+        out = ttnn.transformer.scaled_dot_product_attention(
+            *operands, is_causal=is_causal, compute_kernel_config=tt_config.compute_kernel_config
+        )
+        return compute_pcc(ttnn.to_torch(out).float(), ref)
+
+    assert pcc(False) > OPERATOR_PCC
+    causal = pcc(True)
+    assert causal < 0.7, f"causal should sit far from bidirectional, measured 0.43 to 0.48, got {causal:.3f}"
+
+
+@pytest.mark.parametrize("seqlen", [37, 100, 128, 513])
+def test_all_ones_mask_matches_no_mask(device, tt_config, config, seqlen):
+    """A mask that keeps everything must be a no-op. Tile padding is what breaks this.
+
+    The mask is (B, 1, S, S) in TILE layout, so S rounds up to a multiple of 32 and the pad
+    columns take whatever the conversion fills them with. 0 is additively neutral, meaning
+    "attend here", so SDPA counts them in the softmax denominator and the output shrinks: at
+    S=37 the norm was 0.69x before additive_attention_mask padded with dtype-min instead.
+
+    Gated on the norm, not PCC. PCC is insensitive to a near-uniform scale, and at S=513 it
+    did not move at all while the norm was 0.96x.
+    """
+    batch = 2
+    heads, head_dim = config.num_attention_heads, config.head_dim
+    query, key, value = (torch.randn(batch, heads, seqlen, head_dim) for _ in range(3))
+    operands = [to_device(t, device) for t in (query, key, value)]
+
+    def run(mask):
+        out = ttnn.transformer.scaled_dot_product_attention(
+            *operands, attn_mask=mask, is_causal=False, compute_kernel_config=tt_config.compute_kernel_config
+        )
+        return ttnn.to_torch(out).float()
+
+    unmasked = run(None)
+    kept = run(additive_attention_mask(torch.ones(batch, seqlen, dtype=torch.long), device))
+
+    assert torch.equal(kept, unmasked), (
+        f"an all-ones mask changed the result at S={seqlen}; "
+        f"norm ratio {(kept.norm() / unmasked.norm()).item():.4f}"
+    )
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_nlp_concat_heads(device, config, batch, seqlen):
+    """aten.permute + aten.reshape -> ttnn.experimental.nlp_concat_heads."""
+    heads, head_dim = config.num_attention_heads, config.head_dim
+    context = torch.randn(batch, heads, seqlen, head_dim)
+
+    out = ttnn.experimental.nlp_concat_heads(to_device(context, device))
+
+    ref = context.permute(0, 2, 1, 3).reshape(batch, 1, seqlen, config.hidden_size)
+    assert_with_pcc(ref, out, OPERATOR_PCC)

--- a/models/experimental/nomic_embed_text_v2_moe/tests/pcc/test_ttnn_operators_moe.py
+++ b/models/experimental/nomic_embed_text_v2_moe/tests/pcc/test_ttnn_operators_moe.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-operator PCC validation for the router and the expert FFN.
+
+The router's softmax feeds a top-2 selection, so an error large enough to reorder two
+near-tied experts is not a small error: it sends the token to a different pair of
+4.7M-parameter experts. Hence the explicit kernel config on the softmax and fp32 logits held
+until the last moment ttnn.scatter allows.
+
+The expert chain is the dense-all-experts formulation from ARCHITECTURE.md section 4, which
+replaces upstream's data-dependent ragged loop with two broadcast-batch matmuls, a multiply
+and a reduce. Each of those five operators is tested here on its own.
+
+Measured results are tabulated in docs/OPERATOR_MAPPING.md.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+from models.common.metrics import compute_max_abs_error, compute_pcc
+from models.common.utility_functions import run_for_blackhole
+from models.experimental.nomic_embed_text_v2_moe.tt.common import (
+    pack_expert_weights,
+    to_device,
+    transpose_linear_weight,
+)
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+pytestmark = [run_for_blackhole(), pytest.mark.use_module_device]
+
+OPERATOR_PCC = 0.999
+
+# (batch, seqlen). 37 is deliberately off-tile: padding bugs only surface when S is not a
+# multiple of 32, and S is the batch's longest tokenized sequence, so that is the common case.
+TOKEN_SHAPES = [(1, 128), (2, 512), (2, 37)]
+
+# The router softmax's budget. On identical fp32 logits the port's config measures 1.4e-3 to
+# 1.9e-3 across seeds, HiFi4 without fp32 accumulation 5.4e-3 to 6.8e-3, the stock config
+# 2.7e-2 to 3.0e-2. HiFi4 alone clears the budget by as little as 7%, so the control below is
+# seeded rather than left to chance. Gating on max-abs is deliberate: all three exceed 0.9996 PCC.
+SOFTMAX_MAX_ABS = 5e-3
+
+
+def router_probabilities(tokens: int, experts: int) -> torch.Tensor:
+    """A plausible (1, 1, T, E) softmax distribution over experts."""
+    return torch.randn(1, 1, tokens, experts).softmax(dim=-1)
+
+
+# Router.
+
+
+@pytest.mark.needs_weights
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_router_linear(device, tt_config, config, state_dict, batch, seqlen):
+    """aten.mm -> ttnn.linear at the real router weights.
+
+    768 -> 8 is the narrowest matmul in the model, the only bias-free one, and the only one
+    kept in fp32.
+    """
+    weight = state_dict["encoder.layers.1.mlp.router.layer.weight"]
+    x = torch.randn(1, 1, batch * seqlen, config.hidden_size)
+
+    out = ttnn.linear(
+        to_device(x, device, dtype=tt_config.router_dtype),
+        to_device(transpose_linear_weight(weight), device, dtype=tt_config.router_dtype),
+        compute_kernel_config=tt_config.compute_kernel_config,
+    )
+
+    assert_with_pcc(torch.nn.functional.linear(x, weight), out, OPERATOR_PCC)
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_softmax(device, tt_config, config, batch, seqlen):
+    """aten._softmax -> ttnn.softmax with the HiFi4 kernel config, gated on max-abs."""
+    logits = torch.randn(1, 1, batch * seqlen, config.num_experts)
+
+    out = ttnn.softmax(
+        to_device(logits, device, dtype=tt_config.router_dtype),
+        dim=-1,
+        compute_kernel_config=tt_config.compute_kernel_config,
+    )
+
+    ref = logits.softmax(dim=-1)
+    assert_with_pcc(ref, out, OPERATOR_PCC)
+    assert compute_max_abs_error(ttnn.to_torch(out).float(), ref) < SOFTMAX_MAX_ABS
+
+
+def test_softmax_needs_both_hifi4_and_fp32_accumulation(device, tt_config, config):
+    """Negative control: neither half of the kernel config is optional here.
+
+    HiFi4 alone still misses the budget, so the fp32 accumulator is not a refinement on top of
+    it. numeric_stable changes the reduction order rather than the fidelity and measures like
+    the stock config. All four variants score above 0.9996 PCC, so only max-abs separates them.
+    """
+    logits = torch.randn(1, 1, 1024, config.num_experts)
+    ref = logits.softmax(dim=-1)
+    logits_tt = to_device(logits, device, dtype=tt_config.router_dtype)
+    hifi4_only = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    def max_abs(**kwargs):
+        return compute_max_abs_error(ttnn.to_torch(ttnn.softmax(logits_tt, dim=-1, **kwargs)).float(), ref)
+
+    ported = max_abs(compute_kernel_config=tt_config.compute_kernel_config)
+    without_fp32_acc = max_abs(compute_kernel_config=hifi4_only)
+    stock = max_abs()
+    stable = max_abs(numeric_stable=True)
+
+    assert ported < SOFTMAX_MAX_ABS, f"the port's own config missed its budget at {ported:.3e}"
+    assert without_fp32_acc > SOFTMAX_MAX_ABS, f"HiFi4 alone should miss it, got {without_fp32_acc:.3e}"
+    assert stock > without_fp32_acc, f"HiFi4 should beat the stock config, got {stock:.3e}"
+    assert stable > SOFTMAX_MAX_ABS, f"numeric_stable is not a substitute, got {stable:.3e}"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_topk(device, config, dtype, batch, seqlen):
+    """aten.topk -> ttnn.topk over the 8-wide expert axis.
+
+    Indices, not values, are what matter: a flipped index reroutes the token to different
+    experts entirely. Fed the same numbers as torch, the operator picks the same experts with
+    bit-identical weights, so it introduces no routing error of its own.
+
+    The contract asserted is that the chosen experts carry the top-k probabilities, not that
+    the index tensors are equal. In bfloat16 an 8-wide probability row lands on a coarse enough
+    grid that two experts sometimes hold exactly the same value, and torch and ttnn order a tie
+    differently. That is a tie, not a disagreement; fp32 has no ties at these shapes and is
+    checked index for index.
+    """
+    torch_dtype = torch.float32 if dtype == ttnn.float32 else torch.bfloat16
+    probabilities = router_probabilities(batch * seqlen, config.num_experts).to(torch_dtype).float()
+
+    values, indices = ttnn.topk(to_device(probabilities, device, dtype=dtype), k=config.moe_top_k, dim=-1)
+
+    ref_values, ref_indices = torch.topk(probabilities, config.moe_top_k, dim=-1)
+    selected = ttnn.to_torch(indices).long()
+    assert int(selected.max()) < config.num_experts
+    assert torch.equal(ttnn.to_torch(values).float(), ref_values)
+    assert torch.equal(torch.gather(probabilities, -1, selected), ref_values)
+    if dtype == ttnn.float32:
+        assert torch.equal(selected, ref_indices)
+
+
+def test_rounding_probabilities_to_bfloat16_before_topk_flips_routing(device, config):
+    """Why the router stays fp32 through the topk, not just up to it.
+
+    ttnn.scatter rejects fp32, so the chain has to reach bfloat16 somewhere. Casting the
+    probabilities first, then selecting, reroutes 0.34% to 0.59% of tokens: bfloat16 quantizes an
+    8-wide probability row coarsely enough that near-ties collapse into exact ties and the
+    boundary lands on a different expert. Selecting in fp32 and casting only the two chosen
+    weights reroutes none. ttnn.topk accepts fp32 and its uint32 index feeds ttnn.scatter
+    directly, so the later cast costs nothing.
+    """
+    tokens = 4096
+    probabilities = router_probabilities(tokens, config.num_experts)
+    reference = torch.topk(probabilities, config.moe_top_k, dim=-1).indices
+
+    def selection(dtype):
+        _, indices = ttnn.topk(to_device(probabilities, device, dtype=dtype), k=config.moe_top_k, dim=-1)
+        return ttnn.to_torch(indices).long()
+
+    assert torch.equal(selection(ttnn.float32), reference)
+    flipped = int((~(selection(ttnn.bfloat16) == reference).all(dim=-1)).sum())
+    assert flipped > 0, "bfloat16 no longer costs routing decisions; re-check whether fp32 topk still pays"
+
+
+def test_topk_on_bfloat8_b_is_silently_wrong(device, config):
+    """Negative control: bfloat8_b is accepted and returns a wrong selection.
+
+    A tile-wide shared exponent flattens an 8-wide probability row, so the block format that
+    suits weights does not suit this. It does not raise, which is the whole problem.
+    """
+    probabilities = router_probabilities(512, config.num_experts)
+
+    _, indices = ttnn.topk(to_device(probabilities, device, dtype=ttnn.bfloat8_b), k=config.moe_top_k, dim=-1)
+
+    ref_indices = torch.topk(probabilities, config.moe_top_k, dim=-1).indices
+    disagreeing = int((~(ttnn.to_torch(indices).long() == ref_indices).all(dim=-1)).sum())
+    assert disagreeing > 0, "bfloat8_b topk agreed with torch; re-check whether this is still a trap"
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_scatter_builds_the_dense_routing_weights(device, tt_config, config, batch, seqlen):
+    """aten.zeros_like + aten.scatter_ -> ttnn.zeros_like + ttnn.scatter, on the real chain.
+
+    The index comes straight off the fp32 topk as uint32 and needs no cast; only the values and
+    the destination are bfloat16, which is the narrowest cast that satisfies scatter. The dense
+    (T, E) result is what the expert gate multiply consumes: exactly moe_top_k non-zero entries
+    per row, carrying the softmax weights unrenormalized.
+    """
+    probabilities = router_probabilities(batch * seqlen, config.num_experts)
+    values, indices = ttnn.topk(
+        to_device(probabilities, device, dtype=tt_config.router_dtype), k=config.moe_top_k, dim=-1
+    )
+
+    dense = ttnn.scatter(
+        to_device(torch.zeros_like(probabilities), device),
+        dim=-1,
+        index=indices,
+        src=ttnn.typecast(values, tt_config.activation_dtype),
+    )
+
+    ref_values, ref_indices = torch.topk(probabilities, config.moe_top_k, dim=-1)
+    ref = torch.zeros_like(probabilities).scatter_(-1, ref_indices, ref_values)
+    got = ttnn.to_torch(dense).float()
+    assert torch.equal((got != 0).sum(-1), torch.full(got.shape[:-1], config.moe_top_k))
+    assert (got.sum(-1) < 1.0).all(), "the top-k weights must reach the gate unrenormalized"
+    assert_with_pcc(ref, dense, OPERATOR_PCC)
+
+
+def test_scatter_rejects_float32(device, config, expect_error):
+    """Negative control: the router cannot stay fp32 all the way through.
+
+    This restriction is what forces a cast somewhere after the softmax. It does not dictate
+    where: ttnn.topk takes fp32, so the cast lands after the selection rather than before it,
+    which is what test_rounding_probabilities_to_bfloat16_before_topk_flips_routing measures.
+    """
+    probabilities = to_device(router_probabilities(512, config.num_experts), device, dtype=ttnn.float32)
+    values, indices = ttnn.topk(ttnn.typecast(probabilities, ttnn.bfloat16), k=config.moe_top_k, dim=-1)
+
+    with expect_error(RuntimeError, "input_dtype == DataType::FLOAT32"):
+        ttnn.scatter(ttnn.zeros_like(probabilities), dim=-1, index=indices, src=values)
+
+
+# Experts.
+
+
+@pytest.mark.needs_weights
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_expert_matmuls(device, tt_config, config, state_dict, batch, seqlen):
+    """aten.matmul -> broadcast-batch ttnn.matmul, both expert projections.
+
+    (1, 1, T, H) against (1, E, H, F) runs every token through every expert in one call, which
+    is what removes upstream's data-dependent gather. The (1, E, T, F) intermediate is the
+    port's peak transient and scales with batch times sequence length, not sequence length
+    alone.
+    """
+    prefix = "encoder.layers.1.mlp.experts.mlp."
+    w1, w2 = pack_expert_weights(state_dict[prefix + "w1"], state_dict[prefix + "w2"], config)
+    x = torch.randn(1, 1, batch * seqlen, config.hidden_size)
+
+    x_tt = to_device(x, device)
+    hidden = ttnn.matmul(x_tt, to_device(w1, device), compute_kernel_config=tt_config.compute_kernel_config)
+    activated = ttnn.gelu(hidden)
+    out = ttnn.matmul(activated, to_device(w2, device), compute_kernel_config=tt_config.compute_kernel_config)
+
+    ref_hidden = torch.matmul(x, w1)
+    ref_activated = torch.nn.functional.gelu(ref_hidden, approximate="none")
+    assert tuple(hidden.shape) == (1, config.num_experts, batch * seqlen, config.intermediate_size)
+    assert_with_pcc(ref_hidden, hidden, OPERATOR_PCC)
+    assert_with_pcc(ref_activated, activated, OPERATOR_PCC)
+    assert_with_pcc(torch.matmul(ref_activated, w2), out, OPERATOR_PCC)
+
+
+@pytest.mark.needs_weights
+def test_transposed_expert_weights_are_a_shape_error(device, tt_config, config, state_dict, expect_error):
+    """Negative control: on the packed operand, the w2 misorientation is loud.
+
+    Viewing w2 as (E, H, F) instead of (E, F, H) succeeds in torch, because E*F*H is symmetric
+    in F and H, and the reference computes uncorrelated noise from it without raising. Packing
+    to a 4D operand moves the mistake into the matmul's inner-dimension check, so
+    pack_expert_weights is what turns a silent failure into a loud one.
+    """
+    w2 = state_dict["encoder.layers.1.mlp.experts.mlp.w2"]
+    transposed = w2.view(config.num_experts, config.hidden_size, config.intermediate_size).unsqueeze(0)
+    activated = to_device(torch.randn(1, config.num_experts, 128, config.intermediate_size), device)
+
+    with expect_error(RuntimeError, "width of the first tensor must be equal to the height"):
+        ttnn.matmul(
+            activated, to_device(transposed.contiguous(), device), compute_kernel_config=tt_config.compute_kernel_config
+        )
+
+
+@pytest.mark.parametrize("batch, seqlen", TOKEN_SHAPES)
+def test_gate_multiply_and_expert_reduce(device, tt_config, config, batch, seqlen):
+    """aten.mul + aten.sum over the expert axis -> ttnn.mul + fast_reduce_nc(dims=[1]).
+
+    The gate arrives as the dense (1, 1, T, E) routing weights permuted to (1, E, T, 1), whose
+    trailing singleton broadcasts over the hidden axis. Only moe_top_k of the E slots are
+    non-zero, so the reduce is a weighted sum over two experts even though eight were computed.
+
+    fast_reduce_nc returns the tile-padded row count, not T: at T=74 the output is 96 rows, the
+    trailing 22 zero. The data is right, the logical shape is not, so a caller must slice back
+    to T. ttnn.sum(dim=1, keepdim=True) reaches the same PCC without the quirk and is the
+    alternative if that slice ever costs more than it saves.
+    """
+    tokens = batch * seqlen
+    experts, hidden = config.num_experts, config.hidden_size
+    per_expert = torch.randn(1, experts, tokens, hidden)
+    probabilities = router_probabilities(tokens, experts)
+    values, indices = torch.topk(probabilities, config.moe_top_k, dim=-1)
+    dense = torch.zeros_like(probabilities).scatter_(-1, indices, values)
+
+    gate = ttnn.permute(to_device(dense, device), (0, 3, 2, 1))
+    gated = ttnn.multiply(to_device(per_expert, device), gate)
+    summed = ttnn.experimental.fast_reduce_nc(gated, dims=[1], compute_kernel_config=tt_config.compute_kernel_config)
+
+    ref_gated = per_expert * dense.permute(0, 3, 2, 1)
+    padded = -(-tokens // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+    reduced = ttnn.to_torch(summed).float()
+    assert tuple(gate.shape) == (1, experts, tokens, 1)
+    assert tuple(summed.shape) == (1, 1, padded, hidden)
+    if padded > tokens:
+        assert reduced[:, :, tokens:].abs().max() == 0, "fast_reduce_nc padding is expected to be zero"
+    assert_with_pcc(ref_gated, gated, OPERATOR_PCC)
+    assert_with_pcc(ref_gated.sum(dim=1, keepdim=True), reduced[:, :, :tokens], OPERATOR_PCC)
+
+
+@pytest.mark.needs_weights
+def test_shared_bias_must_be_added_after_the_weighted_sum(device, config, state_dict):
+    """aten.add -> ttnn.add, once, outside the reduce. PCC cannot police this.
+
+    The eight experts share one (H,) bias. Adding it inside the per-expert loop scales it by
+    the routed-weight sum, leaving an offset of (sum(w) - 1) * bias. Since the top-2 weights
+    are deliberately not renormalized, that sum is below 1, so the offset is real. It is also
+    nearly constant across tokens, and PCC mean-centres, so the wrong result still correlates
+    above 0.9999. Only max-abs sees it.
+    """
+    tokens, experts, hidden = 512, config.num_experts, config.hidden_size
+    bias = state_dict["encoder.layers.1.mlp.experts.bias"]
+    weighted_sum = torch.randn(1, 1, tokens, hidden)
+    probabilities = router_probabilities(tokens, experts)
+    routed_weight_sum = torch.topk(probabilities, config.moe_top_k, dim=-1).values.sum(-1, keepdim=True)
+    assert (routed_weight_sum < 1.0).all(), "top-k weights are not renormalized, so they must sum below 1"
+
+    sum_tt = to_device(weighted_sum, device)
+    bias_tt = to_device(bias.reshape(1, 1, 1, hidden), device)
+    correct = ttnn.to_torch(ttnn.add(sum_tt, bias_tt)).float()
+    inside_the_loop = ttnn.to_torch(
+        ttnn.add(sum_tt, ttnn.multiply(bias_tt, to_device(routed_weight_sum, device)))
+    ).float()
+
+    assert_with_pcc(weighted_sum + bias, correct, OPERATOR_PCC)
+    assert compute_pcc(inside_the_loop, correct) > 0.9999, "if PCC caught this, the comment above is stale"
+    assert compute_max_abs_error(inside_the_loop, correct) > 1e-3

--- a/models/experimental/nomic_embed_text_v2_moe/tt/__init__.py
+++ b/models/experimental/nomic_embed_text_v2_moe/tt/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/models/experimental/nomic_embed_text_v2_moe/tt/common.py
+++ b/models/experimental/nomic_embed_text_v2_moe/tt/common.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preparation of the tensors the TTNN ops consume.
+
+Weight reorientation and expert packing run once at load and never touch the device; the rotary
+tables and the attention mask are built on the host and returned on device; the two reshapes
+take device tensors.
+
+Two layouts carry the activation between sub-blocks:
+
+    (B, 1, S, H)      attention and pooling, where the batch axis has to stay separate
+    (1, 1, B*S, H)    everything else, one flat token axis
+
+Neither is a preference. Attention mixes tokens along S, so flattening the batch away lets one
+text attend to another: PCC 0.71 against per-sequence attention, a wrong answer rather than a
+less precise one. Pooling also reduces along S, and has to produce one mean per text rather
+than one per batch.
+
+The MoE matmuls force the opposite. ttnn.matmul broadcasts a weight's batch dims only when
+every batch dim of the activation is 1, so (1, 1, T, H) x (1, E, H, F) gives (1, E, T, F) while
+(B, 1, S, H) raises outright. The spare dim at position 1 is what the expert axis expands into
+and what fast_reduce_nc collapses again.
+
+Those two are what crosses a sub-block boundary, not every shape in the model. Sub-blocks take
+others internally, (B, A, S, D) head-split, (1, B*A, S, D) for rotary and (1, E, T, F) across
+the experts, each produced and consumed by the op that owns it.
+
+The flat form keeps tokens batch-major, matching the reference's own x.view(-1, H), so the
+router's per-token weights stay aligned with the expert outputs.
+
+The round trip is exact at every length tested, including ones that are not tile multiples. It
+is free only when B is 1 or S is a multiple of 32, where the batch rows concatenate in place
+and the reshape is pure metadata. Otherwise the tile padding sits in different places in the
+two layouts and the data is physically copied.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import ttnn
+
+from models.experimental.nomic_embed_text_v2_moe.reference.configuration_nomic_moe import NomicMoEConfig
+from models.experimental.nomic_embed_text_v2_moe.reference.modeling_nomic_moe import build_extended_attention_mask
+from models.experimental.nomic_embed_text_v2_moe.tt.model_config import (
+    ACTIVATION_DTYPE,
+    LAYOUT,
+    MEMORY_CONFIG,
+)
+from models.tt_transformers.tt.rope import get_rot_mats_hf
+
+
+def to_device(
+    tensor: torch.Tensor,
+    device,
+    dtype: ttnn.DataType = ACTIVATION_DTYPE,
+    layout: ttnn.Layout = LAYOUT,
+    memory_config: ttnn.MemoryConfig = MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    """Move a torch tensor onto the device under this port's defaults."""
+    return ttnn.from_torch(tensor, dtype=dtype, layout=layout, device=device, memory_config=memory_config)
+
+
+def transpose_linear_weight(weight: torch.Tensor) -> torch.Tensor:
+    """Reorient an (out_features, in_features) checkpoint weight for ttnn.linear.
+
+    torch applies x @ w.T; ttnn.linear multiplies by the weight as given, so it wants
+    (in_features, out_features).
+
+    Skipping this raises on four of the five projections. attn.out_proj is 768x768, so there the
+    untransposed weight typechecks and computes noise instead: PCC 0.001 to 0.004 across seeds,
+    uncorrelated in every one.
+
+    contiguous() is not required, since ttnn.from_torch reads the strided view correctly. It
+    keeps the copy explicit and at load time.
+    """
+    return weight.transpose(0, 1).contiguous()
+
+
+def pack_expert_weights(
+    w1: torch.Tensor, w2: torch.Tensor, config: NomicMoEConfig
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Split the two (E*F, H) expert blocks into broadcast-batch matmul operands.
+
+    The expert axis is outer, each expert's slab stored (F, H). w1 is applied transposed and w2
+    is not, so only w1 needs the transpose. The results are (1, E, H, F) and (1, E, F, H), ready
+    to broadcast against a (1, 1, T, H) activation.
+
+    Viewing either as (E, H, F) is an equally legal reshape, since E*F*H is symmetric in F and H.
+    In torch that mistake is silent: the wrong slab plus a .T has the right shape and returns
+    noise, which test_w2_transposed_view_typechecks_but_is_garbage pins. The 4D operand is what
+    makes it loud, since there is no .T to paper over it and the inner dimensions stop agreeing;
+    test_transposed_expert_weights_are_a_shape_error asserts it raises.
+    """
+    expert_shape = (config.num_experts, config.intermediate_size, config.hidden_size)
+    return (
+        w1.view(*expert_shape).transpose(1, 2).unsqueeze(0).contiguous(),
+        w2.view(*expert_shape).unsqueeze(0).contiguous(),
+    )
+
+
+def additive_attention_mask(
+    attention_mask: torch.Tensor, device, dtype: ttnn.DataType = ACTIVATION_DTYPE
+) -> ttnn.Tensor:
+    """Turn a (B, S) keep-mask into the (B, 1, S, S) additive mask SDPA takes, on device.
+
+    Shares build_extended_attention_mask with the reference rather than restating it, so the two
+    sides derive the fill value the same way, then materialises the query axis. Torch SDPA
+    broadcasts a (B, 1, 1, S) mask over queries; ttnn's rejects it with
+    mask_shape[2] == q_shape[2], so only the head axis may stay singleton.
+
+    The tile padding has to be dtype-min too, not the 0 a TILE conversion defaults to. S rounds
+    up to a multiple of 32, and 0 means "attend here", so SDPA otherwise counts the pad columns
+    in the softmax denominator: at S=37 the output norm drops to 0.69x. PCC is nearly blind to
+    it, moving only 0.9998 to 0.9974, so the guard is
+    test_all_ones_mask_matches_no_mask rather than a PCC gate.
+
+    attention_mask holds 1 for real tokens and 0 for padding. dtype has to match the SDPA
+    operands, an fp32 mask against bf16 q/k/v being rejected, and the fill value is built in
+    that dtype rather than cast down to it: fp32's finfo.min is outside bf16's range and would
+    round to -inf. The result is 0.0 at real-token keys and dtype-min everywhere else.
+    """
+    torch_dtype = {ttnn.bfloat16: torch.bfloat16, ttnn.float32: torch.float32}[dtype]
+    seqlen = attention_mask.shape[-1]
+    mask = build_extended_attention_mask(attention_mask, torch_dtype).expand(-1, -1, seqlen, -1)
+    row_major = ttnn.from_torch(mask.contiguous(), dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    return ttnn.to_layout(row_major, LAYOUT, pad_value=float(torch.finfo(torch_dtype).min))
+
+
+def rotary_tables(
+    device, config: NomicMoEConfig, seqlen: int, dtype: ttnn.DataType = ACTIVATION_DTYPE
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    """Build the (1, 1, S, head_dim) cos/sin tables rotary_embedding_hf reads, on device.
+
+    Delegates to tt_transformers' get_rot_mats_hf, whose unscaled path computes the same
+    inv_freq, outer product and concat widening as NomicBertRotaryEmbedding plus
+    apply_rotary_emb. test_rotary_tables_match_the_reference holds them bit-exact in fp32.
+
+    The concat widening is load-bearing: interleaving gives the GPT-J lane pairing, which under
+    the kernel's NeoX rotate-half is not a rotation and does not preserve the per-plane norm.
+    """
+    cos, sin = get_rot_mats_hf(
+        head_dim=config.head_dim,
+        device=device,
+        seq_len=seqlen,
+        theta=config.rotary_emb_base,
+        rope_scaling=None,
+        datatype=dtype,
+    )
+    return cos, sin
+
+
+def flatten_tokens(x: ttnn.Tensor) -> ttnn.Tensor:
+    """(B, 1, S, H) -> (1, 1, B*S, H), batch-major."""
+    batch, _, seqlen, hidden = x.shape
+    return ttnn.reshape(x, (1, 1, batch * seqlen, hidden))
+
+
+def unflatten_tokens(x: ttnn.Tensor, batch: int, seqlen: int) -> ttnn.Tensor:
+    """(1, 1, B*S, H) -> (B, 1, S, H). B and S are arguments because the flat form has lost them."""
+    return ttnn.reshape(x, (batch, 1, seqlen, x.shape[-1]))

--- a/models/experimental/nomic_embed_text_v2_moe/tt/model_config.py
+++ b/models/experimental/nomic_embed_text_v2_moe/tt/model_config.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device-side settings every TTNN op in this port runs under.
+
+One compute kernel config for everything: HiFi4 with fp32 destination accumulation. Both
+halves were measured on a p300c at T=1024, against the router's 5e-3 max-abs budget:
+
+  math fidelity        softmax max-abs is 2.7e-2 to 3.0e-2 at the stock config, 5.4e-3 to
+                       6.8e-3 with HiFi4 alone, 1.4e-3 to 1.9e-3 with both. The router's
+                       budget is 5e-3, so HiFi4 alone misses it, but not by much.
+  destination accum    a bf16 accumulator costs 6x to 15x max-abs on every matmul. fc2, a
+                       3072-deep reduction, degrades from 1.35e-1 to 2.08e+00; the router's
+                       768-deep matmul reroutes 28 tokens in 1024 rather than 1.
+
+fp32_dest_acc_en halves the destination register budget, trading throughput for accuracy.
+Phase 1 is gated on correctness; Phase 2 can lower it per op group once there is a throughput
+number to weigh against. No sharding, no program configs, everything DRAM-interleaved.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import ttnn
+
+ACTIVATION_DTYPE = ttnn.bfloat16
+WEIGHT_DTYPE = ttnn.bfloat16
+
+# The one path kept at higher precision: the router's softmax feeds a top-2 selection, so a
+# near-tie decided by rounding changes which experts a token visits. Rounding the probabilities
+# to bfloat16 before the topk reroutes 0.34% to 0.59% of tokens. ttnn.scatter rejects float32 so a cast
+# is unavoidable, but ttnn.topk takes fp32 and its uint32 index feeds the scatter unchanged, so
+# only the two selected weights are cast, after the selection.
+ROUTER_DTYPE = ttnn.float32
+
+LAYOUT = ttnn.TILE_LAYOUT
+MEMORY_CONFIG = ttnn.DRAM_MEMORY_CONFIG
+
+
+@dataclass(frozen=True)
+class TtModelConfig:
+    """The settings that depend on the device, plus the dtypes and layout they go with.
+
+    Model dimensions are not here; they come from the vendored config.json via
+    reference.configuration_nomic_moe, the one source both sides read.
+    """
+
+    core_grid: ttnn.CoreCoord
+    compute_kernel_config: ttnn.DeviceComputeKernelConfig
+
+    activation_dtype: ttnn.DataType = ACTIVATION_DTYPE
+    weight_dtype: ttnn.DataType = WEIGHT_DTYPE
+    router_dtype: ttnn.DataType = ROUTER_DTYPE
+    layout: ttnn.Layout = LAYOUT
+
+    @classmethod
+    def from_device(cls, device) -> "TtModelConfig":
+        """Build the config from an open ttnn device or single-device mesh.
+
+        The grid is queried, never hardcoded: this p300c reports 11x10, not the (8, 10) that
+        models/tt_transformers/tt/model_config.py implies.
+
+        math_approx_mode is off because it selects cheaper SFPU polynomials.
+        """
+        return cls(
+            core_grid=device.compute_with_storage_grid_size(),
+            compute_kernel_config=ttnn.init_device_compute_kernel_config(
+                device.arch(),
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_approx_mode=False,
+                fp32_dest_acc_en=True,
+                packer_l1_acc=False,
+            ),
+        )


### PR DESCRIPTION
Closes #56453

Steps 2 and 3 of the porting skill: every aten operator in the reference is mapped to TTNN and validated on one Blackhole p300c, before any module is built on top of them.

## Contents

- `tt/model_config.py` - one compute kernel config for every operator (HiFi4 with fp32 destination accumulation), dtypes, layout. Grid read from the device, never hardcoded.
- `tt/common.py` - host-side tensor prep: weight reorientation, expert packing, rotary tables, attention mask, and the two activation-layout reshapes.
- `tests/pcc/test_ttnn_operators*.py` - 90 tests, one per operator at model shapes, each against the torch operator the reference uses. Eleven negative controls cover the ways an operator can be wrong without failing.
- `docs/OPERATOR_MAPPING.md` - the mapping, measured PCC per operator, API and shape differences.

No TTNN modules yet; that is step 4.

## Two silent bugs found while validating

**Router on a bf16 accumulator.** `fp32_dest_acc_en=False` on matmuls meant the deliberately-fp32 router accumulated in bf16, rerouting 28 tokens per 1024 instead of 1. The fp32 tensor dtype was giving false confidence: it says nothing about the accumulator the matmul uses. One HiFi4 plus fp32-accumulation config is now used everywhere.

**Attention mask tile padding.** The `(B, 1, S, S)` mask rounds S up to a multiple of 32, and the pad columns defaulted to 0, which in an additive mask means "attend here". SDPA counted them in the softmax denominator: at S=37 the output norm fell to 0.69x. The mask is now built in ROW_MAJOR and converted with `pad_value=finfo.min`.

PCC caught neither. It is scale-blind (at S=513 it did not move at all while the norm was 0.96x), and every shape under test was tile-aligned. The suite now gates on max-abs and norm where PCC cannot see, and covers a deliberately off-tile sequence length.

## Verification

146 tests pass on a p300c (90 new, 56 from Phase 0). Measured numbers in `OPERATOR_MAPPING.md` were re-derived from the device; the 42-operator inventory was re-captured from the model and matches exactly.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:avelickov/54920-nomic-embed-text-v2-moe-ttnn-port)