### PR TITLE
[Cleanup] Metal 2.0 port: untilize with UntilizeMultiCoreBlockProgramFactory

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -3077,8 +3077,9 @@ def test_untilize_codegen_with_resident_l1_buffers(device, headroom_regime, warm
     Two regimes, both of which must simply produce the right answer:
       - shallower_cb_plan: enough headroom for the single-buffered codegen plan but not the
         double-buffered one, so the program factory must degrade the tier it picks.
-      - no_cb_plan_fits: not even the single-buffered codegen plan fits, so the program factory
-        must build the native-equivalent program instead of failing.
+      - no_cb_plan_fits: not even the single-buffered codegen plan fits, so ttnn.untilize's routing
+        (codegen_cb_plan_fits_live_l1) must send the call to the native untilize op instead of
+        dispatching a codegen program that has no CB plan.
 
     This asserts only on the result, never on which implementation served it.
 
@@ -3160,26 +3161,31 @@ def test_untilize_codegen_with_resident_l1_buffers(device, headroom_regime, warm
 
 
 @pytest.mark.parametrize(
-    "dtype, tile_aligned",
-    [(ttnn.bfloat8_b, True), (ttnn.bfloat16, False)],
-    ids=["bfloat8_b_tile_aligned", "bfloat16_unpadding"],
+    "dtype, tile_aligned, output_in_l1",
+    [(ttnn.bfloat8_b, True, False), (ttnn.bfloat8_b, True, True), (ttnn.bfloat16, False, False)],
+    ids=["bfloat8_b_tile_aligned", "bfloat8_b_tile_aligned_l1_output", "bfloat16_unpadding"],
 )
-def test_untilize_codegen_native_tier_routes_to_native(device, dtype, tile_aligned):
+def test_untilize_codegen_native_tier_routes_to_native(device, expect_error, dtype, tile_aligned, output_in_l1):
     """The codegen op's Native tier (no codegen CB plan fits live L1) is served by the native
     untilize op through ttnn.untilize's routing, not by the codegen op reaching into another
     device-op's program factories.
 
-    Both cases are in the codegen gate's static scope (supported_by_codegen is true), and both pin
+    All cases are in the codegen gate's static scope (supported_by_codegen is true), and all pin
     a resident L1 buffer so that not even the single-buffered codegen CB plan fits the L1 that is
-    free right now. The routed call must then produce the right answer via native.
+    free right now. The routed call must then produce the right answer via native, and the forced
+    codegen entry (which by design never falls back) must fail loudly on the same L1 state.
 
-      - bfloat8_b_tile_aligned: the codegen plan is sized by the bf16 OUTPUT tile (2048 B) while
-        the native op's own row-fits-in-L1 check (enough_space_height) uses the bf8_b INPUT tile
-        (1088 B). A headroom window between the two makes codegen land on Native while native
-        selects its ordinary multicore factory. Before the Native tier was lifted into
+      - bfloat8_b_tile_aligned: the codegen plan is sized by two bf16 OUTPUT tiles per Wt
+        (planning tile = max(in, out) = 2048 B) while the native op's row-fits-in-L1 check
+        (enough_space_height) sizes one bf8_b INPUT tile plus one bf16 OUTPUT tile per Wt
+        (1088 + 2048 B). A headroom window between the two makes codegen land on Native while
+        native selects its ordinary multicore factory. Before the Native tier was lifted into
         ttnn.untilize, this configuration threw ("native fallback selected a program factory
         without descriptor support") because that factory is Metal 2.0 and no longer exposes
         create_descriptor.
+      - bfloat8_b_tile_aligned_l1_output: same window, with the (bf16) output interleaved in L1,
+        so both the codegen gate and native's check must reserve the pending output by its
+        OUTPUT dtype; sizing that reservation by the bf8_b input under-reserves it by half.
       - bfloat16_unpadding: the non-tile-aligned (with-unpadding) codegen path, routed to the
         native untilize_with_unpadding op.
 
@@ -3196,9 +3202,9 @@ def test_untilize_codegen_native_tier_routes_to_native(device, dtype, tile_align
 
     if tile_aligned:
         wt = 128
-        # Native's enough_space_height threshold (input tile) .. codegen's single-buffer plan
-        # (planning tile = max(in, out) = bf16 out tile).
-        low_bound = 2 * wt * BF8_TILE_BYTES
+        # Native's enough_space_height threshold (one input tile + one output tile per Wt) ..
+        # codegen's single-buffer plan (two planning tiles = max(in, out) = bf16 out tile per Wt).
+        low_bound = wt * (BF8_TILE_BYTES + BF16_TILE_BYTES)
         single_buffer_bytes = 2 * wt * BF16_TILE_BYTES
         headroom_target = (low_bound + single_buffer_bytes) // 2
         expected_headroom = (low_bound, single_buffer_bytes)
@@ -3211,8 +3217,19 @@ def test_untilize_codegen_native_tier_routes_to_native(device, dtype, tile_align
         # Non-tile-aligned logical width (padded width stays 32 * wt).
         input_torch_tensor = torch.randn([1, total_tile_rows, 32, 32 * wt - 1], dtype=torch.bfloat16)
 
-    if info.cb_limit <= single_buffer_bytes:
-        pytest.skip(f"needs more than {single_buffer_bytes} B of CB space, device offers {info.cb_limit} B")
+    output_memory_config = ttnn.L1_MEMORY_CONFIG if output_in_l1 else ttnn.DRAM_MEMORY_CONFIG
+    if output_in_l1:
+        # Both the codegen gate and native's check reserve the output's per-core footprint out of
+        # the free L1 before deciding, so shift the window up by exactly that reservation: the
+        # busiest bank's share of the row-major (bf16) output pages.
+        out_row_bytes = 32 * wt * 2  # one row-major page: a bf16 row of the padded width
+        out_pages = total_tile_rows * 32
+        pending_out_bytes = -(-out_pages // info.l1_num_banks) * out_row_bytes
+        headroom_target += pending_out_bytes
+        expected_headroom = (expected_headroom[0] + pending_out_bytes, expected_headroom[1] + pending_out_bytes)
+
+    if info.cb_limit <= headroom_target:
+        pytest.skip(f"needs more than {headroom_target} B of CB space, device offers {info.cb_limit} B")
     tiles_per_bank = (info.cb_limit - headroom_target) // BF16_TILE_BYTES
     if tiles_per_bank <= 0:
         pytest.skip("device L1 is too small to leave a meaningful headroom window")
@@ -3236,7 +3253,12 @@ def test_untilize_codegen_native_tier_routes_to_native(device, dtype, tile_align
             low <= actual_headroom < high
         ), f"resident L1 buffer left {actual_headroom} B above the CB base; this case needs it in [{low}, {high})"
 
-        output = ttnn.untilize(input_ttnn_tensor)
+        # The forced codegen entry skips the live-L1 gate on purpose; with no codegen CB plan fitting
+        # it must fail in the codegen program factory rather than quietly serve native.
+        with expect_error(RuntimeError, "no codegen CB plan fits"):
+            _force_codegen(input_ttnn_tensor, memory_config=output_memory_config)
+
+        output = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config)
         assert output.layout == ttnn.ROW_MAJOR_LAYOUT
         assert_equal(golden, ttnn.to_torch(output))
     finally:

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -3160,6 +3160,90 @@ def test_untilize_codegen_with_resident_l1_buffers(device, headroom_regime, warm
 
 
 @pytest.mark.parametrize(
+    "dtype, tile_aligned",
+    [(ttnn.bfloat8_b, True), (ttnn.bfloat16, False)],
+    ids=["bfloat8_b_tile_aligned", "bfloat16_unpadding"],
+)
+def test_untilize_codegen_native_tier_routes_to_native(device, dtype, tile_aligned):
+    """The codegen op's Native tier (no codegen CB plan fits live L1) is served by the native
+    untilize op through ttnn.untilize's routing, not by the codegen op reaching into another
+    device-op's program factories.
+
+    Both cases are in the codegen gate's static scope (supported_by_codegen is true), and both pin
+    a resident L1 buffer so that not even the single-buffered codegen CB plan fits the L1 that is
+    free right now. The routed call must then produce the right answer via native.
+
+      - bfloat8_b_tile_aligned: the codegen plan is sized by the bf16 OUTPUT tile (2048 B) while
+        the native op's own row-fits-in-L1 check (enough_space_height) uses the bf8_b INPUT tile
+        (1088 B). A headroom window between the two makes codegen land on Native while native
+        selects its ordinary multicore factory. Before the Native tier was lifted into
+        ttnn.untilize, this configuration threw ("native fallback selected a program factory
+        without descriptor support") because that factory is Metal 2.0 and no longer exposes
+        create_descriptor.
+      - bfloat16_unpadding: the non-tile-aligned (with-unpadding) codegen path, routed to the
+        native untilize_with_unpadding op.
+
+    Every tile row is given to a different core (total tile rows == compute grid area) so the
+    codegen planner sizes its CBs by the whole tile row (Wt), like the two native checks do.
+    """
+    torch.manual_seed(42)
+
+    BF16_TILE_BYTES = 2048
+    BF8_TILE_BYTES = 1088
+    info = ttnn._ttnn.reports.get_device_info(device)
+    grid = device.compute_with_storage_grid_size()
+    total_tile_rows = grid.x * grid.y
+
+    if tile_aligned:
+        wt = 128
+        # Native's enough_space_height threshold (input tile) .. codegen's single-buffer plan
+        # (planning tile = max(in, out) = bf16 out tile).
+        low_bound = 2 * wt * BF8_TILE_BYTES
+        single_buffer_bytes = 2 * wt * BF16_TILE_BYTES
+        headroom_target = (low_bound + single_buffer_bytes) // 2
+        expected_headroom = (low_bound, single_buffer_bytes)
+        input_torch_tensor = torch.randn([1, total_tile_rows, 32, 32 * wt], dtype=torch.bfloat16)
+    else:
+        wt = 192  # inside the gate's wide-chunk threshold: 2 * 192 * 2048 <= 800_000
+        single_buffer_bytes = 2 * wt * BF16_TILE_BYTES
+        headroom_target = 512 * 1024
+        expected_headroom = (0, single_buffer_bytes)
+        # Non-tile-aligned logical width (padded width stays 32 * wt).
+        input_torch_tensor = torch.randn([1, total_tile_rows, 32, 32 * wt - 1], dtype=torch.bfloat16)
+
+    if info.cb_limit <= single_buffer_bytes:
+        pytest.skip(f"needs more than {single_buffer_bytes} B of CB space, device offers {info.cb_limit} B")
+    tiles_per_bank = (info.cb_limit - headroom_target) // BF16_TILE_BYTES
+    if tiles_per_bank <= 0:
+        pytest.skip("device L1 is too small to leave a meaningful headroom window")
+
+    input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    # bfloat8_b rounds the values; the golden is what native produces for the same input, which
+    # is exact against codegen/native alike since untilize only relayouts values.
+    golden = ttnn.to_torch(_force_native(input_ttnn_tensor))
+
+    resident = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, 1, 32 * tiles_per_bank, 32 * info.l1_num_banks]),
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        device,
+        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+    )
+    try:
+        actual_headroom = resident.buffer_address() - info.address_at_first_l1_cb_buffer
+        low, high = expected_headroom
+        assert (
+            low <= actual_headroom < high
+        ), f"resident L1 buffer left {actual_headroom} B above the CB base; this case needs it in [{low}, {high})"
+
+        output = ttnn.untilize(input_ttnn_tensor)
+        assert output.layout == ttnn.ROW_MAJOR_LAYOUT
+        assert_equal(golden, ttnn.to_torch(output))
+    finally:
+        ttnn.deallocate(resident)
+
+
+@pytest.mark.parametrize(
     "tensor_shape",
     [
         (1, 1, 32, 7328),

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_cb_plan.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_cb_plan.cpp
@@ -9,12 +9,10 @@
 #include <numeric>
 
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/work_split.hpp>
 
-#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::constants;
@@ -132,62 +130,12 @@ CodegenCbPlan tier_from_depths(const CbPlan& plan, uint32_t pages_per_unit) {
     return CodegenCbPlan::SingleBoth;
 }
 
-NativeCacheIdentity identity_from_ncores(
-    const ttnn::NcoresWHsb& sb, uint32_t width_tiles, uint32_t height_tiles) {
-    NativeCacheIdentity id;
-    id.enough_space_height = false;
-    id.split_valid = true;
-    id.ncores = sb.ncores;
-    id.nblocks_per_core = sb.nblocks_per_core;
-    id.single_block_size = sb.single_block_size;
-    if (id.single_block_size == 0) {
-        id.split_valid = false;
-        return id;
-    }
-    uint32_t total_blocks_width = sb.total_blocks_width;
-    uint32_t total_blocks_height = sb.total_blocks_height;
-    id.full_cores_per_row = width_tiles / id.single_block_size;
-    id.has_cliff_row = (id.full_cores_per_row < total_blocks_width);
-    id.full_cores_per_col = height_tiles / id.single_block_size;
-    id.has_cliff_col = (id.full_cores_per_col < total_blocks_height);
-    id.single_block_size_cliff_row = width_tiles - (id.full_cores_per_row * id.single_block_size);
-    id.single_block_size_cliff_col = height_tiles - (id.full_cores_per_col * id.single_block_size);
-    id.single_sub_block_size = sb.single_sub_block_size;
-    return id;
-}
-
-NativeCacheIdentity block_split_identity(
-    uint32_t grid_area,
-    uint32_t nblocks,
-    uint32_t width_tiles,
-    uint32_t height_tiles,
-    uint32_t cb_block_size_limit) {
-    auto wh = ttnn::compute_ncores_wh(grid_area, nblocks, width_tiles, height_tiles);
-    ttnn::NcoresWHsb sb{
-        wh.ncores,
-        wh.nblocks_per_core,
-        wh.total_blocks_width,
-        wh.total_blocks_height,
-        wh.single_block_size,
-        wh.single_block_size};
-    if (cb_block_size_limit >= 1 && wh.single_block_size > cb_block_size_limit) {
-        auto maybe = ttnn::try_compute_ncores_wh_sb(
-            grid_area, nblocks, width_tiles, height_tiles, cb_block_size_limit);
-        if (!maybe.has_value()) {
-            NativeCacheIdentity sentinel;
-            sentinel.enough_space_height = false;
-            sentinel.split_valid = false;
-            return sentinel;
-        }
-        sb = *maybe;
-    }
-    return identity_from_ncores(sb, width_tiles, height_tiles);
-}
-
 }  // namespace
 
 ChosenCodegenCbPlan choose_codegen_cb_plan(
-    const UntilizeCodegenOperationAttributes& attrs, const UntilizeCodegenTensorArgs& tensor_args) {
+    const UntilizeCodegenOperationAttributes& attrs,
+    const UntilizeCodegenTensorArgs& tensor_args,
+    uint32_t reserved_l1_bytes_per_core) {
     const Tensor& input = tensor_args.input;
     auto out_spec = UntilizeCodegenDeviceOperation::compute_output_specs(attrs, tensor_args);
     DataType in_dtype = input.dtype();
@@ -197,67 +145,13 @@ ChosenCodegenCbPlan choose_codegen_cb_plan(
     auto out_fmt = datatype_to_dataformat_converter(out_dtype);
     uint32_t tile_size_for_planning = std::max(tt::tile_size(in_fmt), tt::tile_size(out_fmt));
     uint64_t usable_l1 = ttnn::operations::data_movement::get_max_l1_space(input);
+    usable_l1 = usable_l1 > reserved_l1_bytes_per_core ? usable_l1 - reserved_l1_bytes_per_core : 0;
     auto pages = pages_for_builder(input, fp32);
     auto depths = plan_cb_depths(usable_l1, pages.pages_per_unit, tile_size_for_planning, pages.block_units);
     if (!depths.has_value()) {
         return ChosenCodegenCbPlan{CodegenCbPlan::Native, std::nullopt};
     }
     return ChosenCodegenCbPlan{tier_from_depths(*depths, pages.pages_per_unit), depths};
-}
-
-NativeCacheIdentity native_cache_identity(
-    const UntilizeCodegenOperationAttributes& attrs,
-    const UntilizeCodegenTensorArgs& tensor_args,
-    CodegenCbPlan plan) {
-    (void)attrs;
-    NativeCacheIdentity zeros;
-    if (plan != CodegenCbPlan::Native) {
-        return zeros;
-    }
-
-    namespace dm = ttnn::operations::data_movement;
-    const Tensor& input = tensor_args.input;
-    auto in_fmt = datatype_to_dataformat_converter(input.dtype());
-    uint32_t single_tile_size = tt::tile_size(in_fmt);
-    uint32_t num_tiles_per_row = input.padded_shape()[-1] / TILE_WIDTH;
-    const bool enough_space_height =
-        dm::is_enough_space(input, single_tile_size, single_tile_size, num_tiles_per_row);
-    if (enough_space_height) {
-        NativeCacheIdentity id;
-        id.enough_space_height = true;
-        return id;
-    }
-
-    auto out_spec = UntilizeCodegenDeviceOperation::compute_output_specs(attrs, tensor_args);
-    auto out_fmt = datatype_to_dataformat_converter(out_spec.data_type());
-    uint32_t output_single_tile_size = tt::tile_size(out_fmt);
-    uint32_t max_l1_size = dm::get_max_l1_space(input);
-    uint32_t denom = single_tile_size + output_single_tile_size;
-    uint32_t cb_block_size_limit = denom == 0 ? 0 : max_l1_size / denom;
-
-    const auto& logical_shape = input.logical_shape();
-    const bool tile_aligned = logical_shape[-2] % TILE_HEIGHT == 0 && logical_shape[-1] % TILE_WIDTH == 0;
-    auto* device = input.device();
-    CoreCoord grid_size = device->compute_with_storage_grid_size();
-
-    if (tile_aligned) {
-        uint32_t a_tile_width = input.tensor_spec().tile().get_width();
-        uint32_t a_tile_height = input.tensor_spec().tile().get_height();
-        uint32_t width_tiles = input.padded_shape()[-1] / a_tile_width;
-        uint32_t height_tiles = input.padded_shape()[-2] / a_tile_height;
-        uint32_t nblocks = (input.padded_shape()[-1] * input.padded_shape()[-2]) / (a_tile_height * a_tile_width);
-        uint32_t grid_area = static_cast<uint32_t>(grid_size.x) * static_cast<uint32_t>(grid_size.y);
-        return block_split_identity(grid_area, nblocks, width_tiles, height_tiles, cb_block_size_limit);
-    }
-
-    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
-    CoreRangeSet available_grid(default_cores);
-    uint32_t width_tiles = input.padded_shape()[-1] / TILE_WIDTH;
-    uint32_t height_tiles = input.padded_shape()[-2] / TILE_HEIGHT;
-    uint32_t nblocks =
-        (input.padded_shape()[-1] * input.padded_shape()[-2]) / (TILE_HEIGHT * TILE_WIDTH);
-    return block_split_identity(
-        available_grid.num_cores(), nblocks, width_tiles, height_tiles, cb_block_size_limit);
 }
 
 }  // namespace ttnn::prim::untilize_codegen_detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_cb_plan.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_cb_plan.hpp
@@ -11,6 +11,10 @@
 
 namespace ttnn::prim::untilize_codegen_detail {
 
+// The three CB depth tiers a codegen builder can plan, plus `Native`: no codegen plan fits the L1
+// budget it was given. The codegen op never serves `Native` itself -- ttnn::untilize consults the
+// same chooser before dispatching (codegen_cb_plan_fits_live_l1) and routes such a case to the
+// native untilize prim as a whole, so inside the codegen op `Native` is a hard error.
 enum class CodegenCbPlan : uint8_t { DoubleBoth, DoubleIn, SingleBoth, Native };
 
 struct CbPlan {
@@ -30,32 +34,20 @@ struct ChosenCodegenCbPlan {
     std::optional<CbPlan> depths;
 };
 
-// Live-L1 CB tier for this (already output-allocated) dispatch. Output tile size comes from
-// UntilizeCodegenDeviceOperation::compute_output_specs so bf8_b->bf16 demotion is not copied.
+// Live-L1 CB tier for this dispatch: the L1 free right now (get_max_l1_space), less
+// `reserved_l1_bytes_per_core`, planned exactly as the program factory's builders plan it. Output
+// tile size comes from UntilizeCodegenDeviceOperation::compute_output_specs so bf8_b->bf16
+// demotion is not copied.
+//
+// Two callers, two moments:
+//   * compute_program_hash / create_descriptor pass 0: they run after the op's output tensor has
+//     been allocated, so the live query already reflects it.
+//   * ttnn::untilize's routing runs BEFORE the output is allocated and passes the output's
+//     pending per-core L1 footprint (get_pending_l1_output_reservation), so its Native-vs-codegen
+//     decision predicts the budget the two later calls will actually see.
 ChosenCodegenCbPlan choose_codegen_cb_plan(
-    const UntilizeCodegenOperationAttributes& attrs, const UntilizeCodegenTensorArgs& tensor_args);
-
-// Discrete native-fallback identity hashed with the codegen tier. Zeros when tier is not Native
-// or when enough_space_height is true. split_valid is false when the block split has no solution
-// (sentinel: forces a cache miss so create_descriptor can TT_FATAL as the factory does today).
-struct NativeCacheIdentity {
-    bool enough_space_height = false;
-    bool split_valid = true;
-    uint32_t ncores = 0;
-    uint32_t nblocks_per_core = 0;
-    uint32_t single_block_size = 0;
-    uint32_t single_block_size_cliff_row = 0;
-    uint32_t single_block_size_cliff_col = 0;
-    bool has_cliff_row = false;
-    bool has_cliff_col = false;
-    uint32_t full_cores_per_row = 0;
-    uint32_t full_cores_per_col = 0;
-    uint32_t single_sub_block_size = 0;
-};
-
-NativeCacheIdentity native_cache_identity(
     const UntilizeCodegenOperationAttributes& attrs,
     const UntilizeCodegenTensorArgs& tensor_args,
-    CodegenCbPlan plan);
+    uint32_t reserved_l1_bytes_per_core = 0);
 
 }  // namespace ttnn::prim::untilize_codegen_detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_device_operation.cpp
@@ -68,28 +68,16 @@ UntilizeCodegenDeviceOperation::tensor_return_value_t UntilizeCodegenDeviceOpera
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
+// The CB tier is a function of the L1 that is free right now (choose_codegen_cb_plan samples it on
+// every dispatch), so it is part of the cache key: an occupancy change that crosses a tier is a
+// cache miss that rebuilds with the new depths, not a hit that replays a plan sized for L1 that is
+// no longer free. Only the codegen tiers are ever keyed here -- a case for which no codegen plan
+// fits is routed to the native prim by ttnn::untilize before it reaches this op.
 ttsl::hash::hash_t UntilizeCodegenDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto chosen = untilize_codegen_detail::choose_codegen_cb_plan(operation_attributes, tensor_args);
-    const auto native =
-        untilize_codegen_detail::native_cache_identity(operation_attributes, tensor_args, chosen.tier);
     return ttsl::hash::hash_objects_with_default_seed(
-        ttsl::hash::type_hash<UntilizeCodegenDeviceOperation>,
-        operation_attributes,
-        tensor_args,
-        chosen.tier,
-        native.enough_space_height,
-        native.split_valid,
-        native.ncores,
-        native.nblocks_per_core,
-        native.single_block_size,
-        native.single_block_size_cliff_row,
-        native.single_block_size_cliff_col,
-        native.has_cliff_row,
-        native.has_cliff_col,
-        native.full_cores_per_row,
-        native.full_cores_per_col,
-        native.single_sub_block_size);
+        ttsl::hash::type_hash<UntilizeCodegenDeviceOperation>, operation_attributes, tensor_args, chosen.tier);
 }
 
 Tensor untilize_codegen(const Tensor& input, tt::tt_metal::MemoryConfig output_mem_config) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.cpp
@@ -6,9 +6,7 @@
 
 #include <algorithm>
 #include <optional>
-#include <type_traits>
 #include <utility>
-#include <variant>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
@@ -20,8 +18,6 @@
 #include <tt_stl/small_vector.hpp>
 
 #include "ttnn/operations/data_movement/common/common.hpp"
-#include "ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp"
-#include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp"
 #include "untilize_codegen_cb_plan.hpp"
 #include "untilize_codegen_device_operation.hpp"
 #include "untilize_codegen_supported.hpp"
@@ -408,69 +404,16 @@ std::optional<ProgramDescriptor> build_with_unpadding(
     return desc;
 }
 
-// Native untilize factories, used when no codegen CB plan fits live L1 (see kUsableL1Note).
-ProgramDescriptor build_native_equivalent(
-    const UntilizeCodegenOperationAttributes& operation_attributes, const Tensor& input, const Tensor& output) {
-    namespace dm = ttnn::operations::data_movement;
-
-    // Several native factories take `UntilizeTensorReturnValue&` (non-const). A Tensor is a
-    // shallow, refcounted handle, so this copy aliases the same buffer the op allocated.
-    Tensor out = output;
-
-    const bool fp32_dest_acc_en = input.dtype() == DataType::INT32 || input.dtype() == DataType::UINT32 ||
-                                  input.dtype() == DataType::FLOAT32;
-    auto in_fmt = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    uint32_t single_tile_size = tt::tile_size(in_fmt);
-    uint32_t num_tiles_per_row = input.padded_shape()[-1] / TILE_WIDTH;
-    // Same derivation the native free functions do before calling their prim; note this is itself
-    // a live-L1 query (get_max_l1_space), consistent with the snapshot taken in create_descriptor.
-    const bool enough_space_height =
-        dm::is_enough_space(input, single_tile_size, single_tile_size, num_tiles_per_row);
-
-    const auto& logical_shape = input.logical_shape();
-    const bool tile_aligned = logical_shape[-2] % TILE_HEIGHT == 0 && logical_shape[-1] % TILE_WIDTH == 0;
-
-    if (!tile_aligned) {
-        ttnn::Shape output_tensor_end(ttsl::SmallVector<uint32_t>(logical_shape.rank(), 0));
-        int logical_rank = static_cast<int>(logical_shape.rank());
-        for (int index = -1; index >= -logical_rank; --index) {
-            output_tensor_end[index] = logical_shape[index] - 1;
-        }
-        UntilizeWithUnpaddingParams params{
-            .output_tensor_end = output_tensor_end,
-            .output_mem_config = operation_attributes.output_mem_config,
-            .use_multicore = true,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .enough_space_height = enough_space_height,
-            .sub_core_grids = std::nullopt};
-        auto pf = UntilizeWithUnpaddingDeviceOperation::select_program_factory(params, input);
-        return std::visit(
-            [&](auto&& factory) { return std::decay_t<decltype(factory)>::create_descriptor(params, input, out); }, pf);
-    }
-
-    UntilizeOperationAttributes attrs{
-        .output_mem_config = operation_attributes.output_mem_config,
-        .use_multicore = true,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .sub_core_grids = std::nullopt,
-        .enough_space_height = enough_space_height,
-        // supported_by_codegen() rejects sharded output, so the sharded pf_type branches are
-        // unreachable here; pass false to match what untilize_native would compute.
-        .pf_type = dm::get_pf_type(/*output_is_sharded=*/false, input)};
-    UntilizeTensorArgs args{.input = input};
-    auto pf = UntilizeDeviceOperation::select_program_factory(attrs, args);
-    return std::visit(
-        [&](auto&& factory) -> ProgramDescriptor {
-            using Factory = std::decay_t<decltype(factory)>;
-            if constexpr (requires { Factory::create_descriptor(attrs, args, out); }) {
-                return Factory::create_descriptor(attrs, args, out);
-            } else {
-                TT_THROW(
-                    "untilize codegen: native fallback selected a program factory without descriptor support; "
-                    "the live-L1 fallback must select a descriptor-backed multicore factory");
-            }
-        },
-        pf);
+// No codegen CB plan fits the L1 that is free right now. ttnn::untilize runs the same chooser
+// (codegen_cb_plan_fits_live_l1) before dispatching and routes such a case to the native prim as a
+// whole, so this factory never builds anything but a codegen program; reaching here means L1
+// occupancy moved between routing and program build, or the codegen prim was forced
+// (untilize_force_codegen, which by design never falls back to native).
+[[noreturn]] void throw_no_codegen_cb_plan(uint64_t usable_l1) {
+    TT_THROW(
+        "untilize codegen: no codegen CB plan fits the {} B of L1 free on this device right now; ttnn::untilize "
+        "routes such a case to the native untilize prim before dispatch",
+        usable_l1);
 }
 
 }  // namespace
@@ -499,8 +442,10 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
     // kUsableL1Note: live-L1 is sampled here on a cache MISS so every builder plans against one
     // snapshot (get_max_l1_space: lowest_occupied_compute_l1_address ?: l1_size_per_core, minus
     // allocator base). The SAME chooser (choose_codegen_cb_plan) also runs on every dispatch from
-    // compute_program_hash, so a later occupancy change that crosses a CB tier (or Native
-    // block-split) is a new cache key rather than a hit with a frozen plan.
+    // compute_program_hash, so a later occupancy change that crosses a CB tier is a new cache key
+    // rather than a hit with a frozen plan. Both of those run after the output tensor has been
+    // allocated; ttnn::untilize ran the chooser once more before that, with the output's pending
+    // L1 footprint reserved, and only dispatched here because some codegen tier fit.
     //
     // get_max_l1_space is therefore on the untilize-codegen hot path (hash), not miss-only: it
     // takes the allocator mutex and walks the L1 free list per sub-device. create_descriptor
@@ -510,7 +455,7 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
 
     auto chosen = untilize_codegen_detail::choose_codegen_cb_plan(operation_attributes, tensor_args);
     if (chosen.tier == untilize_codegen_detail::CodegenCbPlan::Native) {
-        return build_native_equivalent(operation_attributes, input, output);
+        throw_no_codegen_cb_plan(a.usable_l1);
     }
 
     // Wt/Ht/NC are derived from the PADDED (physical, tile-aligned) shape, which the reader/
@@ -528,13 +473,14 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
     uint32_t ht = h / TILE_HEIGHT;
     uint32_t total_tile_rows = nc * ht;
 
-    // Each branch below picks the codegen builder this shape belongs to, exactly as before. The
-    // only new behaviour is that a builder may decline (nullopt) when its CB plan does not fit the
-    // L1 that is free right now, in which case we emit the native-equivalent program instead of
-    // failing the op. Under the opt-in ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK build this function
-    // is re-invoked on cache hits and diffed against the cached descriptor; if L1 occupancy has
-    // changed enough since the miss to flip a tier, that check can report a spurious mismatch.
-    // That build is a debug aid (OFF by default) and never runs in production dispatch.
+    // Each branch below picks the codegen builder this shape belongs to. A builder declines
+    // (nullopt) when its CB plan does not fit the L1 that is free right now; choose_codegen_cb_plan
+    // above mirrors each builder's plan against the same snapshot, so a decline here is the same
+    // hard error as the Native tier above. Under the opt-in ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK
+    // build this function is re-invoked on cache hits and diffed against the cached descriptor; if
+    // L1 occupancy has changed enough since the miss to flip a tier, that check can report a
+    // spurious mismatch. That build is a debug aid (OFF by default) and never runs in production
+    // dispatch.
 
     // Non-tile-aligned logical shapes (bf16 only -- see supported_by_codegen) route through the
     // with-unpadding builder instead of build_untilize_tile's variants. h == ht * TILE_HEIGHT
@@ -546,14 +492,14 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
         if (auto desc = build_with_unpadding(a, wt, total_tile_rows, logical_shape[-2], logical_shape[-1], h)) {
             return std::move(*desc);
         }
-        return build_native_equivalent(operation_attributes, input, output);
+        throw_no_codegen_cb_plan(a.usable_l1);
     }
 
     if (total_tile_rows == 1 && wt > 1) {
         if (auto desc = build_column_parallel(a, wt)) {
             return std::move(*desc);
         }
-        return build_native_equivalent(operation_attributes, input, output);
+        throw_no_codegen_cb_plan(a.usable_l1);
     }
 
     auto grid = a.device->compute_with_storage_grid_size();
@@ -564,13 +510,13 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
             if (auto desc = build_2d_column(a, wt, total_tile_rows, ncol)) {
                 return std::move(*desc);
             }
-            return build_native_equivalent(operation_attributes, input, output);
+            throw_no_codegen_cb_plan(a.usable_l1);
         }
     }
     if (auto desc = build_main_split(a, wt, total_tile_rows)) {
         return std::move(*desc);
     }
-    return build_native_equivalent(operation_attributes, input, output);
+    throw_no_codegen_cb_plan(a.usable_l1);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.hpp
@@ -14,10 +14,12 @@ struct UntilizeCodegenOperationAttributes;
 struct UntilizeCodegenTensorArgs;
 
 struct UntilizeCodegenProgramFactory {
-    // Builds the codegen untilize program (or native-equivalent) for the already-validated,
-    // already output-allocated case. Live L1 is sampled on every dispatch in
-    // compute_program_hash (choose_codegen_cb_plan) so a CB-tier / Native-block-split change
-    // is a cache miss. create_descriptor itself still runs only on a miss.
+    // Builds the codegen untilize program for the already-validated, already output-allocated
+    // case. Live L1 is sampled on every dispatch in compute_program_hash (choose_codegen_cb_plan)
+    // so a CB-tier change is a cache miss. create_descriptor itself still runs only on a miss.
+    // It never builds anything but a codegen program: a case for which no codegen CB plan fits
+    // the free L1 is routed to the native prim by ttnn::untilize before dispatch, and is a hard
+    // error if it reaches this factory anyway.
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeCodegenOperationAttributes& operation_attributes,
         const UntilizeCodegenTensorArgs& tensor_args,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
@@ -136,8 +136,16 @@ bool codegen_cb_plan_fits_live_l1(const Tensor& input, const tt::tt_metal::Memor
     // the hash and the program; routing runs before that allocation, so reserve the output's
     // per-core L1 footprint here to see the budget those two will (issue #21358 for the native op).
     const auto out_spec = ttnn::prim::UntilizeCodegenDeviceOperation::compute_output_specs(attrs, tensor_args);
+    // require_constructible: the spec was just built from these same (shape, dtype, layout, mem_config) by
+    // compute_output_specs, so a construction failure here is a bug, not a case to wave through with a 0 B
+    // reservation that would make this gate more permissive than the program factory it predicts.
     const uint32_t pending_l1_output_bytes = get_pending_l1_output_reservation(
-        input, out_spec.padded_shape(), output_mem_config, out_spec.data_type(), Layout::ROW_MAJOR);
+        input,
+        out_spec.padded_shape(),
+        output_mem_config,
+        out_spec.data_type(),
+        Layout::ROW_MAJOR,
+        /*require_constructible=*/true);
 
     return plan::choose_codegen_cb_plan(attrs, tensor_args, pending_l1_output_bytes).tier !=
            plan::CodegenCbPlan::Native;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
@@ -11,6 +11,10 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/work_split.hpp>
 
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "untilize_codegen_cb_plan.hpp"
+#include "untilize_codegen_device_operation.hpp"
+
 namespace ttnn::operations::data_movement::untilize_codegen {
 
 uint32_t usable_l1_bytes(const tt::tt_metal::IDevice* device) {
@@ -61,7 +65,7 @@ bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig&
     // slot per tile each) cannot fit even an empty core's L1 is out of scope for every codegen
     // builder no matter what else is resident, so reject it here and let "auto" pick native.
     // This is a static bound only -- whether the plan fits the L1 that is actually free right now
-    // is decided once, inside the program factory (see UntilizeCodegenProgramFactory).
+    // is codegen_cb_plan_fits_live_l1's business (routing) and the program factory's (CB tier).
     auto column_parallel_plan_fits = [&](uint32_t wt) {
         auto* device = input.device();
         auto grid = device->compute_with_storage_grid_size();
@@ -115,6 +119,28 @@ bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig&
     }
 
     return true;
+}
+
+bool codegen_cb_plan_fits_live_l1(const Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
+    using tt::tt_metal::Layout;
+    namespace plan = ttnn::prim::untilize_codegen_detail;
+
+    if (input.storage_type() != ttnn::StorageType::DEVICE || input.buffer() == nullptr) {
+        return true;
+    }
+
+    const ttnn::prim::UntilizeCodegenOperationAttributes attrs{.output_mem_config = output_mem_config};
+    const ttnn::prim::UntilizeCodegenTensorArgs tensor_args{.input = input};
+
+    // The codegen op allocates its output (create_output_tensors) before it samples live L1 for
+    // the hash and the program; routing runs before that allocation, so reserve the output's
+    // per-core L1 footprint here to see the budget those two will (issue #21358 for the native op).
+    const auto out_spec = ttnn::prim::UntilizeCodegenDeviceOperation::compute_output_specs(attrs, tensor_args);
+    const uint32_t pending_l1_output_bytes = get_pending_l1_output_reservation(
+        input, out_spec.padded_shape(), output_mem_config, out_spec.data_type(), Layout::ROW_MAJOR);
+
+    return plan::choose_codegen_cb_plan(attrs, tensor_args, pending_l1_output_bytes).tier !=
+           plan::CodegenCbPlan::Native;
 }
 
 bool supported_execution_controls(bool use_multicore, const std::optional<CoreRangeSet>& sub_core_grids) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.hpp
@@ -23,9 +23,9 @@ namespace ttnn::operations::data_movement::untilize_codegen {
 // the allocator will actually hand out. Shared between the two so they stay in lockstep.
 //
 // Deliberately a STATIC device property: it must not consult live L1 occupancy (see
-// supported_by_codegen below). How much of this budget is actually free at program-build time
-// is the program factory's business, via get_max_l1_space() -- it is the only place that can
-// observe it once, consistently.
+// supported_by_codegen below). How much of this budget is actually free is the business of
+// codegen_cb_plan_fits_live_l1 (routing) and the codegen op's hash/program factory (CB tier),
+// via get_max_l1_space().
 uint32_t usable_l1_bytes(const tt::tt_metal::IDevice* device);
 
 // Correctness-only: true iff the codegen build_untilize_tile path can produce a bit-exact
@@ -40,8 +40,24 @@ uint32_t usable_l1_bytes(const tt::tt_metal::IDevice* device);
 // change between them. Making it depend on mutable device state (e.g. live L1 occupancy, which
 // the op's own create_output_tensors() moves by allocating the output) breaks that invariant:
 // routing sees true, dispatches to codegen, and validate then TT_FATALs on the same tensor.
-// Live-L1 accounting belongs in the program factory, which decides once per cache miss.
+// Live-L1 accounting is codegen_cb_plan_fits_live_l1 below (routing only) and the codegen op's
+// own hash/program factory (CB tier), never this predicate.
 bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config);
+
+// Live-L1 routing gate, deliberately NOT pure: true iff at least one codegen CB plan fits the L1
+// that is free on the device right now, once the output tensor this call is about to allocate is
+// reserved out of it (get_pending_l1_output_reservation, the same accounting untilize_native's
+// enough_space_height applies). Consulted ONLY by ttnn::untilize's routing, alongside
+// supported_by_codegen() and is_demoted(): false sends the whole call to the native untilize prims
+// through their ordinary entry points. Never consulted by validate (it would TT_FATAL a case that
+// routing already sent elsewhere) and never by untilize_force_codegen (which must not fall back).
+//
+// This is the same chooser the codegen op runs in compute_program_hash and create_descriptor
+// (choose_codegen_cb_plan), evaluated one allocation earlier with that allocation reserved, so the
+// tier those two later see is the one predicted here; the codegen op itself never builds a native
+// program and treats "no plan fits" as an error. A host-resident or unallocated input has no L1 to
+// plan against and returns true, so the codegen op's validate reports the established error.
+bool codegen_cb_plan_fits_live_l1(const Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config);
 
 // Every codegen builder places work over the full compute-with-storage grid and has no
 // single-core variant, so it can honour neither of the native op's core-placement controls.

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
@@ -5,18 +5,17 @@
 #include "untilize_multi_core_block_program_factory.hpp"
 
 #include "ttnn/common/constants.hpp"
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
@@ -28,21 +27,47 @@ using ttnn::operations::data_movement::BlockDirection;
 using ttnn::operations::data_movement::BlockPlan;
 using ttnn::operations::data_movement::buffer_set_for_core;
 using ttnn::operations::data_movement::make_block_plan;
-using ttnn::operations::data_movement::push_buffer_set;
 
 }  // namespace
 
-ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreBlockProgramFactory::create_program_artifacts(
     const UntilizeOperationAttributes& operation_attributes,
     const UntilizeTensorArgs& tensor_args,
     UntilizeTensorReturnValue& tensor_return_value) {
     const auto& a = tensor_args.input;
     const Tensor& output = tensor_return_value;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
-    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
-    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
-    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+
+    // Spec names are function-local: the op's factories are unity-built, and same-named
+    // anonymous-namespace constants across them would redefine.
+    const DFBSpecName IN_FULL{"in_full"};
+    const DFBSpecName OUT_FULL{"out_full"};
+    const DFBSpecName IN_CLIFFROW{"in_cliffrow"};
+    const DFBSpecName OUT_CLIFFROW{"out_cliffrow"};
+    const TensorParamName INPUT{"input"};
+    const TensorParamName OUTPUT{"output"};
+    const KernelSpecName READER_FULL{"reader_full"};
+    const KernelSpecName WRITER_FULL{"writer_full"};
+    const KernelSpecName READER_CLIFFROW{"reader_cliffrow"};
+    const KernelSpecName WRITER_CLIFFROW{"writer_cliffrow"};
+    const KernelSpecName COMPUTE_FULL{"compute_full"};
+    const KernelSpecName COMPUTE_CLIFF_COL_ROW{"compute_cliff_col_row"};
+    const KernelSpecName COMPUTE_CLIFF_ROW{"compute_cliff_row"};
+    const KernelSpecName COMPUTE_CLIFF_COL{"compute_cliff_col"};
+
+    constexpr const char* READER_SRC =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+        "reader_unary_interleaved_wh_multicore_metal2.cpp";
+    constexpr const char* WRITER_SRC =
+        "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+        "writer_unary_stick_layout_wh_multicore_metal2.cpp";
+    constexpr const char* COMPUTE_SRC =
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh_metal2.cpp";
+
+    tt::DataFormat input_data_format = datatype_to_dataformat_converter(a.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_data_format);
+    tt::DataFormat output_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_data_format);
 
     const auto& input_shape = a.padded_shape();
     const uint32_t a_tile_height = a.tensor_spec().tile().get_height();
@@ -50,6 +75,9 @@ ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
     // RowMajor: this factory's runtime-arg loop walks grid_to_cores(..., row_wise=true), so the
     // split has to hand cores out in that same order. The block factory is never reached with
     // sub_core_grids set -- that routes to the sub-core-grid factory instead.
+    //
+    // `make_block_plan` reads live L1 occupancy, so it is only valid on a program-cache miss --
+    // which is the only time this function runs.
     const BlockPlan plan = make_block_plan(
         BlockDirection::Untilize,
         BlockCoreOrder::RowMajor,
@@ -66,7 +94,8 @@ ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
         plan.split;
 
     // Same grid `make_block_plan` split over -- the runtime-arg loop below walks it in core order.
-    const CoreCoord grid_size = a.device()->compute_with_storage_grid_size();
+    IDevice* device = a.device();
+    const CoreCoord grid_size = device->compute_with_storage_grid_size();
 
     if (single_sub_block_size > 0 && single_block_size % single_sub_block_size) {
         TT_FATAL(false, "single_block_size is not divided by single_sub_block_size");
@@ -84,12 +113,21 @@ ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
         row_size_bytes = input_shape[-1] * a.element_size();
     }
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
-    ProgramDescriptor desc;
+    ProgramSpec spec{.name = "untilize_multi_core_block"};
 
+    // Each non-empty buffer set gets its own input/output DFB pair, sized for that set's block width
+    // (see BlockBufferSet in data_movement/common). The cliff-row pair exists only when the split
+    // produced a cliff row. The sizes mirror `push_buffer_set` -- `block_tiles` pages of one tile
+    // each, default tile shape, nothing borrowed -- so `make_block_plan` stays the single source of
+    // the split and the sizing.
+    const auto in_dfb_of = [&](const BlockBufferSet& set) -> const DFBSpecName& {
+        return (&set == &cliffrow_set) ? IN_CLIFFROW : IN_FULL;
+    };
+    const auto out_dfb_of = [&](const BlockBufferSet& set) -> const DFBSpecName& {
+        return (&set == &cliffrow_set) ? OUT_CLIFFROW : OUT_FULL;
+    };
     for (const BlockBufferSet* set : {&full_set, &cliffrow_set}) {
         if (set->empty()) {
             continue;
@@ -98,16 +136,24 @@ ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
             set->block_tiles > 0,
             "Buffer set on cores {} has a zero block width; its buffers would be empty",
             set->core_ranges.str());
-        push_buffer_set(
-            desc,
-            *set,
-            input_single_tile_size,
-            output_single_tile_size,
-            input_cb_data_format,
-            output_cb_data_format,
-            /*dram_alignment=*/0,
-            a_tile_height);
+        spec.dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = in_dfb_of(*set),
+            .entry_size = input_single_tile_size,
+            .num_entries = set->block_tiles,
+            .data_format_metadata = input_data_format,
+        });
+        spec.dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = out_dfb_of(*set),
+            .entry_size = output_single_tile_size,
+            .num_entries = set->block_tiles,
+            .data_format_metadata = output_data_format,
+        });
     }
+
+    spec.tensor_parameters = {
+        TensorParameter{.unique_id = INPUT, .spec = a.tensor_spec()},
+        TensorParameter{.unique_id = OUTPUT, .spec = output.tensor_spec()},
+    };
 
     // reader
     uint32_t num_tiles_2d = a.padded_shape()[-1] * a.padded_shape()[-2] / TILE_HW;
@@ -123,112 +169,190 @@ ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
     uint32_t total_num_rows = output.logical_shape()[-2];
 
     // One reader and one writer per buffer set, each over that set's cores and bound to that set's
-    // indices. A set's cores are exactly the cores whose block width its buffers are sized for, so
+    // DFB pair. A set's cores are exactly the cores whose block width its buffers are sized for, so
     // every writer instance's contiguous walk from `get_read_ptr()` stays inside a buffer that is an
-    // exact multiple of the block it drains.
-    auto make_reader_kernel = [&](const BlockBufferSet& set) {
-        std::vector<uint32_t> reader_compile_time_args = {
-            num_tiles_2d, third_dim, total_tiles_per_row, set.input_index};
-        TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-
-        KernelDescriptor reader_desc;
-        reader_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp";
-        reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        reader_desc.core_ranges = set.core_ranges;
-        reader_desc.compile_time_args = std::move(reader_compile_time_args);
-        reader_desc.config = ReaderConfigDescriptor{};
-        return reader_desc;
+    // exact multiple of the block it drains. The set's cores are the union of the compute regions
+    // below, so the reader/writer specs are shared by that set's work units.
+    auto make_reader_spec = [&](const KernelSpecName& id, const BlockBufferSet& set) {
+        return KernelSpec{
+            .unique_id = id,
+            .source = std::filesystem::path{READER_SRC},
+            .dfb_bindings = {DFBBinding{
+                .dfb_spec_name = in_dfb_of(set),
+                .accessor_name = "in",
+                .endpoint_type = DFBEndpointType::PRODUCER,
+            }},
+            .tensor_bindings = {TensorBinding{
+                .tensor_parameter_name = INPUT,
+                .accessor_name = "src",
+            }},
+            .compile_time_args =
+                {
+                    {"num_tiles_per_2d", num_tiles_2d},
+                    {"third_dim", third_dim},
+                    {"total_tiles_per_row", total_tiles_per_row},
+                },
+            .runtime_arg_schema =
+                {
+                    .runtime_arg_names = {"start_id", "single_block_size_row_arg", "single_block_size_col_arg"},
+                },
+            .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        };
     };
 
-    auto make_writer_kernel = [&](const BlockBufferSet& set) {
-        std::vector<uint32_t> writer_ct_args = {
-            total_num_rows, third_dim, TILE_HEIGHT, row_size_bytes, set.output_index};
-        TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
-
-        KernelDescriptor writer_desc;
-        writer_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-            "writer_unary_stick_layout_wh_multicore.cpp";
-        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        writer_desc.core_ranges = set.core_ranges;
-        writer_desc.compile_time_args = std::move(writer_ct_args);
-        writer_desc.config = WriterConfigDescriptor{};
-        return writer_desc;
+    auto make_writer_spec = [&](const KernelSpecName& id, const BlockBufferSet& set) {
+        return KernelSpec{
+            .unique_id = id,
+            .source = std::filesystem::path{WRITER_SRC},
+            .dfb_bindings = {DFBBinding{
+                .dfb_spec_name = out_dfb_of(set),
+                .accessor_name = "out",
+                .endpoint_type = DFBEndpointType::CONSUMER,
+            }},
+            .tensor_bindings = {TensorBinding{
+                .tensor_parameter_name = OUTPUT,
+                .accessor_name = "dst",
+            }},
+            .compile_time_args =
+                {
+                    {"total_num_rows", total_num_rows},
+                    {"third_dim", third_dim},
+                    {"tile_height", TILE_HEIGHT},
+                    {"unpadded_X_size", row_size_bytes},
+                },
+            .runtime_arg_schema =
+                {
+                    .runtime_arg_names =
+                        {"width_size",
+                         "start_row_id",
+                         "start_column_id",
+                         "single_block_size_row_arg",
+                         "single_block_size_col_arg",
+                         "sub_block_width_size",
+                         "single_sub_block_size_row_arg"},
+                },
+            .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        };
     };
 
-    KernelDescriptor full_reader_desc = make_reader_kernel(full_set);
-    KernelDescriptor full_writer_desc = make_writer_kernel(full_set);
-    KernelDescriptor cliffrow_reader_desc = make_reader_kernel(cliffrow_set);
-    KernelDescriptor cliffrow_writer_desc = make_writer_kernel(cliffrow_set);
+    // Push each non-empty set's reader and writer.
+    if (!full_set.empty()) {
+        spec.kernels.push_back(make_reader_spec(READER_FULL, full_set));
+        spec.kernels.push_back(make_writer_spec(WRITER_FULL, full_set));
+    }
+    if (!cliffrow_set.empty()) {
+        spec.kernels.push_back(make_reader_spec(READER_CLIFFROW, cliffrow_set));
+        spec.kernels.push_back(make_writer_spec(WRITER_CLIFFROW, cliffrow_set));
+    }
 
     // compute
     uint32_t single_sub_block_size_wh = single_block_size * single_block_size / single_sub_block_size;
     uint32_t single_sub_block_size_cliff_col_wh =
         single_block_size_cliff_col * single_block_size / single_sub_block_size;
 
-    std::vector<std::pair<std::string, std::string>> compute_kernel_defines;
-    if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
-        input_cb_data_format == tt::DataFormat::Float32) {
-        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
+    KernelSpec::CompilerOptions::Defines compute_defines;
+    if (input_data_format == tt::DataFormat::Int32 || input_data_format == tt::DataFormat::UInt32 ||
+        input_data_format == tt::DataFormat::Float32) {
+        compute_defines.insert({"DST_ACCUM_MODE", "1"});
     }
-
-    const std::string compute_kernel_path =
-        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp";
 
     // The compute kernel stays split per region -- each region has its own block *count* -- but each
     // instance binds the buffer set matching its cores' block *width*. The region's block-width CTA
-    // (the second one) must equal that set's `block_tiles`, since it is the page count the kernel
-    // waits on and pops; the assertion below keeps the two from drifting apart.
-    auto make_compute_kernel =
-        [&](const CoreRangeSet& cores, const BlockBufferSet& set, uint32_t block_size_col, uint32_t block_size_row) {
-            TT_FATAL(
-                block_size_row == set.block_tiles,
-                "Compute on cores {} expects a block width of {} tiles but its buffers hold {}",
-                cores.str(),
-                block_size_row,
-                set.block_tiles);
-            // fp32 unpack is marked for exactly the buffer this kernel reads. Marking both sets'
-            // indices would set it on `cliffrow_set.input_index` even when that set is empty -- an
-            // operand with no CB on any core -- and would do so in the full-set kernels too.
-            std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-            if (fp32_dest_acc_en) {
-                unpack_to_dest_mode[set.input_index] = UnpackToDestMode::UnpackToDestFp32;
-            }
+    // (`block_size_row`) must equal that set's `block_tiles`, since it is the page count the kernel
+    // waits on and pops; the assertion below keeps the two from drifting apart. Each region is its
+    // own work unit: the same source with different compile-time block sizes over disjoint cores.
+    auto add_compute_region = [&](const KernelSpecName& id,
+                                  const char* work_unit_name,
+                                  const CoreRangeSet& cores,
+                                  const BlockBufferSet& set,
+                                  uint32_t block_size_col,
+                                  uint32_t block_size_row) {
+        TT_FATAL(
+            block_size_row == set.block_tiles,
+            "Compute on cores {} expects a block width of {} tiles but its buffers hold {}",
+            cores.str(),
+            block_size_row,
+            set.block_tiles);
+        // fp32 unpack is marked for exactly the buffer this kernel reads. Marking both sets' DFBs
+        // would name `cliffrow_set`'s input even when that set is empty -- an operand with no buffer
+        // on any core -- and would do so in the full-set kernels too.
+        ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+        if (fp32_dest_acc_en) {
+            compute_cfg.unpack_modes.insert({in_dfb_of(set), UnpackMode::UnpackToDest});
+        }
 
-            KernelDescriptor cd;
-            cd.kernel_source = compute_kernel_path;
-            cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
-            cd.core_ranges = cores;
-            cd.compile_time_args = {block_size_col, block_size_row, third_dim, set.input_index, set.output_index};
-            cd.defines = compute_kernel_defines;
-            cd.config = ComputeConfigDescriptor{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
-            };
-            return cd;
-        };
+        const bool is_cliff_row_set = (&set == &cliffrow_set);
+        spec.kernels.push_back(KernelSpec{
+            .unique_id = id,
+            .source = std::filesystem::path{COMPUTE_SRC},
+            .compiler_options = {.defines = compute_defines, .opt_level = KernelBuildOptLevel::O3},
+            .dfb_bindings =
+                {DFBBinding{
+                     .dfb_spec_name = in_dfb_of(set),
+                     .accessor_name = "src",
+                     .endpoint_type = DFBEndpointType::CONSUMER,
+                 },
+                 DFBBinding{
+                     .dfb_spec_name = out_dfb_of(set),
+                     .accessor_name = "out",
+                     .endpoint_type = DFBEndpointType::PRODUCER,
+                 }},
+            .compile_time_args =
+                {
+                    {"block_size_col", block_size_col},
+                    {"block_size_row", block_size_row},
+                    {"third_dim", third_dim},
+                },
+            .hw_config = std::move(compute_cfg),
+        });
+        spec.work_units.push_back(WorkUnitSpec{
+            .name = work_unit_name,
+            .kernels =
+                {is_cliff_row_set ? READER_CLIFFROW : READER_FULL,
+                 is_cliff_row_set ? WRITER_CLIFFROW : WRITER_FULL,
+                 id},
+            .target_nodes = cores,
+        });
+    };
 
-    std::vector<KernelDescriptor> compute_kernels;
-    compute_kernels.reserve(4);
     if (!core_range.empty()) {
-        compute_kernels.push_back(
-            make_compute_kernel(core_range, full_set, single_sub_block_size_wh, single_sub_block_size));
+        add_compute_region(
+            COMPUTE_FULL, "wu_full", core_range, full_set, single_sub_block_size_wh, single_sub_block_size);
     }
     if (has_cliff_col && has_cliff_row) {
-        compute_kernels.push_back(make_compute_kernel(
-            cliff_col_row_core_range, cliffrow_set, single_block_size_cliff_col, single_block_size_cliff_row));
+        add_compute_region(
+            COMPUTE_CLIFF_COL_ROW,
+            "wu_cliff_col_row",
+            cliff_col_row_core_range,
+            cliffrow_set,
+            single_block_size_cliff_col,
+            single_block_size_cliff_row);
     }
     if (has_cliff_row) {
-        compute_kernels.push_back(
-            make_compute_kernel(cliff_row_core_range, cliffrow_set, single_block_size, single_block_size_cliff_row));
+        add_compute_region(
+            COMPUTE_CLIFF_ROW,
+            "wu_cliff_row",
+            cliff_row_core_range,
+            cliffrow_set,
+            single_block_size,
+            single_block_size_cliff_row);
     }
     if (has_cliff_col) {
-        compute_kernels.push_back(make_compute_kernel(
-            cliff_col_core_range, full_set, single_sub_block_size_cliff_col_wh, single_sub_block_size));
+        add_compute_region(
+            COMPUTE_CLIFF_COL,
+            "wu_cliff_col",
+            cliff_col_core_range,
+            full_set,
+            single_sub_block_size_cliff_col_wh,
+            single_sub_block_size);
     }
 
     // RUNTIME ARGS
+    KernelRunArgs full_reader_run{.kernel = READER_FULL};
+    KernelRunArgs full_writer_run{.kernel = WRITER_FULL};
+    KernelRunArgs cliffrow_reader_run{.kernel = READER_CLIFFROW};
+    KernelRunArgs cliffrow_writer_run{.kernel = WRITER_CLIFFROW};
+
     const auto& cores = grid_to_cores(ncores, grid_size.x, grid_size.y, true);
     uint32_t start_row_id = 0;
     uint32_t start_column_id = 0;
@@ -270,8 +394,8 @@ ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
         // Route this core's args to the reader/writer instance for its buffer set.
         const BlockBufferSet& set = buffer_set_for_core(plan, core);
         const bool is_cliff_row_core = (&set == &cliffrow_set);
-        KernelDescriptor& reader_desc = is_cliff_row_core ? cliffrow_reader_desc : full_reader_desc;
-        KernelDescriptor& writer_desc = is_cliff_row_core ? cliffrow_writer_desc : full_writer_desc;
+        KernelRunArgs& reader_run = is_cliff_row_core ? cliffrow_reader_run : full_reader_run;
+        KernelRunArgs& writer_run = is_cliff_row_core ? cliffrow_writer_run : full_writer_run;
         TT_FATAL(
             single_sub_block_size_row_arg == set.block_tiles,
             "Core {} is fed a sub-block of {} tiles but the buffers on it hold {}. The work split "
@@ -280,24 +404,26 @@ ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
             single_sub_block_size_row_arg,
             set.block_tiles);
 
-        // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
-        // framework patches addresses on cache hits. This factory defines no
-        // override_runtime_arguments, so `resolve_bindings` walks every kernel's bindings and both
-        // pairs refresh on their own.
-        reader_desc.emplace_runtime_args(
-            core, {src0_buffer, tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
-
-        // writer runtime args
-        writer_desc.emplace_runtime_args(
+        // reader runtime args -- the input address is not an arg: it travels through the `src`
+        // tensor binding, which the framework refreshes on every program-cache hit.
+        AddRuntimeArgsForNode(
+            reader_run.runtime_arg_values,
             core,
-            {dst_buffer,
-             TILE_WIDTH * el_size * single_block_size_row_arg,
-             start_row_id,
-             start_column_id,
-             single_block_size_row_arg,
-             single_block_size_col_arg,
-             TILE_WIDTH * el_size * single_sub_block_size_row_arg,
-             single_sub_block_size_row_arg});
+            {{"start_id", tile_start_id},
+             {"single_block_size_row_arg", single_block_size_row_arg},
+             {"single_block_size_col_arg", single_block_size_col_arg}});
+
+        // writer runtime args (the output address likewise travels through the `dst` binding)
+        AddRuntimeArgsForNode(
+            writer_run.runtime_arg_values,
+            core,
+            {{"width_size", TILE_WIDTH * el_size * single_block_size_row_arg},
+             {"start_row_id", start_row_id},
+             {"start_column_id", start_column_id},
+             {"single_block_size_row_arg", single_block_size_row_arg},
+             {"single_block_size_col_arg", single_block_size_col_arg},
+             {"sub_block_width_size", TILE_WIDTH * el_size * single_sub_block_size_row_arg},
+             {"single_sub_block_size_row_arg", single_sub_block_size_row_arg}});
 
         uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * el_size);
         start_column_id = end_column_id % row_size_bytes;
@@ -313,20 +439,21 @@ ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
         }
     }
 
-    // Push each non-empty set's reader and writer.
+    ProgramRunArgs run_args;
     if (!full_set.empty()) {
-        desc.kernels.push_back(std::move(full_reader_desc));
-        desc.kernels.push_back(std::move(full_writer_desc));
+        run_args.kernel_run_args.push_back(std::move(full_reader_run));
+        run_args.kernel_run_args.push_back(std::move(full_writer_run));
     }
     if (!cliffrow_set.empty()) {
-        desc.kernels.push_back(std::move(cliffrow_reader_desc));
-        desc.kernels.push_back(std::move(cliffrow_writer_desc));
+        run_args.kernel_run_args.push_back(std::move(cliffrow_reader_run));
+        run_args.kernel_run_args.push_back(std::move(cliffrow_writer_run));
     }
-    for (auto& cd : compute_kernels) {
-        desc.kernels.push_back(std::move(cd));
-    }
+    run_args.tensor_args = {
+        {INPUT, TensorArgument{a.mesh_tensor()}},
+        {OUTPUT, TensorArgument{output.mesh_tensor()}},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.hpp
@@ -4,14 +4,16 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeMultiCoreBlockProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const UntilizeOperationAttributes& operation_attributes,
         const UntilizeTensorArgs& tensor_args,
         UntilizeTensorReturnValue& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp
@@ -2,6 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// NOTE: A Metal 2.0 fork of this kernel lives beside it, as
+// untilize_wh_metal2.cpp. Ops ported to Metal 2.0 bind the fork; this file serves
+// the consumers still on the legacy API. Until the last of them migrates and
+// this file is retired, changes here likely belong in the fork too.
+
 #include "api/debug/dprint.h"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh_metal2.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// NOTE: This is the Metal 2.0 fork of untilize_wh.cpp, which lives beside it. Ops ported to Metal 2.0
+// bind this file; the original serves the consumers still on the legacy API. Until the last of them
+// migrates and the original is retired, changes here likely belong there too.
+//
+// The binding names below (dfb::src, dfb::out) and named args are this fork's interface — shared with
+// the sibling untilize_metal2.cpp / untilize_variable_num_blocks_metal2.cpp forks so a factory can
+// bind any of the untilize compute kernels with one vocabulary.
+
+#include "api/debug/dprint.h"
+#include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t block_size_col = get_arg(args::block_size_col);
+    const uint32_t block_size_row = get_arg(args::block_size_row);
+    const uint32_t third_dim = get_arg(args::third_dim);
+
+    // Each region binds the buffer set matching its block width: `src` / `out` are that set's input
+    // and output buffers -- see BlockBufferSet in data_movement/common.
+    compute_kernel_hw_startup(dfb::src, dfb::out);
+    compute_kernel_lib::untilize<
+        block_size_row,
+        dfb::src,
+        dfb::out,
+        compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
+        compute_kernel_lib::untilize_config::WaitMode::WaitBlock,
+        compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(
+        block_size_col * third_dim);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
@@ -127,6 +127,8 @@ ttnn::Tensor untilize_force_codegen(
             "chunking threshold). This entry never falls back to native, because a forced leg that "
             "quietly served native would make any comparison against native vacuous. Use ttnn::untilize "
             "if you want the case routed.");
+        // Deliberately no codegen_cb_plan_fits_live_l1 gate here either: if no codegen CB plan fits
+        // the L1 free right now, the prim's program factory fails loudly rather than serving native.
         return ttnn::prim::untilize_codegen(normalized_input, output_mem_config);
     };
 
@@ -144,6 +146,7 @@ ttnn::Tensor untilize(
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    using ttnn::operations::data_movement::untilize_codegen::codegen_cb_plan_fits_live_l1;
     using ttnn::operations::data_movement::untilize_codegen::is_demoted;
     using ttnn::operations::data_movement::untilize_codegen::supported_by_codegen;
     using ttnn::operations::data_movement::untilize_codegen::supported_execution_controls;
@@ -154,11 +157,19 @@ ttnn::Tensor untilize(
     // via build_ndiml_untilize -- otherwise a logical-rank>4 input reaches supported_by_codegen /
     // is_demoted / the codegen dispatch itself on the raw, un-squeezed tensor, while the native
     // path's equivalent decisions run on the squeezed 4D tensor.
+    //
+    // Three gates, in order: static scope (supported_by_codegen), perf ledger (is_demoted), and
+    // the live-L1 gate (codegen_cb_plan_fits_live_l1) -- the last is the codegen op's own CB
+    // planner run ahead of dispatch, so a case for which no codegen CB plan fits the L1 free right
+    // now takes the native path as a whole (untilize_native -> prim::untilize or
+    // untilize_with_unpadding, deriving fp32_dest_acc_en / enough_space_height / pf_type exactly
+    // as any other native call) instead of the codegen op building a native program itself.
     auto dispatch = [=](const ttnn::Tensor& normalized_input) -> ttnn::Tensor {
         const auto output_mem_config = memory_config.value_or(normalized_input.memory_config());
 
         if (controls_ok && supported_by_codegen(normalized_input, output_mem_config) &&
-            !is_demoted(normalized_input, output_mem_config)) {
+            !is_demoted(normalized_input, output_mem_config) &&
+            codegen_cb_plan_fits_live_l1(normalized_input, output_mem_config)) {
             return ttnn::prim::untilize_codegen(normalized_input, output_mem_config);
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
@@ -59,9 +59,16 @@ ttnn::Tensor untilize_native(
     }
     bool fp32_dest_acc_en = input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32 ||
                             input_tensor.dtype() == DataType::FLOAT32;
+    // The native prim emits BFLOAT16 for a BFLOAT8_B input (UntilizeDeviceOperation::compute_output_specs),
+    // so size the output CB estimate and the pending output buffer by the output dtype: sizing them by the
+    // input's 1088 B tile under-reserves a 2048 B/tile output and can keep enough_space_height true for a row
+    // whose input+output CBs no longer fit beside the freshly allocated L1 output.
+    const DataType output_dtype =
+        input_tensor.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor.dtype();
     auto input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    auto output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_dtype);
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    uint32_t output_single_tile_size = input_single_tile_size;
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / tt::constants::TILE_WIDTH;
 
@@ -72,7 +79,7 @@ ttnn::Tensor untilize_native(
         input_tensor,
         input_tensor.padded_shape(),
         memory_config.value_or(input_tensor.memory_config()),
-        input_tensor.dtype(),
+        output_dtype,
         Layout::ROW_MAJOR);
 
     bool enough_space_height = operations::data_movement::is_enough_space(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore_metal2.cpp
@@ -1,11 +1,15 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// NOTE: A Metal 2.0 fork of this kernel lives beside it, as
-// writer_unary_stick_layout_wh_multicore_metal2.cpp. Ops ported to Metal 2.0 bind the fork; this
-// file serves the consumers still on the legacy API. Until the last of them migrates and this
-// file is retired, changes here likely belong in the fork too.
+// NOTE: This is the Metal 2.0 fork of writer_unary_stick_layout_wh_multicore.cpp, which lives beside
+// it. Ops ported to Metal 2.0 bind this file; the original serves the consumers still on the legacy
+// API. Until the last of them migrates and the original is retired, changes here likely belong there
+// too.
+//
+// The binding names below (dfb::out, tensor::dst) and the named argument set are this fork's
+// interface: every later consumer inherits them, so they are taken from the kernel's own vocabulary
+// rather than any one op's locals, and are not renamed once a consumer exists.
 
 #include <stdint.h>
 #include <cstdint>
@@ -15,22 +19,19 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr std::uint32_t total_num_rows = get_compile_time_arg_val(0);
-    constexpr std::uint32_t third_dim = get_compile_time_arg_val(1);
-    constexpr std::uint32_t tile_height = get_compile_time_arg_val(2);
-    constexpr std::uint32_t unpadded_X_size = get_compile_time_arg_val(3);
-    // The block factories emit one writer instance per buffer set, so the output buffer index is a
-    // compile-time arg rather than a fixed c_16 -- see BlockBufferSet in data_movement/common.
-    constexpr std::uint32_t dfb_id_out0 = get_compile_time_arg_val(4);
-    constexpr auto dst_args = TensorAccessorArgs<5>();
+    constexpr auto total_num_rows = get_arg(args::total_num_rows);
+    constexpr auto third_dim = get_arg(args::third_dim);
+    constexpr auto tile_height = get_arg(args::tile_height);
+    constexpr auto unpadded_X_size = get_arg(args::unpadded_X_size);
 
-    const std::uint32_t dst_addr = get_arg_val<std::uint32_t>(0);
-
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(tensor::dst);
     Noc noc;
-    DataflowBuffer dfb_out0(dfb_id_out0);
+    // The block factories emit one writer instance per buffer set; each instance's `out` binding is
+    // the output buffer sized for that set's block width -- see BlockBufferSet in data_movement/common.
+    DataflowBuffer dfb_out0(dfb::out);
 
     auto write_block = [&](std::uint32_t num_rows,
                            std::uint32_t start_row_id,
@@ -64,16 +65,16 @@ void kernel_main() {
         dfb_out0.pop_front(single_block_size * has_rows);
     };
 
-    const std::uint32_t width_size = get_arg_val<std::uint32_t>(1);
+    const std::uint32_t width_size = get_arg(args::width_size);
 
     std::uint32_t size_2d = 0;
     for (std::uint32_t dim3 = 0; dim3 < third_dim; dim3++) {
-        std::uint32_t start_row_id = get_arg_val<std::uint32_t>(2);
-        std::uint32_t start_column_id = get_arg_val<std::uint32_t>(3);
-        std::uint32_t single_block_size_row_arg = get_arg_val<std::uint32_t>(4);
-        std::uint32_t single_block_size_col_arg = get_arg_val<std::uint32_t>(5);
-        std::uint32_t sub_block_width_size = get_arg_val<std::uint32_t>(6);
-        std::uint32_t single_sub_block_size_row_arg = get_arg_val<std::uint32_t>(7);
+        std::uint32_t start_row_id = get_arg(args::start_row_id);
+        std::uint32_t start_column_id = get_arg(args::start_column_id);
+        std::uint32_t single_block_size_row_arg = get_arg(args::single_block_size_row_arg);
+        std::uint32_t single_block_size_col_arg = get_arg(args::single_block_size_col_arg);
+        std::uint32_t sub_block_width_size = get_arg(args::sub_block_width_size);
+        std::uint32_t single_sub_block_size_row_arg = get_arg(args::single_sub_block_size_row_arg);
 
         for (std::uint32_t b = 0; b < single_block_size_col_arg; b++) {
             std::uint32_t this_block_num_rows = tile_height;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp
@@ -3,6 +3,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// NOTE: A Metal 2.0 fork of this kernel lives beside it, as
+// reader_unary_interleaved_wh_multicore_metal2.cpp. Ops ported to Metal 2.0 bind the fork; this
+// file serves the consumers still on the legacy API. Until the last of them migrates and this
+// file is retired, changes here likely belong in the fork too.
+
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore_metal2.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// NOTE: This is the Metal 2.0 fork of reader_unary_interleaved_wh_multicore.cpp, which lives beside it.
+// Ops ported to Metal 2.0 bind this file; the original serves the consumers still on the legacy API.
+// Until the last of them migrates and the original is retired, changes here likely belong there too.
+//
+// The binding names below (dfb::in, tensor::src) and the named argument set are this fork's
+// interface: every later consumer inherits them, so they are taken from the kernel's own vocabulary
+// rather than any one op's locals, and are not renamed once a consumer exists.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const auto start_id = get_arg(args::start_id);
+    const auto single_block_size_row_arg = get_arg(args::single_block_size_row_arg);
+    const auto single_block_size_col_arg = get_arg(args::single_block_size_col_arg);
+
+    constexpr auto num_tiles_per_2d = get_arg(args::num_tiles_per_2d);
+    constexpr auto third_dim = get_arg(args::third_dim);
+    constexpr auto total_tiles_per_row = get_arg(args::total_tiles_per_row);
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+
+    const auto s = TensorAccessor(tensor::src);
+
+    Noc noc;
+    // The block factories emit one reader instance per buffer set; each instance's `in` binding is
+    // the input buffer sized for that set's block width -- see BlockBufferSet in data_movement/common.
+    DataflowBuffer dfb(dfb::in);
+    const uint32_t tile_bytes = dfb.get_tile_size();
+
+#ifdef BACKWARDS
+    for (uint32_t dim = 0; dim > -third_dim; dim--) {
+        for (uint32_t c = 0; c > -single_block_size_col_arg; c--) {
+            for (uint32_t r = 0; r > -single_block_size_row_arg; r--) {
+                uint32_t tile = -start_id + dim * num_tiles_per_2d + c * total_tiles_per_row + r;
+#else
+    for (uint32_t dim = 0; dim < third_dim; dim++) {
+        for (uint32_t c = 0; c < single_block_size_col_arg; c++) {
+            for (uint32_t r = 0; r < single_block_size_row_arg; r++) {
+                uint32_t tile = start_id + dim * num_tiles_per_2d + c * total_tiles_per_row + r;
+#endif
+                dfb.reserve_back(onetile);
+                noc.async_read(s, dfb, tile_bytes, {.page_id = tile}, {.offset_bytes = 0});
+
+                noc.async_read_barrier();
+                dfb.push_back(onetile);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Ports `UntilizeMultiCoreBlockProgramFactory` from `create_descriptor` to `ProgramSpecFactoryConcept` (`create_program_artifacts`), the same shape as the six sibling factories ported in #53586. After this, the only legacy pieces in `untilize/` are the ND-shard-identical factory (framework prerequisite, #53584) and the codegen device op.

Two commits, in review order:

1. **Prerequisite: decide the codegen Native tier in the composite, not via other ops' `create_descriptor`.** The codegen op's Native fallback (`build_native_equivalent`) picked a factory from `UntilizeDeviceOperation` / `UntilizeWithUnpaddingDeviceOperation` and called its legacy `create_descriptor`, which already `TT_THROW`s for the six ported factories and would have widened to Block. `ttnn::untilize` now gates codegen on `codegen_cb_plan_fits_live_l1()` (reserves the pending output footprint, runs the same CB planner) and routes to `untilize_native` as a whole when no plan fits. `build_native_equivalent` and the codegen hash's mirror of the Block core split are deleted; `compute_program_hash` covers (type, attrs, tensor_args, tier); hash-time planning and codegen-tier caching are unchanged. Adds a test that pins L1 so codegen lands on Native for an already-ported factory.
2. **Port.** The block work split stays on `make_block_plan` / `buffer_set_for_core`; each non-empty `BlockBufferSet` becomes its own input/output `DataflowBufferSpec` pair (the cliff-row pair only when the split produced a cliff row), the two reader/writer instances and up to four compute instances become same-source `KernelSpec`s in per-region `WorkUnitSpec`s, tensor addresses travel as tensor bindings, and every CTA/RTA is named. `opt_level = O3` explicit on the compute specs (legacy default). The three kernels are shared with the untilize_with_unpadding block-interleaved factory, so each gets a `_metal2` fork beside the original (`reader_unary_interleaved_wh_multicore_metal2.cpp`, `writer_unary_stick_layout_wh_multicore_metal2.cpp`, `untilize_wh_metal2.cpp`) and the originals gain only a pointer comment. The untilize_with_unpadding port (#51308) reuses the forks as-is and is the sunset point for the three legacy copies.

### Notes for reviewers
- **Conditional spec, unconditional kernel:** the cliff-row DFB pair, its `KernelSpec`s, `WorkUnitSpec`s and run-args are emitted iff the split produced a cliff row. The kernels themselves bind exactly one input and one output DFB, so no `#ifdef` is needed.
- **Four compute `KernelSpec`s, not one:** `block_size_row` is an NTTP into `compute_kernel_lib::untilize<...>`, so per-region CTAs stay CTAs rather than being demoted to RTAs. One `KernelSpec` (reader/writer) appears in several work units, as `untilize_multi_core_program_factory.cpp` already does.
- `BlockBufferSet::input_index` / `output_index` become unused by this factory but remain load-bearing for the legacy block factories; not a missed translation.
- The five legacy `TT_FATAL`s are kept verbatim. No custom `compute_program_hash` exists on `UntilizeDeviceOperation` and none is added.
- **Validation** on Wormhole B0, Watcher on, Metal 2.0 legality checks forced (both check sites confirmed live by log marker), all identical to the pre-port baseline taken after commit 1:
  - `test_untilize.py`: **834 passed / 4 skipped / 2 xfailed**
  - `test_untilize_with_unpadding.py` (co-binder guard for the forked kernels): **363 passed / 6 skipped / 6 xfailed**
  - `test_untilize_block_per_node_cb_size`: **6 passed**, program-cache assertion intact
  - ad-hoc `untilize_force_native` sweep, 3 shapes × L1/DRAM × bf16/bf8_b: **12/12** bit-exact
- The readiness sheet's `Known op issues = Per-node CB size` cell for this row is stale; that was fixed by #54392.
- Device validation ran on main `8e18a76b7a2`; the branch is rebased onto current main with no changes to these files in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-untilize-codegen-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-untilize-codegen-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-untilize-codegen-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-untilize-codegen-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-untilize-codegen-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-untilize-codegen-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-untilize-codegen-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-untilize-codegen-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-untilize-codegen-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-untilize-codegen-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-untilize-codegen-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-untilize-codegen-prereq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-untilize-codegen-prereq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-untilize-codegen-prereq)
