### PR TITLE
[skip ci] produce_data: cover re-run attempts

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -166,17 +166,6 @@ jobs:
           echo "attempt-number=$attempt_number" >> "$GITHUB_OUTPUT"
 
           echo "::notice title=target-workflow-link::The workflow being analyzed is available at https://github.com/${{ github.repository }}/actions/runs/${run_id}/attempts/${attempt_number}"
-      # There is deliberately no `gh api rate_limit` step here. GITHUB_TOKEN's budget is
-      # 15,000/hr shared across the whole repository, but that endpoint reports a
-      # per-token view: it printed "used: 0, remaining: 15000" sixty seconds before this
-      # job's next call was rejected with "API rate limit exceeded for installation", and
-      # it did so on every run while the repository was exhausting the shared budget. It
-      # is free to call and it misdirected three separate investigations, so it is worse
-      # than no signal at all.
-      #
-      # The honest signals are the x-ratelimit-* response headers on a real request
-      # (`gh api -i`), and the gh error text that the download script now surfaces
-      # instead of swallowing.
       - name: Output auxiliary values
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -166,12 +166,17 @@ jobs:
           echo "attempt-number=$attempt_number" >> "$GITHUB_OUTPUT"
 
           echo "::notice title=target-workflow-link::The workflow being analyzed is available at https://github.com/${{ github.repository }}/actions/runs/${run_id}/attempts/${attempt_number}"
-      - name: Get API rate limit status
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo "[Info] Grabbing API rate limit status"
-          gh api rate_limit
+      # There is deliberately no `gh api rate_limit` step here. GITHUB_TOKEN's budget is
+      # 15,000/hr shared across the whole repository, but that endpoint reports a
+      # per-token view: it printed "used: 0, remaining: 15000" sixty seconds before this
+      # job's next call was rejected with "API rate limit exceeded for installation", and
+      # it did so on every run while the repository was exhausting the shared budget. It
+      # is free to call and it misdirected three separate investigations, so it is worse
+      # than no signal at all.
+      #
+      # The honest signals are the x-ratelimit-* response headers on a real request
+      # (`gh api -i`), and the gh error text that the download script now surfaces
+      # instead of swallowing.
       - name: Output auxiliary values
         env:
           GH_TOKEN: ${{ github.token }}

--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -13,9 +13,23 @@ set_up_dirs() {
     mkdir -p generated/cicd/$workflow_run_id/logs
 }
 
