### PR TITLE
[Performance] Blackhole DRAM endpoint relocation on the CMFW bundle version

### DIFF
--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(
     PRIVATE
         test_metal_common_libs
         Boost::smart_ptr
+        yaml-cpp::yaml-cpp
 )
 
 TT_ENABLE_UNITY_BUILD(unit_tests_api_lib)

--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -3,9 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
 
+#include <array>
 #include <set>
 #include <cstdint>
+#include <string>
+#include <vector>
 
 #include <tt-metalium/core_coord.hpp>
 #include <umd/device/types/arch.hpp>
@@ -166,6 +170,42 @@ TEST_F(DramSubchannelHelperFixture, MetalDramCoresLogicalResolvesToTranslatedSet
     EXPECT_EQ(resolved, expected) << "LOGICAL and TRANSLATED requests named different DRAM cores";
     // No two logical coords may collapse onto one core, or a core would go unvisited.
     EXPECT_EQ(resolved.size(), logical_cores.size()) << "LOGICAL DRAM coords are not distinct after resolution";
+}
+
+// SYS-4948: each dram_view carries two endpoint assignments and the loader picks one from the CMFW
+// version. CI runs on pre-relocation firmware, so the relocated_* pair is never parsed there -- a
+// typo in it would pass CI and only surface once the new firmware rolls out, as a device-init abort
+// or a noc collision. Validate both pairs here so either one being malformed fails at PR time.
+TEST_F(DramSubchannelHelperFixture, DramViewsCarryBothEndpointAssignments) {
+    auto mesh_device = devices_[0];
+    auto* device = mesh_device->get_devices()[0];
+    const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device->id());
+
+    const std::string& descriptor_path = soc_desc.device_descriptor_file_path;
+    YAML::Node descriptor = YAML::LoadFile(descriptor_path);
+    YAML::Node dram_views = descriptor["dram_views"];
+    ASSERT_TRUE(dram_views) << "no dram_views in " << descriptor_path;
+
+    const int num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
+    ASSERT_GT(num_subchannels, 0);
+
+    constexpr std::array<const char*, 4> endpoint_keys = {
+        "eth_endpoint", "worker_endpoint", "relocated_eth_endpoint", "relocated_worker_endpoint"};
+
+    for (const auto& dram_view : dram_views) {
+        const size_t channel = dram_view["channel"].as<size_t>();
+        for (const char* key : endpoint_keys) {
+            ASSERT_TRUE(dram_view[key]) << "channel " << channel << " is missing '" << key << "'";
+            const auto subchannels = dram_view[key].as<std::vector<int>>();
+            EXPECT_FALSE(subchannels.empty()) << "channel " << channel << " has an empty '" << key << "'";
+            for (int subchannel : subchannels) {
+                EXPECT_GE(subchannel, 0) << "channel " << channel << " '" << key << "' has negative subchannel";
+                EXPECT_LT(subchannel, num_subchannels)
+                    << "channel " << channel << " '" << key << "' subchannel " << subchannel
+                    << " exceeds the DRAM grid (" << num_subchannels << " subchannels)";
+            }
+        }
+    }
 }
 
 TEST_F(DramSubchannelHelperFixture, RejectsOutOfRangeBank) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
@@ -26,6 +26,15 @@
 //                          zone so the per-tile profiler writes don't pace the consumer and
 //                          back-pressure the reader. Compute cost is then copy + NOPs
 //                          only, which is what we want when balancing NOPs vs read BW.)
+//   4: PASSTHROUGH       (1 = CB handshake only: no copy_tile / pack_tile / NOP spin, so the math
+//                          datapath is completely idle. Set by --bypass-compute, implied by
+//                          --write-only. Takes compute out of the measured path in BOTH
+//                          directions: on the write side the writer is no longer paced by the
+//                          packer producing one tile at a time; on the read side the reader is no
+//                          longer back-pressured through cb_in once the CB fills.
+//                          NOTE lean mode (PROFILE_PER_TILE=0) drops only INSTRUMENTATION -- it
+//                          still unpacks and packs every tile -- so it is not sufficient on its
+//                          own for either direction. NUM_NOPS_PER_TILE is ignored when set.)
 //
 // Runtime args:
 //   0: n_tiles
