### PR TITLE
[tt-train] PolyNorm FW/BW: use first-column SFPU ops for sqrt/recip

### DIFF
--- a/tt-train/sources/ttml/metal/common/first_column_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/common/first_column_compute_utils.hpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_unary/recip.h"
+#include "api/compute/eltwise_unary/sqrt.h"
+#ifdef TRISC_MATH
+#include "experimental/llk_sfpu/ckernel_sfpu_sdpa_fw.h"
+#endif
+
+// First-column SFPU variants for the column vectors produced by ReduceDim::REDUCE_ROW.
+//
+// A REDUCE_ROW output only carries meaningful data in column 0 of each row. Column 0 lives
+// in faces 0 and 2; faces 1 and 3 hold columns 16-31 and are never needed. VectorMode::C
+// visits only faces 0 and 2, and a stride-2 dst_reg walk covers the column-0 half of each
+// face, so these ops cost 2 faces x 4 iterations = 8 SFPU iterations instead of the
+// full-tile 4 x 8 = 32.
+//
+// Both variants pair with the standard full-tile inits (sqrt_tile_init, recip_tile_init);
+// only the per-tile traversal changes.
+
+#ifdef TRISC_MATH
+namespace _first_column_detail {
+
+// sqrt over ITERATIONS SFPU vectors, advancing dst_reg by DST_STRIDE each step.
+//
+// Calls the same _calculate_sqrt_body_ that _calculate_sqrt_internal_ uses, with the same
+// template arguments sqrt_tile passes (calculate_sqrt defaults legacy_compat to false, so
+// sqrt_tile takes the _internal_ path). The lanes this touches therefore get results
+// identical to sqrt_tile.
+template <int ITERATIONS, bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool FAST_APPROX, int DST_STRIDE = 1>
+inline void sfpi_sqrt() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat tmp = ckernel::sfpu::_calculate_sqrt_body_<APPROXIMATION_MODE, /*RECIPROCAL*/ false, FAST_APPROX>(
+            sfpi::dst_reg[0]);
+        if constexpr (!is_fp32_dest_acc_en) {
+            tmp = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
+        }
+        sfpi::dst_reg[0] = tmp;
+        if constexpr (DST_STRIDE == 1) {
+            sfpi::dst_reg++;
+        } else {
+            sfpi::dst_reg += DST_STRIDE;
+        }
+    }
+}
+
+}  // namespace _first_column_detail
+#endif  // TRISC_MATH
+
+// First-column sqrt (2 faces x 4 half-face iterations, VectorMode::C).
+// Pair with the standard sqrt_tile_init(), which programs the constants the body reads.
+template <bool FAST_APPROX = false, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
+inline void sqrt_tile_first_column(uint32_t idst) {
+#ifdef TRISC_MATH
+    _llk_math_eltwise_unary_sfpu_params_(
+        _first_column_detail::sfpi_sqrt</*ITERATIONS*/ 4, APPROX, is_fp32_dest_acc_en, FAST_APPROX, /*DST_STRIDE*/ 2>,
+        idst,
+        VectorMode::C);
+#endif  // TRISC_MATH
+}
+
+// First-column reciprocal (2 faces x 4 half-face iterations, VectorMode::C).
+// Moved here from sdpa_fw's private kernel utils, unchanged apart from moving the
+// TRISC_MATH guard inside the body so it matches sqrt_tile_first_column above and can be
+// called without a MATH(( )) wrapper. Pair with the standard recip_tile_init().
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
+inline void recip_tile_first_column(uint32_t idst) {
+#ifdef TRISC_MATH
+    SFPU_UNARY_CALL(
+        DST_SYNC_MODE, is_fp32_dest_acc_en, calculate_recip_first_column, (is_fp32_dest_acc_en), idst, VectorMode::C);
+#endif  // TRISC_MATH
+}

--- a/tt-train/sources/ttml/metal/ops/polynorm_bw/device/kernels/compute/polynorm_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/polynorm_bw/device/kernels/compute/polynorm_bw_kernel.cpp
@@ -74,6 +74,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/tile_move_copy.h"
 #include "tt-train/sources/ttml/metal/common/compute_utils.hpp"
+#include "tt-train/sources/ttml/metal/common/first_column_compute_utils.hpp"
 
 constexpr uint32_t num_rows_per_core = get_compile_time_arg_val(0);
 constexpr uint32_t block_size = get_compile_time_arg_val(1);