+# Artifacts persist across run attempts, so a re-run's analysis would otherwise
+# re-download every test_reports_* zip the original attempt produced -- 56 of them on
+# run 34609986416, none of them new. Attempts after the first therefore download only
+# the reports created since that attempt started; the rest were already collected when
+# the earlier attempt was analysed.
+#
+# First attempts (about two thirds of executions) keep the unconditional path, so the
+# common case pays no extra listing.
 download_artifacts() {
     local repo=$1
     local workflow_run_id=$2
+    local attempt_number=$3
+
+    if [[ -n "$attempt_number" && "$attempt_number" -gt 1 ]]; then
+        download_artifacts_created_since_attempt_start "$repo" "$workflow_run_id" "$attempt_number"
+        return
+    fi
 
     echo "[info] Downloading test reports for workflow run $workflow_run_id"
     # `gh run download` lists the run's artifacts itself, so the separate
@@ -28,6 +42,52 @@ download_artifacts() {
     # throttled fetch gets mistaken for a run that simply had no test reports.
     local download_error
     if ! download_error=$(gh run download --repo $repo -D generated/cicd/$workflow_run_id/artifacts --pattern 'test_reports_*' $workflow_run_id 2>&1 >/dev/null); then
+        echo "[Warning] Test reports not downloaded for workflow run $workflow_run_id: ${download_error:-no reason given}"
+    fi
+}
+
+# Only the test_reports_* artifacts this attempt produced. One listing call replaces one
+# download call per stale artifact, and a re-run in which no job uploaded a fresh report
+# costs the listing alone.
+download_artifacts_created_since_attempt_start() {
+    local repo=$1
+    local workflow_run_id=$2
+    local attempt_number=$3
+
+    local attempt_started
+    if ! attempt_started=$(gh api "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number" --jq '.run_started_at' 2>&1); then
+        echo "[Warning] could not read attempt $attempt_number start time (${attempt_started:-no reason given}); downloading all test reports"
+        download_artifacts "$repo" "$workflow_run_id" 1
+        return
+    fi
+    echo "[info] attempt $attempt_number started $attempt_started; only test reports newer than that are this attempt's"
+
+    local listing
+    if ! listing=$(gh api --paginate "/repos/$repo/actions/runs/$workflow_run_id/artifacts" 2>&1); then
+        echo "[Warning] could not list artifacts for workflow run $workflow_run_id: ${listing:-no reason given}"
+        return
+    fi
+
+    # jq compares the ISO-8601 timestamps lexicographically, which is ordering-correct
+    # for the UTC "...Z" form the API returns.
+    local fresh
+    fresh=$(printf '%s' "$listing" | jq -r --arg since "$attempt_started" \
+        '[.artifacts[]? | select((.name | startswith("test_reports_")) and .created_at > $since) | .name] | unique | .[]')
+
+    if [[ -z "$fresh" ]]; then
+        echo "[info] attempt $attempt_number uploaded no new test reports; the earlier attempt's analysis collected the rest"
+        return
+    fi
+
+    local -a name_args=()
+    local name
+    while IFS= read -r name; do
+        [[ -n "$name" ]] && name_args+=(--name "$name")
+    done <<< "$fresh"
+    echo "[info] downloading ${#name_args[@]} new test report artifact(s) for attempt $attempt_number"
+
+    local download_error
+    if ! download_error=$(gh run download --repo $repo -D generated/cicd/$workflow_run_id/artifacts "${name_args[@]}" $workflow_run_id 2>&1 >/dev/null); then
         echo "[Warning] Test reports not downloaded for workflow run $workflow_run_id: ${download_error:-no reason given}"
     fi
 }
@@ -83,14 +143,29 @@ get_jobs_with_pagination_fallback() {
     fi
 }
 
-# Fetch every job log for the attempt in ONE request.
+# Fetch job logs an archive at a time instead of a job at a time.
 #
-# GitHub serves the whole attempt's logs as a single zip:
+# GitHub serves a run attempt's logs as a single zip:
 #   GET /repos/{repo}/actions/runs/{id}/attempts/{n}/logs
-# The previous implementation instead called /actions/jobs/{job_id}/logs once per job,
-# which made this script's cost scale with the size of the run being analyzed. On a
-# 129-job merge-gate run that was 129 requests against the repository's shared
-# 15,000/hr GITHUB_TOKEN budget, and produce_data runs ~173 times an hour.
+# which replaces calling /actions/jobs/{job_id}/logs once per job -- 129 requests for a
+# 129-job merge-gate run, against the repository's shared 15,000/hr GITHUB_TOKEN budget,
+# with produce_data running hundreds of times an hour.
+#
+# An attempt's archive holds only the jobs that ran in THAT attempt, while the jobs list
+# returns every job of the run. So a re-run's archive is nearly empty even though its
+# jobs list is full: on run 34609986416 the attempt-3 archive had 2 logs and the
+# attempt-1 archive had 85, for a jobs list of 97 both times. Fetching only the current
+# attempt therefore left ~83 jobs to the per-job fallback and paid the old price for
+# them, which is what re-runs were costing (~129 calls each, a third of executions).
+#
+# Hence the walk: extract attempt n, and while jobs that ran still have no log, extract
+# n-1, n-2 ... 1. That is one request per attempt rather than one per job. Walking
+# downward also means a job re-run in a later attempt keeps the later log, because the
+# extractor never overwrites one it has already written.
+#
+# The jobs list cannot shortcut this. Its run_attempt field is simply the attempt that
+# was queried -- attempt 1 and attempt 3 both return all 97 jobs, stamped 1 and 3
+# respectively -- so which attempt a job actually ran in is only knowable by elimination.
 #
 # The unpacking is a Python helper rather than `unzip` because archive entries carry job
 # and step names verbatim, emoji included: `unzip` can fail to create such a name, and
@@ -98,39 +173,50 @@ get_jobs_with_pagination_fallback() {
 # partial extraction -- observed truncating at 46 of 85 job logs. See
 # extract_job_logs_from_archive.py, which also explains the entry-name-to-job-id mapping.
 #
-# Any job the archive does not cover -- including any whose name does not resolve to
-# exactly one job, which the helper leaves unmapped on purpose -- falls through to the
-# per-job path in download_logs_for_all_jobs, so an ambiguous or missing entry costs one
-# request instead of risking a log filed under the wrong job.
-#
-# Returns non-zero if the archive could not be fetched or unpacked at all.
-download_logs_archive_for_attempt() {
+# Whatever no archive covers -- including any name that does not resolve to exactly one
+# job, which the helper leaves unmapped on purpose -- still falls through to the per-job
+# path in download_logs_for_all_jobs.
+
+# Jobs whose conclusion says they ran but which still have no log on disk. Pure local
+# bookkeeping: no API calls, so it is cheap to consult between attempts.
+count_ran_jobs_missing_logs() {
+    local logs_dir=$1
+    local jobs_data=$2
+
+    local missing=0
+    local job_id
+    while IFS= read -r job_id; do
+        [[ -z "$job_id" ]] && continue
+        [[ -s "$logs_dir/$job_id.log" ]] || missing=$((missing + 1))
+    done < <(printf '%s' "$jobs_data" | jq -r '.jobs[]? | select(.conclusion != "skipped" and .conclusion != null) | .id')
+    echo "$missing"
+}
+
+# Extract one attempt's archive into <job_id>.log. Returns non-zero only if the archive
+# could not be fetched or unpacked, which the caller treats as "try the next attempt"
+# rather than as fatal.
+extract_one_attempt_archive() {
     local repo=$1
     local workflow_run_id=$2
-    local attempt_number=$3
-    local jobs_data=$4
+    local attempt=$3
+    local jobs_file=$4
+    local logs_dir=$5
 
-    local logs_dir="generated/cicd/$workflow_run_id/logs"
     local script_dir
     script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
     local tmp_dir
     tmp_dir=$(mktemp -d)
     local archive="$tmp_dir/logs.zip"
-    local jobs_file="$tmp_dir/jobs.json"
 
-    printf '%s' "$jobs_data" > "$jobs_file"
-
-    echo "[info] fetching the whole attempt's logs as one archive"
     # Same escape-sequence handling as the per-job path: gh >= 2.97.0 needs the flag,
     # older images in the fleet do not have it. Both errors are surfaced rather than
     # discarded -- a 403 here is the signal that the repository's hourly REST budget is
     # gone, and silencing it turns that into an unexplained fallback.
     local archive_error retry_error
-    if ! archive_error=$(gh api --allow-escape-sequences "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/logs" 2>&1 >"$archive"); then
-        if ! retry_error=$(gh api "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/logs" 2>&1 >"$archive"); then
-            echo "[Warning] could not download the attempt log archive: ${retry_error:-no reason given}"
-            echo "[Warning] first attempt (with --allow-escape-sequences) said: ${archive_error:-no reason given}"
-            echo "[Warning] falling back to per-job downloads"
+    if ! archive_error=$(gh api --allow-escape-sequences "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt/logs" 2>&1 >"$archive"); then
+        if ! retry_error=$(gh api "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt/logs" 2>&1 >"$archive"); then
+            echo "[Warning] could not download the attempt $attempt log archive: ${retry_error:-no reason given}"
+            echo "[Warning] first try (with --allow-escape-sequences) said: ${archive_error:-no reason given}"
             rm -rf "$tmp_dir"
             return 1
         fi
@@ -140,13 +226,41 @@ download_logs_archive_for_attempt() {
             --archive "$archive" \
             --jobs-json "$jobs_file" \
             --logs-dir "$logs_dir"; then
-        echo "[Warning] falling back to per-job log downloads"
         rm -rf "$tmp_dir"
         return 1
     fi
 
     rm -rf "$tmp_dir"
     return 0
+}
+
+download_logs_archives_walking_attempts() {
+    local repo=$1
+    local workflow_run_id=$2
+    local attempt_number=$3
+    local jobs_data=$4
+
+    local logs_dir="generated/cicd/$workflow_run_id/logs"
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local jobs_file="$tmp_dir/jobs.json"
+    printf '%s' "$jobs_data" > "$jobs_file"
+
+    local attempt
+    for (( attempt = attempt_number; attempt >= 1; attempt-- )); do
+        echo "[info] fetching attempt $attempt's logs as one archive"
+        extract_one_attempt_archive "$repo" "$workflow_run_id" "$attempt" "$jobs_file" "$logs_dir" || true
+
+        local missing
+        missing=$(count_ran_jobs_missing_logs "$logs_dir" "$jobs_data")
+        if [[ "$missing" -eq 0 ]]; then
+            echo "[info] every job that ran has a log after $(( attempt_number - attempt + 1 )) archive request(s)"
+            break
+        fi
+        echo "[info] $missing job(s) that ran still have no log"
+    done
+
+    rm -rf "$tmp_dir"
 }
 
 download_logs_for_all_jobs() {
@@ -159,7 +273,7 @@ download_logs_for_all_jobs() {
     # Get jobs using the pagination fallback function
     jobs_data=$(get_jobs_with_pagination_fallback "$repo" "$workflow_run_id" "$attempt_number")
 
-    download_logs_archive_for_attempt "$repo" "$workflow_run_id" "$attempt_number" "$jobs_data" || true
+    download_logs_archives_walking_attempts "$repo" "$workflow_run_id" "$attempt_number" "$jobs_data"
 
     # Process the jobs data
     echo "$jobs_data" | jq -c '.jobs[] | {id: .id, conclusion: .conclusion}' | while read -r job; do
@@ -228,7 +342,7 @@ main() {
     fi
 
     set_up_dirs "$workflow_run_id"
-    download_artifacts "$repo" "$workflow_run_id"
+    download_artifacts "$repo" "$workflow_run_id" "$attempt_number"
     download_logs_for_all_jobs "$repo" "$workflow_run_id" "$attempt_number"
 }
 

--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -79,15 +79,32 @@ download_artifacts_created_since_attempt_start() {
         return
     fi
 
+    local -a fresh_names=()
     local -a name_args=()
     local name
     while IFS= read -r name; do
-        [[ -n "$name" ]] && name_args+=(--name "$name")
+        [[ -z "$name" ]] && continue
+        fresh_names+=("$name")
+        name_args+=(--name "$name")
     done <<< "$fresh"
-    echo "[info] downloading ${#name_args[@]} new test report artifact(s) for attempt $attempt_number"
+    echo "[info] downloading ${#fresh_names[@]} new test report artifact(s) for attempt $attempt_number"
+
+    # Every name goes in one `gh run download`: each invocation does its own artifact
+    # listing, so one call per artifact would cost two requests per report instead of one.
+    #
+    # The destination differs by count because gh's layout does. Several --name arguments
+    # each get their own <name>/ directory, but a lone --name flattens its files straight
+    # into -D -- and get_workflow_run_uuids_to_test_reports_paths_ globs for
+    # test_reports_* directories, so a flattened download silently yields no test results
+    # at all. Naming the directory ourselves in that case keeps the layout uniform.
+    local dest="generated/cicd/$workflow_run_id/artifacts"
+    if [[ "${#fresh_names[@]}" -eq 1 ]]; then
+        dest="$dest/${fresh_names[0]}"
+        mkdir -p "$dest"
+    fi
 
     local download_error
-    if ! download_error=$(gh run download --repo $repo -D generated/cicd/$workflow_run_id/artifacts "${name_args[@]}" $workflow_run_id 2>&1 >/dev/null); then
+    if ! download_error=$(gh run download --repo $repo -D "$dest" "${name_args[@]}" $workflow_run_id 2>&1 >/dev/null); then
         echo "[Warning] Test reports not downloaded for workflow run $workflow_run_id: ${download_error:-no reason given}"
     fi
 }

--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -13,14 +13,10 @@ set_up_dirs() {
     mkdir -p generated/cicd/$workflow_run_id/logs
 }
 
-# Artifacts persist across run attempts, so a re-run's analysis would otherwise
-# re-download every test_reports_* zip the original attempt produced -- 56 of them on
-# run 34609986416, none of them new. Attempts after the first therefore download only
-# the reports created since that attempt started; the rest were already collected when
-# the earlier attempt was analysed.
-#
-# First attempts (about two thirds of executions) keep the unconditional path, so the
-# common case pays no extra listing.
+# Artifacts persist across attempts, so a re-run would otherwise re-download every
+# test_reports_* zip the first attempt produced. Later attempts fetch only the reports
+# created since the attempt started; the rest were collected when the earlier attempt was
+# analysed. First attempts keep the unconditional path and pay no extra listing.
 download_artifacts() {
     local repo=$1
     local workflow_run_id=$2
@@ -46,9 +42,7 @@ download_artifacts() {
     fi
 }
 
-# Only the test_reports_* artifacts this attempt produced. One listing call replaces one
-# download call per stale artifact, and a re-run in which no job uploaded a fresh report
-# costs the listing alone.
+# Only the test_reports_* artifacts this attempt produced.
 download_artifacts_created_since_attempt_start() {
     local repo=$1
     local workflow_run_id=$2
@@ -68,8 +62,7 @@ download_artifacts_created_since_attempt_start() {
         return
     fi
 
-    # jq compares the ISO-8601 timestamps lexicographically, which is ordering-correct
-    # for the UTC "...Z" form the API returns.
+    # Lexicographic compare is ordering-correct for the UTC "...Z" form the API returns.
     local fresh
     fresh=$(printf '%s' "$listing" | jq -r --arg since "$attempt_started" \
         '[.artifacts[]? | select((.name | startswith("test_reports_")) and .created_at > $since) | .name] | unique | .[]')
@@ -89,14 +82,11 @@ download_artifacts_created_since_attempt_start() {
     done <<< "$fresh"
     echo "[info] downloading ${#fresh_names[@]} new test report artifact(s) for attempt $attempt_number"
 
-    # Every name goes in one `gh run download`: each invocation does its own artifact
-    # listing, so one call per artifact would cost two requests per report instead of one.
-    #
-    # The destination differs by count because gh's layout does. Several --name arguments
-    # each get their own <name>/ directory, but a lone --name flattens its files straight
-    # into -D -- and get_workflow_run_uuids_to_test_reports_paths_ globs for
-    # test_reports_* directories, so a flattened download silently yields no test results
-    # at all. Naming the directory ourselves in that case keeps the layout uniform.
+    # One invocation for all names, because each `gh run download` re-lists the artifacts.
+    # Its layout depends on the count: several --name args each get a <name>/ directory,
+    # but a lone --name flattens into -D. The parsers glob for test_reports_* directories,
+    # so a flattened download would silently yield no test results -- name that directory
+    # ourselves.
     local dest="generated/cicd/$workflow_run_id/artifacts"
     if [[ "${#fresh_names[@]}" -eq 1 ]]; then
         dest="$dest/${fresh_names[0]}"
@@ -160,42 +150,27 @@ get_jobs_with_pagination_fallback() {
     fi
 }
 
-# Fetch job logs an archive at a time instead of a job at a time.
-#
-# GitHub serves a run attempt's logs as a single zip:
+# Fetch job logs an archive at a time rather than a job at a time, via
 #   GET /repos/{repo}/actions/runs/{id}/attempts/{n}/logs
-# which replaces calling /actions/jobs/{job_id}/logs once per job -- 129 requests for a
-# 129-job merge-gate run, against the repository's shared 15,000/hr GITHUB_TOKEN budget,
-# with produce_data running hundreds of times an hour.
 #
 # An attempt's archive holds only the jobs that ran in THAT attempt, while the jobs list
-# returns every job of the run. So a re-run's archive is nearly empty even though its
-# jobs list is full: on run 34609986416 the attempt-3 archive had 2 logs and the
-# attempt-1 archive had 85, for a jobs list of 97 both times. Fetching only the current
-# attempt therefore left ~83 jobs to the per-job fallback and paid the old price for
-# them, which is what re-runs were costing (~129 calls each, a third of executions).
+# returns every job of the run. A re-run's archive is therefore nearly empty while its
+# jobs list is full, and fetching only the current attempt leaves most jobs to the
+# per-job fallback -- the old one-request-per-job cost.
 #
-# Hence the walk: extract attempt n, and while jobs that ran still have no log, extract
-# n-1, n-2 ... 1. That is one request per attempt rather than one per job. Walking
-# downward also means a job re-run in a later attempt keeps the later log, because the
-# extractor never overwrites one it has already written.
+# Hence the walk: extract attempt n, then n-1 ... 1 while jobs that ran still have no
+# log. One request per attempt instead of one per job. Newest-first also means a job
+# re-run in a later attempt keeps the later log, since the extractor never overwrites.
 #
-# The jobs list cannot shortcut this. Its run_attempt field is simply the attempt that
-# was queried -- attempt 1 and attempt 3 both return all 97 jobs, stamped 1 and 3
-# respectively -- so which attempt a job actually ran in is only knowable by elimination.
+# The jobs list cannot shortcut this: its run_attempt field is just the attempt that was
+# queried, and job ids are disjoint between attempts, so which attempt ran a job is only
+# knowable by elimination.
 #
-# The unpacking is a Python helper rather than `unzip` because archive entries carry job
-# and step names verbatim, emoji included: `unzip` can fail to create such a name, and
-# having no tty to answer its "continue?" prompt it then aborts and leaves a silently
-# partial extraction -- observed truncating at 46 of 85 job logs. See
-# extract_job_logs_from_archive.py, which also explains the entry-name-to-job-id mapping.
-#
-# Whatever no archive covers -- including any name that does not resolve to exactly one
-# job, which the helper leaves unmapped on purpose -- still falls through to the per-job
-# path in download_logs_for_all_jobs.
+# Unpacking is a Python helper rather than `unzip`; see extract_job_logs_from_archive.py,
+# which also covers the entry-name-to-job-id mapping. Anything no archive covers falls
+# through to the per-job path in download_logs_for_all_jobs.
 
-# Jobs whose conclusion says they ran but which still have no log on disk. Pure local
-# bookkeeping: no API calls, so it is cheap to consult between attempts.
+# Jobs whose conclusion says they ran but which still have no log. Local only, no API.
 count_ran_jobs_missing_logs() {
     local logs_dir=$1
     local jobs_data=$2
@@ -209,9 +184,8 @@ count_ran_jobs_missing_logs() {
     echo "$missing"
 }
 
-# Extract one attempt's archive into <job_id>.log. Returns non-zero only if the archive
-# could not be fetched or unpacked, which the caller treats as "try the next attempt"
-# rather than as fatal.
+# Extract one attempt's archive. Non-zero means the archive could not be fetched or
+# unpacked, which the caller treats as "try the next attempt" rather than as fatal.
 extract_one_attempt_archive() {
     local repo=$1
     local workflow_run_id=$2
@@ -225,10 +199,8 @@ extract_one_attempt_archive() {
     tmp_dir=$(mktemp -d)
     local archive="$tmp_dir/logs.zip"
 
-    # Same escape-sequence handling as the per-job path: gh >= 2.97.0 needs the flag,
-    # older images in the fleet do not have it. Both errors are surfaced rather than
-    # discarded -- a 403 here is the signal that the repository's hourly REST budget is
-    # gone, and silencing it turns that into an unexplained fallback.
+    # gh >= 2.97.0 needs the escape-sequence flag, older images in the fleet lack it.
+    # Errors are surfaced, not discarded: a 403 here means the repo's REST budget is gone.
     local archive_error retry_error
     if ! archive_error=$(gh api --allow-escape-sequences "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt/logs" 2>&1 >"$archive"); then
         if ! retry_error=$(gh api "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt/logs" 2>&1 >"$archive"); then
@@ -296,12 +268,9 @@ download_logs_for_all_jobs() {
     echo "$jobs_data" | jq -c '.jobs[] | {id: .id, conclusion: .conclusion}' | while read -r job; do
         job_id=$(echo "$job" | jq -r '.id')
         job_conclusion=$(echo "$job" | jq -r '.conclusion')
-        # The attempt archive above normally supplied this already, so only jobs it did
-        # not cover cost a request here. Skipped jobs and jobs that never reached a
-        # conclusion have no log to serve, and asking anyway cost *two* requests each:
-        # the 404 from the first call is a non-zero exit, so the "||" retry below fires
-        # and 404s in turn. On the run this was measured against that was 44 of 129 jobs,
-        # so 88 guaranteed-wasted requests.
+        # The archives above normally supplied this already, so only jobs they missed
+        # cost a request. Skipped jobs have no log to serve, and asking cost two requests
+        # each -- the first 404 is a non-zero exit, so the "||" retry fires and 404s too.
         if [[ ! -s generated/cicd/$workflow_run_id/logs/$job_id.log ]] &&
            [[ "$job_conclusion" != "skipped" && "$job_conclusion" != "null" && -n "$job_conclusion" ]]; then
             echo "[info] download logs for job with id $job_id, attempt number $attempt_number"

--- a/infra/data_collection/github/extract_job_logs_from_archive.py
+++ b/infra/data_collection/github/extract_job_logs_from_archive.py
@@ -4,37 +4,30 @@
 
 """Unpack a GitHub run-attempt log archive into the <job_id>.log layout this pipeline expects.
 
-GitHub serves every job log for a run attempt as one zip:
+GitHub serves a run attempt's job logs as one zip:
 
     GET /repos/{repo}/actions/runs/{run_id}/attempts/{attempt}/logs
 
-which replaces the one-request-per-job loop download_cicd_logs_and_artifacts.sh used to
-run. That loop made this pipeline's API cost scale with the size of the run being
-analyzed -- 129 requests for a 129-job merge-gate run, against the repository's shared
-15,000/hr GITHUB_TOKEN budget, ~173 times an hour.
+which replaces calling /actions/jobs/{job_id}/logs once per job.
 
-Everything downstream reads <job_id>.log, so archive entries have to be mapped back onto
-job ids. Entry names are the job name with "/" rewritten to "_" and nothing else changed
--- measured exact on 85/85 entries of run 34360282367 -- so that substitution is the
-primary match. Emoji and characters like "[", "]", "(" and "," survive byte-for-byte in
-the central directory; the "?" that `unzip -l` shows for them is its own display
-rendering, not archive content.
+Entries must be matched to jobs by NAME, not id: GitHub mints a fresh set of job ids for
+every attempt, so the ids in attempt n's jobs list do not appear in attempt n-1's. Entry
+names are the job name with "/" rewritten to "_" and nothing else changed, so that
+substitution is the primary match. Emoji and characters like "[", "]" and "," survive
+byte-for-byte; the "?" that `unzip -l` shows is its own display rendering.
 
-A normalized comparison (lowercased, everything but [a-z0-9] dropped) runs as a second
-tier in case GitHub ever changes the substitution. It is deliberately not the primary
-match: it maps distinct job names onto the same key ("a/b" and "a-b" both become "ab"),
-and a wrong match here is worse than a missing one, because it files a job's failure
-signature and runner telemetry under a different job.
+A normalized comparison (lowercased, everything but [a-z0-9] dropped) is a second tier in
+case that substitution ever changes. It is not the primary match because it maps distinct
+names onto one key ("a/b" and "a-b" both become "ab"), and a wrong match is worse than a
+missing one: it files a job's failure signature and runner telemetry under another job.
 
-So any name -- at either tier -- that does not resolve to exactly one job is left
-unmapped on purpose. The caller falls back to a per-job request for those, which costs
-one request and makes misattribution impossible rather than merely unobserved.
+So a name that does not resolve to exactly one job is left unmapped on purpose, for the
+caller to fall back on a per-job request.
 
-Reading the zip directly, rather than shelling out to `unzip`, also keeps archive-supplied
-names off the filesystem entirely: the only paths written are <job_id>.log. `unzip` can
-fail to create an entry whose name contains emoji, and having no tty to answer the
-"continue?" prompt that follows, it aborts and leaves a silently partial extraction --
-observed truncating at 46 of 85 job logs.
+Reading the zip in Python rather than shelling out to `unzip` also keeps archive-supplied
+names off the filesystem: the only paths written are <job_id>.log. `unzip` can fail to
+create a name containing emoji and, with no tty to answer its "continue?" prompt, aborts
+and leaves a silently partial extraction.
 """
 
 import argparse
@@ -62,10 +55,9 @@ def normalize(name: str) -> str:
 
 
 def _unique_index(jobs: list, key) -> dict:
-    """key(job name) -> job id, holding only keys that exactly one job produces.
+    """key(job name) -> job id, for keys that exactly one job produces.
 
-    Keys claimed by more than one job are dropped rather than resolved, so an ambiguous
-    name can never be silently attributed to whichever job happened to be listed first.
+    Keys several jobs produce are dropped rather than resolved by list order.
     """
     grouped = defaultdict(list)
     for job in jobs:
@@ -80,9 +72,8 @@ def _unique_index(jobs: list, key) -> dict:
 def resolve_entries(archive: zipfile.ZipFile, jobs: list) -> dict:
     """Archive entry name -> job id, for entries that map to exactly one job.
 
-    Both directions are checked for ambiguity: a name matching several jobs is dropped by
-    _unique_index, and a job claimed by several entries is dropped here. What survives is
-    a strict one-to-one mapping.
+    Ambiguity is checked both ways -- a name several jobs match, and a job several entries
+    claim -- so what survives is strictly one-to-one.
     """
     by_archive_name = _unique_index(jobs, archive_name_for)
     by_normalized = _unique_index(jobs, normalize)
@@ -110,13 +101,9 @@ def resolve_entries(archive: zipfile.ZipFile, jobs: list) -> dict:
 def extract(archive_path: pathlib.Path, jobs: list, logs_dir: pathlib.Path) -> tuple:
     """Write each resolved entry to <job_id>.log, leaving any that already exists alone.
 
-    An existing file is never overwritten because the caller walks attempts newest-first:
-    a job re-run in a later attempt must keep that attempt's log, not the stale one from
-    the attempt it originally ran in.
-
-    Returns (written, resolved) so a walk can tell an unusable archive from one that was
-    read fine but had nothing new to add -- the normal case for every attempt after the
-    first one that covers a job.
+    Nothing is overwritten because the caller walks attempts newest-first: a job re-run in
+    a later attempt must keep that attempt's log. Returns (written, resolved) so the walk
+    can tell an unusable archive from one that simply had nothing new.
     """
     written = 0
     resolved = 0
@@ -126,8 +113,6 @@ def extract(archive_path: pathlib.Path, jobs: list, logs_dir: pathlib.Path) -> t
             target_path = logs_dir / f"{job_id}.log"
             if target_path.exists() and target_path.stat().st_size > 0:
                 continue
-            # Written under an id we chose, so no archive-supplied name -- and no emoji
-            # or overlong path -- ever reaches the filesystem.
             with archive.open(entry_name) as source, open(target_path, "wb") as target:
                 while chunk := source.read(1024 * 1024):
                     target.write(chunk)
@@ -158,9 +143,8 @@ def main() -> int:
         print(f"[Warning] could not unpack the attempt log archive: {exc}", file=sys.stderr)
         return 1
 
-    # Nothing recognizable at all means the archive was not usable, so say so and let the
-    # caller move on. Resolving entries but writing none is different and expected during
-    # an attempt walk: a later attempt already supplied those logs.
+    # Resolving nothing means the archive was unusable. Resolving but writing nothing is
+    # expected during a walk: a later attempt already supplied those logs.
     if resolved == 0:
         print("[Warning] attempt log archive contained no recognizable job logs", file=sys.stderr)
         return 1

--- a/infra/data_collection/github/extract_job_logs_from_archive.py
+++ b/infra/data_collection/github/extract_job_logs_from_archive.py
@@ -107,16 +107,32 @@ def resolve_entries(archive: zipfile.ZipFile, jobs: list) -> dict:
     return {entry: job_id for entry, job_id in resolved.items() if job_id not in claimed_more_than_once}
 
 
-def extract(archive_path: pathlib.Path, jobs: list, logs_dir: pathlib.Path) -> int:
+def extract(archive_path: pathlib.Path, jobs: list, logs_dir: pathlib.Path) -> tuple:
+    """Write each resolved entry to <job_id>.log, leaving any that already exists alone.
+
+    An existing file is never overwritten because the caller walks attempts newest-first:
+    a job re-run in a later attempt must keep that attempt's log, not the stale one from
+    the attempt it originally ran in.
+
+    Returns (written, resolved) so a walk can tell an unusable archive from one that was
+    read fine but had nothing new to add -- the normal case for every attempt after the
+    first one that covers a job.
+    """
+    written = 0
+    resolved = 0
     with zipfile.ZipFile(archive_path) as archive:
-        resolved = resolve_entries(archive, jobs)
-        for entry_name, job_id in resolved.items():
+        for entry_name, job_id in resolve_entries(archive, jobs).items():
+            resolved += 1
+            target_path = logs_dir / f"{job_id}.log"
+            if target_path.exists() and target_path.stat().st_size > 0:
+                continue
             # Written under an id we chose, so no archive-supplied name -- and no emoji
             # or overlong path -- ever reaches the filesystem.
-            with archive.open(entry_name) as source, open(logs_dir / f"{job_id}.log", "wb") as target:
+            with archive.open(entry_name) as source, open(target_path, "wb") as target:
                 while chunk := source.read(1024 * 1024):
                     target.write(chunk)
-    return len(resolved)
+            written += 1
+    return written, resolved
 
 
 def main() -> int:
@@ -137,18 +153,19 @@ def main() -> int:
         return 1
 
     try:
-        written = extract(args.archive, jobs, args.logs_dir)
+        written, resolved = extract(args.archive, jobs, args.logs_dir)
     except (OSError, zipfile.BadZipFile) as exc:
         print(f"[Warning] could not unpack the attempt log archive: {exc}", file=sys.stderr)
         return 1
 
-    # No logs at all means the archive was not usable; let the caller fall back rather
-    # than proceed with an empty logs dir, which the parsers downstream assert against.
-    if written == 0:
+    # Nothing recognizable at all means the archive was not usable, so say so and let the
+    # caller move on. Resolving entries but writing none is different and expected during
+    # an attempt walk: a later attempt already supplied those logs.
+    if resolved == 0:
         print("[Warning] attempt log archive contained no recognizable job logs", file=sys.stderr)
         return 1
 
-    print(f"[info] recovered {written} job logs from the archive in 1 request")
+    print(f"[info] recovered {written} job logs from the archive in 1 request ({resolved - written} already present)")
     return 0
 
 

--- a/infra/tests/data_collection/test_extract_job_logs_from_archive.py
+++ b/infra/tests/data_collection/test_extract_job_logs_from_archive.py
@@ -4,12 +4,11 @@
 
 """Tests for the run-attempt log archive unpacker.
 
-The helper is standard-library-only by design, so these run without the rest of the
-data-collection dependency set.
+Standard-library-only, so these run without the data-collection dependency set.
 
-The cases that matter are the ones where a wrong answer is silent: an entry attributed to
-the wrong job produces a plausible, non-empty <job_id>.log, which the caller's "is the
-file missing?" fallback check cannot detect. Those are covered explicitly.
+The cases that matter are the silent ones: an entry attributed to the wrong job writes a
+plausible, non-empty <job_id>.log that the caller's "is the file missing?" fallback cannot
+detect.
 """
 
 import io
@@ -40,8 +39,7 @@ def test_maps_entries_to_job_ids_on_the_exact_archive_name():
 
 
 def test_slash_in_a_job_name_is_a_underscore_in_the_archive():
-    # "<caller job> / <called job>" is the shape every reusable-workflow job takes, and
-    # the "/" is the one character GitHub rewrites.
+    # The shape every reusable-workflow job takes; "/" is the one character GitHub rewrites.
     archive = _archive({"7_ttnn-merge-gate-tests _ fetch-ttsim (libttsim_bh.so).txt": "body"})
     jobs = _jobs((22, "ttnn-merge-gate-tests / fetch-ttsim (libttsim_bh.so)"))
     assert extractor.resolve_entries(archive, jobs) == {
@@ -50,8 +48,7 @@ def test_slash_in_a_job_name_is_a_underscore_in_the_archive():
 
 
 def test_emoji_and_punctuation_survive_byte_for_byte():
-    # `unzip -l` renders these as "?", but the central directory holds them verbatim, so
-    # the exact-name tier must match without any normalization.
+    # `unzip -l` renders these as "?", but the archive holds them verbatim.
     name = "build-sweeps _ build (Ubuntu 22.04, Release) _ 🛠️ Build Release"
     archive = _archive({f"50_{name}.txt": "body"})
     assert extractor.resolve_entries(archive, _jobs((33, name))) == {f"50_{name}.txt": 33}
@@ -63,14 +60,12 @@ def test_normalized_form_is_a_second_tier_when_the_exact_name_does_not_match():
 
 
 def test_two_jobs_sharing_a_name_are_left_unmapped():
-    # Rather than handing the entry to whichever job the API happened to list first.
     archive = _archive({"0_matrix leg.txt": "body"})
     assert extractor.resolve_entries(archive, _jobs((1, "matrix leg"), (2, "matrix leg"))) == {}
 
 
 def test_distinct_names_colliding_only_under_normalization_are_left_unmapped():
-    # "a/b" -> "a_b" and "a-b" both normalize to "ab". The exact tier still resolves
-    # "a_b", but "a-b" is ambiguous at the normalized tier and must not be guessed.
+    # "a/b" -> "a_b" and "a-b" both normalize to "ab", so the exact tier must resolve them.
     archive = _archive({"0_a_b.txt": "first", "1_a-b.txt": "second"})
     resolved = extractor.resolve_entries(archive, _jobs((1, "a/b"), (2, "a-b")))
     assert resolved == {"0_a_b.txt": 1, "1_a-b.txt": 2}
@@ -127,8 +122,7 @@ def test_ambiguous_job_gets_no_file_so_the_caller_falls_back(tmp_path):
 
 
 def test_an_existing_log_is_not_overwritten_by_an_older_attempt(tmp_path):
-    # The caller walks attempts newest-first, so a job re-run in attempt 3 must keep
-    # attempt 3's log when attempt 1's archive is opened afterwards.
+    # The walk is newest-first, so attempt 1's archive must not clobber attempt 3's log.
     archive_path = tmp_path / "older.zip"
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr("0_flaky job.txt", "stale log from the first attempt")
@@ -143,8 +137,7 @@ def test_an_existing_log_is_not_overwritten_by_an_older_attempt(tmp_path):
 
 
 def test_an_empty_log_is_replaced_rather_than_kept(tmp_path):
-    # A zero-byte file is what a failed earlier write leaves behind; it carries no data,
-    # so an older attempt's real log is better than keeping it.
+    # A zero-byte file is a failed write; an older attempt's real log beats keeping it.
     archive_path = tmp_path / "older.zip"
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr("0_job.txt", "real content")
@@ -159,9 +152,7 @@ def test_an_empty_log_is_replaced_rather_than_kept(tmp_path):
 
 
 def test_archive_that_adds_nothing_new_still_succeeds(tmp_path):
-    # Every attempt after the one that supplied a job's log resolves it again and writes
-    # nothing. That must not read as "archive unusable", or the walk would treat a normal
-    # step as a failure.
+    # Resolving without writing is normal mid-walk and must not read as "archive unusable".
     archive_path = tmp_path / "logs.zip"
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr("0_job.txt", "body")

--- a/infra/tests/data_collection/test_extract_job_logs_from_archive.py
+++ b/infra/tests/data_collection/test_extract_job_logs_from_archive.py
@@ -106,9 +106,9 @@ def test_extract_writes_job_id_named_files_with_the_entry_contents(tmp_path):
     logs_dir = tmp_path / "logs"
     logs_dir.mkdir()
 
-    written = extractor.extract(archive_path, _jobs((11, "build"), (22, "test / run")), logs_dir)
+    written, resolved = extractor.extract(archive_path, _jobs((11, "build"), (22, "test / run")), logs_dir)
 
-    assert written == 2
+    assert (written, resolved) == (2, 2)
     assert (logs_dir / "11.log").read_text() == "first body"
     assert (logs_dir / "22.log").read_text() == "second body"
     # Nothing named after an archive entry reaches disk.
@@ -122,8 +122,56 @@ def test_ambiguous_job_gets_no_file_so_the_caller_falls_back(tmp_path):
     logs_dir = tmp_path / "logs"
     logs_dir.mkdir()
 
-    assert extractor.extract(archive_path, _jobs((1, "matrix leg"), (2, "matrix leg")), logs_dir) == 0
+    assert extractor.extract(archive_path, _jobs((1, "matrix leg"), (2, "matrix leg")), logs_dir) == (0, 0)
     assert list(logs_dir.iterdir()) == []
+
+
+def test_an_existing_log_is_not_overwritten_by_an_older_attempt(tmp_path):
+    # The caller walks attempts newest-first, so a job re-run in attempt 3 must keep
+    # attempt 3's log when attempt 1's archive is opened afterwards.
+    archive_path = tmp_path / "older.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("0_flaky job.txt", "stale log from the first attempt")
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "77.log").write_text("fresh log from the latest attempt")
+
+    written, resolved = extractor.extract(archive_path, _jobs((77, "flaky job")), logs_dir)
+
+    assert (written, resolved) == (0, 1)
+    assert (logs_dir / "77.log").read_text() == "fresh log from the latest attempt"
+
+
+def test_an_empty_log_is_replaced_rather_than_kept(tmp_path):
+    # A zero-byte file is what a failed earlier write leaves behind; it carries no data,
+    # so an older attempt's real log is better than keeping it.
+    archive_path = tmp_path / "older.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("0_job.txt", "real content")
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "88.log").write_bytes(b"")
+
+    written, resolved = extractor.extract(archive_path, _jobs((88, "job")), logs_dir)
+
+    assert (written, resolved) == (1, 1)
+    assert (logs_dir / "88.log").read_text() == "real content"
+
+
+def test_archive_that_adds_nothing_new_still_succeeds(tmp_path):
+    # Every attempt after the one that supplied a job's log resolves it again and writes
+    # nothing. That must not read as "archive unusable", or the walk would treat a normal
+    # step as a failure.
+    archive_path = tmp_path / "logs.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("0_job.txt", "body")
+    jobs_path = tmp_path / "jobs.json"
+    jobs_path.write_text(json.dumps({"jobs": _jobs((5, "job"))}))
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "5.log").write_text("already here")
+
+    assert _run_main(tmp_path, archive_path, jobs_path, logs_dir) == 0
 
 
 def test_malformed_archive_is_reported_rather_than_raising(tmp_path, capsys):


### PR DESCRIPTION
Follow-up to #55964, which cut first-attempt analyses from ~129 API calls to a handful but
left **re-runs paying the old price** — and re-runs are about a third of executions.
tt-metal drained its 15,000/hr `GITHUB_TOKEN` budget again on 2026-09-11 at ~16:10, 54
minutes into the window. Example casualty:
[run 34620654822](https://github.com/tenstorrent/tt-metal/actions/runs/34620654822), a
produce-data job rejected on its own first billed call.

## What the API actually does

Three findings, all verified on
[run 34609986416](https://github.com/tenstorrent/tt-metal/actions/runs/34609986416) — a
`Sanity tests (push)` run that auto-retry retried twice, so it has 3 attempts:

**1. The log archive is per-attempt; the jobs list is per-run.**
`/runs/{id}/attempts/{n}/logs` contains logs only for jobs that executed in attempt `n`.
`/runs/{id}/attempts/{n}/jobs` returns the run's whole job graph regardless of attempt.

| | archive entries | jobs list |
|---|---:|---|
| attempt 3 | 2 | 97 jobs (85 ran) |
| attempt 2 | 2 | 97 jobs (85 ran) |
| attempt 1 | 85 | 97 jobs (85 ran) |

Attempt 1 ran the pipeline; attempts 2 and 3 re-ran one failing job. So analysing attempt 3
extracted 2 logs and sent the other 83 to the per-job fallback, one request each.

**2. `run_attempt` on the jobs list is not the attempt that ran the job.** It echoes the
attempt you queried. Attempt 1 and attempt 3 both return all 97 jobs, stamped `1` and `3`
respectively.

**3. Job ids are disjoint between attempts.** GitHub mints a fresh set of 97 ids per
attempt, covering the whole graph including jobs that never re-executed — zero overlap
between attempt 1's and attempt 3's id sets. Those new ids have no log of their own:

```
job 103324879046: run_attempt=3  started=2026-09-11T14:26:30Z   <- attempt 1's window
```

So logs cannot be matched to jobs by id across attempts. Matching must be by job **name**,
which is what the extractor does.

Together these mean the attempt that produced a given log is only knowable by elimination:
open archives newest-first and see which one supplies each job.

## Changes

**1. Walk the attempts for logs.** Extract attempt `n`, then `n-1` … `1` while jobs that ran
still have no log. One request per attempt instead of one per job. The extractor no longer
overwrites, so newest-first means a job re-run later keeps the later log. The
between-attempt check is local file bookkeeping and costs nothing.

**2. Don't re-download earlier attempts' artifacts.** Artifacts persist across attempts, so
every re-run re-downloaded all 56 `test_reports_*` zips from attempt 1, none of them new.
Later attempts now fetch only reports created since the attempt started. First attempts keep
the unconditional path, so the ~69% common case is untouched.

**3. Delete the `gh api rate_limit` step.** `GITHUB_TOKEN`'s budget is
[15,000/hr shared per repository](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api),
but that endpoint reports a per-token view: it printed `used: 0, remaining: 15000` sixty
seconds before the next call in the same job was rejected with `API rate limit exceeded for
installation`, and did so on every run while the repo was exhausting the shared budget. It is
free to call and it misdirected three investigations. The useful signals are the
`x-ratelimit-*` headers on a real request and the gh error text #55964 made this script
surface — which is what identified this failure immediately.

## Verification

`gh` shimmed to count invocations, output then fed through the real
`create_cicd_json_for_data_analysis`.

**Cost** — run 34609986416 attempt 3, 85 jobs ran:

| | before | after |
|---|---:|---:|
| requests | ~129 | **7** |
| job logs recovered | 85 | 85 |

**Emitted data** — run 34620727674 attempt 3, which has 7 test report artifacts of which
exactly 1 postdates the attempt's start (a re-run that did upload its own report):

| | jobs | tests | host_name resolved |
|---|---:|---:|---:|
| this branch | 20 | 1 | 20/20 |
| walk + every artifact | 20 | 130 | 20/20 |

The current attempt's own test result is kept. The 129 absent ones belong to the three jobs
that ran in earlier attempts and were ingested when those attempts were analysed; rows are
keyed `pipeline_{run_id}_{attempt_start_ts}`, so attempts are separate rows, not overwrites.

**The walk is what preserves hardware telemetry.** Without earlier attempts' logs, 24 of 85
jobs fall back from the physical node to the ephemeral runner pod — `f11-ci-cpu-01` becomes
`tt-ubuntu-2204-large-stable-h6f7m-runner`. That is the CIv2 node/serial attribution from
#49756, and it survives here intact.

85 tests pass, including 3 new ones for the walk: an older attempt must not overwrite a newer
log, a zero-byte log is replaced rather than kept, and an archive that adds nothing new is a
success rather than a failure.

## One gotcha worth a reviewer's eye

`gh run download`'s layout depends on how many `--name` arguments it gets: several each get a
`<name>/` directory, but a lone `--name` flattens its files into `-D`. The parsers glob for
`test_reports_*` directories, so the single-fresh-report case — the typical re-run shape —
would have silently yielded **zero** test results. Second commit names that directory
explicitly.

## Separately: the agentic workflows

Not touched here, but relevant while the budget is tight. Neither
`GH_AW_GITHUB_MCP_SERVER_TOKEN` nor `GH_AW_GITHUB_TOKEN` exists at repo or org level, so the
fallback chain in all six gh-aw workflows —
`secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN`
— resolves to `GITHUB_TOKEN`. Every github-mcp-server call those agents make is billed to
this repository's shared CI budget. Silencer and Repo Assist each started ~100 times in a
22-minute window on 2026-09-11. A dedicated token would move that spend off the CI budget.

cc @williamlyTT