### PR TITLE
[Cleanup] Metal 2.0 port: embedding with EmbeddingsFusedProgramFactory

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -434,7 +434,8 @@ def test_embedding_tiled_sharded_output(
 # width-/block-sharded output whose shard width is strictly smaller than the weight row, so each
 # core reads only its column slice of every weight row (reader runtime arg `weight_offset` != 0).
 # GENERIC reads every token from DRAM; PADDED additionally serves the pad row out of a local cache
-# that must hold the same column slice.
+# that must hold the same column slice; BINARY serves BOTH of its two weight rows out of that cache
+# (vocabulary is exactly {0, 1}), so every output element comes from a cached column slice.
 @pytest.mark.parametrize("batch_size, sentence_size, vocabulary_size", [(2, 256, 4096)])
 @pytest.mark.parametrize(
     "hidden_embedding_dim, output_memory_layout, shard_width, num_cores_x, num_cores_y",
@@ -446,7 +447,9 @@ def test_embedding_tiled_sharded_output(
         (2048, ttnn.TensorMemoryLayout.BLOCK_SHARDED, 512, 4, 4),
     ],
 )
-@pytest.mark.parametrize("embeddings_type", [ttnn.EmbeddingsType.GENERIC, ttnn.EmbeddingsType.PADDED])
+@pytest.mark.parametrize(
+    "embeddings_type", [ttnn.EmbeddingsType.GENERIC, ttnn.EmbeddingsType.PADDED, ttnn.EmbeddingsType.BINARY]
+)
 def test_embedding_tiled_sharded_output_weight_column_offset(
     device,
     batch_size,
@@ -479,11 +482,15 @@ def test_embedding_tiled_sharded_output_weight_column_offset(
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(output_memory_layout, ttnn.BufferType.L1, shard_spec)
 
+    if embeddings_type == ttnn.EmbeddingsType.BINARY:
+        vocabulary_size = 2  # the op requires a two-row weight table; both rows are served from the local cache
     torch_input_tensor = torch.randint(0, vocabulary_size - 1, (batch_size, sentence_size))
     pad_token = None
     if embeddings_type == ttnn.EmbeddingsType.PADDED:
         pad_token = vocabulary_size - 1
         torch_input_tensor[:, ::5] = pad_token  # make sure the local pad-row cache is actually used
+    elif embeddings_type == ttnn.EmbeddingsType.BINARY:
+        torch_input_tensor = torch.randint(0, 2, (batch_size, sentence_size))  # rows 0 and 1, both cached
     torch_weights = torch_random((vocabulary_size, hidden_embedding_dim), -0.1, 0.1, dtype=torch.bfloat16)
     torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -430,6 +430,88 @@ def test_embedding_tiled_sharded_output(
     assert_equal(torch_output_tensor, output_tensor)
 
 
+# Exercises the Fused (RM indices -> TILE output) reader with a per-core weight column offset:
+# width-/block-sharded output whose shard width is strictly smaller than the weight row, so each
+# core reads only its column slice of every weight row (reader runtime arg `weight_offset` != 0).
+# GENERIC reads every token from DRAM; PADDED additionally serves the pad row out of a local cache
+# that must hold the same column slice.
+@pytest.mark.parametrize("batch_size, sentence_size, vocabulary_size", [(2, 256, 4096)])
+@pytest.mark.parametrize(
+    "hidden_embedding_dim, output_memory_layout, shard_width, num_cores_x, num_cores_y",
+    [
+        (1024, ttnn.TensorMemoryLayout.WIDTH_SHARDED, 32, 8, 4),  # one tile wide per core
+        (1024, ttnn.TensorMemoryLayout.WIDTH_SHARDED, 128, 8, 1),
+        (2048, ttnn.TensorMemoryLayout.WIDTH_SHARDED, 256, 8, 1),
+        (1024, ttnn.TensorMemoryLayout.BLOCK_SHARDED, 256, 4, 2),
+        (2048, ttnn.TensorMemoryLayout.BLOCK_SHARDED, 512, 4, 4),
+    ],
+)
+@pytest.mark.parametrize("embeddings_type", [ttnn.EmbeddingsType.GENERIC, ttnn.EmbeddingsType.PADDED])
+def test_embedding_tiled_sharded_output_weight_column_offset(
+    device,
+    batch_size,
+    sentence_size,
+    vocabulary_size,
+    hidden_embedding_dim,
+    output_memory_layout,
+    shard_width,
+    num_cores_x,
+    num_cores_y,
+    embeddings_type,
+):
+    torch.manual_seed(1234)
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if num_cores_x > compute_grid_size.x or num_cores_y > compute_grid_size.y:
+        pytest.skip(f"Need a {num_cores_x}x{num_cores_y} core grid but device has {compute_grid_size}")
+    assert shard_width < hidden_embedding_dim, "test must exercise a non-zero per-core weight column offset"
+
+    fused_height = batch_size * sentence_size
+    num_cores = num_cores_x * num_cores_y
+    if output_memory_layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED:
+        assert shard_width * num_cores == hidden_embedding_dim
+        shard_shape = (fused_height, shard_width)
+    else:
+        assert shard_width * num_cores_x == hidden_embedding_dim
+        shard_shape = (fused_height // num_cores_y, shard_width)
+    shard_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))]
+    )
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(output_memory_layout, ttnn.BufferType.L1, shard_spec)
+
+    torch_input_tensor = torch.randint(0, vocabulary_size - 1, (batch_size, sentence_size))
+    pad_token = None
+    if embeddings_type == ttnn.EmbeddingsType.PADDED:
+        pad_token = vocabulary_size - 1
+        torch_input_tensor[:, ::5] = pad_token  # make sure the local pad-row cache is actually used
+    torch_weights = torch_random((vocabulary_size, hidden_embedding_dim), -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
+
+    input_tensor = ttnn.to_device(
+        ttnn.from_torch(torch_input_tensor, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT),
+        device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    weights = ttnn.to_device(
+        ttnn.from_torch(torch_weights, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT),
+        device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    output_tensor = ttnn.embedding(
+        input_tensor,
+        weights,
+        padding_idx=pad_token,  # non-None selects EmbeddingsType.PADDED
+        embeddings_type=embeddings_type,
+        dtype=ttnn.bfloat16,
+        memory_config=output_mem_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_equal(torch_output_tensor, output_tensor)
+
+
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
     "device_params",

--- a/ttnn/cpp/ttnn/operations/embedding/device/embeddings_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embeddings_fused_program_factory.cpp
@@ -5,17 +5,20 @@
 #include "embeddings_fused_program_factory.hpp"
 #include "embedding_program_factory_common.hpp"
 
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 
 namespace ttnn::prim {
 
 using namespace tt;
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
-tt::tt_metal::ProgramDescriptor EmbeddingsFusedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts EmbeddingsFusedProgramFactory::create_program_artifacts(
     const EmbeddingParams& operation_attributes, const EmbeddingInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input_tensor_arg;
     const auto& weights = tensor_args.weight_arg;
@@ -23,13 +26,9 @@ tt::tt_metal::ProgramDescriptor EmbeddingsFusedProgramFactory::create_descriptor
     const auto& embeddings_type = operation_attributes.embeddings_type;
     const auto& pad_token = operation_attributes.pad_token;
 
-    ProgramDescriptor desc;
-
-    ////////////////////////////////////////////////////////////////////////////
-    //                 Buffer Setup
-    ////////////////////////////////////////////////////////////////////////////
-
-    tt::tt_metal::Buffer* out_buffer = output.buffer();
+    const auto& input_mesh_tensor = a.mesh_tensor();
+    const auto& weights_mesh_tensor = weights.mesh_tensor();
+    const auto& output_mesh_tensor = output.mesh_tensor();
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
@@ -84,7 +83,7 @@ tt::tt_metal::ProgramDescriptor EmbeddingsFusedProgramFactory::create_descriptor
     uint32_t g1_numcores = core_group_1.num_cores();
 
     // Create Buffers
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat input_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
 
     EmbeddingsIndexType embeddings_index_type;
     if (a.dtype() == DataType::BFLOAT16) {
@@ -93,15 +92,15 @@ tt::tt_metal::ProgramDescriptor EmbeddingsFusedProgramFactory::create_descriptor
         embeddings_index_type = EmbeddingsIndexType::UINT32;
     }
 
-    tt::DataFormat weights_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(weights.dtype());
-    uint32_t weights_single_tile_size = tt::tile_size(weights_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
-    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+    tt::DataFormat weights_data_format = tt::tt_metal::datatype_to_dataformat_converter(weights.dtype());
+    uint32_t weights_single_tile_size = tt::tile_size(weights_data_format);
+    tt::DataFormat output_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_data_format);
 
     // Hardcoded limit to reduce L1 usage. Should be updated to be tuned based on overall L1 usage
     constexpr uint32_t max_double_buffer_tiles = 64;
 
-    constexpr uint32_t max_l1_budget_bytes = 1024 * 1024;  // 1MB budget for embedding CB
+    constexpr uint32_t max_l1_budget_bytes = 1024 * 1024;  // 1MB budget for the embedding weights staging buffer
     uint32_t max_tiles_per_chunk = std::min(max_l1_budget_bytes / weights_single_tile_size, num_tiles_per_block);
     max_tiles_per_chunk = std::max(max_tiles_per_chunk, 1U);
 
@@ -130,72 +129,85 @@ tt::tt_metal::ProgramDescriptor EmbeddingsFusedProgramFactory::create_descriptor
         buffering = num_tiles_per_block > max_double_buffer_tiles ? 1 : 2;
     }
 
-    constexpr uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t cb0_size = buffering * tiles_per_chunk * weights_single_tile_size;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb0_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = weights_cb_data_format,
-            .page_size = weights_single_tile_size,
-        }}},
+    // PADDED and BINARY serve some weight rows out of a locally cached copy instead of fetching them
+    // per token; the other embeddings types have no such rows, so the cache is absent for them.
+    const bool use_local_cache = embeddings_type == EmbeddingsType::PADDED || embeddings_type == EmbeddingsType::BINARY;
+
+    // -----------------------------------------------------------------------
+    // Resource names
+    // -----------------------------------------------------------------------
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+    const KernelSpecName COMPUTE_G1{"compute_group_1"};
+    const KernelSpecName COMPUTE_G2{"compute_group_2"};
+
+    const DFBSpecName WEIGHTS_STAGING{"weights_staging"};
+    const DFBSpecName INDEX_SCRATCH{"index_scratch"};
+    const DFBSpecName OUTPUT{"output"};
+    const DFBSpecName WEIGHT_CACHE{"weight_cache"};
+
+    const TensorParamName INPUT_PARAM{"input"};
+    const TensorParamName WEIGHTS_PARAM{"weights"};
+    const TensorParamName OUTPUT_PARAM{"output"};
+
+    ProgramSpec spec;
+    spec.name = "embeddings_fused";
+
+    // -----------------------------------------------------------------------
+    // Dataflow buffers
+    // -----------------------------------------------------------------------
+    // The reader gathers each block's weight rows (one chunk at a time) into this row-major staging
+    // buffer; the compute kernel tilizes them out of it into the output buffer.
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = WEIGHTS_STAGING,
+        .entry_size = weights_single_tile_size,
+        .num_entries = buffering * tiles_per_chunk,
+        .data_format_metadata = weights_data_format,
     });
 
-    constexpr uint32_t src1_cb_index = tt::CBIndex::c_1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = TILE_HEIGHT * input_element_size_bytes,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src1_cb_index,
-            .data_format = input_cb_data_format,
-            .page_size = TILE_HEIGHT * input_element_size_bytes,
-        }}},
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = INDEX_SCRATCH,
+        .entry_size = TILE_HEIGHT * input_element_size_bytes,
+        .num_entries = 1,
+        .data_format_metadata = input_data_format,
     });
 
