### PR TITLE
[skip ci] Use dedicated Copilot runners and repair proxy exclusions

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,7 +25,8 @@ on:
 jobs:
   # The job MUST be called 'copilot-setup-steps' to be recognized by GitHub Copilot Agent
   copilot-setup-steps:
-    runs-on: tt-ubuntu-2204-large-stable
+    # Dedicated ARC scale set; capped separately from the build runner pool.
+    runs-on: tt-ubuntu-2204-copilot-stable
     # Copilot caps this at 59. Submodule checkout is the bulk of it.
     timeout-minutes: 50
 
@@ -35,6 +36,21 @@ jobs:
       contents: read
 
     steps:
+      - name: Keep Copilot local services off the outbound proxy
+        # The runtime starts local Git, MCP, and model API proxies after setup.
+        # Preserve existing exclusions and normalize the runner image's URL prefix.
+        # GITHUB_ENV persists these values into the generated runtime steps.
+        run: |
+          bypass="localhost,127.0.0.1,::1"
+          for existing in "${no_proxy:-}" "${NO_PROXY:-}"; do
+            existing="${existing#http://}"
+            existing="${existing#https://}"
+            if [ -n "$existing" ]; then
+              bypass="$bypass,$existing"
+            fi
+          done
+          printf 'no_proxy=%s\nNO_PROXY=%s\n' "$bypass" "$bypass" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Copilot cloud agent gets past repository setup on our self-hosted runners, then its local Git/MCP/model services encounter HTTP 403s because loopback traffic is sent to the outbound proxy. The [failed run](https://github.com/tenstorrent/tt-metal/actions/runs/34645541140/job/103415315423) reproduces this after the required integrated-firewall disablement.

Switch the agent to the existing `tt-ubuntu-2204-copilot-stable` ARC scale set and add a first setup step that normalizes and preserves proxy exclusions, adds `localhost,127.0.0.1,::1`, and writes both `no_proxy` and `NO_PROXY` to `$GITHUB_ENV` for subsequent agent-runtime steps.

The dedicated set is [configured in github-ci-infra](https://github.com/tenstorrent/github-ci-infra/blob/574c5bf2d42aa8b4925ccd0d1662e9d67e6321cf/ansible/inventories/prod/group_vars/arc_runnersets.yaml#L1616) with the same Ubuntu 22.04 large template, zero minimum runners, and a six-runner cap. It gives Copilot its own runner allocation limit and queue, while sharing the existing `cpu.regular` scheduler capacity with build jobs.

### Notes for reviewers

- Infrastructure correction: https://github.com/tenstorrent/github-ci-infra/pull/1568. This setup workaround works with existing runner images and does not require that image rollout first. Existing outbound proxy settings remain in use.
- `GITHUB_ENV` is intentional: these values must reach the generated runtime steps after setup.
- Verified locally: repository-pinned yamllint; YAML parsing and runner-label check against the infrastructure inventory; shell syntax; `git diff --check`; and a local HTTP-service/restricted-proxy reproduction using the actual first setup step. Malformed, normal, and unset exclusions all change loopback responses from 403 to 200 while nonlocal traffic remains proxied.
- [Setup workflow validation](https://github.com/tenstorrent/tt-metal/actions/runs/34648454468) passed in 57 seconds on `tt-ubuntu-2204-copilot-stable-tx7nr-runner-gxl6z`, confirming that the dedicated pool picked up the job and all setup steps succeeded. A fresh cloud-agent task after merge to `main` is still necessary to validate Git, MCP, and the first model turn; the standalone setup workflow does not exercise those services.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/copilot-runner-proxy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/copilot-runner-proxy-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/copilot-runner-proxy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/copilot-runner-proxy-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/copilot-runner-proxy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/copilot-runner-proxy-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/copilot-runner-proxy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/copilot-runner-proxy-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/copilot-runner-proxy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/copilot-runner-proxy-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/copilot-runner-proxy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/copilot-runner-proxy-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/copilot-runner-proxy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/copilot-runner-proxy-fix)