@@ -49,6 +58,7 @@ void kernel_main() {
     constexpr uint32_t cb_out = get_compile_time_arg_val(1);
     constexpr uint32_t num_nops_per_tile = get_compile_time_arg_val(2);
     constexpr uint32_t profile_per_tile = get_compile_time_arg_val(3);
+    constexpr uint32_t passthrough = get_compile_time_arg_val(4);
 
     const uint32_t n_tiles = get_arg_val<uint32_t>(0);
     const uint32_t program_id = get_arg_val<uint32_t>(1);
@@ -56,8 +66,11 @@ void kernel_main() {
     // no barrier between reps. Matches the reader/writer unroll so the whole op runs un-synced.
     const uint32_t workload_repeat = get_arg_val<uint32_t>(2) > 0 ? get_arg_val<uint32_t>(2) : 1;
 
-    compute_kernel_hw_startup(cb_in, cb_out);
-    copy_init(cb_in);
+    // Skip math-datapath setup entirely in passthrough mode -- nothing below touches it.
+    if constexpr (!passthrough) {
+        compute_kernel_hw_startup(cb_in, cb_out);
+        copy_init(cb_in);
+    }
 
     // Device 2.0 CB handles for the flow-control ops (wait/reserve/push/pop). The tile-copy /
     // pack LLK calls below still take the raw CB ids.
@@ -111,11 +124,15 @@ void kernel_main() {
                 }
             }
 
-            if constexpr (profile_per_tile) {
-                DeviceZoneScopedN("MATH");
-                copy_one_tile();
-            } else {
-                copy_one_tile();
+            // passthrough: no unpack/copy/pack at all -- the CB payload is whatever L1 already
+            // held (never validated in this mode), so the writer streams at its own pace.
+            if constexpr (!passthrough) {
+                if constexpr (profile_per_tile) {
+                    DeviceZoneScopedN("MATH");
+                    copy_one_tile();
+                } else {
+                    copy_one_tile();
+                }
             }
 
             out_cb.push_back(1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
@@ -15,7 +15,7 @@
 //                              invocation, no barrier between reps; 0/1 = normal single pass)
 //   6: read_progress_every    (mode 2: emit a READ_PROG timestamp every N pages completed; 0=off)
 //
-// Compile-time args (see TensorAccessorArgs<8> for src accessor):
+// Compile-time args (see TensorAccessorArgs<9> for src accessor):
 //   0: cb_in
 //   1: READER_MODE            (0 = reserve N, read+push one-by-one with a global barrier
 //                              1 = reserve N, read all, single barrier, push N
@@ -36,6 +36,9 @@
 //   7: READ_BYTES_OVERRIDE     (reader_mode 2 only; 0 = read full page. >0 = NoC-read only this
 //                              many bytes per page but still push a full CB page -- "cheap read"
 //                              for the output-bound regime, valid only because payload is dummy.)
+//   8: WRITE_ONLY              (1 = issue NO NoC read at all; just run the CB handshake so the
+//                              consumer advances, leaving the read path completely idle. For pure
+//                              write-BW measurement. Takes precedence over READER_MODE.)
 //
 // Profiler on first tile of the slice only: READ_BEFORE_BARRIER / READ_AFTER_BARRIER
 // (research only; gated by PROFILE_DETAIL).
@@ -81,7 +84,9 @@ void kernel_main() {
     // Cheap-read override (reader_mode 2 only): 0 = read the full page; >0 = NoC-read only this
     // many BYTES per page but still push a full CB page (dummy payload -> reads ~free).
     constexpr uint32_t READ_BYTES_OVERRIDE = get_compile_time_arg_val(7);
-    constexpr auto src_args = TensorAccessorArgs<8>();
+    // Pure write-BW mode: no NoC reads whatsoever (see header). CB handshake only.
+    constexpr uint32_t WRITE_ONLY = get_compile_time_arg_val(8);
+    constexpr auto src_args = TensorAccessorArgs<9>();
 
     constexpr uint32_t chunk_size = PUSH_TILE_COUNT > 0 ? PUSH_TILE_COUNT : 1;
     constexpr uint32_t tiles_per_page = TILES_PER_PAGE > 0 ? TILES_PER_PAGE : 1;
@@ -115,6 +120,33 @@ void kernel_main() {
     // src accessor is configured with the matching page_size at build time.
     const uint32_t start_page_id = effective_start_tile_id / tiles_per_page;
     const uint32_t n_pages = n_tiles / tiles_per_page;
+
+    // Pure write-BW mode: no NoC read at all. We still run the CB handshake so compute and the
+    // writer advance exactly as they normally do; the CB payload is whatever L1 already held,
+    // which is fine because it is never validated in this mode. Markers are emitted in the same
+    // order as the read paths so the profiler walkers still pair up -- but the
+    // READ_BEFORE->READ_LAST span is a CB-push span here, NOT a read-BW span.
+    if constexpr (WRITE_ONLY) {
+        for (uint32_t rep = 0; rep < workload_repeat; ++rep) {  // kernel-unroll: no barrier between reps
+            DETAIL_MARK("READ_BEFORE_BARRIER", effective_start_tile_id);
+            for (uint32_t p = 0; p < n_pages; ++p) {
+                in_cb.reserve_back(tiles_per_page);
+                in_cb.push_back(tiles_per_page);
+                if (p == 0) {
+                    DETAIL_MARK("READ_AFTER_BARRIER", effective_start_tile_id);
+                }
+                if (read_progress_every && ((p + 1) % read_progress_every == 0)) {
+                    DeviceTimestampedData("READ_PROG", p + 1);
+                }
+            }
+            DETAIL_MARK("READ_LAST_BARRIER", effective_start_tile_id);
+            if (read_progress_every) {
+                DeviceTimestampedData("READ_PROG", n_pages);
+            }
+        }
+        DETAIL_MARK("NCRISC_DONE", program_id);
+        return;
+    }
 
     if constexpr (READER_MODE == 2) {
         // Per-trid double buffer, N = TRID_IN_FLIGHT reads in flight per side.

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -50,6 +50,18 @@
 //                           off (lean): only the markers the CI metrics consume are
 //                           emitted, minimizing profiler perturbation of the op2op number.
 //
+// Direction isolation (for DRAM bandwidth measurement rather than op-to-op latency):
+//   --read-only             isolate read BW: the writer pops the output CB without writing to
+//                           DRAM. Implies --bypass-compute.
+//   --write-only            isolate write BW: the reader issues NO NoC read, just the CB
+//                           handshake, so DRAM sees writes only. Implies --bypass-compute.
+//                           Pair with --output-cb-depth-tiles > 2; at depth 2 the writer
+//                           flushes every tile and the result is CB-bound, not DRAM-bound.
+//   --bypass-compute        compute becomes a CB pass-through (no unpack/copy/pack), taking the
+//                           math datapath out of the measured path. Implied by the two above;
+//                           pass it explicitly only for a full read+write op. --compute-nops is
+//                           rejected with it, and output validation is skipped.
+//
 // Research characterization knobs (ungated; used by op_to_op_sweep.py, not the CI gate):
 //   --kernel-unroll N        repeat the whole reader/compute/writer workload N times inside
 //                            ONE program invocation with no barrier between reps (default 1).
@@ -200,6 +212,13 @@ struct BenchmarkConfig {
     // Read-only mode: writer pops from output CB but skips DRAM writes.
     // Isolates pure DRAM read BW through the reader pipeline.
     bool read_only = false;
+    // Write-only mode: reader issues no NoC read at all (CB handshake only), so DRAM sees
+    // writes and nothing else. Isolates pure DRAM write BW. Implies --bypass-compute.
+    bool write_only = false;
+    // Compute becomes a CB pass-through: no unpack/copy/pack, math datapath idle. Implied by
+    // --read-only and --write-only; pass explicitly only for a full read+write op with compute
+    // taken out of the measured path. Skips output validation (the CB payload is stale L1).
+    bool bypass_compute = false;
     // Detailed profiling (research only). Default OFF = lean: kernels emit only the
     // markers the CI metrics consume -- compute PROG_ID / tile-0 TILE_IDX / FINISH_LAST_PUSH
     // (for pack_to_unpack) plus the firmware {BRISC,NCRISC,TRISC}-KERNEL zones (for the gated
@@ -307,6 +326,22 @@ BenchmarkConfig parse_args(const std::vector<std::string>& args) {
     }
     if (test_args::has_command_option(args, "--read-only")) {
         cfg.read_only = true;
+    }
+    if (test_args::has_command_option(args, "--write-only")) {
+        cfg.write_only = true;
+    }
+    if (test_args::has_command_option(args, "--bypass-compute")) {
+        cfg.bypass_compute = true;
+    }
+    // Isolating one direction only measures that direction if compute is out of the path:
+    // otherwise the packer paces the writer (write side) or back-pressures the reader (read side).
+    if (cfg.read_only || cfg.write_only) {
+        cfg.bypass_compute = true;
+    }
+    // Keep this AFTER every assignment to bypass_compute above. Ordered before them it silently
+    // validates output that passthrough never wrote.
+    if (cfg.bypass_compute) {
+        cfg.skip_output_validation = true;
     }
     if (test_args::has_command_option(args, "--skip-output-validation")) {
         cfg.skip_output_validation = true;
@@ -721,6 +756,18 @@ BuiltProgram build_program(
     // Compute -> writer unchanged: still wait_front(1) / pack one tile at a time.
     const uint32_t output_cb_depth = cfg.output_cb_depth_tiles > 0 ? cfg.output_cb_depth_tiles : 2;
 
+    TT_FATAL(!(cfg.read_only && cfg.write_only), "--read-only and --write-only isolate opposite directions; pick one");
+    // The writer flushes on a full output CB, so a shallow one throttles the very traffic
+    // --write-only exists to measure.
+    TT_FATAL(
+        !cfg.write_only || output_cb_depth > 2,
+        "--write-only needs --output-cb-depth-tiles > 2 (got {}); at depth 2 the writer flushes after "
+        "every tile and the measured rate is CB-bound, not DRAM-bound",
+        output_cb_depth);
+    TT_FATAL(
+        !(cfg.bypass_compute && cfg.num_nops_per_tile > 0),
+        "--compute-nops ({}) has no effect with a pass-through compute kernel (implied by --read-only/--write-only)",
+        cfg.num_nops_per_tile);
     TT_FATAL(
         input_cb_depth >= push_tiles,
         "input CB depth ({}) must be >= --reader-push-tiles ({})",
@@ -797,7 +844,7 @@ BuiltProgram build_program(
     // Compile-time args order MUST match reader_interleaved.cpp:
     //   [0]=cb_in, [1]=READER_MODE, [2]=PUSH_TILE_COUNT, [3]=TILES_PER_PAGE,
     //   [4]=TRID_IN_FLIGHT, [5]=CROSS_PROGRAM_OFFSET_TILES, [6]=PROFILE_DETAIL,
-    //   [7]=READ_BYTES_OVERRIDE, then TensorAccessorArgs starting at index 8.
+    //   [7]=READ_BYTES_OVERRIDE, [8]=WRITE_ONLY, then TensorAccessorArgs starting at index 9.
     const uint32_t cross_program_offset_tiles = cfg.cross_program_dram_offset ? total_num_tiles : 0u;
     // Mode-2 cheap-read reads READ_BYTES_OVERRIDE bytes into the fixed cb_base landing zone;
     // a value larger than one DRAM page would read past the accessor page and overrun that L1
@@ -817,7 +864,8 @@ BuiltProgram build_program(
         trid_in_flight,
         cross_program_offset_tiles,
         cfg.profile_detail ? 1u : 0u,
-        cfg.reader_read_bytes};
+        cfg.reader_read_bytes,
+        cfg.write_only ? 1u : 0u};
     // Defaults: reader=NOC0, writer=NOC1 (measured best). --reader-noc/--writer-noc override.
     // HARD CONSTRAINT: the two data-movement kernels on a core must be on DIFFERENT NoCs.
     // Putting both on the same NoC hangs the device (requires a chip reset), so fail fast.
@@ -862,7 +910,7 @@ BuiltProgram build_program(
 
     // Compute: copy_tile + tunable NOP spin.
     std::vector<uint32_t> compute_compile_time_args = {
-        kInputCbId, kOutputCbId, cfg.num_nops_per_tile, cfg.profile_detail ? 1u : 0u};
+        kInputCbId, kOutputCbId, cfg.num_nops_per_tile, cfg.profile_detail ? 1u : 0u, cfg.bypass_compute ? 1u : 0u};
     auto compute_kernel = CreateKernel(
         program,
         "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp",
@@ -950,7 +998,7 @@ int main(int argc, char** argv) {
             "op_to_op_latency: device_id={}, pages_per_core={}, reader_push_tiles={}, input_cb_depth_tiles={}, "
             "output_cb_depth_tiles={}, reader_mode={}, compute_nops={}, num_programs={}, warmup={}, use_trace={}, "
             "use_device_profiler={}, use_realtime_profiler={}, trace_region_size={}, trace_warmup_replays={}, "
-            "read_only={}",
+            "read_only={}, write_only={}, bypass_compute={}",
             cfg.device_id,
             cfg.num_pages_per_core,
             cfg.reader_push_tile_count,
@@ -965,7 +1013,9 @@ int main(int argc, char** argv) {
             cfg.use_realtime_profiler,
             cfg.trace_region_size,
             cfg.trace_warmup_replays,
-            cfg.read_only);
+            cfg.read_only,
+            cfg.write_only,
+            cfg.bypass_compute);
         TT_FATAL(cfg.num_programs >= 1, "--num-programs must be >= 1");
         TT_FATAL(cfg.num_pages_per_core >= 1, "--num-pages-per-core must be >= 1");
         TT_FATAL(cfg.reader_push_tile_count >= 1, "--reader-push-tiles must be >= 1");
@@ -1183,7 +1233,7 @@ int main(int argc, char** argv) {
                 "dispatch done/go: --use-realtime-profiler -> profile_log_device_rt.csv).");
         }
 
-        if (!cfg.read_only && !cfg.skip_output_validation) {
+        if (!cfg.read_only && !cfg.write_only && !cfg.bypass_compute && !cfg.skip_output_validation) {
             std::vector<uint32_t> output_data;
             distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
 

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -10,6 +10,27 @@
 #include <umd/device/types/arch.hpp>
 
 namespace {
+// SYS-4948: first CMFW bundle whose DRAM telemetry lives on the relocated endpoints. Metal's noc0
+// assignment has to match wherever CMFW polls, so this threshold decides which endpoint pair the
+// descriptor loads.
+//
+// This is the bundle from tt-system-firmware PR #1452, which self-reports as 19.13.2.0. It is not
+// public: a board only reports it after being deliberately flashed with that bundle. The public
+// release line is far below it (latest tag v19.6.0), so any board that has not been flashed stays on
+// the pre-relocation endpoints, which is the safe direction -- it only costs bandwidth, whereas
+// selecting relocated endpoints on a CMFW that has not moved puts a noc on an endpoint CMFW polls
+// (the SYS-1419 hang).
+//
+// Revisit only if the relocation ends up shipping publicly under a different version than 19.13.2.
+constexpr tt::umd::FirmwareBundleVersion kBlackholeRelocatedDramEndpointFirmware(19, 13, 2);
+
+// FirmwareBundleVersion::compare_firmware_bundle normalizes major >= 80 to 0 as a legacy marker, so
+// such a threshold would compare below every real version and enable the relocation everywhere --
+// the opposite of raising the bar. Reject that outright rather than shipping it silently.
+static_assert(
+    kBlackholeRelocatedDramEndpointFirmware.major < 80,
+    "Threshold major >= 80 is treated as a legacy version and would match every firmware.");
+
 // True if physical DRAM `channel` is harvested per `dram_harvesting_mask`. Single home for the
 // bit-masking convention used across the DRAM-view helpers below.
 bool is_dram_channel_harvested(uint32_t dram_harvesting_mask, size_t channel) {
@@ -253,8 +274,25 @@ tt::tt_metal::CoreCoord metal_SocDescriptor::get_dram_compute_grid_size() const 
     return tt::tt_metal::CoreCoord(this->get_num_dram_views(), get_grid_size(tt::CoreType::DRAM).y);
 }
 
-void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
+bool metal_SocDescriptor::uses_relocated_dram_endpoints(
+    const std::optional<tt::umd::FirmwareBundleVersion>& firmware_version) const {
+    // Only Blackhole reserves a CMFW-owned noc0 DRAM endpoint, so no other arch has a second
+    // assignment to choose between.
+    if (this->arch != tt::ARCH::BLACKHOLE) {
+        return false;
+    }
+    // An unreadable version means we cannot prove CMFW has moved. Staying on the pre-relocation
+    // endpoints only costs bandwidth, whereas guessing wrong collides a noc with CMFW (SYS-1419).
+    if (!firmware_version.has_value()) {
+        return false;
+    }
+    return firmware_version.value() >= kBlackholeRelocatedDramEndpointFirmware;
+}
+
+void metal_SocDescriptor::load_dram_metadata_from_device_descriptor(bool use_relocated_dram_endpoints) {
     YAML::Node device_descriptor_yaml = YAML::LoadFile(this->device_descriptor_file_path);
+    const char* eth_endpoint_key = use_relocated_dram_endpoints ? "relocated_eth_endpoint" : "eth_endpoint";
+    const char* worker_endpoint_key = use_relocated_dram_endpoints ? "relocated_worker_endpoint" : "worker_endpoint";
     this->dram_view_size = device_descriptor_yaml["dram_view_size"].as<uint64_t>();
     const size_t num_dram_views_in_descriptor = device_descriptor_yaml["dram_views"].size();
     this->dram_core_size = num_dram_views_in_descriptor * this->dram_view_size;
@@ -282,7 +320,15 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
         }
         size_t address_offset = dram_view["address_offset"].as<size_t>();
 
-        const auto eth_endpoint_ids = dram_view["eth_endpoint"].as<std::vector<int>>();
+        TT_FATAL(
+            dram_view[eth_endpoint_key] && dram_view[worker_endpoint_key],
+            "DRAM view for channel {} is missing '{}'/'{}' in {}",
+            channel,
+            eth_endpoint_key,
+            worker_endpoint_key,
+            this->device_descriptor_file_path);
+
+        const auto eth_endpoint_ids = dram_view[eth_endpoint_key].as<std::vector<int>>();
         std::vector<tt::tt_metal::CoreCoord> eth_dram_cores;
         std::vector<size_t> eth_endpoints;
         eth_dram_cores.reserve(eth_endpoint_ids.size());
@@ -300,7 +346,7 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
             eth_endpoints.push_back(eth_endpoint);
         }
 
-        const auto worker_endpoint_ids = dram_view["worker_endpoint"].as<std::vector<int>>();
+        const auto worker_endpoint_ids = dram_view[worker_endpoint_key].as<std::vector<int>>();
         std::vector<tt::tt_metal::CoreCoord> worker_dram_cores;
         std::vector<size_t> worker_endpoints;
         worker_dram_cores.reserve(worker_endpoint_ids.size());
@@ -399,9 +445,12 @@ void metal_SocDescriptor::generate_physical_routing_to_profiler_flat_id() {
 // removing the harvested physical coordinates Metal needs the true harvesting state so we generate physical
 // descriptors from virtual coordinates We also initialize additional lookup tables to translate physical coordinates to
 // virtual coordinates because UMD APIs expect virtual coordinates.
-metal_SocDescriptor::metal_SocDescriptor(const SocDescriptor& other, const tt::BoardType& /*board_type*/) :
+metal_SocDescriptor::metal_SocDescriptor(
+    const SocDescriptor& other,
+    const tt::BoardType& /*board_type*/,
+    std::optional<tt::umd::FirmwareBundleVersion> firmware_version) :
     SocDescriptor(other) {
-    this->load_dram_metadata_from_device_descriptor();
+    this->load_dram_metadata_from_device_descriptor(this->uses_relocated_dram_endpoints(firmware_version));
     this->generate_logical_eth_coords_mapping();
     this->generate_physical_routing_to_profiler_flat_id();
 }

--- a/tt_metal/llrt/metal_soc_descriptor.hpp
+++ b/tt_metal/llrt/metal_soc_descriptor.hpp
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <cstddef>
 #include <map>
+#include <optional>
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
@@ -16,6 +17,7 @@
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
+#include <umd/device/utils/semver.hpp>
 
 //! SocDescriptor contains information regarding the SOC configuration targeted.
 /*!
@@ -40,7 +42,13 @@ public:
 
     std::map<tt::tt_metal::CoreCoord, int> logical_eth_core_to_chan_map;
 
-    metal_SocDescriptor(const SocDescriptor& other, const tt::BoardType& board_type);
+    // `firmware_version` is the cluster-wide CMFW bundle version, or nullopt when it cannot be read.
+    // On Blackhole it selects which DRAM endpoint assignment the descriptor loads (see SYS-4948 in
+    // blackhole_140_arch.yaml); nullopt keeps the pre-relocation assignment.
+    metal_SocDescriptor(
+        const SocDescriptor& other,
+        const tt::BoardType& board_type,
+        std::optional<tt::umd::FirmwareBundleVersion> firmware_version = std::nullopt);
 
     tt::tt_metal::CoreCoord get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const;
     tt::tt_metal::CoreCoord get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const;
@@ -100,7 +108,11 @@ private:
     // Argument must be a TRANSLATED (UMD) coord; a metal-logical {view, subchannel} coord never matches.
     bool is_noc0_dram_endpoint(const tt::tt_metal::CoreCoord& translated_coord) const;
 
-    void load_dram_metadata_from_device_descriptor();
+    // True when this chip's CMFW has relocated its DRAM telemetry endpoints, so the descriptor must
+    // load the relocated_* endpoint pairs to keep noc0 aligned with CMFW (SYS-4948).
+    bool uses_relocated_dram_endpoints(const std::optional<tt::umd::FirmwareBundleVersion>& firmware_version) const;
+
+    void load_dram_metadata_from_device_descriptor(bool use_relocated_dram_endpoints);
     void generate_logical_eth_coords_mapping();
     void generate_physical_routing_to_profiler_flat_id();
 };

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -418,7 +418,15 @@ void Cluster::get_metal_desc_from_tt_desc() {
         if (this->target_type_ == TargetDevice::Silicon) {
             umd_soc.device_descriptor_file_path = silicon_dram_metadata_yaml;
         }
-        this->sdesc_per_chip_.emplace(id, metal_SocDescriptor(umd_soc, this->get_cluster_desc()->get_board_type(id)));
+        // The CMFW bundle version drives the Blackhole DRAM endpoint selection (SYS-4948). It is
+        // cluster-wide rather than per-chip because UMD's topology discovery already rejects a
+        // cluster whose chips disagree (TopologyDiscovery::verify_fw_bundle_version).
+        this->sdesc_per_chip_.emplace(
+            id,
+            metal_SocDescriptor(
+                umd_soc,
+                this->get_cluster_desc()->get_board_type(id),
+                this->get_cluster_desc()->get_cluster_firmware_bundle_version()));
     }
 }
 

--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -23,54 +23,79 @@ dram:
 # Eth and worker dram endpoints represent subchannel id from dram array for each noc.
 # For example, a dram view where channel is 0 and worker_endpoint is [1, 2] would resolve to dram core at position [0,2] for noc1 which is 0-11.
 # Endpoint assignment for noc0 needs to be the same endpoint used by CMFW to read DRAM telemetry to avoid SYS-1419.
+#
+# SYS-4948: CMFW relocates its DRAM telemetry endpoints as of the firmware version named by
+# kBlackholeRelocatedDramEndpointFirmware (metal_soc_descriptor.cpp). Because noc0 must track CMFW,
+# each view carries both assignments and the loader picks one from the reported firmware version:
+#   eth_endpoint / worker_endpoint                     -> CMFW before the relocation
+#   relocated_eth_endpoint / relocated_worker_endpoint -> CMFW at or after the relocation
+# Running either set against the wrong firmware puts a noc on an endpoint CMFW is polling, which is
+# the SYS-1419 hang. Delete the pre-relocation pair once the minimum supported firmware clears the
+# threshold. The relocated pairs also relieve noc congestion, worth ~17% read / ~55% write DRAM BW.
 dram_views:
   [
     {
       channel: 0,
       eth_endpoint: [2, 1],
       worker_endpoint: [2, 1],
+      relocated_eth_endpoint: [0, 2],
+      relocated_worker_endpoint: [0, 2],
       address_offset: 0
     },
     {
       channel: 1,
       eth_endpoint: [0, 1],
       worker_endpoint: [0, 1],
+      relocated_eth_endpoint: [1, 2],
+      relocated_worker_endpoint: [1, 2],
       address_offset: 0
     },
     {
       channel: 2,
       eth_endpoint: [0, 1],
       worker_endpoint: [0, 1],
+      relocated_eth_endpoint: [1, 2],
+      relocated_worker_endpoint: [1, 2],
       address_offset: 0
     },
     {
       channel: 3,
       eth_endpoint: [0, 1],
       worker_endpoint: [0, 1],
+      relocated_eth_endpoint: [1, 2],
+      relocated_worker_endpoint: [1, 2],
       address_offset: 0
     },
     {
       channel: 4,
       eth_endpoint: [2, 1],
       worker_endpoint: [2, 1],
+      relocated_eth_endpoint: [2, 0],
+      relocated_worker_endpoint: [2, 0],
       address_offset: 0
     },
     {
       channel: 5,
       eth_endpoint: [2, 1],
       worker_endpoint: [2, 1],
+      relocated_eth_endpoint: [2, 0],
+      relocated_worker_endpoint: [2, 0],
       address_offset: 0
     },
     {
       channel: 6,
       eth_endpoint: [2, 1],
       worker_endpoint: [2, 1],
+      relocated_eth_endpoint: [2, 0],
+      relocated_worker_endpoint: [2, 0],
       address_offset: 0
     },
     {
       channel: 7,
       eth_endpoint: [2, 1],
       worker_endpoint: [2, 1],
+      relocated_eth_endpoint: [2, 0],
+      relocated_worker_endpoint: [2, 0],
       address_offset: 0
     }
   ]


### PR DESCRIPTION
### PR Category

Performance

### Summary

Each of Blackhole's eight DRAM channels exposes three subchannels, and the noc0/noc1 endpoints currently selected from them are unbalanced in two ways. Channels 0 and 4 both place their noc0 endpoint on row 11, and every noc1 endpoint shares a row with another noc1 endpoint — on rows 1, 4, 7 and 10. Row 1 is the ethernet row, so DRAM traffic there contends with eth traffic. Reassigning the endpoints so that no two endpoints of the same noc share a row, and nothing lands on the eth row at all, is worth roughly 17% interleaved read bandwidth on noc0 and 50% write on noc1.

Metal cannot make that move on its own. Because of BH-76 (GDDR hangs when all tensix cores drive all three noc ports on different VCs) the syseng management firmware has to sit on a noc0 DRAM endpoint, sharing that core with noc0. CMFW and Metal therefore have to agree on *which* endpoint that is: if Metal moves to the new assignment while CMFW still polls the old one, a noc lands on an endpoint CMFW is using, which is the SYS-1419 hang. That is why this is gated on the firmware version rather than applied unconditionally.

So `blackhole_140_arch.yaml` now carries **both** assignments per `dram_view` — the existing `eth_endpoint`/`worker_endpoint` plus new `relocated_eth_endpoint`/`relocated_worker_endpoint` — and `metal_SocDescriptor` selects between them based on the cluster's CMFW bundle version. Below the threshold nothing changes; at or above it the relocated pair is loaded.

Measured on p150b at 110 cores, relocated vs pre-relocation:

| direction | relocated | pre-relocation | gain |
| --- | --- | --- | --- |
| read | 511 us/program | 585 us | ~14.5% |
| write | 503 us/program | 790 us | ~57% |

Relates to SYS-4948.

### Notes for reviewers

**The threshold constant.** `19.13.2` is the bundle from tt-system-firmware PR https://github.com/tenstorrent/tt-system-firmware/pull/1452 . It is not public — the latest public release is `v19.6.0` — so a board only reports it after being deliberately flashed with that bundle. Every board that has not been flashed therefore keeps today's assignment, which is the safe direction: it costs bandwidth but cannot hang. There is a `static_assert(major < 80)` on the constant because UMD's `compare_firmware_bundle` normalizes `major >= 80` to `0` as a legacy marker, so a placeholder threshold like `99.0.0` would compare *below* every real version and silently enable the relocation everywhere — the exact opposite of raising the bar. Bundles with `major >= 80` do exist in the wild, so this is not hypothetical.

**The resulting assignment, for checking against the ticket.** With the relocated pairs selected, the noc0 DRAM endpoints — the ones syseng firmware shares a core with — come out as `0-0`, `0-4`, `0-7`, `0-10` and `9-3`, `9-6`, `9-8`, `9-11`, which is the layout agreed in SYS-4948. noc1 gets `0-3`, `0-6`, `0-8`, `0-11` and `9-0`, `9-2`, `9-5`, `9-9`. No row carries more than one endpoint of either noc, and row 1 (ethernet) carries none. For comparison, today's assignment puts noc0 on row 11 twice (`0-11` and `9-11`) and doubles up noc1 on rows 1, 4, 7 and 10.

**Firmware dependency.** The matching firmware change (tt-system-firmware https://github.com/tenstorrent/tt-system-firmware/pull/1452 ) is still open and marked DNM, so `19.13.2` is a test version rather than a release. If the relocation ends up shipping publicly under a different version, the threshold constant needs updating — the comment on it says as much.

**Why the version is read cluster-wide rather than per-chip.** UMD's topology discovery already refuses to bring up a cluster whose chips disagree (`TopologyDiscovery::verify_fw_bundle_version`, with `cmfw_mismatch_action` defaulting to `THROW`), so a per-chip read would add nothing. When the version cannot be read at all, the descriptor keeps the pre-relocation assignment.

**Why there is a descriptor test.** CI runs on pre-relocation firmware, so the `relocated_*` keys are never parsed there. A typo in them would pass CI and only surface once the new firmware rolls out, as a device-init abort or a noc collision. `DramViewsCarryBothEndpointAssignments` parses *both* pairs and range-checks them against the DRAM grid, so either one being malformed fails at PR time. I confirmed it actually catches this by injecting an out-of-range subchannel and watching it fail for the right reason.

**The new benchmark flags.** `--write-only` and `--bypass-compute` are added to `test_op_to_op_latency` so the write half of the table above is reproducible from this branch. Previously only the read side could be measured upstream. `--write-only` leaves the read path completely idle (the reader runs the CB handshake and issues no NoC read); `--bypass-compute` makes compute a CB pass-through so the packer stops pacing the writer. Both are implied by `--read-only`/`--write-only`, since isolating one direction only measures that direction with compute out of the measured path. Output validation is skipped whenever compute is bypassed — the CB payload is stale L1 at that point — and I verified that a full read+write run still validates its output as before.

**Reproducing the numbers.** Requires a board flashed with fw 19.13.2. No environment variables are needed, but `TT_METAL_SLOW_DISPATCH_MODE` must not be set, since `--use-trace` requires fast dispatch. Build with `cmake --build build --target test_op_to_op_latency -j`, then run the read case:

    ./build/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency \
      --read-only --input-cb-depth-tiles 64 --output-cb-depth-tiles 8 --num-programs 2 \
      --reader-trid-in-flight 24 --reader-noc 0 --writer-noc 1 --reader-dbuf-trid \
      --reader-push-tiles 2 --num-pages-per-core 1024 --compute-nops 0 --use-trace \
      --trace-warmup-replays 1 --num-active-cores 110

and the write case:

    ./build/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency \
      --write-only --input-cb-depth-tiles 64 --output-cb-depth-tiles 32 --num-programs 4 \
      --reader-trid-in-flight 8 --reader-noc 0 --writer-noc 1 --reader-dbuf-trid \
      --reader-push-tiles 2 --num-pages-per-core 1024 --compute-nops 0 --use-trace \
      --trace-warmup-replays 1 --num-active-cores 110

Read the `Trace replay (after warmup): ... avg N us/program` line. To A/B without reflashing, raise `kBlackholeRelocatedDramEndpointFirmware` above `19.13.2` to force the pre-relocation path.

**Known gaps, for visibility rather than for this PR.** The relocated path gets no CI coverage, because CI boards run public firmware and so Merge Gate only ever exercises the pre-relocation branch; that stays true until CI boards are flashed with 19.13.2. Perf is measured on p150b only, with P100A and P300 still to come (P300 matters most, being the first real exercise of the cluster-wide firmware version read). Model and end-to-end workload numbers are being picked up with the Blaze team. 


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/sys4948-fw-gated-dram-endpoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/sys4948-fw-gated-dram-endpoints)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/sys4948-fw-gated-dram-endpoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/sys4948-fw-gated-dram-endpoints)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/sys4948-fw-gated-dram-endpoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/sys4948-fw-gated-dram-endpoints)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/sys4948-fw-gated-dram-endpoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/sys4948-fw-gated-dram-endpoints)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/sys4948-fw-gated-dram-endpoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/sys4948-fw-gated-dram-endpoints)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/sys4948-fw-gated-dram-endpoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/sys4948-fw-gated-dram-endpoints)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/sys4948-fw-gated-dram-endpoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/sys4948-fw-gated-dram-endpoints)