-    constexpr uint32_t output_cb_index = tt::CBIndex::c_2;
-    uint32_t output_cb_size;
+    uint32_t output_dfb_total_size;
     if (output_sharded) {
-        output_cb_size = output.buffer()->aligned_size_per_bank();
+        output_dfb_total_size = output.buffer()->aligned_size_per_bank();
     } else {
-        output_cb_size = buffering * tiles_per_chunk * output_single_tile_size;
+        output_dfb_total_size = buffering * tiles_per_chunk * output_single_tile_size;
     }
-    CBDescriptor output_cb_desc{
-        .total_size = output_cb_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
+    // The output buffer's total size has to divide evenly by its tile-sized entry. When the output is
+    // sharded the total is the shard's own aligned size per bank, which the op's validation makes a
+    // whole number of tiles; assert it here so a disagreement fails loudly at construction rather than
+    // as a framework rejection of the borrowed buffer's size.
+    TT_FATAL(
+        output_dfb_total_size % output_single_tile_size == 0,
+        "Embedding output buffer size {} B must be divisible by its tile size {} B",
+        output_dfb_total_size,
+        output_single_tile_size);
+    DataflowBufferSpec out_dfb{
+        .unique_id = OUTPUT,
+        .entry_size = output_single_tile_size,
+        .num_entries = output_dfb_total_size / output_single_tile_size,
+        .data_format_metadata = output_data_format,
     };
     if (output_sharded) {
-        output_cb_desc.buffer = out_buffer;
+        // The output buffer *is* the output shard: it is built on the output tensor's own SRAM, so the
+        // tiles compute packs land in place and no writer kernel is created below.
+        out_dfb.borrowed_from = OUTPUT_PARAM;
     }
-    desc.cbs.push_back(std::move(output_cb_desc));
+    spec.dataflow_buffers.push_back(std::move(out_dfb));
 
-    constexpr uint32_t src2_cb_index = tt::CBIndex::c_3;
-    if (embeddings_type == EmbeddingsType::PADDED) {
+    if (use_local_cache) {
         uint32_t cache_page_size = round_up_to_mul32(weight_page_size);
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = cache_page_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = src2_cb_index,
-                .data_format = weights_cb_data_format,
-                .page_size = cache_page_size,
-            }}},
-        });
-    } else if (embeddings_type == EmbeddingsType::BINARY) {
-        uint32_t cache_page_size = round_up_to_mul32(weight_page_size);
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = 2 * cache_page_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = src2_cb_index,
-                .data_format = weights_cb_data_format,
-                .page_size = cache_page_size,
-            }}},
+        // PADDED caches the single pad row; BINARY caches rows 0 and 1.
+        spec.dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = WEIGHT_CACHE,
+            .entry_size = cache_page_size,
+            .num_entries = (embeddings_type == EmbeddingsType::PADDED) ? 1u : 2u,
+            .data_format_metadata = weights_data_format,
         });
     }
     uint32_t weight_block_size;
