### PR TITLE
[Performance] Expand common host STL precompiled headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,13 +284,22 @@ target_precompile_headers(
         <fmt/format.h>
         <nlohmann/json.hpp>
         <algorithm>
+        <array>
+        <chrono>
         <cstddef>
         <cstdint>
+        <fstream>
         <functional>
         <map>
         <memory>
+        <mutex>
+        <optional>
+        <set>
+        <sstream>
+        <thread>
         <tuple>
         <unordered_map>
+        <unordered_set>
         <variant>
         <vector>
 )


### PR DESCRIPTION
### PR Category
Performance

### Summary
Closes #56293.

Expand `metal_common_pch` with `<chrono>`, `<fstream>`, `<mutex>`, `<set>`, `<sstream>`, `<thread>`, and `<unordered_set>`. Each is directly included by 20–91 files in a host-focused `tt_metal/` scan, with usage across multiple targets that reuse `TT::CommonPCH`.

Also list `<array>` and `<optional>` explicitly, since both are common host dependencies. Keep the STL list alphabetized.

### Notes for reviewers
`<array>` and `<optional>` are already included transitively with the locally checked dependencies/toolchain; their explicit entries document the intended PCH contents. No build-time speedup is claimed without a Linux build comparison.

Validation:
- Gersemi 0.16.2 and the applicable whitespace, EOF, merge-conflict, file-size, and `git diff --check` checks passed.
- A standalone CMake smoke project using the exact updated PCH block, the repository's `tt_reuse_precompile_headers` helper, fmt 11.1.4, and nlohmann/json 3.11.3 built and ran with PCH enabled and disabled. The enabled build created a PCH and reused it in the consumer, with invalid-PCH warnings treated as errors.
- Smoke validation used Apple Clang 21/libc++ in C++20 mode. A full Linux tt-metal build and compile-time benchmark were not run locally.

Replaces #56294 with the same commit and patch on a branch in `tenstorrent/tt-metal`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/expand-host-stl-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/expand-host-stl-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/expand-host-stl-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/expand-host-stl-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/expand-host-stl-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/expand-host-stl-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/expand-host-stl-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/expand-host-stl-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/expand-host-stl-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/expand-host-stl-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/expand-host-stl-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/expand-host-stl-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/expand-host-stl-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/expand-host-stl-pch)