### PR TITLE
[Bug fix] Fix optional_output_tensor handling in ttnn.mse_loss and ttnn.l1_loss for SUM/MEAN reductions

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_losses.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_losses.py
@@ -95,3 +95,92 @@ def test_l1_loss(device, input_shapes, loss_mode):
         assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=3)
     else:
         assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [1, 1, 32, 32],
+        [2, 64, 32, 32],
+    ],
+)
+@pytest.mark.parametrize(
+    "loss_mode",
+    [
+        ["none", ttnn.LossReductionMode.NONE],
+        ["mean", ttnn.LossReductionMode.MEAN],
+        ["sum", ttnn.LossReductionMode.SUM],
+    ],
+)
+def test_mse_loss_with_output_tensor(device, input_shapes, loss_mode):
+    torch_input_tensor_a = torch.randn((input_shapes), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.randn((input_shapes), dtype=torch.bfloat16)
+    golden_fn = ttnn.get_golden_function(ttnn.mse_loss)
+    torch_output_tensor = golden_fn(
+        torch_input_tensor_a.to(torch.float32), torch_input_tensor_b.to(torch.float32), reduction=loss_mode[0]
+    )
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    out_shape = input_shapes if loss_mode[0] == "none" else [1, 1, 32, 32]
+    preallocated_out = ttnn.empty(out_shape, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    returned_tensor = ttnn.mse_loss(
+        input_tensor_a, input_tensor_b, reduction=loss_mode[1], output_tensor=preallocated_out
+    )
+
+    actual_res = ttnn.to_torch(returned_tensor)
+    actual_out = ttnn.to_torch(preallocated_out)
+
+    if loss_mode[0] in ("mean", "sum"):
+        assert_with_ulp(torch_output_tensor, actual_res, ulp_threshold=3)
+        assert_with_ulp(torch_output_tensor, actual_out, ulp_threshold=3)
+    else:
+        assert_with_pcc(torch_output_tensor, actual_res, 0.9999)
+        assert_with_pcc(torch_output_tensor, actual_out, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [1, 1, 32, 32],
+        [2, 64, 32, 32],
+    ],
+)
+@pytest.mark.parametrize(
+    "loss_mode",
+    [
+        ["none", ttnn.LossReductionMode.NONE],
+        ["mean", ttnn.LossReductionMode.MEAN],
+        ["sum", ttnn.LossReductionMode.SUM],
+    ],
+)
+def test_l1_loss_with_output_tensor(device, input_shapes, loss_mode):
+    torch_input_tensor_a = torch.randn((input_shapes), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.randn((input_shapes), dtype=torch.bfloat16)
+    golden_fn = ttnn.get_golden_function(ttnn.l1_loss)
+    torch_output_tensor = golden_fn(
+        torch_input_tensor_a.to(torch.float32), torch_input_tensor_b.to(torch.float32), reduction=loss_mode[0]
+    )
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    out_shape = input_shapes if loss_mode[0] == "none" else [1, 1, 32, 32]
+    preallocated_out = ttnn.empty(out_shape, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    returned_tensor = ttnn.l1_loss(
+        input_tensor_a, input_tensor_b, reduction=loss_mode[1], output_tensor=preallocated_out
+    )
+
+    actual_res = ttnn.to_torch(returned_tensor)
+    actual_out = ttnn.to_torch(preallocated_out)
+
+    if loss_mode[0] in ("mean", "sum"):
+        assert_with_ulp(torch_output_tensor, actual_res, ulp_threshold=3)
+        assert_with_ulp(torch_output_tensor, actual_out, ulp_threshold=3)
+    else:
+        assert_with_pcc(torch_output_tensor, actual_res, 0.9999)
+        assert_with_pcc(torch_output_tensor, actual_out, 0.9999)
+

--- a/ttnn/cpp/ttnn/operations/loss/loss.cpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/data_movement/copy/copy.hpp"
 
 namespace ttnn::operations::loss::loss_utils {
 
@@ -31,22 +32,31 @@ Tensor loss_function(
         case LossFunction::MSE: fused_ops.push_back(EltwiseUnaryWithParam{UnaryOpType::SQUARE}); break;
         default: TT_THROW("unsupported loss function {}. Please change.", loss_kind);
     }
-    Tensor result = ttnn::subtract(ref, prediction, std::nullopt, memory_config, optional_output_tensor, fused_ops);
+
+    if (reduce_mode == LossReductionMode::NONE) {
+        return ttnn::subtract(ref, prediction, std::nullopt, memory_config, optional_output_tensor, fused_ops);
+    }
+
+    Tensor diff = ttnn::subtract(ref, prediction, std::nullopt, memory_config, std::nullopt, fused_ops);
+    Tensor reduced;
 
     switch (reduce_mode) {
         case LossReductionMode::SUM:
-            return ttnn::sum(
-                result, /*dim_arg=*/std::nullopt, /*keepdim=*/false, memory_config.value_or(ref.memory_config()));
-        case LossReductionMode::MEAN:
-            return ttnn::mean(
-                result, /*dim_arg=*/std::nullopt, /*keepdim=*/false, memory_config.value_or(ref.memory_config()));
-        case LossReductionMode::NONE:
-        default:
-            // TODO: old code indicated this path is unsupported, but the all post commit test pipeline uses this path.
-            // Need to update test or replace this comment with a throw.
+            reduced = ttnn::sum(
+                diff, /*dim_arg=*/std::nullopt, /*keepdim=*/false, memory_config.value_or(ref.memory_config()));
             break;
+        case LossReductionMode::MEAN:
+            reduced = ttnn::mean(
+                diff, /*dim_arg=*/std::nullopt, /*keepdim=*/false, memory_config.value_or(ref.memory_config()));
+            break;
+        default: TT_THROW("unsupported loss reduction mode {}.", reduce_mode);
     }
-    return result;
+
+    if (optional_output_tensor.has_value()) {
+        ttnn::copy(reduced, optional_output_tensor.value());
+        return optional_output_tensor.value();
+    }
+    return reduced;
 }
 
 }  // namespace ttnn::operations::loss::loss_utils
@@ -59,7 +69,8 @@ Tensor mse_loss(
     operations::loss::LossReductionMode mode,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
-    return operations::loss::loss_utils::loss_function(ref, prediction, operations::loss::LossFunction::MSE, mode, memory_config, optional_output_tensor);
+    return operations::loss::loss_utils::loss_function(
+        ref, prediction, operations::loss::LossFunction::MSE, mode, memory_config, optional_output_tensor);
 }
 
 Tensor l1_loss(
@@ -68,7 +79,8 @@ Tensor l1_loss(
     operations::loss::LossReductionMode mode,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
-    return operations::loss::loss_utils::loss_function(ref, prediction, operations::loss::LossFunction::MAE, mode, memory_config, optional_output_tensor);
+    return operations::loss::loss_utils::loss_function(
+        ref, prediction, operations::loss::LossFunction::MAE, mode, memory_config, optional_output_tensor);
 }
 
 }  // namespace ttnn


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #56295

In `ttnn/cpp/ttnn/operations/loss/loss.cpp`, `loss_function` previously passed `optional_output_tensor` unconditionally to `ttnn::subtract`. When `reduce_mode` is `LossReductionMode::SUM` or `LossReductionMode::MEAN`:
1. If the caller preallocated `output_tensor` with the reduced scalar/tile shape `[1, 1, 32, 32]`, `subtract` crashed with a fatal shape mismatch against input `[B, C, H, W]`.
2. If the caller preallocated `output_tensor` with full input shape `[B, C, H, W]`, `subtract` wrote unreduced elementwise differences into it, while `mean`/`sum` allocated a brand new tensor for the return value, silently corrupting the caller's preallocated buffer.

**Changes:**
- In `loss_function`, only pass `optional_output_tensor` to `ttnn::subtract` when `reduce_mode == LossReductionMode::NONE`.
- For `SUM` and `MEAN`, compute subtraction into an intermediate tensor, perform the reduction, and copy the reduced result into `optional_output_tensor` via `ttnn::copy`.
- Added official regression tests in `tests/ttnn/nightly/unit_tests/operations/eltwise/test_losses.py` (`test_mse_loss_with_output_tensor`, `test_l1_loss_with_output_tensor`) covering `NONE`, `MEAN`, and `SUM` reductions.

### Notes for reviewers
- Code formatted with `clang-format`.
- Fix adheres to standard `ttnn::copy` semantics for preallocated device buffers.
- Added regression tests for both `mse_loss` and `l1_loss` with preallocated `output_tensor`.