@@ -207,105 +219,228 @@ tt::tt_metal::ProgramDescriptor EmbeddingsFusedProgramFactory::create_descriptor
 
     // TODO: Can increase size for larger reads
     uint32_t input_block_size_bytes = TILE_HEIGHT * input_element_size_bytes;
-    // Create Kernels
-    // reader
-    std::vector<uint32_t> embedding_compile_time_args = {
-        (std::uint32_t)src0_cb_index,
-        (std::uint32_t)src1_cb_index,
-        (std::uint32_t)src2_cb_index,
-        (std::uint32_t)input_page_size,
-        (std::uint32_t)weight_page_size,
-        (std::uint32_t)weight_block_size,
-        (std::uint32_t)tiles_per_chunk,
-        (std::uint32_t)input_block_size_bytes,
-        (std::uint32_t)num_chunks,
-        (std::uint32_t)last_chunk_tiles};
-    tt::tt_metal::TensorAccessorArgs(*a.buffer()).append_to(embedding_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*weights.buffer()).append_to(embedding_compile_time_args);
 
-    KernelDescriptor::Defines embedding_defines = {
-        {enchantum::to_string(embeddings_type).data(), "1"}, {enchantum::to_string(embeddings_index_type).data(), "1"}};
+    // -----------------------------------------------------------------------
+    // Tensor parameters
+    //
+    // The output parameter is declared in every configuration: the writer binds it when the output is
+    // interleaved, and the borrowed output buffer resolves its address from it when the output is
+    // sharded.
+    // -----------------------------------------------------------------------
+    spec.tensor_parameters.push_back(
+        TensorParameter{.unique_id = INPUT_PARAM, .spec = input_mesh_tensor.tensor_spec()});
+    spec.tensor_parameters.push_back(
+        TensorParameter{.unique_id = WEIGHTS_PARAM, .spec = weights_mesh_tensor.tensor_spec()});
+    spec.tensor_parameters.push_back(
+        TensorParameter{.unique_id = OUTPUT_PARAM, .spec = output_mesh_tensor.tensor_spec()});
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(embedding_compile_time_args);
-    reader_desc.defines = embedding_defines;
-    reader_desc.config = ReaderConfigDescriptor{};
+    // -----------------------------------------------------------------------
+    // Reader
+    // -----------------------------------------------------------------------
+    Group<DFBBinding> reader_dfb_bindings;
+    reader_dfb_bindings.push_back(DFBBinding{
+        .dfb_spec_name = WEIGHTS_STAGING,
+        .accessor_name = "in0",
+        .endpoint_type = DFBEndpointType::PRODUCER,
+    });
+    // The index scratch page never leaves the reader: it reserves the page once, decodes indices out
+    // of it, and commits it at the end only to leave the buffer balanced. Both roles are the reader's.
+    reader_dfb_bindings.push_back(DFBBinding{
+        .dfb_spec_name = INDEX_SCRATCH,
+        .accessor_name = "in1",
+        .endpoint_type = DFBEndpointType::PRODUCER,
+    });
+    reader_dfb_bindings.push_back(DFBBinding{
+        .dfb_spec_name = INDEX_SCRATCH,
+        .accessor_name = "in1",
+        .endpoint_type = DFBEndpointType::CONSUMER,
+    });
+    if (use_local_cache) {
+        // Likewise the weight cache: the reader fills it and reads tokens back out of it, with no
+        // hand-off to another kernel.
+        reader_dfb_bindings.push_back(DFBBinding{
+            .dfb_spec_name = WEIGHT_CACHE,
+            .accessor_name = "local_cache",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        });
+        reader_dfb_bindings.push_back(DFBBinding{
+            .dfb_spec_name = WEIGHT_CACHE,
+            .accessor_name = "local_cache",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        });
+    }
 
-    // Compute kernels: split across the two core groups, each with its own
-    // per_core_block_cnt compile-time arg. We must build them as separate
-    // KernelDescriptors because their compile_time_args / core_ranges differ.
-    std::optional<KernelDescriptor> compute_desc_1;
-    std::optional<KernelDescriptor> compute_desc_2;
+    // These defines and the weight cache's DFB binding share one condition, the embeddings type. That
+    // is what lets the reader name the cache handle at all: a dfb:: handle exists only on the builds
+    // where the host binds it, so the reader's reference to it is compiled out under the same defines
+    // on the builds where it is not.
+    KernelSpec::CompilerOptions::Defines embedding_defines{
+        {enchantum::to_string(embeddings_type).data(), "1"},
+        {enchantum::to_string(embeddings_index_type).data(), "1"},
+    };
+
+    Group<std::string> reader_rta_names = {"input_start_id", "input_start_offset", "weight_offset", "num_blocks"};
+    if (embeddings_type == EmbeddingsType::PADDED) {
+        reader_rta_names.push_back("pad_token");
+    }
+
+    spec.kernels.push_back(KernelSpec{
+        .unique_id = READER,
+        .source = "ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp",
+        .compiler_options = {.defines = embedding_defines},
+        .dfb_bindings = std::move(reader_dfb_bindings),
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = INPUT_PARAM, .accessor_name = "input"},
+                TensorBinding{.tensor_parameter_name = WEIGHTS_PARAM, .accessor_name = "weights"},
+            },
+        .compile_time_args =
+            {
+                {"input_page_size", input_page_size},
+                {"weight_block_size", weight_block_size},
+                {"tiles_per_chunk", tiles_per_chunk},
+                {"input_block_size_bytes", input_block_size_bytes},
+                {"num_chunks", num_chunks},
+                {"last_chunk_tiles", last_chunk_tiles},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = std::move(reader_rta_names)},
+        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+    });
+
+    // -----------------------------------------------------------------------
+    // Compute
+    //
+    // Split across the two core groups, each with its own per_core_block_cnt compile-time arg, so the
+    // two groups are two KernelSpecs of the same source rather than one spec with the count demoted to
+    // a runtime arg. The source itself is config-selected: the chunked kernel when a block's tiles do
+    // not fit the L1 budget in one go, the shared tilize kernel otherwise.
+    // -----------------------------------------------------------------------
     const char* compute_kernel_path =
         use_chunked_processing ? "ttnn/cpp/ttnn/operations/embedding/device/kernels/compute/tilize_chunked.cpp"