@@ -192,10 +193,12 @@ void reduce_sum_to_inv_rms(const uint32_t cb_sum, const uint32_t cb_inv_rms) {
     binop_with_scalar_tile_init();
     add_unary_tile(reg_acc, get_eps_fp32_bits());
 
+    // REDUCE_ROW output: only column 0 carries data, so use the first-column SFPU
+    // variants (8 iterations instead of 32 per tile).
     sqrt_tile_init();
-    sqrt_tile(reg_acc);
+    sqrt_tile_first_column(reg_acc);
     recip_tile_init<false>();
-    recip_tile<false>(reg_acc);
+    recip_tile_first_column(reg_acc);
 
     tile_regs_commit();
     pack_and_push(reg_acc, cb_inv_rms);

--- a/tt-train/sources/ttml/metal/ops/polynorm_fw/device/kernels/compute/polynorm_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/polynorm_fw/device/kernels/compute/polynorm_fw_kernel.cpp
@@ -18,6 +18,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/tile_move_copy.h"
 #include "tt-train/sources/ttml/metal/common/compute_utils.hpp"
+#include "tt-train/sources/ttml/metal/common/first_column_compute_utils.hpp"
 
 constexpr uint32_t num_rows_per_core = get_compile_time_arg_val(0);
 constexpr uint32_t block_size = get_compile_time_arg_val(1);
@@ -76,15 +77,17 @@ void reduce_sum_pows_to_inv_rms_triplet() {
     add_unary_tile(reg_a2, eps_fp32_bits);
 
     // sqrt then reciprocal to produce inv_rms.
+    // These are REDUCE_ROW outputs, so only column 0 carries data: use the first-column
+    // SFPU variants (8 iterations instead of 32 per tile).
     sqrt_tile_init();
-    sqrt_tile(reg_a0);
-    sqrt_tile(reg_a1);
-    sqrt_tile(reg_a2);
+    sqrt_tile_first_column(reg_a0);
+    sqrt_tile_first_column(reg_a1);
+    sqrt_tile_first_column(reg_a2);
 
     recip_tile_init<false>();
-    recip_tile<false>(reg_a0);
-    recip_tile<false>(reg_a1);
-    recip_tile<false>(reg_a2);
+    recip_tile_first_column(reg_a0);
+    recip_tile_first_column(reg_a1);
+    recip_tile_first_column(reg_a2);
 
     tile_regs_commit();
     pack_l1_acc_block(cb_inv_rms, /*first_block=*/true, /*num_tiles=*/3U, /*dst_start_index=*/0U);

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
@@ -21,10 +21,8 @@
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/reduce.h"
 #include "api/compute/tile_move_copy.h"
+#include "tt-train/sources/ttml/metal/common/first_column_compute_utils.hpp"
 #include "tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp"
-#ifdef TRISC_MATH
-#include "experimental/llk_sfpu/ckernel_sfpu_sdpa_fw.h"
-#endif
 
 constexpr uint32_t onetile = 1U;
 
@@ -37,17 +35,8 @@ inline constexpr uint32_t round_up(uint32_t a, uint32_t b) {
     return ((a + b - 1U) / b) * b;
 }
 
-// SFPU intrinsics for first-column-only operations.
-// Column vectors (from row-reduce) only have meaningful data in column 0,
-// so we process 4 SFPU iterations (half-face) instead of the standard 8,
-// saving ~75% of SFPU cycles.
-#ifdef TRISC_MATH
-template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-void recip_tile_first_column(uint32_t idst) {
-    SFPU_UNARY_CALL(
-        DST_SYNC_MODE, is_fp32_dest_acc_en, calculate_recip_first_column, (is_fp32_dest_acc_en), idst, VectorMode::C);
-}
-#endif  // TRISC_MATH
+// recip_tile_first_column now lives in metal/common/first_column_compute_utils.hpp
+// so that other ops (PolyNorm) can use it too.
 
 // Apply an attention mask to a Q@K^T score tile already sitting in DST register `register_idx`.
 //


### PR DESCRIPTION
### PR Category
Performance.

### Summary
PolyNorm applies `sqrt_tile` and `recip_tile` to `REDUCE_ROW` outputs, where only column 0 of each row carries data. Both were full-tile calls: 4 faces x 8 iterations = 32 SFPU iterations to produce 32 useful values.

- **sqrt** now uses a first-column variant: `VectorMode::C` (faces 0 and 2 only, since faces 1 and 3 hold columns 16-31) with a stride-2 `dst_reg` walk covering the column-0 half of each face. 8 SFPU iterations instead of 32, a 4x reduction on this path.
- **recip** keeps its original algorithm and is restricted to `VectorMode::C`: `recip_tile<false>(reg, VectorMode::C)`. 16 iterations instead of 32, 2x, bit-identical numerics. See "Notes for reviewers" for why not 4x.

Adds `metal/common/first_column_compute_utils.hpp` holding `sqrt_tile_first_column`, shaped like `sqrt_tile`: an LLK-style body `ckernel::sfpu::calculate_sqrt_first_column` (mirroring the existing `calculate_recip_first_column`) and a `namespace ckernel` wrapper that goes through `MATH(SFPU_UNARY_CALL(...))`, so the `dst_index` bounds check applies. Only the two PolyNorm compute kernels and the new header are touched; nothing outside `tt-train/`, and SDPA is untouched.

Closes #42980

### Notes for reviewers

**Reciprocal is 2x, not 4x, deliberately.** A first-column recip would have to change the reciprocal algorithm: the only first-column body in tree, `calculate_recip_first_column`, uses `sfpu_reciprocal_iter`, while `recip_tile<false>` resolves to `_calculate_reciprocal_fast_8b_3c_`. The extra 2x is worth ~0.04% end-to-end, below what the benchmark resolves, and `PolyNormOpTest`'s 2e-2 tolerance cannot show such a swap is bit-safe. `TODO(#42980)` in `polynorm_bw_kernel.cpp` records this; the natural place to revisit is the `sqrt`+`recip` -> first-column `rsqrt` consolidation (`_calculate_sqrt_body_` already has a `RECIPROCAL` flag), as a separate change with lane-level accuracy tests.

**The sqrt side changes no arithmetic**: it calls the same `_calculate_sqrt_body_` that `_calculate_sqrt_internal_` uses with the template arguments `sqrt_tile` passes, so results are identical on the lanes it touches.

**Tests**: `PolyNormOpTest` 12/12 on Blackhole, re-run after the review changes (kernels JIT-recompiled).

**Benchmark**, `polynorm_fusion_benchmark` on Blackhole, mean of 3 runs each side. Metric is the Total table's `Fused ms`; `Composite ms` cannot be affected by this change and moved only +/-0.04%, which validates the measurement.

| Case | Before (ms) | After (ms) | Delta | Run-to-run band |
|---|---|---|---|---|
| tinyllama B=1 | 1.27 | 1.26 | -0.79% | 0.00% |
| tinyllama B=2 | 2.44 | 2.43 | -0.27% | 0.41% |
| tinyllama B=4 | 3.61 | 3.61 | -0.18% | 0.28% |
| tinyllama B=8 | 5.99 | 5.97 | -0.33% | 0.00% |
| tinyllama B=16 | 11.73 | 11.75 | +0.14% | 0.09% |
| undisclosed-model B=1 | 1.85 | 1.85 | +0.00% | 0.00% |
| undisclosed-model B=2 | 2.72 | 2.71 | -0.25% | 0.37% |
| undisclosed-model B=4 | 4.46 | 4.44 | -0.37% | 0.45% |
| undisclosed-model B=8 | 8.64 | 8.64 | -0.04% | 0.12% |
| undisclosed-model B=16 | 16.47 | 16.41 | -0.34% | 0.06% |

9 of 10 cases are <= 0, mean -0.24%. tinyllama B=16 is nominally +0.14% against a 0.09% band; given every comparable case moved the other way at this magnitude I read it as noise, but I'd rather report it than drop it. The end-to-end gain is small because this path runs once per row while the Pass-2 inner loop dominates, as the issue anticipated.

This table was measured with the earlier 4x recip variant. The merged code saves 40 of the 48 SFPU iterations that version saved per sqrt+recip pair, so the expected mean is ~-0.20%; the difference is below the run-to-run bands, so it was not re-measured.

**Review changes** (second commit, 3078c68): took the recip fallback with a `TODO(#42980)`; moved the sqrt body into `ckernel::sfpu` and the wrapper onto `SFPU_UNARY_CALL` (restores `_sfpu_check_`, fixes the namespace and reserved-identifier nits, adds `#pragma GCC unroll 4`, removes the dead `DST_STRIDE==1` branch); reverted `sdpa_compute_utils.hpp` so SDPA is untouched and the header no longer includes `experimental/llk_sfpu/ckernel_sfpu_sdpa_fw.h`. Hoisting `recip_tile_first_column` out of `sdpa_fw` is left for its own PR.

**Not included:** the `sqrt`+`recip` -> single `rsqrt_tile_first_column` consolidation, which #42980 notes as a separate PR needing test-tolerance review.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jlachowski/42980-sqrt-first-column-polynorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jlachowski/42980-sqrt-first-column-polynorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jlachowski/42980-sqrt-first-column-polynorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jlachowski/42980-sqrt-first-column-polynorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jlachowski/42980-sqrt-first-column-polynorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jlachowski/42980-sqrt-first-column-polynorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jlachowski/42980-sqrt-first-column-polynorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jlachowski/42980-sqrt-first-column-polynorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jlachowski/42980-sqrt-first-column-polynorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jlachowski/42980-sqrt-first-column-polynorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jlachowski/42980-sqrt-first-column-polynorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jlachowski/42980-sqrt-first-column-polynorm)