-                               : "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp";
+                               : "ttnn/cpp/ttnn/kernel/compute/tilize_metal2.cpp";
+
+    // Legacy compute config left every field at its default; ComputeGen1Config's defaults reproduce
+    // them exactly (HiFi4, precise SFPU, 16-bit dest, double-buffered dest, no unpack-mode entries).
+    ComputeHardwareConfig compute_hw = ComputeGen1Config{};
+
+    auto make_compute = [&](const KernelSpecName& unique_id, uint32_t per_core_block_cnt) {
+        Group<DFBBinding> compute_dfb_bindings;
+        compute_dfb_bindings.push_back(DFBBinding{
+            .dfb_spec_name = WEIGHTS_STAGING,
+            .accessor_name = "in",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        });
+        compute_dfb_bindings.push_back(DFBBinding{
+            .dfb_spec_name = OUTPUT,
+            .accessor_name = "out",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        });
+        if (output_sharded) {
+            // With no writer kernel the compute kernel is the output buffer's only endpoint: it packs
+            // tiles straight into the output shard and nothing drains them, so it holds both roles.
+            compute_dfb_bindings.push_back(DFBBinding{
+                .dfb_spec_name = OUTPUT,
+                .accessor_name = "out",
+                .endpoint_type = DFBEndpointType::CONSUMER,
+            });
+        }
+
+        KernelSpec::CompileTimeArgs compute_compile_time_args;
+        if (use_chunked_processing) {
+            compute_compile_time_args = {
+                {"per_core_block_cnt", per_core_block_cnt},
+                {"tiles_per_chunk", tiles_per_chunk},
+                {"num_chunks", num_chunks},
+                {"last_chunk_tiles", last_chunk_tiles},
+            };
+        } else {
+            // The shared tilize kernel processes each block as one chunk of tiles_per_chunk tiles.
+            compute_compile_time_args = {
+                {"per_core_block_cnt", per_core_block_cnt},
+                {"per_core_block_tile_cnt", tiles_per_chunk},
+            };
+        }
+
+        return KernelSpec{
+            .unique_id = unique_id,
+            .source = compute_kernel_path,
+            // O3 explicitly: the legacy compute config set no opt_level and so resolved to O3, but
+            // Metal 2.0's type-agnostic CompilerOptions defaults to O2. Leaving it unset would drop a
+            // level on both compute specs' compile and link.
+            .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
+            .dfb_bindings = std::move(compute_dfb_bindings),
+            .compile_time_args = std::move(compute_compile_time_args),
+            .hw_config = compute_hw,
+        };
+    };
+
+    // -----------------------------------------------------------------------
+    // Writer
+    //
+    // A sharded output needs no writer: compute has already packed its tiles into the output shard.
+    // TODO: We can use the second risc to do more work in parallel
+    // -----------------------------------------------------------------------
+    if (!output_sharded) {
+        // Tilized writer
+        spec.kernels.push_back(KernelSpec{
+            .unique_id = WRITER,
+            .source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+                      "writer_unary_interleaved_start_id_metal2.cpp",
+            .dfb_bindings =
+                {
+                    DFBBinding{
+                        .dfb_spec_name = OUTPUT,
+                        .accessor_name = "out",
+                        .endpoint_type = DFBEndpointType::CONSUMER,
+                    },
+                },
+            .tensor_bindings =
+                {
+                    TensorBinding{.tensor_parameter_name = OUTPUT_PARAM, .accessor_name = "dst"},
+                },
+            .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+            .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Work units: one per core group, each running the data-movement kernels together with that
+    // group's compute spec. The two groups' node sets are disjoint and together cover all_cores.
+    // -----------------------------------------------------------------------
+    Group<KernelSpecName> data_movement_kernels = {READER};
+    if (!output_sharded) {
+        data_movement_kernels.push_back(WRITER);
+    }
 
     if (num_blocks_per_core_group_1 > 0) {
-        std::vector<uint32_t> compute_args_1 = {
-            uint32_t(src0_cb_index),                // input embeddings_cb_index
-            uint32_t(output_cb_index),              // output_cb_index
-            uint32_t(num_blocks_per_core_group_1),  // per_core_block_cnt
-            uint32_t(tiles_per_chunk),              // tiles_per_chunk
-            uint32_t(num_chunks),                   // num_chunks per block
-            uint32_t(last_chunk_tiles)              // last_chunk_tiles
-        };
-        KernelDescriptor compute_desc;
-        compute_desc.kernel_source = compute_kernel_path;
-        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc.core_ranges = core_group_1;
-        compute_desc.compile_time_args = std::move(compute_args_1);
-        compute_desc.config = ComputeConfigDescriptor{};
-        compute_desc_1 = std::move(compute_desc);
+        spec.kernels.push_back(make_compute(COMPUTE_G1, num_blocks_per_core_group_1));
+        Group<KernelSpecName> group_1_kernels = data_movement_kernels;
+        group_1_kernels.push_back(COMPUTE_G1);
+        spec.work_units.push_back(WorkUnitSpec{
+            .name = "core_group_1",
+            .kernels = std::move(group_1_kernels),
+            .target_nodes = core_group_1,
+        });
     }
 
     if (num_blocks_per_core_group_2 > 0) {
-        std::vector<uint32_t> compute_args_2 = {
-            uint32_t(src0_cb_index),                // input embeddings_cb_index
-            uint32_t(output_cb_index),              // output_cb_index
-            uint32_t(num_blocks_per_core_group_2),  // per_core_block_cnt
-            uint32_t(tiles_per_chunk),              // tiles_per_chunk
-            uint32_t(num_chunks),                   // num_chunks per block
-            uint32_t(last_chunk_tiles)              // last_chunk_tiles
-        };
-        KernelDescriptor compute_desc;
-        compute_desc.kernel_source = compute_kernel_path;
-        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc.core_ranges = core_group_2;
-        compute_desc.compile_time_args = std::move(compute_args_2);
-        compute_desc.config = ComputeConfigDescriptor{};
-        compute_desc_2 = std::move(compute_desc);
+        spec.kernels.push_back(make_compute(COMPUTE_G2, num_blocks_per_core_group_2));
+        Group<KernelSpecName> group_2_kernels = data_movement_kernels;
+        group_2_kernels.push_back(COMPUTE_G2);
+        spec.work_units.push_back(WorkUnitSpec{
+            .name = "core_group_2",
+            .kernels = std::move(group_2_kernels),
+            .target_nodes = core_group_2,
+        });
     }
 
-    // TODO: We can use the second risc to do more work in parallel
-    std::optional<KernelDescriptor> writer_desc;
-    if (!output_sharded) {
-        std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
-        tt::tt_metal::TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
-
-        // Tilized writer
-        KernelDescriptor w;
-        w.kernel_source =
-            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-        w.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        w.core_ranges = all_cores;
-        w.compile_time_args = std::move(writer_compile_time_args);
-        w.config = WriterConfigDescriptor{};
-        writer_desc = std::move(w);
-    }
-
+    // -----------------------------------------------------------------------
+    // Run args
+    // -----------------------------------------------------------------------
     auto cores = corerange_to_cores(all_cores, std::nullopt, row_major);
 
-    auto* a_buffer = a.buffer();
-    auto* weights_buffer = weights.buffer();
-    auto* output_buffer = output.buffer();
-
-    reader_desc.runtime_args.reserve(cores.size());
-    if (writer_desc.has_value()) {
-        writer_desc->runtime_args.reserve(cores.size());
-    }
+    KernelRunArgs reader_run_args{.kernel = READER};
+    KernelRunArgs writer_run_args{.kernel = WRITER};
 
     uint32_t input_offset = 0;
     uint32_t weight_offset = 0;
@@ -317,23 +452,24 @@ tt::tt_metal::ProgramDescriptor EmbeddingsFusedProgramFactory::create_descriptor
 
         // Reader
         {
-            KernelDescriptor::RTArgList reader_args;
-            reader_args.push_back(a_buffer);
-            reader_args.push_back(weights_buffer);
-            reader_args.push_back(input_offset / num_blocks_per_batch);
-            reader_args.push_back(input_offset % num_blocks_per_batch * input_block_size_bytes);
-            reader_args.push_back(weight_offset);
-            reader_args.push_back(local_num_blocks);
+            AddRuntimeArgsForNode(
+                reader_run_args.runtime_arg_values,
+                core,
+                {{"input_start_id", input_offset / num_blocks_per_batch},
+                 {"input_start_offset", input_offset % num_blocks_per_batch * input_block_size_bytes},
+                 {"weight_offset", weight_offset},
+                 {"num_blocks", local_num_blocks}});
             if (embeddings_type == EmbeddingsType::PADDED) {
-                reader_args.push_back(pad_token.value());
+                AddRuntimeArgsForNode(reader_run_args.runtime_arg_values, core, {{"pad_token", pad_token.value()}});
             }
-            reader_desc.emplace_runtime_args(core, reader_args);
         }
 
         // Writer
         if (!output_sharded) {
-            writer_desc->emplace_runtime_args(
-                core, {output_buffer, static_cast<uint32_t>(num_tiles_per_block * local_num_blocks), tile_offset});
+            AddRuntimeArgsForNode(
+                writer_run_args.runtime_arg_values,
+                core,
+                {{"num_pages", num_tiles_per_block * local_num_blocks}, {"start_id", tile_offset}});
             tile_offset += local_num_blocks * num_tiles_per_block;
             input_offset += local_num_blocks;
         } else {
@@ -345,18 +481,16 @@ tt::tt_metal::ProgramDescriptor EmbeddingsFusedProgramFactory::create_descriptor
         }
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    if (writer_desc.has_value()) {
-        desc.kernels.push_back(std::move(*writer_desc));
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args.push_back(std::move(reader_run_args));
+    if (!output_sharded) {
+        run_args.kernel_run_args.push_back(std::move(writer_run_args));
     }
-    if (compute_desc_1.has_value()) {
-        desc.kernels.push_back(std::move(*compute_desc_1));
-    }
-    if (compute_desc_2.has_value()) {
-        desc.kernels.push_back(std::move(*compute_desc_2));
-    }
+    run_args.tensor_args.emplace(INPUT_PARAM, input_mesh_tensor);
+    run_args.tensor_args.emplace(WEIGHTS_PARAM, weights_mesh_tensor);
+    run_args.tensor_args.emplace(OUTPUT_PARAM, output_mesh_tensor);
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/embedding/device/embeddings_fused_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embeddings_fused_program_factory.hpp
@@ -5,12 +5,13 @@
 #pragma once
 
 #include "embedding_device_operation_types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct EmbeddingsFusedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const EmbeddingParams& operation_attributes, const EmbeddingInputs& tensor_args, Tensor& tensor_return_value);
 };
 

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/compute/tilize_chunked.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/compute/tilize_chunked.cpp
@@ -2,20 +2,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Chunked tilize for the tilized-output embedding program factory: used when a block's tiles do not
+// fit the L1 staging budget in one go, so each block is tilized as num_chunks chunks with a possibly
+// partial last chunk.
+//
+// Binding vocabulary the Metal 2.0 KernelSpec supplies for this source:
+//   dfb::in  — row-major weights staging DFB, bound CONSUMER
+//   dfb::out — tiled output DFB, bound PRODUCER
+//   args::per_core_block_cnt, args::tiles_per_chunk, args::num_chunks, args::last_chunk_tiles — compile-time args
+
 #include <cstdint>
 
 #include "api/compute/tilize.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
-    constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(2);
-    constexpr uint32_t tiles_per_chunk = get_compile_time_arg_val(3);
-    constexpr uint32_t num_chunks = get_compile_time_arg_val(4);
-    constexpr uint32_t last_chunk_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t per_core_block_cnt = get_arg(args::per_core_block_cnt);
+    constexpr uint32_t tiles_per_chunk = get_arg(args::tiles_per_chunk);
+    constexpr uint32_t num_chunks = get_arg(args::num_chunks);
+    constexpr uint32_t last_chunk_tiles = get_arg(args::last_chunk_tiles);
 
-    compute_kernel_hw_startup(cb_id_in0, cb_id_out0);
+    compute_kernel_hw_startup(dfb::in, dfb::out);
     // Process the block in chunks to fit within L1 memory limits.
     // When num_tiles_per_block divides evenly (last_chunk_tiles ==
     // tiles_per_chunk), use the original single-call path. Otherwise the
@@ -24,8 +32,8 @@ void kernel_main() {
     if constexpr (last_chunk_tiles == tiles_per_chunk) {
         compute_kernel_lib::tilize<
             tiles_per_chunk,
-            cb_id_in0,
-            cb_id_out0,
+            dfb::in,
+            dfb::out,
             compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
             compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
             compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(
@@ -35,16 +43,16 @@ void kernel_main() {
             if constexpr (num_chunks > 1) {
                 compute_kernel_lib::tilize<
                     tiles_per_chunk,
-                    cb_id_in0,
-                    cb_id_out0,
+                    dfb::in,
+                    dfb::out,
                     compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
                     compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
                     compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(num_chunks - 1);
             }
             compute_kernel_lib::tilize<
                 last_chunk_tiles,
-                cb_id_in0,
-                cb_id_out0,
+                dfb::in,
+                dfb::out,
                 compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
                 compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
                 compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(1);

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
@@ -31,28 +31,48 @@ uint32_t pad_local_addr;
 uint32_t zero_local_addr;
 uint32_t one_local_addr;
 
+// Fills the local weight cache (pad row under PADDED, rows 0 and 1 under BINARY) with
+// `weight_stick_size` bytes of each cached row, starting `weight_col_offset_bytes` into the row.
+// The offset is the core's column slice of the weight row (non-zero only for width-/block-sharded
+// output); it is applied per read so that `weights` can be built on the clean buffer base.
 template <typename T>
 FORCE_INLINE constexpr void prepare_local_cache(
     const Noc& noc,
     uint32_t local_cache_cb,
     const T& weights,
     uint32_t weight_stick_size,
-    uint32_t pad_token_arg_idx = 0) {
+    uint32_t pad_token_arg_idx = 0,
+    uint32_t weight_col_offset_bytes = 0) {
 #if defined PADDED
     pad_token = get_arg_val<uint32_t>(pad_token_arg_idx);
     CircularBuffer cb(local_cache_cb);
     cb.reserve_back(1);
     pad_local_addr = cb.get_write_ptr();
-    noc.async_read(weights, CoreLocalMem<uint32_t>(pad_local_addr), weight_stick_size, {.page_id = pad_token}, {});
+    noc.async_read(
+        weights,
+        CoreLocalMem<uint32_t>(pad_local_addr),
+        weight_stick_size,
+        {.page_id = pad_token, .offset_bytes = weight_col_offset_bytes},
+        {});
     noc.async_read_barrier();
 #elif defined BINARY
     CircularBuffer cb(local_cache_cb);
     cb.reserve_back(2);
     zero_local_addr = cb.get_write_ptr();
-    noc.async_read(weights, CoreLocalMem<uint32_t>(zero_local_addr), weight_stick_size, {.page_id = 0}, {});
+    noc.async_read(
+        weights,
+        CoreLocalMem<uint32_t>(zero_local_addr),
+        weight_stick_size,
+        {.page_id = 0, .offset_bytes = weight_col_offset_bytes},
+        {});
 
     one_local_addr = zero_local_addr + weight_stick_size;
-    noc.async_read(weights, CoreLocalMem<uint32_t>(one_local_addr), weight_stick_size, {.page_id = 1}, {});
+    noc.async_read(
+        weights,
+        CoreLocalMem<uint32_t>(one_local_addr),
+        weight_stick_size,
+        {.page_id = 1, .offset_bytes = weight_col_offset_bytes},
+        {});
 
     noc.async_read_barrier();
 #endif
@@ -60,6 +80,12 @@ FORCE_INLINE constexpr void prepare_local_cache(
 
 // Issues an async read of one token's weight stick (or a chunk of it) into the destination L1
 // address. Caller must barrier before use.
+//
+// `chunk_offset_bytes` selects the chunk within the (already column-sliced) stick and applies to
+// both the DRAM read and the local-cache replay. `weight_col_offset_bytes` is the core's column
+// slice of the weight row; it applies to the DRAM read only, because prepare_local_cache already
+// filled the local cache from that offset. Passing it here (rather than folding it into the
+// accessor's base address) keeps `weights` on the clean buffer base.
 template <typename T>
 FORCE_INLINE void read_token_async(
     const Noc& noc,
@@ -67,7 +93,9 @@ FORCE_INLINE void read_token_async(
     const T& weights,
     uint32_t dst_l1_addr,
     uint32_t size_bytes,
-    uint32_t weight_offset_bytes = 0) {
+    uint32_t chunk_offset_bytes = 0,
+    uint32_t weight_col_offset_bytes = 0) {
+    const uint32_t weight_offset_bytes = weight_col_offset_bytes + chunk_offset_bytes;
 #if defined PADDED
     if (token == pad_token) {
         const uint8_t noc_id = noc.get_noc_id();
@@ -76,7 +104,7 @@ FORCE_INLINE void read_token_async(
             src,
             CoreLocalMem<uint32_t>(dst_l1_addr),
             size_bytes,
-            {.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = pad_local_addr + weight_offset_bytes},
+            {.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = pad_local_addr + chunk_offset_bytes},
             {});
         return;
     }
@@ -94,7 +122,7 @@ FORCE_INLINE void read_token_async(
         src,
         CoreLocalMem<uint32_t>(dst_l1_addr),
         size_bytes,
-        {.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = local_addr + weight_offset_bytes},
+        {.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = local_addr + chunk_offset_bytes},
         {});
 #elif defined BFP16
     union {

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common_metal2.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common_metal2.hpp
@@ -41,28 +41,48 @@ uint32_t one_local_addr;
 //
 // `pad_token_value` is the token that PADDED treats as padding. The caller supplies it because the
 // two readers take it from different arguments.
+//
+// `weight_col_offset_bytes` is the core's column slice of the weight row (non-zero only for
+// width-/block-sharded output); it is applied per read so that `weights` can be built on the clean
+// buffer base.
 template <typename T>
 FORCE_INLINE constexpr void prepare_local_cache(
     const Noc& noc,
     DFBBindingToken local_cache,
     const T& weights,
     uint32_t weight_stick_size,
-    uint32_t pad_token_value = 0) {
+    uint32_t pad_token_value = 0,
+    uint32_t weight_col_offset_bytes = 0) {
 #if defined PADDED
     pad_token = pad_token_value;
     DataflowBuffer dfb(local_cache);
     dfb.reserve_back(1);
     pad_local_addr = dfb.get_write_ptr();
-    noc.async_read(weights, CoreLocalMem<uint32_t>(pad_local_addr), weight_stick_size, {.page_id = pad_token}, {});
+    noc.async_read(
+        weights,
+        CoreLocalMem<uint32_t>(pad_local_addr),
+        weight_stick_size,
+        {.page_id = pad_token, .offset_bytes = weight_col_offset_bytes},
+        {});
     noc.async_read_barrier();
 #elif defined BINARY
     DataflowBuffer dfb(local_cache);
     dfb.reserve_back(2);
     zero_local_addr = dfb.get_write_ptr();
-    noc.async_read(weights, CoreLocalMem<uint32_t>(zero_local_addr), weight_stick_size, {.page_id = 0}, {});
+    noc.async_read(
+        weights,
+        CoreLocalMem<uint32_t>(zero_local_addr),
+        weight_stick_size,
+        {.page_id = 0, .offset_bytes = weight_col_offset_bytes},
+        {});
 
     one_local_addr = zero_local_addr + weight_stick_size;
-    noc.async_read(weights, CoreLocalMem<uint32_t>(one_local_addr), weight_stick_size, {.page_id = 1}, {});
+    noc.async_read(
+        weights,
+        CoreLocalMem<uint32_t>(one_local_addr),
+        weight_stick_size,
+        {.page_id = 1, .offset_bytes = weight_col_offset_bytes},
+        {});
 
     noc.async_read_barrier();
 #endif
@@ -70,6 +90,12 @@ FORCE_INLINE constexpr void prepare_local_cache(
 
 // Issues an async read of one token's weight stick (or a chunk of it) into the destination L1
 // address. Caller must barrier before use.
+//
+// `chunk_offset_bytes` selects the chunk within the (already column-sliced) stick and applies to
+// both the DRAM read and the local-cache replay. `weight_col_offset_bytes` is the core's column
+// slice of the weight row; it applies to the DRAM read only, because prepare_local_cache already
+// filled the local cache from that offset. Passing it here (rather than folding it into the
+// accessor's base address) keeps `weights` on the clean buffer base.
 template <typename T>
 FORCE_INLINE void read_token_async(
     const Noc& noc,
@@ -77,7 +103,9 @@ FORCE_INLINE void read_token_async(
     const T& weights,
     uint32_t dst_l1_addr,
     uint32_t size_bytes,
-    uint32_t weight_offset_bytes = 0) {
+    uint32_t chunk_offset_bytes = 0,
+    uint32_t weight_col_offset_bytes = 0) {
+    const uint32_t weight_offset_bytes = weight_col_offset_bytes + chunk_offset_bytes;
 #if defined PADDED
     if (token == pad_token) {
         const uint8_t noc_id = noc.get_noc_id();
@@ -86,7 +114,7 @@ FORCE_INLINE void read_token_async(
             src,
             CoreLocalMem<uint32_t>(dst_l1_addr),
             size_bytes,
-            {.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = pad_local_addr + weight_offset_bytes},
+            {.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = pad_local_addr + chunk_offset_bytes},
             {});
         return;
     }
@@ -104,7 +132,7 @@ FORCE_INLINE void read_token_async(
         src,
         CoreLocalMem<uint32_t>(dst_l1_addr),
         size_bytes,
-        {.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = local_addr + weight_offset_bytes},
+        {.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = local_addr + chunk_offset_bytes},
         {});
 #elif defined BFP16
     union {

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
@@ -2,50 +2,68 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Reader for the tilized-output embedding program factory: gathers each block's weight rows into the
+// row-major staging buffer that the tilize compute kernel drains. Bound through Metal 2.0 named
+// bindings (dfb:: / tensor:: / args::), so the buffer indices and argument slots are supplied by the
+// host KernelSpec rather than positional compile-time and runtime args.
+
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
-#include "ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp"
+#include "ttnn/operations/embedding/device/kernels/dataflow/embeddings_common_metal2.hpp"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     Noc noc;
 
-    const uint32_t input_buffer_src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t weight_buffer_src_addr = get_arg_val<uint32_t>(1);
-    const uint32_t input_start_id = get_arg_val<uint32_t>(2);
-    const uint32_t input_start_offset = get_arg_val<uint32_t>(3);
-    const uint32_t weight_offset = get_arg_val<uint32_t>(4);
-    const uint32_t num_blocks = get_arg_val<uint32_t>(5);
+    const uint32_t input_start_id = get_arg(args::input_start_id);
+    const uint32_t input_start_offset = get_arg(args::input_start_offset);
+    const uint32_t weight_offset = get_arg(args::weight_offset);
+    const uint32_t num_blocks = get_arg(args::num_blocks);
 
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(2);
+    constexpr uint32_t input_page_size = get_arg(args::input_page_size);
+    constexpr uint32_t weight_block_size = get_arg(args::weight_block_size);
+    constexpr uint32_t tiles_per_chunk = get_arg(args::tiles_per_chunk);
+    constexpr uint32_t input_block_size_bytes = get_arg(args::input_block_size_bytes);
+    constexpr uint32_t num_chunks = get_arg(args::num_chunks);
+    constexpr uint32_t last_chunk_tiles = get_arg(args::last_chunk_tiles);
 
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(3);
-    constexpr uint32_t weight_block_size = get_compile_time_arg_val(5);
-    constexpr uint32_t tiles_per_chunk = get_compile_time_arg_val(6);
-    constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(7);
-    constexpr uint32_t num_chunks = get_compile_time_arg_val(8);
-    constexpr uint32_t last_chunk_tiles = get_compile_time_arg_val(9);
-
-    constexpr auto input_args = TensorAccessorArgs<10>();
-    constexpr auto weights_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
-    auto input = TensorAccessor(input_args, input_buffer_src_addr);
+    auto input = TensorAccessor(tensor::input);
     // `weight_offset` is this core's column slice of each weight row (non-zero only for width-/
     // block-sharded output). It is applied as a per-read offset below, not folded into the
     // accessor base, so both accessors sit on their buffers' clean base addresses.
-    auto weights = TensorAccessor(weights_args, weight_buffer_src_addr);
+    auto weights = TensorAccessor(tensor::weights);
 
+    // The local weight cache exists only for the embeddings types that serve some weight rows out of
+    // local SRAM, so it is bound (and named) only on those builds.
+#if defined PADDED
     prepare_local_cache(
-        noc, cb_id_in2, weights, weight_block_size, /*pad_token_arg_idx=*/6, /*weight_col_offset_bytes=*/weight_offset);
+        noc,
+        dfb::local_cache,
+        weights,
+        weight_block_size,
+        get_arg(args::pad_token),
+        /*weight_col_offset_bytes=*/weight_offset);
+#elif defined BINARY
+    prepare_local_cache(
+        noc,
+        dfb::local_cache,
+        weights,
+        weight_block_size,
+        /*pad_token_value=*/0,
+        /*weight_col_offset_bytes=*/weight_offset);
+#endif
 
-    CircularBuffer cb_in0(cb_id_in0);
-    CircularBuffer cb_in1(cb_id_in1);
+    // dfb_in0 stages the weight rows this reader gathers for one chunk; the compute kernel tilizes them
+    // out of it.
+    DataflowBuffer dfb_in0(dfb::in0);
+    // dfb_in1 is this reader's private scratch page for the block of indices it is working through.
+    DataflowBuffer dfb_in1(dfb::in1);
 
-    cb_in1.reserve_back(1);
-    uint32_t input_l1_addr = cb_in1.get_write_ptr();
+    dfb_in1.reserve_back(1);
+    uint32_t input_l1_addr = dfb_in1.get_write_ptr();
 
     volatile tt_l1_ptr input_token_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr input_token_t*>(input_l1_addr);
 
@@ -72,8 +90,8 @@ void kernel_main() {
             const uint32_t weight_chunk_size = is_last ? last_chunk_bytes : full_chunk_bytes;
             const uint32_t weight_chunk_offset = chunk * full_chunk_bytes;
 
-            cb_in0.reserve_back(this_chunk_tiles);
-            uint32_t l1_write_addr = cb_in0.get_write_ptr();
+            dfb_in0.reserve_back(this_chunk_tiles);
+            uint32_t l1_write_addr = dfb_in0.get_write_ptr();
 
             for (uint32_t k = 0; k < tile_height; ++k) {
                 input_token_t token = input_l1_ptr[k];
@@ -82,7 +100,7 @@ void kernel_main() {
                 l1_write_addr += weight_chunk_size;
             }
             noc.async_read_barrier();
-            cb_in0.push_back(this_chunk_tiles);
+            dfb_in0.push_back(this_chunk_tiles);
         }
 
         offset += input_block_size_bytes;
@@ -91,7 +109,7 @@ void kernel_main() {
             curr_row++;
         }
     }
-    // cb_in1 is reserved once as an index scratch buffer (no downstream consumer); commit the
-    // reservation so the CB is left balanced.
-    cb_in1.push_back(1);
+    // dfb_in1 is reserved once as an index scratch buffer (no downstream consumer); commit the
+    // reservation so the buffer is left balanced.
+    dfb_in1.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
@@ -33,9 +33,13 @@ void kernel_main() {
     constexpr auto input_args = TensorAccessorArgs<10>();
     constexpr auto weights_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     auto input = TensorAccessor(input_args, input_buffer_src_addr);
-    auto weights = TensorAccessor(weights_args, weight_buffer_src_addr + weight_offset);
+    // `weight_offset` is this core's column slice of each weight row (non-zero only for width-/
+    // block-sharded output). It is applied as a per-read offset below, not folded into the
+    // accessor base, so both accessors sit on their buffers' clean base addresses.
+    auto weights = TensorAccessor(weights_args, weight_buffer_src_addr);
 
-    prepare_local_cache(noc, cb_id_in2, weights, weight_block_size, /*pad_token_arg_idx=*/6);
+    prepare_local_cache(
+        noc, cb_id_in2, weights, weight_block_size, /*pad_token_arg_idx=*/6, /*weight_col_offset_bytes=*/weight_offset);
 
     CircularBuffer cb_in0(cb_id_in0);
     CircularBuffer cb_in1(cb_id_in1);
@@ -73,7 +77,8 @@ void kernel_main() {
 
             for (uint32_t k = 0; k < tile_height; ++k) {
                 input_token_t token = input_l1_ptr[k];
-                read_token_async(noc, token, weights, l1_write_addr, weight_chunk_size, weight_chunk_offset);
+                read_token_async(
+                    noc, token, weights, l1_write_addr, weight_chunk_size, weight_chunk_offset, weight_offset);
                 l1_write_addr += weight_chunk_size;
             }
             noc.async_read_barrier();


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Ports `EmbeddingsFusedProgramFactory` (RM indices → TILE output, the llama path) from the `ProgramDescriptor` API to `ProgramSpecFactoryConcept` (`create_program_artifacts`). With the RM and TilizedIndices factories already ported in #53425, the whole `EmbeddingsDeviceOperation` is now on Metal 2.0.

Two commits, in review order:

1. **Prerequisite: build the Fused reader's weights `TensorAccessor` on the clean base.** The reader folded the per-core column-slice byte offset into the accessor base address; Metal 2.0 hands kernels only a clean tensor base. The accessor is now built on the buffer address and the column offset travels as a separate per-read `weight_col_offset_bytes` (PADDED/BINARY cache fills take it, cache replays do not). NoC addresses are byte-identical. The same two parameters (default 0) are mirrored into `embeddings_common_metal2.hpp`. Adds a test for tilized output with width-/block-sharded weights narrower than the row, in GENERIC and PADDED modes.
2. **Port.** Host: `create_descriptor` → `create_program_artifacts`. CBs become DFBs (`weights_staging` / `index_scratch` / `output` / `weight_cache`); the sharded output buffer is `borrowed_from` the output `TensorParameter`; `index_scratch` and `weight_cache` self-loop on the reader, and `output` self-loops on compute when sharded (no writer). Buffer-address RTAs and `TensorAccessorArgs` plumbing become tensor bindings; every CTA/RTA is named. The two compute core groups stay two `KernelSpec`s of one source with `per_core_block_cnt` a CTA; `opt_level = O3` explicit (legacy compute default); `ComputeGen1Config{}` matches the legacy all-defaults `ComputeConfigDescriptor{}` field for field. Kernels: `embeddings_tilize.cpp` and `tilize_chunked.cpp` (this factory is their sole binder) convert in place to named bindings; the reader includes the existing `embeddings_common_metal2.hpp` fork and gates `dfb::local_cache` / `args::pad_token` under `PADDED` / `BINARY`. The borrowed writer binds the existing `writer_unary_interleaved_start_id_metal2.cpp` fork; the non-chunked compute binds the shared-pool `tilize_metal2.cpp`.

Relates to #53427 and #52228: the legacy `embeddings_common.hpp` and the borrowed `data_movement/tilize/.../tilize.cpp` now have no binders and can be deleted.

### Notes for reviewers
- **Dropped args, all dead in the kernels:** the reader CTA `weight_page_size`, and the two compute CTAs the non-chunked kernel never read. One `TT_FATAL` added (output buffer size divisible by page size), hoisted from the legacy `CircularBufferConfig` check.
- **Preprocessor gating, not `if constexpr`:** `dfb::local_cache` / `args::pad_token` only exist in the generated bindings under PADDED/BINARY, so the reader gates the `prepare_local_cache` call with `#if defined`. An unconditional reference fails to compile on every GENERIC build.
- **Validation** on Wormhole B0, Watcher on, Metal 2.0 legality checks forced (both check sites confirmed live by log marker):
  - `tests/ttnn/unit_tests/operations/data_movement/test_embedding.py`: **273 passed / 2 skipped**, identical to the pre-port baseline taken after commit 1.
  - `tests/tt_eager/python_api_testing/unit_testing/misc/test_embedding.py -k tilized`: **54 passed**.
  - The 108 `test_embedding_tiled_input` / `test_tiled` cases (TilizedIndices factory, untouched here) faulted under Watcher on the tested base with the `index_scratch` overflow of #49082 / #53435; that fix has since landed on main as #55836, and those cases passed with Watcher off.
- Device validation ran on main `8e18a76b7a2`; the branch is rebased onto current main with no changes to the Fused factory or its kernels in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-embedding-fused-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-embedding-fused-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-embedding-fused-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-embedding-fused-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-embedding-fused-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-embedding-fused-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-embedding-fused-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-embedding-fused-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-embedding-fused-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-embedding-fused-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-embedding-fused-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-embedding-fused-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-embedding-fused-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-embedding-fused-prereq)
