### PR TITLE
MiniMax-H3 audio decoder: time-packed late bands, cheaper split modes, host-edge fixes (1.28x at main's accuracy)

### DIFF
--- a/models/tt_dit/layers/audio_ops.py
+++ b/models/tt_dit/layers/audio_ops.py
@@ -244,15 +244,17 @@ def prepare_conv3d_weight_state(
         # `ttnn.to_torch` refuses on a multi-host mesh; the helper reads a shard this host owns.
         return local_device_to_torch(prepared)
 
+    w_hi = w_5d.float().bfloat16().float()
     if stack:
-        w_hi = w_5d.float().bfloat16().float()
         state["weight"] = _prepare(torch.cat([w_hi, w_5d.float() - w_hi, w_hi], dim=1))
     elif split:
-        w_hi = w_5d.float().bfloat16().float()
         state["weight"] = _prepare(w_hi)
         state["weight_lo"] = _prepare(w_5d.float() - w_hi)
     else:
-        state["weight"] = _prepare(w_5d)
+        # No residual term: hand the multiplier a weight it can represent. Measured on the packed resamplers,
+        # the FPU's own truncation of an fp32 weight lands at 60.8 dB where the same conv with the bf16-rounded
+        # weight lands at 65.1 dB (round-to-nearest beats the hardware's truncation).
+        state["weight"] = _prepare(w_hi)
 
 
 def _t_neighbor_pad(

--- a/models/tt_dit/layers/audio_ops.py
+++ b/models/tt_dit/layers/audio_ops.py
@@ -43,7 +43,10 @@ DEFAULT_MAX_C_IN_BLOCK = 128
 
 
 def weights_variant(
-    split_mode: str, max_c_in_block: int = DEFAULT_MAX_C_IN_BLOCK, pack_bands: dict[int, int] | None = None
+    split_mode: str,
+    max_c_in_block: int = DEFAULT_MAX_C_IN_BLOCK,
+    pack_bands: dict[int, int] | None = None,
+    resampler_split_mode: str | None = None,
 ) -> str:
     """Cache-key suffix for the precision levers that change the prepared parameter set.
 
@@ -63,6 +66,8 @@ def weights_variant(
     if pack_bands:
         # Time-packed bands hold dense packed weights of other shapes (layers/audio_pack.py).
         suffix += "_pack" + "-".join(f"{b}x{k}" for b, k in sorted(pack_bands.items()))
+        if resampler_split_mode is not None and resampler_split_mode != split_mode:
+            suffix += f"_rs-{resampler_split_mode}"
     return suffix
 
 

--- a/models/tt_dit/layers/audio_ops.py
+++ b/models/tt_dit/layers/audio_ops.py
@@ -1090,15 +1090,27 @@ class Conv1dViaConv3d(Module):
         # The conv3d's own input width: 3x under the stacked split (see stack_operand).
         self.conv_in_channels = self.in_channels * (STACK_BLOCKS if self.split_mode == "stack" else 1)
 
+        # Blockings are tabled for the real (in, out, k); under the stacked split the conv3d sees 3x the input
+        # channels, so the table's C_in block is widened until conv3d's "C_in blocks <= cores" limit holds.
+        grid = self.mesh_device.compute_with_storage_grid_size()
         self.conv_config = get_conv3d_config(
-            self.conv_in_channels,
-            self.out_channels,
-            self.kernel_size,
-            dtype,
-            grid_size=self.mesh_device.compute_with_storage_grid_size(),
-            h_factor=1,
-            w_factor=1,
+            self.in_channels, self.out_channels, self.kernel_size, dtype, grid_size=grid, h_factor=1, w_factor=1
         )
+        if self.conv_in_channels != self.in_channels:
+            cores = grid.x * grid.y
+            c_in_block = self.conv_config.C_in_block
+            while self.conv_in_channels // c_in_block > cores or self.conv_in_channels % c_in_block:
+                c_in_block += 32
+            self.conv_config = ttnn.Conv3dConfig(
+                weights_dtype=self.conv_config.weights_dtype,
+                output_layout=self.conv_config.output_layout,
+                T_out_block=self.conv_config.T_out_block,
+                W_out_block=self.conv_config.W_out_block,
+                H_out_block=self.conv_config.H_out_block,
+                C_out_block=self.conv_config.C_out_block,
+                C_in_block=c_in_block,
+                compute_with_storage_grid_size=grid,
+            )
 
         # Column-parallel C-TP: each chip owns out_channels/factor C_out; C_in stays full (gathered).
         self.out_channels_shard = self.out_channels // channel_factor(parallel_config)

--- a/models/tt_dit/layers/audio_ops.py
+++ b/models/tt_dit/layers/audio_ops.py
@@ -40,7 +40,9 @@ WEIGHT_SPLIT_MODES = ("weight", "full")
 DEFAULT_MAX_C_IN_BLOCK = 128
 
 
-def weights_variant(split_mode: str, max_c_in_block: int = DEFAULT_MAX_C_IN_BLOCK) -> str:
+def weights_variant(
+    split_mode: str, max_c_in_block: int = DEFAULT_MAX_C_IN_BLOCK, pack_bands: dict[int, int] | None = None
+) -> str:
     """Cache-key suffix for the precision levers that change the prepared parameter set.
 
     ``split_mode`` decides whether the ``weight_lo`` residual parameters exist, so device-weight
@@ -56,6 +58,9 @@ def weights_variant(split_mode: str, max_c_in_block: int = DEFAULT_MAX_C_IN_BLOC
     suffix = "" if split_mode == "off" else f"_split-{split_mode}"
     if max_c_in_block != DEFAULT_MAX_C_IN_BLOCK:
         suffix += f"_cinb{max_c_in_block}"
+    if pack_bands:
+        # Time-packed bands hold dense packed weights of other shapes (layers/audio_pack.py).
+        suffix += "_pack" + "-".join(f"{b}x{k}" for b, k in sorted(pack_bands.items()))
     return suffix
 
 

--- a/models/tt_dit/layers/audio_ops.py
+++ b/models/tt_dit/layers/audio_ops.py
@@ -31,9 +31,11 @@ from ..utils.tensor import local_device_to_torch
 # Per-mesh cache of constant zeros buffers, keyed by id(mesh_device).
 _ZEROS_CACHE: dict = {}
 
-CONV_SPLIT_MODES = ("off", "weight", "act", "full")
+CONV_SPLIT_MODES = ("off", "weight", "act", "full", "stack")
 # Modes that carry a prepared weight residual (``weight_lo``).
 WEIGHT_SPLIT_MODES = ("weight", "full")
+# Operand blocks of the stacked split: one conv over [x_hi | x_hi | x_lo] against [W_hi ; W_lo ; W_hi].
+STACK_BLOCKS = 3
 
 # Default cap on conv3d's C_in_block for the H3 audio blocking table; the sweep that keeps it at
 # 128 lives in `blockings_minimax_h3_audio`.
@@ -75,6 +77,14 @@ def _split_operand(x: ttnn.Tensor) -> tuple[ttnn.Tensor, ttnn.Tensor]:
     return hi, ttnn.subtract(x, hi)
 
 
+def stack_operand(x_BTC: ttnn.Tensor) -> ttnn.Tensor:
+    """``[x_hi | x_hi | x_lo]`` along channels: the full split's three products as one conv over 3x the input
+    channels against ``[W_hi ; W_lo ; W_hi]`` -- 2 typecasts, 1 subtract, 1 concat and 1 conv3d instead of 8 ops,
+    the same FLOPs, one fp32 accumulator instead of two extra adds."""
+    x_hi, x_lo = _split_operand(x_BTC)
+    return ttnn.concat([x_hi, x_hi, x_lo], dim=-1)
+
+
 def conv3d_maybe_split(
     *,
     split_mode: str,
@@ -96,7 +106,7 @@ def conv3d_maybe_split(
 
     ``bias`` is applied to exactly one term, since it is not a factor of the product being split.
     """
-    if split_mode == "off":
+    if split_mode in ("off", "stack"):  # stack: the caller already stacked the input (stack_operand)
         return ttnn.experimental.conv3d(
             input_tensor=input_tensor, weight_tensor=weight_tensor, bias_tensor=bias_tensor, **conv_kwargs
         )
@@ -202,13 +212,15 @@ def prepare_conv3d_weight_state(
     unpadded_in: int | None = None,
     in_channels: int | None = None,
     split: bool = False,
+    stack: bool = False,
 ) -> None:
     """Zero-pad the 5D conv weight/bias to aligned size, prepare, and write to ``state``.
 
     With ``split``, also writes ``state["weight_lo"]``: the weight is decomposed into ``hi = bf16(w)`` and
     the exact residual ``lo = w - hi``, each prepared separately, so `conv3d_maybe_split` can recover the
     mantissa bits the ~11-bit multiplier drops. The padding above is applied once, before the split, so
-    the bias is never padded twice.
+    the bias is never padded twice. With ``stack``, the three terms of the full split are one weight
+    ``[W_hi ; W_lo ; W_hi]`` over ``3 * in_channels`` (see ``stack_operand``).
     """
     if out_channels != unpadded_out:
         pad_co = out_channels - unpadded_out
@@ -227,7 +239,10 @@ def prepare_conv3d_weight_state(
         # `ttnn.to_torch` refuses on a multi-host mesh; the helper reads a shard this host owns.
         return local_device_to_torch(prepared)
 
-    if split:
+    if stack:
+        w_hi = w_5d.float().bfloat16().float()
+        state["weight"] = _prepare(torch.cat([w_hi, w_5d.float() - w_hi, w_hi], dim=1))
+    elif split:
         w_hi = w_5d.float().bfloat16().float()
         state["weight"] = _prepare(w_hi)
         state["weight_lo"] = _prepare(w_5d.float() - w_hi)
@@ -910,6 +925,7 @@ class Conv2dViaConv3d(Module):
         # An explicit constructor argument: MiniMax-H3 opts in, LTX keeps the "off" default. See
         # `conv3d_maybe_split`; splitting only helps an fp32 datapath.
         self.split_mode = split_mode if dtype == ttnn.float32 else "off"
+        assert self.split_mode != "stack", "stacked split is implemented for Conv1dViaConv3d only"
 
         d = self.kernel_size[0] * self.kernel_size[1] * self.kernel_size[2] * self.in_channels
         self.weight = Parameter(total_shape=[d, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
@@ -1068,8 +1084,14 @@ class Conv1dViaConv3d(Module):
             self.halo_pad_left = 0
             self.halo_pad_right = 0
 
+        # An explicit constructor argument: MiniMax-H3 opts in, LTX's audio path keeps the fast
+        # default. Splitting only helps an fp32 datapath.
+        self.split_mode = split_mode if dtype == ttnn.float32 else "off"
+        # The conv3d's own input width: 3x under the stacked split (see stack_operand).
+        self.conv_in_channels = self.in_channels * (STACK_BLOCKS if self.split_mode == "stack" else 1)
+
         self.conv_config = get_conv3d_config(
-            self.in_channels,
+            self.conv_in_channels,
             self.out_channels,
             self.kernel_size,
             dtype,
@@ -1100,10 +1122,6 @@ class Conv1dViaConv3d(Module):
             packer_l1_acc=True,
         )
 
-        # An explicit constructor argument: MiniMax-H3 opts in, LTX's audio path keeps the fast
-        # default. Splitting only helps an fp32 datapath.
-        self.split_mode = split_mode if dtype == ttnn.float32 else "off"
-
         self.same_pad = same_pad
         self.eff_k = eff_k
         # Boundary fill of the T halo exchange at the global sequence ends ("zeros" | "replicate").
@@ -1132,6 +1150,7 @@ class Conv1dViaConv3d(Module):
                 unpadded_in=self.unpadded_in_channels,
                 in_channels=self.in_channels,
                 split=self.split_mode in WEIGHT_SPLIT_MODES,
+                stack=self.split_mode == "stack",
             )
         if "bias" in state and self.bias is not None:
             state["bias"] = state["bias"].reshape(1, -1)
@@ -1141,7 +1160,7 @@ class Conv1dViaConv3d(Module):
 
     def _alloc_weight_bias(self) -> None:
         """Allocate weight/bias; column-parallel shards C_out across the channel axis at load."""
-        d = self.kernel_size[0] * self.kernel_size[1] * self.kernel_size[2] * self.in_channels
+        d = self.kernel_size[0] * self.kernel_size[1] * self.kernel_size[2] * self.conv_in_channels
         mesh_axes = [None, channel_axis(self.parallel_config)] if self._is_col_parallel() else None
 
         self.weight = Parameter(
@@ -1210,6 +1229,8 @@ class Conv1dViaConv3d(Module):
             )
             x_BTC = ttnn.concat([zero_pad, x_BTC], dim=1)
 
+        if self.split_mode == "stack":
+            x_BTC = stack_operand(x_BTC)
         x_5d = ttnn.reshape(x_BTC, (x_BTC.shape[0], x_BTC.shape[1], 1, 1, x_BTC.shape[2]))
 
         out_5d = conv3d_maybe_split(

--- a/models/tt_dit/layers/audio_ops.py
+++ b/models/tt_dit/layers/audio_ops.py
@@ -31,7 +31,9 @@ from ..utils.tensor import local_device_to_torch
 # Per-mesh cache of constant zeros buffers, keyed by id(mesh_device).
 _ZEROS_CACHE: dict = {}
 
-CONV_SPLIT_MODES = ("off", "weight", "full")
+CONV_SPLIT_MODES = ("off", "weight", "act", "full")
+# Modes that carry a prepared weight residual (``weight_lo``).
+WEIGHT_SPLIT_MODES = ("weight", "full")
 
 # Default cap on conv3d's C_in_block for the H3 audio blocking table; the sweep that keeps it at
 # 128 lives in `blockings_minimax_h3_audio`.
@@ -84,13 +86,25 @@ def conv3d_maybe_split(
     cannot help. Conv is linear in both arguments, so splitting an operand into ``hi = bf16(v)`` plus
     the exact residual ``lo = v - hi`` lets a second conv carry the dropped mantissa bits.
     ``split_mode="weight"`` splits the weight only (2 convs, measured 1.5x less error on ``conv_pre``);
-    ``"full"`` splits both (3 convs -- the ``lo*lo`` term is negligible and omitted; 1.9x).
+    ``"act"`` splits the activation only (2 convs); ``"full"`` splits both (3 convs -- the ``lo*lo`` term is
+    negligible and omitted; 1.9x).
 
     ``bias`` is applied to exactly one term, since it is not a factor of the product being split.
     """
     if split_mode == "off":
         return ttnn.experimental.conv3d(
             input_tensor=input_tensor, weight_tensor=weight_tensor, bias_tensor=bias_tensor, **conv_kwargs
+        )
+    if split_mode == "act":
+        # Activation-only split (2 convs): measured on the H3 decoder, the weight split adds nothing the
+        # activation split does not already give (weight-only 50.8 dB vs off 51.3 dB; full 67.4 dB).
+        x_hi, x_lo = _split_operand(input_tensor)
+        out = ttnn.experimental.conv3d(
+            input_tensor=x_hi, weight_tensor=weight_tensor, bias_tensor=bias_tensor, **conv_kwargs
+        )
+        return ttnn.add(
+            out,
+            ttnn.experimental.conv3d(input_tensor=x_lo, weight_tensor=weight_tensor, bias_tensor=None, **conv_kwargs),
         )
     assert weight_lo_tensor is not None, f"split_mode={split_mode!r} needs a prepared weight residual"
 
@@ -896,7 +910,7 @@ class Conv2dViaConv3d(Module):
         self.weight = Parameter(total_shape=[d, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
         self.weight_lo = (
             Parameter(total_shape=[d, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
-            if self.split_mode != "off"
+            if self.split_mode in WEIGHT_SPLIT_MODES
             else None
         )
         self.bias = Parameter(total_shape=[1, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
@@ -919,7 +933,7 @@ class Conv2dViaConv3d(Module):
                 dtype=self.dtype,
                 unpadded_out=self.unpadded_out_channels,
                 out_channels=self.out_channels,
-                split=self.split_mode != "off",
+                split=self.split_mode in WEIGHT_SPLIT_MODES,
             )
         if "bias" in state:
             state["bias"] = state["bias"].reshape(1, -1)
@@ -1087,6 +1101,8 @@ class Conv1dViaConv3d(Module):
 
         self.same_pad = same_pad
         self.eff_k = eff_k
+        # Boundary fill of the T halo exchange at the global sequence ends ("zeros" | "replicate").
+        self.halo_padding_mode = "zeros"
 
         self._alloc_weight_bias()
 
@@ -1110,7 +1126,7 @@ class Conv1dViaConv3d(Module):
                 out_channels=self.out_channels,
                 unpadded_in=self.unpadded_in_channels,
                 in_channels=self.in_channels,
-                split=self.split_mode != "off",
+                split=self.split_mode in WEIGHT_SPLIT_MODES,
             )
         if "bias" in state and self.bias is not None:
             state["bias"] = state["bias"].reshape(1, -1)
@@ -1139,7 +1155,7 @@ class Conv1dViaConv3d(Module):
                 dtype=self.dtype,
                 mesh_axes=mesh_axes,
             )
-            if self.split_mode != "off"
+            if self.split_mode in WEIGHT_SPLIT_MODES
             else None
         )
         self.bias = (
@@ -1177,7 +1193,7 @@ class Conv1dViaConv3d(Module):
                 pad_right=self.halo_pad_right,
                 parallel_config=self.parallel_config,
                 ccl_manager=self.ccl_manager,
-                padding_mode="zeros",
+                padding_mode=self.halo_padding_mode,
             )
         elif self.external_pad_front > 0:
             B, T, C = x_BTC.shape

--- a/models/tt_dit/layers/audio_pack.py
+++ b/models/tt_dit/layers/audio_pack.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Time-packed 1-D ops for the vocoder's narrow late bands.
+
+With 8 or 16 channels a ``(T, C)`` fp32 row is a 32- or 64-byte DRAM page and every op in the band runs at a few
+GB/s. Packing ``k`` consecutive time steps into one row, ``(T, C) -> (T / k, k * C)`` (a plain row-major reshape),
+gives 128-byte pages and ``k``x fewer of them. Every op in an AMP block is shift-invariant with an integer rate, so
+each has an exact packed form as a dense conv over packed rows:
+
+* a dilated ``Conv1d`` becomes a ``Conv1d`` on ``k * C_in -> k * C_out`` with a few taps;
+* the 2x anti-alias upsampler becomes ``k * C -> 2k * C``, the 2x downsampler ``2k * C -> k * C``;
+* ``SnakeBeta`` keeps working elementwise with its per-channel parameters tiled ``k`` times.
+
+The packed weights are read off the reference op's impulse responses (``packed_weight``), so any shift-invariant
+torch op can be packed without deriving index arithmetic by hand. The dense form multiplies zeros where the
+original coupling is absent, but conv3d already pads the channel dim to 32, so at ``k * C = 32`` the FLOPs are
+unchanged while the channel pad/trim ops disappear. Only the global sequence ends differ from the unpacked op: a
+replicate pad of packed rows repeats the last ``k`` samples instead of the last one.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+import ttnn
+
+from .audio_ops import Conv1dViaConv3d, SnakeBeta, _make_kaiser_sinc_kernel_1d
+from .module import Module
+
+
+def packed_weight(
+    op, *, c_in: int, c_out: int, k_in: int, k_out: int, support: int, q_half: int | None = None
+) -> torch.Tensor:
+    """Dense packed weight ``(k_out * c_out, k_in * c_in, K')`` of a shift-invariant torch op.
+
+    ``op`` maps ``(1, c_in, L)`` to ``(1, c_out, L * k_out / k_in)`` (no bias) and commutes with shifts by ``k_in``
+    input / ``k_out`` output samples. ``support`` bounds the op's receptive field in input samples. The result is a
+    "same"-padded odd-length kernel (zero taps pad an asymmetric reach), so ``F.conv1d(X', W', padding=K'//2)`` on
+    packed rows reproduces ``op`` away from the sequence ends. ``q_half`` fixes ``K' = 2 * q_half + 1`` (a weight
+    with chance zero taps must keep the kernel its module was built for); ``None`` trims zero taps symmetrically.
+    """
+    q_max = -(-(support + k_in) // k_in) + 1
+    rows = 2 * q_max + 5
+    t0 = rows // 2
+    width = k_out * c_out
+    taps = torch.zeros(2 * q_max + 1, k_in * c_in, width, dtype=torch.float64)
+    for r in range(k_in):
+        for ci in range(c_in):
+            x = torch.zeros(1, c_in, rows * k_in, dtype=torch.float64)
+            x[0, ci, t0 * k_in + r] = 1.0
+            with torch.no_grad():
+                y = op(x)
+            assert y.shape[-1] == rows * k_out, f"op must map {rows * k_in} -> {rows * k_out} samples, got {y.shape}"
+            y_rows = y[0].transpose(0, 1).reshape(rows, width)  # (T', k_out * c_out), slot-major
+            for d in range(-q_max, q_max + 1):
+                taps[q_max - d, r * c_in + ci] = y_rows[t0 + d]
+    if q_half is None:
+        # Trim zero taps symmetrically so the kernel stays "same"-padded.
+        nonzero = [q for q in range(taps.shape[0]) if taps[q].abs().max() > 0]
+        assert nonzero, "op has no response"
+        trim = min(nonzero[0], taps.shape[0] - 1 - nonzero[-1])
+    else:
+        trim = q_max - q_half
+        assert trim >= 0, f"q_half {q_half} exceeds the probed reach {q_max}"
+        assert taps[:trim].abs().max() == 0 and taps[taps.shape[0] - trim :].abs().max() == 0, "response outside q_half"
+    taps = taps[trim : taps.shape[0] - trim]
+    return taps.permute(2, 1, 0).contiguous().float()  # (k_out*c_out, k_in*c_in, K') = Conv1d weight layout
+
+
+def conv1d_same(weight: torch.Tensor, dilation: int):
+    """Bias-free "same" ``Conv1d`` closure for ``packed_weight``."""
+    k = weight.shape[-1]
+    pad = (k - 1) * dilation // 2
+    w = weight.double()
+    return lambda x: F.conv1d(x, w, padding=pad, dilation=dilation)
+
+
+def upsample2x_ref(taps: torch.Tensor, channels: int):
+    """BigVGAN ``UpSample1d`` (ratio 2) as a bias-free closure: replicate pad, ``2 * conv_transpose1d``, crop."""
+    k = taps.numel()
+    pad = k // 2 - 1
+    crop = pad * 2 + (k - 2) // 2
+    w = taps.double().reshape(1, 1, k).expand(channels, 1, k).contiguous()
+
+    def op(x):
+        xp = F.pad(x, (pad, pad), mode="replicate")
+        y = 2.0 * F.conv_transpose1d(xp, w, stride=2, groups=channels)
+        return y[..., crop : y.shape[-1] - crop]
+
+    return op
+
+
+def downsample2x_ref(taps: torch.Tensor, channels: int):
+    """BigVGAN ``DownSample1d`` (ratio 2): replicate pad ``(k/2 - 1, k/2)``, strided depthwise conv."""
+    k = taps.numel()
+    w = taps.double().reshape(1, 1, k).expand(channels, 1, k).contiguous()
+
+    def op(x):
+        xp = F.pad(x, (k // 2 - 1, k // 2), mode="replicate")
+        return F.conv1d(xp, w, stride=2, groups=channels)
+
+    return op
+
+
+def kaiser_taps(ratio: int = 2, kernel_size: int = 12) -> torch.Tensor:
+    return _make_kaiser_sinc_kernel_1d(cutoff=0.5 / ratio, half_width=0.6 / ratio, kernel_size=kernel_size)
+
+
+class PackedConv1d(Conv1dViaConv3d):
+    """A dilated "same" ``Conv1d`` on ``k``-packed rows: ``(B, T/k, k*C_in) -> (B, T/k, k*C_out)``.
+
+    Loads the ordinary ``(C_out, C_in, K)`` torch weight and bias and packs them at load time.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int, *, kernel_size: int, dilation: int = 1, pack: int, **kw):
+        support = (kernel_size - 1) * dilation + 1
+        probe = packed_weight(
+            conv1d_same(torch.ones(out_channels, in_channels, kernel_size), dilation),
+            c_in=in_channels,
+            c_out=out_channels,
+            k_in=pack,
+            k_out=pack,
+            support=support,
+        )
+        super().__init__(
+            pack * in_channels, pack * out_channels, kernel_size=probe.shape[-1], dilation=1, padding_mode="zeros", **kw
+        )
+        self.pack = pack
+        self.orig = (out_channels, in_channels, kernel_size)
+        self.orig_dilation = dilation
+        self.q_half = probe.shape[-1] // 2
+
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        if "weight" in state:
+            w = state["weight"]
+            assert tuple(w.shape) == self.orig, (tuple(w.shape), self.orig)
+            state["weight"] = packed_weight(
+                conv1d_same(w, self.orig_dilation),
+                c_in=self.orig[1],
+                c_out=self.orig[0],
+                k_in=self.pack,
+                k_out=self.pack,
+                support=(self.orig[2] - 1) * self.orig_dilation + 1,
+                q_half=self.q_half,
+            )
+        if "bias" in state:
+            state["bias"] = state["bias"].reshape(-1).repeat(self.pack)
+        super()._prepare_torch_state(state)
+
+
+def _packed_resample_weight(taps, channels, k_in, k_out, up, q_half=None):
+    ref = (upsample2x_ref if up else downsample2x_ref)(taps, channels)
+    return packed_weight(
+        ref, c_in=channels, c_out=channels, k_in=k_in, k_out=k_out, support=taps.numel() * 2 + 2, q_half=q_half
+    )
+
+
+class PackedResample(Conv1dViaConv3d):
+    """A fixed depthwise 2x resampler (up or down) as a dense conv on packed rows.
+
+    ``k_in`` input slots per row, ``k_out`` output slots per row (``k_out = 2 * k_in`` up, ``k_in / 2`` down). The
+    taps come from the checkpoint filter when it carries one, else the kaiser-sinc default. Replicate padding at the
+    sequence ends becomes a replicate halo of packed rows when T-sharded (zeros when unsharded).
+    """
+
+    def __init__(self, channels: int, *, k_in: int, k_out: int, up: bool, **kw):
+        taps = kaiser_taps()
+        probe = _packed_resample_weight(taps, channels, k_in, k_out, up)
+        super().__init__(
+            k_in * channels, k_out * channels, kernel_size=probe.shape[-1], padding_mode="zeros", bias=False, **kw
+        )
+        self.channels, self.k_in, self.k_out, self.up = channels, k_in, k_out, up
+        self._taps = taps
+        self.q_half = probe.shape[-1] // 2
+        self.halo_padding_mode = "replicate"
+
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        taps = state.pop("filter", None)
+        if taps is not None:
+            self._taps = taps.reshape(-1).float()
+        state["weight"] = _packed_resample_weight(
+            self._taps, self.channels, self.k_in, self.k_out, self.up, q_half=self.q_half
+        )
+        super()._prepare_torch_state(state)
+
+
+class PackedActivation1d(Module):
+    """``UpSample1d(2x) -> SnakeBeta -> DownSample1d(2x)`` on ``k``-packed rows: three ops plus the snake's layout
+    round trip, against ~25 today. Loads the unpacked ``Activation1d`` state (``act.alpha``, ``act.beta`` and the
+    optional resampler filters), tiling the per-channel snake parameters over the ``2k`` slots of the upsampled row.
+    """
+
+    def __init__(
+        self,
+        *,
+        channels: int,
+        pack: int,
+        mesh_device,
+        dtype=ttnn.float32,
+        parallel_config=None,
+        ccl_manager=None,
+        split_mode="off",
+    ):
+        super().__init__()
+        self.channels, self.pack = channels, pack
+        common = dict(
+            mesh_device=mesh_device,
+            dtype=dtype,
+            parallel_config=parallel_config,
+            ccl_manager=ccl_manager,
+            split_mode=split_mode,
+        )
+        self.up = PackedResample(channels, k_in=pack, k_out=2 * pack, up=True, **common)
+        self.act = SnakeBeta(
+            2 * pack * channels,
+            alpha_logscale=True,
+            mesh_device=mesh_device,
+            dtype=dtype,
+            parallel_config=parallel_config,
+        )
+        self.down = PackedResample(channels, k_in=2 * pack, k_out=pack, up=False, **common)
+
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        for name in ("act.alpha", "act.beta"):
+            if name in state:
+                state[name] = state[name].reshape(-1).repeat(2 * self.pack)
+        if "upsample.filter" in state:
+            state["up.filter"] = state.pop("upsample.filter")
+        if "downsample.lowpass.filter" in state:
+            state["down.filter"] = state.pop("downsample.lowpass.filter")
+
+    def forward(self, x_BTC: ttnn.Tensor) -> ttnn.Tensor:
+        y = self.up(x_BTC)
+        y = self.act(y)
+        if y.layout != ttnn.ROW_MAJOR_LAYOUT:
+            y = ttnn.to_layout(y, ttnn.ROW_MAJOR_LAYOUT)
+        return self.down(y)

--- a/models/tt_dit/layers/audio_pack.py
+++ b/models/tt_dit/layers/audio_pack.py
@@ -201,17 +201,15 @@ class PackedActivation1d(Module):
         parallel_config=None,
         ccl_manager=None,
         split_mode="off",
+        resampler_split_mode: str | None = None,
     ):
         super().__init__()
         self.channels, self.pack = channels, pack
-        common = dict(
-            mesh_device=mesh_device,
-            dtype=dtype,
-            parallel_config=parallel_config,
-            ccl_manager=ccl_manager,
-            split_mode=split_mode,
-        )
-        self.up = PackedResample(channels, k_in=pack, k_out=2 * pack, up=True, **common)
+        # The resamplers' fixed kaiser taps tolerate a cheaper split than the learned convs: measured on the H3
+        # decoder, no split on them costs 2.3 dB (67.3 -> 65.1) and saves 72 ms of 414.
+        rs_mode = split_mode if resampler_split_mode is None else resampler_split_mode
+        common = dict(mesh_device=mesh_device, dtype=dtype, parallel_config=parallel_config, ccl_manager=ccl_manager)
+        self.up = PackedResample(channels, k_in=pack, k_out=2 * pack, up=True, split_mode=rs_mode, **common)
         self.act = SnakeBeta(
             2 * pack * channels,
             alpha_logscale=True,
@@ -219,7 +217,7 @@ class PackedActivation1d(Module):
             dtype=dtype,
             parallel_config=parallel_config,
         )
-        self.down = PackedResample(channels, k_in=2 * pack, k_out=pack, up=False, **common)
+        self.down = PackedResample(channels, k_in=2 * pack, k_out=pack, up=False, split_mode=rs_mode, **common)
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         for name in ("act.alpha", "act.beta"):

--- a/models/tt_dit/models/audio_vae/minimax_h3/decoder_minimax_h3_audio.py
+++ b/models/tt_dit/models/audio_vae/minimax_h3/decoder_minimax_h3_audio.py
@@ -88,6 +88,7 @@ class MiniMaxH3AudioDecoder(Module):
         self.split_mode = split_mode
         self.max_c_in_block = max_c_in_block
         self.pack_bands = dict(pack_bands or {})
+        self._pad_masks: dict = {}
 
         # H3's audio channel schedule differs from LTX's at both ends, so every conv misses
         # _FP32_BLOCKINGS. Seed stubs before any conv is built; see that module for why stubs.
@@ -167,9 +168,23 @@ class MiniMaxH3AudioDecoder(Module):
             x = torch.nn.functional.pad(x, (0, 0, 0, t_pad))
         x_dev = ttnn.from_torch(x, device=self.mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=self.dtype)
         projected_dev = self.dec_in_proj(x_dev)
+        if t_pad:
+            # k=1 with a bias: the zero pad rows project to the bias, but the vocoder expects zero pad rows
+            # (conv_pre reads them). One multiply by a cached (1, T + t_pad, 1) validity mask restores that.
+            projected_dev = ttnn.multiply(projected_dev, self._pad_row_mask(x.shape[1], t_pad))
         return self.decoder.forward_device_BTC(
             projected_dev, t_pad=t_pad, traced=traced, trace_key=tuple(latents_BCT.shape)
         )
+
+    def _pad_row_mask(self, t_total: int, t_pad: int) -> ttnn.Tensor:
+        key = (t_total, t_pad)
+        mask = self._pad_masks.get(key)
+        if mask is None:
+            m = torch.ones(1, t_total, 1, dtype=torch.float32)
+            m[:, t_total - t_pad :, :] = 0.0
+            mask = ttnn.from_torch(m, device=self.mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=self.dtype)
+            self._pad_masks[key] = mask
+        return mask
 
     def _t_padding(self, num_frames: int) -> int:
         """T padding needed for tile-aligned per-chip shards; zero when unsharded."""

--- a/models/tt_dit/models/audio_vae/minimax_h3/decoder_minimax_h3_audio.py
+++ b/models/tt_dit/models/audio_vae/minimax_h3/decoder_minimax_h3_audio.py
@@ -68,6 +68,7 @@ class MiniMaxH3AudioDecoder(Module):
         ccl_manager: CCLManager | None = None,
         split_mode: str = "full",
         max_c_in_block: int = DEFAULT_MAX_C_IN_BLOCK,
+        pack_bands: dict[int, int] | None = None,
     ) -> None:
         super().__init__()
         self.mesh_device = mesh_device
@@ -122,6 +123,7 @@ class MiniMaxH3AudioDecoder(Module):
             ccl_manager=ccl_manager,
             # H3-only opt-in: LTX's vocoder keeps its default single-conv weights.
             split_mode=split_mode,
+            pack_bands=pack_bands,
         )
 
     def _project_latents_device(self, latents_BCT: torch.Tensor) -> torch.Tensor:

--- a/models/tt_dit/models/audio_vae/minimax_h3/decoder_minimax_h3_audio.py
+++ b/models/tt_dit/models/audio_vae/minimax_h3/decoder_minimax_h3_audio.py
@@ -159,8 +159,17 @@ class MiniMaxH3AudioDecoder(Module):
         """
         _, channels, _ = latents_BCT.shape
         assert channels == self.latent_channels, f"expected {self.latent_channels} latent channels, got {channels}"
-        projected = self._project_latents_device(latents_BCT)
-        return self.decoder.forward_BCT_traced(projected) if traced else self.decoder.forward_BCT(projected)
+        # dec_in_proj is a k=1 conv, so it runs on the vocoder's own T padding and hands its output to the
+        # vocoder on device: no readback + re-upload of the (B, T, 2048) projection between the two.
+        x = latents_BCT.transpose(1, 2).float().contiguous()  # (B, T, C)
+        t_pad = self.decoder.t_pad_for(x.shape[1])
+        if t_pad:
+            x = torch.nn.functional.pad(x, (0, 0, 0, t_pad))
+        x_dev = ttnn.from_torch(x, device=self.mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=self.dtype)
+        projected_dev = self.dec_in_proj(x_dev)
+        return self.decoder.forward_device_BTC(
+            projected_dev, t_pad=t_pad, traced=traced, trace_key=tuple(latents_BCT.shape)
+        )
 
     def _t_padding(self, num_frames: int) -> int:
         """T padding needed for tile-aligned per-chip shards; zero when unsharded."""

--- a/models/tt_dit/models/audio_vae/minimax_h3/decoder_minimax_h3_audio.py
+++ b/models/tt_dit/models/audio_vae/minimax_h3/decoder_minimax_h3_audio.py
@@ -69,6 +69,7 @@ class MiniMaxH3AudioDecoder(Module):
         split_mode: str = "full",
         max_c_in_block: int = DEFAULT_MAX_C_IN_BLOCK,
         pack_bands: dict[int, int] | None = None,
+        resampler_split_mode: str | None = None,
     ) -> None:
         super().__init__()
         self.mesh_device = mesh_device
@@ -88,6 +89,7 @@ class MiniMaxH3AudioDecoder(Module):
         self.split_mode = split_mode
         self.max_c_in_block = max_c_in_block
         self.pack_bands = dict(pack_bands or {})
+        self.resampler_split_mode = resampler_split_mode
         self._pad_masks: dict = {}
 
         # H3's audio channel schedule differs from LTX's at both ends, so every conv misses
@@ -126,6 +128,7 @@ class MiniMaxH3AudioDecoder(Module):
             # H3-only opt-in: LTX's vocoder keeps its default single-conv weights.
             split_mode=split_mode,
             pack_bands=pack_bands,
+            resampler_split_mode=resampler_split_mode,
         )
 
     def _project_latents_device(self, latents_BCT: torch.Tensor) -> torch.Tensor:

--- a/models/tt_dit/models/audio_vae/minimax_h3/decoder_minimax_h3_audio.py
+++ b/models/tt_dit/models/audio_vae/minimax_h3/decoder_minimax_h3_audio.py
@@ -87,6 +87,7 @@ class MiniMaxH3AudioDecoder(Module):
         # (see compute_depthwise_conv1d.cpp).
         self.split_mode = split_mode
         self.max_c_in_block = max_c_in_block
+        self.pack_bands = dict(pack_bands or {})
 
         # H3's audio channel schedule differs from LTX's at both ends, so every conv misses
         # _FP32_BLOCKINGS. Seed stubs before any conv is built; see that module for why stubs.

--- a/models/tt_dit/models/audio_vae/vocoder_ltx.py
+++ b/models/tt_dit/models/audio_vae/vocoder_ltx.py
@@ -102,6 +102,7 @@ class AMPBlock1(Module):
         ccl_manager: CCLManager | None = None,
         split_mode: str = "off",
         pack: int | None = None,
+        resampler_split_mode: str | None = None,
     ) -> None:
         super().__init__()
         self.channels = channels
@@ -142,7 +143,13 @@ class AMPBlock1(Module):
         def act():
             if pack is not None:
                 assert activation == "snakebeta", "packed blocks implement SnakeBeta only"
-                return PackedActivation1d(channels=channels, pack=pack, split_mode=split_mode, **common)
+                return PackedActivation1d(
+                    channels=channels,
+                    pack=pack,
+                    split_mode=split_mode,
+                    resampler_split_mode=resampler_split_mode,
+                    **common,
+                )
             return Activation1d(
                 channels=channels,
                 activation=act_cls(
@@ -217,11 +224,14 @@ class Vocoder(Module):
         ccl_manager: CCLManager | None = None,
         split_mode: str = "off",
         pack_bands: dict[int, int] | None = None,
+        resampler_split_mode: str | None = None,
     ) -> None:
         super().__init__()
         # band index -> time steps packed per row for that band's AMP blocks (layers/audio_pack.py); the
         # narrow late bands (8-16 channels) run ~2x faster per op on 32-wide packed rows.
         self.pack_bands = dict(pack_bands or {})
+        # split mode of the packed bands' anti-alias resamplers (None = same as the convs)
+        self.resampler_split_mode = resampler_split_mode
 
         if resblock_kernel_sizes is None:
             resblock_kernel_sizes = [3, 7, 11]
@@ -311,6 +321,7 @@ class Vocoder(Module):
                         ccl_manager=ccl_manager,
                         split_mode=split_mode,
                         pack=self.pack_bands.get(i),
+                        resampler_split_mode=resampler_split_mode,
                     )
                 )
 

--- a/models/tt_dit/models/audio_vae/vocoder_ltx.py
+++ b/models/tt_dit/models/audio_vae/vocoder_ltx.py
@@ -101,21 +101,23 @@ class AMPBlock1(Module):
         parallel_config: ParallelFactor | None = None,
         ccl_manager: CCLManager | None = None,
         split_mode: str = "off",
-        pack: int = 1,
+        pack: int | None = None,
     ) -> None:
         super().__init__()
         self.channels = channels
         self.kernel_size = kernel_size
         self.num_branches = len(dilation)
         self.mesh_device = mesh_device
-        # pack > 1: the block runs on time-packed rows (B, T/pack, pack*C); see layers/audio_pack.py.
+        # pack (layers/audio_pack.py): None = the depthwise resamplers and dilated convs as they are; 1 = the
+        # anti-alias resamplers as dense convs on unpacked rows; > 1 = everything on time-packed rows
+        # (B, T/pack, pack*C).
         self.pack = pack
 
         act_cls = SnakeBeta if activation == "snakebeta" else Snake
         common = dict(mesh_device=mesh_device, dtype=dtype, parallel_config=parallel_config, ccl_manager=ccl_manager)
 
         def conv(dil):
-            if pack > 1:
+            if pack is not None and pack > 1:
                 return PackedConv1d(
                     channels,
                     channels,
@@ -138,7 +140,7 @@ class AMPBlock1(Module):
 
         # alpha_logscale=True: checkpoint stores log α / log β, collapsed at load time.
         def act():
-            if pack > 1:
+            if pack is not None:
                 assert activation == "snakebeta", "packed blocks implement SnakeBeta only"
                 return PackedActivation1d(channels=channels, pack=pack, split_mode=split_mode, **common)
             return Activation1d(
@@ -308,7 +310,7 @@ class Vocoder(Module):
                         parallel_config=parallel_config,
                         ccl_manager=ccl_manager,
                         split_mode=split_mode,
-                        pack=self.pack_bands.get(i, 1),
+                        pack=self.pack_bands.get(i),
                     )
                 )
 

--- a/models/tt_dit/models/audio_vae/vocoder_ltx.py
+++ b/models/tt_dit/models/audio_vae/vocoder_ltx.py
@@ -29,6 +29,7 @@ from ...layers.audio_ops import (
     channel_factor,
     partition_channel,
 )
+from ...layers.audio_pack import PackedActivation1d, PackedConv1d
 from ...layers.audio_resample import Activation1d
 from ...layers.module import Module, ModuleList
 from ...parallel.config import ParallelFactor
@@ -37,6 +38,18 @@ from ...utils.tensor import local_device_to_torch
 from ...utils.tracing import traced_function
 
 TILE_HEIGHT = ttnn.TILE_SIZE  # 32; the per-shard T-height floor for HEIGHT_SHARDED convs
+
+
+def _reshape_rows(x: ttnn.Tensor, shape) -> ttnn.Tensor:
+    """Row-major reshape that changes the row width (a device copy); frees the source when it was copied."""
+    y = ttnn.reshape(x, shape)
+    try:
+        distinct = y.buffer_address() != x.buffer_address()
+    except Exception:  # noqa: BLE001 -- no address on this tensor kind: keep both alive rather than risk a free
+        distinct = False
+    if distinct:
+        ttnn.deallocate(x)
+    return y
 
 
 class DilatedConv1d(_AlignedOutConv1d):
@@ -88,88 +101,58 @@ class AMPBlock1(Module):
         parallel_config: ParallelFactor | None = None,
         ccl_manager: CCLManager | None = None,
         split_mode: str = "off",
+        pack: int = 1,
     ) -> None:
         super().__init__()
         self.channels = channels
         self.kernel_size = kernel_size
         self.num_branches = len(dilation)
         self.mesh_device = mesh_device
+        # pack > 1: the block runs on time-packed rows (B, T/pack, pack*C); see layers/audio_pack.py.
+        self.pack = pack
 
         act_cls = SnakeBeta if activation == "snakebeta" else Snake
+        common = dict(mesh_device=mesh_device, dtype=dtype, parallel_config=parallel_config, ccl_manager=ccl_manager)
 
-        self.convs1 = ModuleList(
-            [
-                DilatedConv1d(
-                    in_channels=channels,
-                    out_channels=channels,
+        def conv(dil):
+            if pack > 1:
+                return PackedConv1d(
+                    channels,
+                    channels,
                     kernel_size=kernel_size,
-                    dilation=dilation[i],
+                    dilation=dil,
+                    pack=pack,
                     bias=True,
-                    mesh_device=mesh_device,
-                    dtype=dtype,
-                    parallel_config=parallel_config,
-                    ccl_manager=ccl_manager,
                     split_mode=split_mode,
+                    **common,
                 )
-                for i in range(self.num_branches)
-            ]
-        )
-        self.convs2 = ModuleList(
-            [
-                DilatedConv1d(
-                    in_channels=channels,
-                    out_channels=channels,
-                    kernel_size=kernel_size,
-                    dilation=1,
-                    bias=True,
-                    mesh_device=mesh_device,
-                    dtype=dtype,
-                    parallel_config=parallel_config,
-                    ccl_manager=ccl_manager,
-                    split_mode=split_mode,
-                )
-                for i in range(self.num_branches)
-            ]
-        )
+            return DilatedConv1d(
+                in_channels=channels,
+                out_channels=channels,
+                kernel_size=kernel_size,
+                dilation=dil,
+                bias=True,
+                split_mode=split_mode,
+                **common,
+            )
+
         # alpha_logscale=True: checkpoint stores log α / log β, collapsed at load time.
-        self.acts1 = ModuleList(
-            [
-                Activation1d(
-                    channels=channels,
-                    activation=act_cls(
-                        channels,
-                        alpha_logscale=True,
-                        mesh_device=mesh_device,
-                        dtype=dtype,
-                        parallel_config=parallel_config,
-                    ),
-                    mesh_device=mesh_device,
-                    dtype=dtype,
-                    parallel_config=parallel_config,
-                    ccl_manager=ccl_manager,
-                )
-                for _ in range(self.num_branches)
-            ]
-        )
-        self.acts2 = ModuleList(
-            [
-                Activation1d(
-                    channels=channels,
-                    activation=act_cls(
-                        channels,
-                        alpha_logscale=True,
-                        mesh_device=mesh_device,
-                        dtype=dtype,
-                        parallel_config=parallel_config,
-                    ),
-                    mesh_device=mesh_device,
-                    dtype=dtype,
-                    parallel_config=parallel_config,
-                    ccl_manager=ccl_manager,
-                )
-                for _ in range(self.num_branches)
-            ]
-        )
+        def act():
+            if pack > 1:
+                assert activation == "snakebeta", "packed blocks implement SnakeBeta only"
+                return PackedActivation1d(channels=channels, pack=pack, split_mode=split_mode, **common)
+            return Activation1d(
+                channels=channels,
+                activation=act_cls(
+                    channels, alpha_logscale=True, mesh_device=mesh_device, dtype=dtype, parallel_config=parallel_config
+                ),
+                **common,
+            )
+
+        self.convs1 = ModuleList([conv(dilation[i]) for i in range(self.num_branches)])
+        self.convs2 = ModuleList([conv(1) for _ in range(self.num_branches)])
+        self.acts1 = ModuleList([act() for _ in range(self.num_branches)])
+        self.acts2 = ModuleList([act() for _ in range(self.num_branches)])
 
     def forward(self, x_BTC: ttnn.Tensor, set_tail=None, x_rep=None) -> ttnn.Tensor:
         # set_tail(xd, mode): materialize the tile-align pad image to an op's boundary when
@@ -231,8 +214,12 @@ class Vocoder(Module):
         parallel_config: ParallelFactor | None = None,
         ccl_manager: CCLManager | None = None,
         split_mode: str = "off",
+        pack_bands: dict[int, int] | None = None,
     ) -> None:
         super().__init__()
+        # band index -> time steps packed per row for that band's AMP blocks (layers/audio_pack.py); the
+        # narrow late bands (8-16 channels) run ~2x faster per op on 32-wide packed rows.
+        self.pack_bands = dict(pack_bands or {})
 
         if resblock_kernel_sizes is None:
             resblock_kernel_sizes = [3, 7, 11]
@@ -321,6 +308,7 @@ class Vocoder(Module):
                         parallel_config=parallel_config,
                         ccl_manager=ccl_manager,
                         split_mode=split_mode,
+                        pack=self.pack_bands.get(i, 1),
                     )
                 )
 
@@ -459,15 +447,17 @@ class Vocoder(Module):
         # A no-op when there is no channel-TP, which is why moving it above the T partition is safe.
         x_dev = partition_channel(x_dev, self.parallel_config, dim=2)
 
-        def _set_tail(xd, cumrate, mode):
+        def _set_tail(xd, cumrate, mode, pack=1):
             # Materialize the tile-align pad image (t_pad*cumrate tail rows) to the op's boundary so
             # it matches unsharded: zeros for gather/zeros-pad convs, the real last row for
-            # replicate-pad activations. No-op when unsharded (t_pad == 0).
+            # replicate-pad activations. No-op when unsharded (t_pad == 0). On packed rows the image
+            # is t_pad*cumrate/pack rows.
             if t_pad == 0:
                 return xd
+            assert (t_pad * cumrate) % pack == 0, f"pad image {t_pad * cumrate} rows not a multiple of pack {pack}"
             return _set_tpad_tail(
                 xd,
-                t_pad * cumrate,
+                t_pad * cumrate // pack,
                 mode=mode,
                 mesh_device=self.mesh_device,
                 parallel_config=self.parallel_config,
@@ -488,7 +478,12 @@ class Vocoder(Module):
             x_dev = _set_tail(x_dev, cumrate, "zeros")  # ups gathers T to full and zero-pads internally
             x_dev = self.ups[i](x_dev)
             cumrate *= self.upsample_rates[i]
-            stage_set_tail = (lambda c: (lambda xd, mode: _set_tail(xd, c, mode)))(cumrate)
+            pack = self.pack_bands.get(i, 1)
+            if pack > 1:
+                B_, T_, C_ = x_dev.shape
+                assert T_ % pack == 0, f"band {i}: local T {T_} not a multiple of pack {pack}"
+                x_dev = _reshape_rows(x_dev, (B_, T_ // pack, pack * C_))
+            stage_set_tail = (lambda c, p: (lambda xd, mode: _set_tail(xd, c, mode, p)))(cumrate, pack)
             start = i * self.num_kernels
             # Mean over the num_kernels parallel AMP branches.
             block_outputs = []
@@ -507,6 +502,9 @@ class Vocoder(Module):
                 acc = new_acc
             x_dev = ttnn.multiply(acc, 1.0 / self.num_kernels)
             ttnn.deallocate(acc)
+            if pack > 1:
+                B_, Tp, Cp = x_dev.shape
+                x_dev = _reshape_rows(x_dev, (B_, Tp * pack, Cp // pack))
 
         x_dev = _set_tail(x_dev, cumrate, "replicate")  # act_post is a replicate-pad activation
         x_dev = self.act_post(x_dev)

--- a/models/tt_dit/models/audio_vae/vocoder_ltx.py
+++ b/models/tt_dit/models/audio_vae/vocoder_ltx.py
@@ -403,6 +403,27 @@ class Vocoder(Module):
             x_t = x_t.reshape(B, S * F, T)
         return self._upload_BCT(x_t)
 
+    def t_pad_for(self, t_rows: int) -> int:
+        """Rows to pad T by so each T-shard holds >= one tile (see ``_upload_BCT``); 0 when unsharded."""
+        if self.parallel_config is None or self.parallel_config.factor <= 1:
+            return 0
+        factor = self.parallel_config.factor
+        per_shard = max(-(-t_rows // factor), TILE_HEIGHT)  # ceil(t_rows / factor), floored at a tile
+        return per_shard * factor - t_rows
+
+    def forward_device_BTC(
+        self, x_dev: ttnn.Tensor, *, t_pad: int, traced: bool = False, trace_key=None
+    ) -> torch.Tensor:
+        """``(B, T + t_pad, C_in)`` ROW_MAJOR already on device (padded per ``t_pad_for``) -> ``(B, C_out, T_out)``
+        torch. Lets a caller that produces the vocoder input on device (MiniMax-H3's ``dec_in_proj``) skip the
+        readback + re-upload that ``forward_BCT`` implies."""
+        self._t_pad = t_pad
+        if traced:
+            y_dev = self._forward_device(x_dev, traced=True, tracer_trace_key=trace_key)
+        else:
+            y_dev = self._forward_device(x_dev)
+        return self._device_to_host(y_dev)
+
     def _upload_BCT(self, x_BCT: torch.Tensor) -> ttnn.Tensor:
         """Upload a plain ``(B, C, T)`` tensor, T-padded for tile-aligned per-chip shards.
 
@@ -416,18 +437,12 @@ class Vocoder(Module):
 
         x_BTC_torch = x_BCT.transpose(1, 2).float().contiguous()
 
-        sharded = self.parallel_config is not None and self.parallel_config.factor > 1
         # Pad T so each shard holds >= one tile: a short clip (T=207 at factor 8 -> 26 rows/shard,
         # under a tile) starves the HEIGHT_SHARDED depthwise conv1d's DRAM slicer. Long clips are
         # unchanged (already >> a tile/shard). Pad rows are masked and cropped from the waveform later.
-        t_pad = 0
-        if sharded:
-            factor = self.parallel_config.factor
-            t_rows = x_BTC_torch.shape[1]
-            per_shard = max(-(-t_rows // factor), TILE_HEIGHT)  # ceil(t_rows / factor), floored at a tile
-            t_pad = per_shard * factor - t_rows
-            if t_pad:
-                x_BTC_torch = torch.nn.functional.pad(x_BTC_torch, (0, 0, 0, t_pad))
+        t_pad = self.t_pad_for(x_BTC_torch.shape[1])
+        if t_pad:
+            x_BTC_torch = torch.nn.functional.pad(x_BTC_torch, (0, 0, 0, t_pad))
         self._t_pad = t_pad
 
         return ttnn.from_torch(x_BTC_torch, device=self.mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=self.dtype)
@@ -513,6 +528,12 @@ class Vocoder(Module):
         x_dev = _set_tail(x_dev, cumrate, "zeros")  # conv_post is zeros-pad
         x_dev = self.conv_post(x_dev)
 
+        # A mono waveform is (T, 1): 4-byte rows, one DRAM page per sample. Carry it as (T/32, 32) through the
+        # clamp, the T gather and the readback (32x fewer pages); _device_to_host flattens it back.
+        B_, T_, C_ = x_dev.shape
+        if C_ == 1 and T_ % TILE_HEIGHT == 0:
+            x_dev = _reshape_rows(x_dev, (B_, T_ // TILE_HEIGHT, TILE_HEIGHT))
+
         if self.apply_final_activation:
             if self.use_tanh_at_final:
                 x_dev = ttnn.tanh(x_dev)
@@ -530,6 +551,8 @@ class Vocoder(Module):
         """Readback + host crop. Trims padded out-channels and the upsampled image of the
         input T-padding (``self._t_pad``), then returns ``(B, out_channels, T_out)``."""
         x_host = local_device_to_torch(x_dev)
+        if self.out_channels == 1 and x_host.shape[-1] == TILE_HEIGHT:
+            x_host = x_host.reshape(x_host.shape[0], -1, 1)  # packed mono output (see _forward_device)
         x_host = x_host[..., : self.out_channels]  # trim any padded out channels
         # Crop the upsampled image of the input T-padding.
         if self._t_pad > 0:

--- a/models/tt_dit/pipelines/minimax_h3/pipeline_minimax_h3.py
+++ b/models/tt_dit/pipelines/minimax_h3/pipeline_minimax_h3.py
@@ -330,8 +330,8 @@ class MiniMaxH3Pipeline:
         # operands for the fp32-exact kernels' best accuracy (~67 dB vs CPU); "off" skips the split
         # for a lower-fidelity decode (~42 dB). Keys the device-weight cache via `weights_variant`.
         # audio_t_factor=4 timings: 2.2 s (full) / 1.6 s (off) on 4x8; default is 8 (~1.4 s full).
-        if audio_split_mode not in ("off", "weight", "full"):
-            raise ValueError(f"audio_split_mode must be 'off', 'weight', or 'full', got {audio_split_mode!r}")
+        if audio_split_mode not in ("off", "weight", "act", "full"):
+            raise ValueError(f"audio_split_mode must be 'off', 'weight', 'act' or 'full', got {audio_split_mode!r}")
         self.audio_split_mode = audio_split_mode
         # Audio T-shard factor/axis: explicit kwarg > MINIMAX_H3_AUDIO_T_FACTOR env > default 8, then the
         # 8->4->1 fallback (32 opt-in); logged before decode.

--- a/models/tt_dit/pipelines/minimax_h3/pipeline_minimax_h3.py
+++ b/models/tt_dit/pipelines/minimax_h3/pipeline_minimax_h3.py
@@ -130,6 +130,20 @@ AUDIO_SHIFT = 3.0
 
 _AUDIO_T_FACTOR_ENV = "MINIMAX_H3_AUDIO_T_FACTOR"
 _DEFAULT_AUDIO_T_FACTOR = 8
+# Time-packed late vocoder bands ("band:k,band:k"; "0" disables). Default: the two narrowest bands on 32-wide rows,
+# measured 0.53 -> 0.45 s traced at unchanged PSNR (layers/audio_pack.py).
+_AUDIO_PACK_ENV = "MINIMAX_H3_AUDIO_PACK"
+_DEFAULT_AUDIO_PACK = "5:2,6:4"
+
+
+def _audio_pack_bands() -> dict[int, int]:
+    raw = os.environ.get(_AUDIO_PACK_ENV, _DEFAULT_AUDIO_PACK).strip()
+    if raw in ("", "0", "off"):
+        return {}
+    try:
+        return {int(b): int(k) for b, k in (item.split(":") for item in raw.split(","))}
+    except ValueError:
+        raise ValueError(f"{_AUDIO_PACK_ENV}={raw!r} must look like '5:2,6:4' or '0'") from None
 
 
 def _requested_audio_t_factor(audio_t_factor: int | None) -> tuple[int, bool]:
@@ -1269,7 +1283,9 @@ class MiniMaxH3Pipeline:
                 ccl_manager=self.ccl_manager,
                 parallel_config=audio_parallel_config,
                 split_mode=self.audio_split_mode,
+                pack_bands=_audio_pack_bands(),
             )
+            logger.info(f"Audio packing: {decoder.pack_bands or 'off'} ({_AUDIO_PACK_ENV})")
 
             def read_state() -> dict[str, torch.Tensor]:
                 """Only the decoder's half of the converted checkpoint.
@@ -1288,7 +1304,8 @@ class MiniMaxH3Pipeline:
                 model_name=MODEL_NAME,
                 # The audio precision levers change the module's parameter set, so they are part of
                 # the cache key -- read off the module so the key cannot drift from what was built.
-                subfolder="audio_decoder" + weights_variant(decoder.split_mode, decoder.max_c_in_block),
+                subfolder="audio_decoder"
+                + weights_variant(decoder.split_mode, decoder.max_c_in_block, decoder.pack_bands),
                 parallel_config=self.vae_parallel_config,
                 mesh_shape=tuple(self.mesh_device.shape),
                 mesh_device=self.mesh_device,

--- a/models/tt_dit/pipelines/minimax_h3/pipeline_minimax_h3.py
+++ b/models/tt_dit/pipelines/minimax_h3/pipeline_minimax_h3.py
@@ -344,8 +344,10 @@ class MiniMaxH3Pipeline:
         # operands for the fp32-exact kernels' best accuracy (~67 dB vs CPU); "off" skips the split
         # for a lower-fidelity decode (~42 dB). Keys the device-weight cache via `weights_variant`.
         # audio_t_factor=4 timings: 2.2 s (full) / 1.6 s (off) on 4x8; default is 8 (~1.4 s full).
-        if audio_split_mode not in ("off", "weight", "act", "full"):
-            raise ValueError(f"audio_split_mode must be 'off', 'weight', 'act' or 'full', got {audio_split_mode!r}")
+        if audio_split_mode not in ("off", "weight", "act", "full", "stack"):
+            raise ValueError(
+                f"audio_split_mode must be 'off', 'weight', 'act', 'full' or 'stack', got {audio_split_mode!r}"
+            )
         self.audio_split_mode = audio_split_mode
         # Audio T-shard factor/axis: explicit kwarg > MINIMAX_H3_AUDIO_T_FACTOR env > default 8, then the
         # 8->4->1 fallback (32 opt-in); logged before decode.

--- a/models/tt_dit/pipelines/minimax_h3/pipeline_minimax_h3.py
+++ b/models/tt_dit/pipelines/minimax_h3/pipeline_minimax_h3.py
@@ -134,6 +134,18 @@ _DEFAULT_AUDIO_T_FACTOR = 8
 # measured 0.53 -> 0.45 s traced at unchanged PSNR (layers/audio_pack.py).
 _AUDIO_PACK_ENV = "MINIMAX_H3_AUDIO_PACK"
 _DEFAULT_AUDIO_PACK = "5:2,6:4"
+# Split mode of the packed bands' anti-alias resamplers ("same" = the convs' mode). "off" is the measured 65 dB /
+# -72 ms point (layers/audio_pack.py).
+_AUDIO_RESAMPLER_SPLIT_ENV = "MINIMAX_H3_AUDIO_RESAMPLER_SPLIT"
+
+
+def _audio_resampler_split_mode() -> str | None:
+    raw = os.environ.get(_AUDIO_RESAMPLER_SPLIT_ENV, "same").strip()
+    if raw in ("", "same"):
+        return None
+    if raw not in ("off", "weight", "act", "full"):
+        raise ValueError(f"{_AUDIO_RESAMPLER_SPLIT_ENV}={raw!r} must be same, off, weight, act or full")
+    return raw
 
 
 def _audio_pack_bands() -> dict[int, int]:
@@ -1286,8 +1298,12 @@ class MiniMaxH3Pipeline:
                 parallel_config=audio_parallel_config,
                 split_mode=self.audio_split_mode,
                 pack_bands=_audio_pack_bands(),
+                resampler_split_mode=_audio_resampler_split_mode(),
             )
-            logger.info(f"Audio packing: {decoder.pack_bands or 'off'} ({_AUDIO_PACK_ENV})")
+            logger.info(
+                f"Audio packing: {decoder.pack_bands or 'off'} ({_AUDIO_PACK_ENV}), resampler split "
+                f"{decoder.resampler_split_mode or 'same'} ({_AUDIO_RESAMPLER_SPLIT_ENV})"
+            )
 
             def read_state() -> dict[str, torch.Tensor]:
                 """Only the decoder's half of the converted checkpoint.
@@ -1307,7 +1323,9 @@ class MiniMaxH3Pipeline:
                 # The audio precision levers change the module's parameter set, so they are part of
                 # the cache key -- read off the module so the key cannot drift from what was built.
                 subfolder="audio_decoder"
-                + weights_variant(decoder.split_mode, decoder.max_c_in_block, decoder.pack_bands),
+                + weights_variant(
+                    decoder.split_mode, decoder.max_c_in_block, decoder.pack_bands, decoder.resampler_split_mode
+                ),
                 parallel_config=self.vae_parallel_config,
                 mesh_shape=tuple(self.mesh_device.shape),
                 mesh_device=self.mesh_device,

--- a/models/tt_dit/pipelines/minimax_h3/pipeline_minimax_h3.py
+++ b/models/tt_dit/pipelines/minimax_h3/pipeline_minimax_h3.py
@@ -137,6 +137,8 @@ _DEFAULT_AUDIO_PACK = "5:2,6:4"
 # Split mode of the packed bands' anti-alias resamplers ("same" = the convs' mode). "off" is the measured 65 dB /
 # -72 ms point (layers/audio_pack.py).
 _AUDIO_RESAMPLER_SPLIT_ENV = "MINIMAX_H3_AUDIO_RESAMPLER_SPLIT"
+# Conv split mode of the audio decoder when the caller passes none ("full" = main's accurate default).
+_AUDIO_SPLIT_ENV = "MINIMAX_H3_AUDIO_SPLIT"
 
 
 def _audio_resampler_split_mode() -> str | None:
@@ -314,7 +316,7 @@ class MiniMaxH3Pipeline:
         topology: ttnn.Topology | None = None,
         coresident: bool | None = None,
         task: str = "t2va",
-        audio_split_mode: str = "full",
+        audio_split_mode: str | None = None,
         audio_t_factor: int | None = None,
     ) -> None:
         self.mesh_device = mesh_device
@@ -356,6 +358,8 @@ class MiniMaxH3Pipeline:
         # operands for the fp32-exact kernels' best accuracy (~67 dB vs CPU); "off" skips the split
         # for a lower-fidelity decode (~42 dB). Keys the device-weight cache via `weights_variant`.
         # audio_t_factor=4 timings: 2.2 s (full) / 1.6 s (off) on 4x8; default is 8 (~1.4 s full).
+        if audio_split_mode is None:
+            audio_split_mode = os.environ.get(_AUDIO_SPLIT_ENV, "full").strip() or "full"
         if audio_split_mode not in ("off", "weight", "act", "full", "stack"):
             raise ValueError(
                 f"audio_split_mode must be 'off', 'weight', 'act', 'full' or 'stack', got {audio_split_mode!r}"
@@ -434,7 +438,7 @@ class MiniMaxH3Pipeline:
         num_links: int | None = None,
         topology: ttnn.Topology | None = None,
         task: str = "t2va",
-        audio_split_mode: str = "full",
+        audio_split_mode: str | None = None,
         audio_t_factor: int | None = None,
     ) -> "MiniMaxH3Pipeline":
         """`task="t2va"` serves both t2va and fl2va; `task="ref2va"` loads `transformer_ref/`.
@@ -1301,8 +1305,9 @@ class MiniMaxH3Pipeline:
                 resampler_split_mode=_audio_resampler_split_mode(),
             )
             logger.info(
-                f"Audio packing: {decoder.pack_bands or 'off'} ({_AUDIO_PACK_ENV}), resampler split "
-                f"{decoder.resampler_split_mode or 'same'} ({_AUDIO_RESAMPLER_SPLIT_ENV})"
+                f"Audio conv split: {decoder.split_mode} ({_AUDIO_SPLIT_ENV}); packing: {decoder.pack_bands or 'off'} "
+                f"({_AUDIO_PACK_ENV}); resampler split {decoder.resampler_split_mode or 'same'} "
+                f"({_AUDIO_RESAMPLER_SPLIT_ENV})"
             )
 
             def read_state() -> dict[str, torch.Tensor]:

--- a/models/tt_dit/tests/models/minimax_h3/sqz_reference.py
+++ b/models/tt_dit/tests/models/minimax_h3/sqz_reference.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""CPU reference clips for the audio-decoder squeeze experiments: encoder latents of a seeded noise clip and their
+reference decode, cached as ``ref_<T>lat_b<B>.pt``. No ttnn import, so it can be precomputed on a host without a
+build:
+
+    MINIMAX_H3_MODEL_PATH=... SQZ_REF_DIR=... python -m models.tt_dit.tests.models.minimax_h3.sqz_reference 600 1
+"""
+
+import json
+import os
+import sys
+import time
+
+import torch
+
+HOP_LENGTH = 800
+
+
+def ref_dir() -> str:
+    return os.environ.get("SQZ_REF_DIR", os.path.join(os.environ.get("TT_METAL_HOME", "."), "generated", "sqz_refs"))
+
+
+def reference_clip(num_latent_frames: int, batch: int):
+    """``(latents, expected)``; computed with the pinned diffusers reference on first use, then cached."""
+    os.makedirs(ref_dir(), exist_ok=True)
+    path = os.path.join(ref_dir(), f"ref_{num_latent_frames}lat_b{batch}.pt")
+    if os.path.exists(path):
+        blob = torch.load(path)
+        return blob["latents"], blob["expected"]
+    from diffusers import AutoencoderKLMiniMaxH3Audio
+    from safetensors.torch import load_file
+
+    weights_dir = os.path.join(os.environ["MINIMAX_H3_MODEL_PATH"], "audio_vae")
+    with open(os.path.join(weights_dir, "config.json")) as fh:
+        config = {k: v for k, v in json.load(fh).items() if not k.startswith("_")}
+    reference = AutoencoderKLMiniMaxH3Audio(**config).eval()
+    reference.load_state_dict(load_file(os.path.join(weights_dir, "diffusion_pytorch_model.safetensors")))
+    torch.manual_seed(1)
+    waveform = torch.randn(batch, 1, num_latent_frames * HOP_LENGTH) * 0.1
+    t0 = time.perf_counter()
+    with torch.no_grad():
+        latents = reference.encode(waveform).latent_dist.mode()[..., :num_latent_frames]
+        expected = reference.decode(latents).sample
+    print(f"CPU reference for {num_latent_frames} latents x batch {batch}: {time.perf_counter() - t0:.1f} s -> {path}")
+    torch.save({"latents": latents, "expected": expected}, path)
+    return latents, expected
+
+
+if __name__ == "__main__":
+    frames, batch = int(sys.argv[1]), int(sys.argv[2])
+    lat, exp = reference_clip(frames, batch)
+    print(f"latents {tuple(lat.shape)} expected {tuple(exp.shape)}")

--- a/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
+++ b/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
@@ -62,8 +62,12 @@ RECIPES = {
     "full_pack34": {"pack": {3: 1, 4: 1, 5: 2, 6: 4}},
     "off_pack34": {"all": "off", "pack": {3: 1, 4: 1, 5: 2, 6: 4}},
     "act_off_ge3_pack34": {"all": "act", "bands_ge": (3, "off"), "post": "off", "pack": {3: 1, 4: 1, 5: 2, 6: 4}},
+    # stacked split (same arithmetic as full, one conv3d over 3x input channels): set at construction
+    "stack": {"build": "stack"},
+    "stack_pack": {"build": "stack", "pack": {5: 2, 6: 4}},
 }
 PACK_KEY = "pack"
+BUILD_KEY = "build"  # split_mode passed to the constructor (needed when it changes the weight shapes)
 
 
 def _conv_modules_by_band(decoder):
@@ -86,6 +90,8 @@ def apply_recipe(decoder, recipe: dict) -> dict:
     counts = {}
     if PACK_KEY in recipe:
         counts["pack"] = dict(recipe[PACK_KEY])
+    if BUILD_KEY in recipe:
+        recipe = {k: v for k, v in recipe.items() if k not in (PACK_KEY, BUILD_KEY)}
     for band, conv in _conv_modules_by_band(decoder):
         mode = None
         if "all" in recipe:
@@ -154,7 +160,8 @@ def test_audio_decode_squeeze(mesh_device, num_latent_frames, batch):
     rows = []
     baseline_out = None
     for name, recipe in _selected_recipes():
-        decoder, _ = _load(mesh_device, pack_bands=recipe.get(PACK_KEY))
+        build = {"split_mode": recipe[BUILD_KEY]} if BUILD_KEY in recipe else {}
+        decoder, _ = _load(mesh_device, pack_bands=recipe.get(PACK_KEY), **build)
         counts = apply_recipe(decoder, recipe)
         eager, _ = _best(lambda: decoder(latents), mesh_device, n=1)
         try:

--- a/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
+++ b/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
@@ -49,7 +49,16 @@ RECIPES = {
     "off_ge3": {"bands_ge": (3, "off"), "post": "off"},
     "off_ge5": {"bands_ge": (5, "off"), "post": "off"},
     "weight_ge3": {"bands_ge": (3, "weight"), "post": "weight"},
+    "act": {"all": "act"},
+    "act_off_ge3": {"all": "act", "bands_ge": (3, "off"), "post": "off"},
+    "act_off_ge5": {"all": "act", "bands_ge": (5, "off"), "post": "off"},
+    # time-packed late bands (layers/audio_pack.py): 2 steps/row at 16 ch, 4 steps/row at 8 ch
+    "full_pack": {"pack": {5: 2, 6: 4}},
+    "act_pack": {"all": "act", "pack": {5: 2, 6: 4}},
+    "off_pack": {"all": "off", "pack": {5: 2, 6: 4}},
+    "act_off_ge3_pack": {"all": "act", "bands_ge": (3, "off"), "post": "off", "pack": {5: 2, 6: 4}},
 }
+PACK_KEY = "pack"
 
 
 def _conv_modules_by_band(decoder):
@@ -70,6 +79,8 @@ def _conv_modules_by_band(decoder):
 def apply_recipe(decoder, recipe: dict) -> dict:
     """Set ``split_mode`` per conv after construction (forward reads it per call; the unused residual is harmless)."""
     counts = {}
+    if PACK_KEY in recipe:
+        counts["pack"] = dict(recipe[PACK_KEY])
     for band, conv in _conv_modules_by_band(decoder):
         mode = None
         if "all" in recipe:
@@ -138,7 +149,7 @@ def test_audio_decode_squeeze(mesh_device, num_latent_frames, batch):
     rows = []
     baseline_out = None
     for name, recipe in _selected_recipes():
-        decoder, _ = _load(mesh_device)
+        decoder, _ = _load(mesh_device, pack_bands=recipe.get(PACK_KEY))
         counts = apply_recipe(decoder, recipe)
         eager, _ = _best(lambda: decoder(latents), mesh_device, n=1)
         try:

--- a/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
+++ b/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
@@ -65,7 +65,11 @@ RECIPES = {
     # stacked split (same arithmetic as full, one conv3d over 3x input channels): set at construction
     "stack": {"build": "stack"},
     "stack_pack": {"build": "stack", "pack": {5: 2, 6: 4}},
+    # packed resamplers (fixed kaiser taps) with a cheaper split than the convs
+    "full_pack_rsact": {"pack": {5: 2, 6: 4}, "resamplers": "act"},
+    "full_pack_rsoff": {"pack": {5: 2, 6: 4}, "resamplers": "off"},
 }
+RESAMPLERS_KEY = "resamplers"
 PACK_KEY = "pack"
 BUILD_KEY = "build"  # split_mode passed to the constructor (needed when it changes the weight shapes)
 
@@ -85,13 +89,27 @@ def _conv_modules_by_band(decoder):
     yield "post", voc.conv_post
 
 
+def _packed_resamplers(decoder):
+    for block in decoder.decoder.resblocks:
+        for act in list(block.acts1) + list(block.acts2):
+            for name in ("up", "down"):
+                if hasattr(act, name):
+                    yield getattr(act, name)
+
+
 def apply_recipe(decoder, recipe: dict) -> dict:
     """Set ``split_mode`` per conv after construction (forward reads it per call; the unused residual is harmless)."""
     counts = {}
+    if RESAMPLERS_KEY in recipe:
+        n = 0
+        for conv in _packed_resamplers(decoder):
+            conv.split_mode = recipe[RESAMPLERS_KEY]
+            n += 1
+        counts[f"resamplers_{recipe[RESAMPLERS_KEY]}"] = n
     if PACK_KEY in recipe:
         counts["pack"] = dict(recipe[PACK_KEY])
-    if BUILD_KEY in recipe:
-        recipe = {k: v for k, v in recipe.items() if k not in (PACK_KEY, BUILD_KEY)}
+    if BUILD_KEY in recipe or RESAMPLERS_KEY in recipe:
+        recipe = {k: v for k, v in recipe.items() if k not in (PACK_KEY, BUILD_KEY, RESAMPLERS_KEY)}
     for band, conv in _conv_modules_by_band(decoder):
         mode = None
         if "all" in recipe:

--- a/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
+++ b/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
@@ -68,8 +68,11 @@ RECIPES = {
     # packed resamplers (fixed kaiser taps) with a cheaper split than the convs
     "full_pack_rsact": {"pack": {5: 2, 6: 4}, "resamplers": "act"},
     "full_pack_rsoff": {"pack": {5: 2, 6: 4}, "resamplers": "off"},
+    # the same point built through the constructor path the pipeline uses
+    "rsoff_built": {"pack": {5: 2, 6: 4}, "build_kwargs": {"resampler_split_mode": "off"}},
 }
 RESAMPLERS_KEY = "resamplers"
+BUILD_KWARGS_KEY = "build_kwargs"  # extra constructor kwargs
 PACK_KEY = "pack"
 BUILD_KEY = "build"  # split_mode passed to the constructor (needed when it changes the weight shapes)
 
@@ -108,8 +111,8 @@ def apply_recipe(decoder, recipe: dict) -> dict:
         counts[f"resamplers_{recipe[RESAMPLERS_KEY]}"] = n
     if PACK_KEY in recipe:
         counts["pack"] = dict(recipe[PACK_KEY])
-    if BUILD_KEY in recipe or RESAMPLERS_KEY in recipe:
-        recipe = {k: v for k, v in recipe.items() if k not in (PACK_KEY, BUILD_KEY, RESAMPLERS_KEY)}
+    if BUILD_KEY in recipe or RESAMPLERS_KEY in recipe or BUILD_KWARGS_KEY in recipe:
+        recipe = {k: v for k, v in recipe.items() if k not in (PACK_KEY, BUILD_KEY, RESAMPLERS_KEY, BUILD_KWARGS_KEY)}
     for band, conv in _conv_modules_by_band(decoder):
         mode = None
         if "all" in recipe:
@@ -179,6 +182,7 @@ def test_audio_decode_squeeze(mesh_device, num_latent_frames, batch):
     baseline_out = None
     for name, recipe in _selected_recipes():
         build = {"split_mode": recipe[BUILD_KEY]} if BUILD_KEY in recipe else {}
+        build.update(recipe.get(BUILD_KWARGS_KEY, {}))
         decoder, _ = _load(mesh_device, pack_bands=recipe.get(PACK_KEY), **build)
         counts = apply_recipe(decoder, recipe)
         eager, _ = _best(lambda: decoder(latents), mesh_device, n=1)

--- a/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
+++ b/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
@@ -175,7 +175,11 @@ def _selected_recipes():
 
 @pytest.mark.timeout(10800)
 @pytest.mark.parametrize(("mesh_device", "device_params"), MESH, indirect=["mesh_device", "device_params"])
-@pytest.mark.parametrize(("num_latent_frames", "batch"), [(600, 1), (207, 2)], ids=["600lat_b1", "207lat_b2"])
+@pytest.mark.parametrize(
+    ("num_latent_frames", "batch"),
+    [(600, 1), (207, 2), (600, 2)],  # (600, 2) = the pipeline's shape: 15 s, stereo as two batch items
+    ids=["600lat_b1", "207lat_b2", "600lat_b2"],
+)
 def test_audio_decode_squeeze(mesh_device, num_latent_frames, batch):
     latents, expected = reference_clip(num_latent_frames, batch)
     rows = []

--- a/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
+++ b/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
@@ -57,6 +57,11 @@ RECIPES = {
     "act_pack": {"all": "act", "pack": {5: 2, 6: 4}},
     "off_pack": {"all": "off", "pack": {5: 2, 6: 4}},
     "act_off_ge3_pack": {"all": "act", "bands_ge": (3, "off"), "post": "off", "pack": {5: 2, 6: 4}},
+    # pack 1 = dense resamplers on unpacked rows (bands 3-4 keep their dilated convs)
+    "full_pack4": {"pack": {4: 1, 5: 2, 6: 4}},
+    "full_pack34": {"pack": {3: 1, 4: 1, 5: 2, 6: 4}},
+    "off_pack34": {"all": "off", "pack": {3: 1, 4: 1, 5: 2, 6: 4}},
+    "act_off_ge3_pack34": {"all": "act", "bands_ge": (3, "off"), "post": "off", "pack": {3: 1, 4: 1, 5: 2, 6: 4}},
 }
 PACK_KEY = "pack"
 

--- a/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
+++ b/models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Speed/accuracy experiments for the H3 audio decoder on a 4x8 Galaxy at T-shard factor 8.
+
+Each *recipe* is a way of building the shipping decoder differently; every recipe is timed traced (best of 3
+after a warm eager call) and scored against the pinned CPU reference decode of the same latents (PSNR, log-mel
+distance), so speed and accuracy move together in one table. The CPU reference is computed once per clip and
+cached under ``SQZ_REF_DIR`` by ``sqz_reference.py`` (needs the pinned diffusers reference importable).
+
+    SQZ_RECIPES=full,weight,off pytest models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py -s -k 600lat_b1
+"""
+
+import os
+import time
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+
+from ....models.audio_vae.minimax_h3.convert_minimax_h3_audio import convert_minimax_h3_audio_state_dict
+from ....parallel.config import ParallelFactor
+from ....parallel.manager import CCLManager
+from ....utils.test import line_params_8k
+from .common import build_audio_decoder, load_config, psnr, weights_subdir
+from .sqz_reference import reference_clip
+
+MESH = [
+    pytest.param(
+        (4, 8),
+        {
+            **line_params_8k,
+            "require_exact_physical_num_devices": True,
+            "l1_small_size": 65536,
+            "trace_region_size": 1_200_000_000,
+        },
+        id="mesh4x8_8k",
+    )
+]
+HOP_LENGTH = 800
+
+# Per-band conv split modes. Band i = ups[i] + its three AMP blocks; "pre" = dec_in_proj + conv_pre, "post" = conv_post.
+# A recipe maps a band selector to a split mode; unspecified convs keep the constructed default ("full").
+RECIPES = {
+    "full": {},
+    "weight": {"all": "weight"},
+    "off": {"all": "off"},
+    "off_ge3": {"bands_ge": (3, "off"), "post": "off"},
+    "off_ge5": {"bands_ge": (5, "off"), "post": "off"},
+    "weight_ge3": {"bands_ge": (3, "weight"), "post": "weight"},
+}
+
+
+def _conv_modules_by_band(decoder):
+    """Yields ``(band, conv)`` for every split-capable conv; band is an int, "pre" or "post"."""
+    voc = decoder.decoder
+    yield "pre", decoder.dec_in_proj
+    yield "pre", voc.conv_pre
+    for i, up in enumerate(voc.ups):
+        yield i, up.conv
+    nk = voc.num_kernels
+    for idx, block in enumerate(voc.resblocks):
+        band = idx // nk
+        for conv in list(block.convs1) + list(block.convs2):
+            yield band, conv
+    yield "post", voc.conv_post
+
+
+def apply_recipe(decoder, recipe: dict) -> dict:
+    """Set ``split_mode`` per conv after construction (forward reads it per call; the unused residual is harmless)."""
+    counts = {}
+    for band, conv in _conv_modules_by_band(decoder):
+        mode = None
+        if "all" in recipe:
+            mode = recipe["all"]
+        if isinstance(band, int) and "bands_ge" in recipe and band >= recipe["bands_ge"][0]:
+            mode = recipe["bands_ge"][1]
+        if band in recipe:
+            mode = recipe[band]
+        if mode is not None:
+            conv.split_mode = mode
+        counts[conv.split_mode] = counts.get(conv.split_mode, 0) + 1
+    return counts
+
+
+def _load(mesh_device, *, factor: int = 8, axis: int = 1, **overrides):
+    weights_dir = weights_subdir("audio_vae")
+    if weights_dir is None:
+        pytest.skip("MiniMax-H3 audio_vae not found; set MINIMAX_H3_MODEL_PATH")
+    from safetensors.torch import load_file
+
+    config = load_config(weights_dir)
+    pc = None if factor <= 1 else ParallelFactor(factor=factor, mesh_axis=axis)
+    ccl = None if pc is None else CCLManager(mesh_device, num_links=1, topology=ttnn.Topology.Linear)
+    decoder = build_audio_decoder(config, mesh_device, parallel_config=pc, ccl_manager=ccl, **overrides)
+    decoder.load_torch_state_dict(
+        convert_minimax_h3_audio_state_dict(
+            load_file(os.path.join(weights_dir, "diffusion_pytorch_model.safetensors"))
+        ),
+        strict=False,
+    )
+    return decoder, config
+
+
+def _log_mel_distance(a: torch.Tensor, b: torch.Tensor, *, n_fft: int = 1024, hop: int = 256) -> float:
+    window = torch.hann_window(n_fft)
+    spectra = []
+    for signal in (a, b):
+        flat = signal.reshape(-1, signal.shape[-1]).float()
+        stft = torch.stft(flat, n_fft=n_fft, hop_length=hop, window=window, return_complex=True)
+        spectra.append(torch.log(stft.abs().clamp_min(1e-5)))
+    return (spectra[0] - spectra[1]).abs().mean().item()
+
+
+def _best(fn, mesh_device, n=3):
+    out = fn()
+    ttnn.synchronize_device(mesh_device)
+    best = float("inf")
+    for _ in range(n):
+        t0 = time.perf_counter()
+        out = fn()
+        ttnn.synchronize_device(mesh_device)
+        best = min(best, time.perf_counter() - t0)
+    return best, out
+
+
+def _selected_recipes():
+    names = os.environ.get("SQZ_RECIPES", "full,weight,off,off_ge3,off_ge5").split(",")
+    return [(n, RECIPES[n]) for n in names if n]
+
+
+@pytest.mark.timeout(10800)
+@pytest.mark.parametrize(("mesh_device", "device_params"), MESH, indirect=["mesh_device", "device_params"])
+@pytest.mark.parametrize(("num_latent_frames", "batch"), [(600, 1), (207, 2)], ids=["600lat_b1", "207lat_b2"])
+def test_audio_decode_squeeze(mesh_device, num_latent_frames, batch):
+    latents, expected = reference_clip(num_latent_frames, batch)
+    rows = []
+    baseline_out = None
+    for name, recipe in _selected_recipes():
+        decoder, _ = _load(mesh_device)
+        counts = apply_recipe(decoder, recipe)
+        eager, _ = _best(lambda: decoder(latents), mesh_device, n=1)
+        try:
+            traced, out = _best(lambda: decoder(latents, traced=True), mesh_device)
+        finally:
+            decoder.release_trace()
+        assert out.shape == expected.shape, f"{name}: shape {tuple(out.shape)} != reference {tuple(expected.shape)}"
+        db_ref = psnr(expected, out)
+        mel = _log_mel_distance(expected, out)
+        if baseline_out is None:
+            baseline_out = out
+        db_base = psnr(baseline_out, out)
+        rows.append((name, counts, eager, traced, db_ref, mel, db_base))
+        logger.info(
+            f"SQZ {name}: split {counts} eager {eager:.4f} s traced {traced:.4f} s | vs CPU ref {db_ref:.2f} dB "
+            f"mel {mel:.4f} | vs {_selected_recipes()[0][0]} {db_base:.2f} dB"
+        )
+        del decoder
+    logger.info(f"=== squeeze table: {num_latent_frames} latents x batch {batch}, 4x8 factor 8, traced best of 3 ===")
+    logger.info(
+        f"{'recipe':>12s} {'eager s':>8s} {'traced s':>9s} {'PSNR ref':>9s} {'mel':>7s} {'PSNR base':>10s}  split counts"
+    )
+    for name, counts, eager, traced, db_ref, mel, db_base in rows:
+        logger.info(f"{name:>12s} {eager:8.4f} {traced:9.4f} {db_ref:9.2f} {mel:7.4f} {db_base:10.2f}  {counts}")

--- a/models/tt_dit/tests/models/minimax_h3/tools/layout_tax_probe.py
+++ b/models/tt_dit/tests/models/minimax_h3/tools/layout_tax_probe.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Layout tax of the late vocoder bands: per-op time on the same 1.9 MB fp32 tensor laid out as ``(T, C)`` rows of
+8 channels (band 6 today, 32-byte DRAM pages) versus ``k`` time steps packed into one row ``(T/k, k*C)``.
+
+Times the ops that dominate bands 5-6 (elementwise add/multiply, tilize + snake_beta + untilize, the T halo
+exchange, a T concat) plus the conv3d cost of the packed dense formulation of a 1-D conv and of the 2x anti-alias
+upsampler, on the 4x8 mesh at factor 8 (32 chips, one op stream each). Wall per op after a warm call, 20 reps
+between mesh syncs, so small ops read as the dispatch floor.
+
+    pytest models/tt_dit/tests/models/minimax_h3/tools/layout_tax_probe.py -s
+"""
+
+import time
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_dit.layers.audio_ops import _t_neighbor_pad, depthwise_tap_filter
+from models.tt_dit.parallel.config import ParallelFactor
+from models.tt_dit.parallel.manager import CCLManager
+from models.tt_dit.utils.conv3d import get_conv3d_config
+from models.tt_dit.utils.test import line_params_8k
+
+MESH_4X8 = [
+    pytest.param(
+        (4, 8),
+        {**line_params_8k, "require_exact_physical_num_devices": True, "l1_small_size": 65536},
+        id="mesh4x8_8k",
+    )
+]
+T_BAND6, C_BAND6 = 60000, 8  # per-chip rows in band 6 at 600 latents, factor 8
+PACK = [1, 4, 8, 16, 32]
+REPS = 20
+
+
+def _time(mesh_device, fn, reps=REPS):
+    out = fn()
+    ttnn.synchronize_device(mesh_device)
+    t0 = time.perf_counter()
+    for _ in range(reps):
+        out = fn()
+    ttnn.synchronize_device(mesh_device)
+    return (time.perf_counter() - t0) / reps * 1e6
+
+
+def _conv3d_us(mesh_device, x_BTC, c_out, kernel, compute):
+    B, T, C = x_BTC.shape
+    cfg = get_conv3d_config(
+        C, c_out, (kernel, 1, 1), ttnn.float32, grid_size=mesh_device.compute_with_storage_grid_size()
+    )
+    w = ttnn.from_torch(
+        torch.randn(kernel * C, c_out) * 0.01,
+        dtype=ttnn.float32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        device=mesh_device,
+    )
+    x5 = ttnn.reshape(x_BTC, (B, T, 1, 1, C))
+
+    def run():
+        return ttnn.experimental.conv3d(
+            input_tensor=x5,
+            weight_tensor=w,
+            bias_tensor=None,
+            config=cfg,
+            output_channels=c_out,
+            kernel_size=(kernel, 1, 1),
+            stride=(1, 1, 1),
+            padding=(kernel // 2, 0, 0),
+            dilation=(1, 1, 1),
+            padding_mode="zeros",
+            dtype=ttnn.float32,
+            compute_kernel_config=compute,
+        )
+
+    return _time(mesh_device, run)
+
+
+@pytest.mark.timeout(3600)
+@pytest.mark.parametrize(("mesh_device", "device_params"), MESH_4X8, indirect=["mesh_device", "device_params"])
+def test_layout_tax(mesh_device):
+    pc = ParallelFactor(factor=8, mesh_axis=1)
+    ccl = CCLManager(mesh_device, num_links=1, topology=ttnn.Topology.Linear)
+    compute = ttnn.init_device_compute_kernel_config(
+        mesh_device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+    rows = []
+    for k in PACK:
+        T, C = T_BAND6 // k, C_BAND6 * k
+        x = ttnn.from_torch(torch.randn(1, T, C), dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device)
+        a = ttnn.from_torch(
+            torch.rand(1, 1, C) + 0.5, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device
+        )
+        b = ttnn.from_torch(
+            torch.rand(1, 1, C) + 0.5, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device
+        )
+        r = {"k": k, "shape": (T, C), "page_B": C * 4}
+        r["add"] = _time(mesh_device, lambda: ttnn.add(x, x))
+        r["mul_ch"] = _time(mesh_device, lambda: ttnn.multiply(x, a))
+        r["tilize"] = _time(mesh_device, lambda: ttnn.to_layout(x, ttnn.TILE_LAYOUT))
+        xt = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
+        at, bt = ttnn.to_layout(a, ttnn.TILE_LAYOUT), ttnn.to_layout(b, ttnn.TILE_LAYOUT)
+        r["snake"] = _time(mesh_device, lambda: ttnn.snake_beta(xt, at, bt))
+        r["untilize"] = _time(mesh_device, lambda: ttnn.to_layout(xt, ttnn.ROW_MAJOR_LAYOUT))
+        r["halo6"] = _time(
+            mesh_device,
+            lambda: _t_neighbor_pad(
+                x, pad_left=6, pad_right=6, parallel_config=pc, ccl_manager=ccl, padding_mode="replicate"
+            ),
+        )
+        r["concatT"] = _time(mesh_device, lambda: ttnn.concat([x, x], dim=1))
+        if k == 1:
+            # today's exact depthwise 12-tap filter on the unpacked layout (band 6: C=8)
+            cache = {}
+            r["dw12"] = _time(
+                mesh_device,
+                lambda: depthwise_tap_filter(
+                    x, [0.05] * 12, 1, mesh_device=mesh_device, dtype=ttnn.float32, cache=cache
+                ),
+            )
+            # the 1-D conv as it runs today: channels padded to 32
+            x32 = ttnn.from_torch(
+                torch.randn(1, T, 32), dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device
+            )
+            r["conv_k3"] = _conv3d_us(mesh_device, x32, 32, 3, compute)
+            r["conv_k11"] = _conv3d_us(mesh_device, x32, 32, 11, compute)
+        else:
+            # packed dense formulations: a k-packed 1-D conv (K=3 -> 2 taps, K=11 -> ceil(10/k)+1 taps) and the 2x
+            # upsampler (out 2*k*C); the extra FLOPs are the price of the wide layout
+            r["conv_k3"] = _conv3d_us(mesh_device, x, C, 2, compute)
+            r["conv_k11"] = _conv3d_us(mesh_device, x, C, -(-10 // k) + 1, compute)
+            r["up2x"] = _conv3d_us(mesh_device, x, 2 * C, 2, compute)
+        rows.append(r)
+        logger.info(f"LAYOUT_TAX {r}")
+    keys = ["add", "mul_ch", "tilize", "snake", "untilize", "halo6", "concatT", "dw12", "conv_k3", "conv_k11", "up2x"]
+    logger.info("=== layout tax, us per op (4x8, factor 8, per-chip band-6 tensor 60000x8 fp32 = 1.9 MB) ===")
+    logger.info(f"{'k':>3s} {'shape':>14s} {'page':>5s} " + " ".join(f"{k:>9s}" for k in keys))
+    for r in rows:
+        logger.info(
+            f"{r['k']:3d} {str(r['shape']):>14s} {r['page_B']:5d} "
+            + " ".join(f"{r[k]:9.0f}" if k in r else f"{'-':>9s}" for k in keys)
+        )

--- a/models/tt_dit/tests/models/minimax_h3/tools/tracy_audio_decode_sqz_harness.py
+++ b/models/tt_dit/tests/models/minimax_h3/tools/tracy_audio_decode_sqz_harness.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Tracy capture of ONE warmed eager audio decode on a 4x8 Galaxy at T-shard factor 8, for a squeeze recipe.
+
+Profiling harness, not a gate. ``SQZ_RECIPE`` names a recipe of ``test_audio_decode_squeeze.py`` (default ``full``);
+one forward inside the signposted window. Run with the device dump disabled and read the profiler's C++ report:
+
+    python -m tracy -p -v --op-support-count 8000 --disable-device-data-dump-to-files \\
+      --disable-device-data-push-to-tracy -m pytest \\
+      models/tt_dit/tests/models/minimax_h3/tools/tracy_audio_decode_sqz_harness.py -k 600lat_b1 -s
+    # -> generated/profiler/.logs/cpp_device_perf_report.csv (per op per chip)
+"""
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_dit.tests.models.minimax_h3.test_audio_decode_squeeze import (
+    PACK_KEY,
+    RECIPES,
+    _load,
+    apply_recipe,
+)
+from models.tt_dit.utils.test import line_params_8k
+
+MESH_4X8 = [
+    pytest.param(
+        (4, 8),
+        {**line_params_8k, "require_exact_physical_num_devices": True, "l1_small_size": 65536},
+        id="mesh4x8_8k",
+    )
+]
+HOP_LENGTH = 800
+
+
+@pytest.mark.parametrize(("mesh_device", "device_params"), MESH_4X8, indirect=["mesh_device", "device_params"])
+@pytest.mark.parametrize(
+    ("num_latent_frames", "batch"),
+    [(207, 1), (207, 2), (600, 1), (600, 2)],
+    ids=["207lat_b1", "207lat_b2", "600lat_b1", "600lat_b2"],  # single tokens: `python -m tracy` re-splits -k args
+)
+def test_tracy_audio_decode_sqz(mesh_device, num_latent_frames, batch):
+    from tracy import signpost
+
+    name = os.environ.get("SQZ_RECIPE", "full")
+    recipe = RECIPES[name]
+    decoder, config = _load(mesh_device, pack_bands=recipe.get(PACK_KEY))
+    counts = apply_recipe(decoder, recipe)
+    torch.manual_seed(2)
+    latents = torch.randn(batch, config["latent_channels"], num_latent_frames)
+    _ = decoder(latents)  # warm the program cache outside the window
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"tracy: recipe {name} {counts}, {num_latent_frames} latents x batch {batch}")
+    signpost("start")
+    _ = decoder(latents)
+    ttnn.synchronize_device(mesh_device)
+    signpost("stop")
+    ttnn.ReadDeviceProfiler(mesh_device)

--- a/models/tt_dit/tests/unit/test_audio_pack.py
+++ b/models/tt_dit/tests/unit/test_audio_pack.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only checks of the time-packed weight construction in ``layers/audio_pack.py``: the dense packed conv on
+``(T/k, k*C)`` rows must reproduce the unpacked op (exactly for zero-padded convs; away from the sequence ends for
+the replicate-padded resamplers) for the vocoder's late-band shapes."""
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from models.tt_dit.layers.audio_pack import (
+    conv1d_same,
+    downsample2x_ref,
+    kaiser_taps,
+    packed_weight,
+    upsample2x_ref,
+)
+
+BANDS = [(8, 4), (16, 2)]  # (channels, pack) -> 32-wide packed rows
+
+
+def _pack(x_1CT, k):
+    """``(1, C, T) -> (1, k*C, T/k)`` slot-major (a row-major reshape of ``(T, C)``)."""
+    c, t = x_1CT.shape[1], x_1CT.shape[2]
+    return x_1CT[0].transpose(0, 1).reshape(t // k, k * c).transpose(0, 1).unsqueeze(0)
+
+
+def _unpack(y_1PT, k, c):
+    p, t = y_1PT.shape[1], y_1PT.shape[2]
+    return y_1PT[0].transpose(0, 1).reshape(t * k, c).transpose(0, 1).unsqueeze(0)
+
+
+def _psnr(ref, test):
+    mse = torch.mean((ref - test) ** 2).item()
+    return float("inf") if mse == 0 else 20 * math.log10(ref.abs().max().item()) - 10 * math.log10(mse)
+
+
+@pytest.mark.parametrize(("channels", "pack"), BANDS)
+@pytest.mark.parametrize("kernel", [3, 7, 11])
+@pytest.mark.parametrize("dilation", [1, 3, 5])
+def test_packed_conv_matches_conv1d(channels, pack, kernel, dilation):
+    torch.manual_seed(0)
+    w = torch.randn(channels, channels, kernel)
+    t = 64 * pack
+    x = torch.randn(1, channels, t)
+    ref = conv1d_same(w, dilation)(x.double()).float()
+    wp = packed_weight(
+        conv1d_same(w, dilation),
+        c_in=channels,
+        c_out=channels,
+        k_in=pack,
+        k_out=pack,
+        support=(kernel - 1) * dilation + 1,
+    )
+    assert wp.shape[0] == pack * channels and wp.shape[1] == pack * channels and wp.shape[-1] % 2 == 1
+    out = _unpack(F.conv1d(_pack(x, pack), wp, padding=wp.shape[-1] // 2), pack, channels)
+    assert torch.allclose(out, ref, atol=1e-4, rtol=1e-4), (out - ref).abs().max()
+
+
+@pytest.mark.parametrize(("channels", "pack"), BANDS)
+def test_packed_upsample_matches_interior(channels, pack):
+    torch.manual_seed(1)
+    taps = kaiser_taps()
+    t = 64 * pack
+    x = torch.randn(1, channels, t)
+    ref = upsample2x_ref(taps, channels)(x.double()).float()
+    wp = packed_weight(
+        upsample2x_ref(taps, channels), c_in=channels, c_out=channels, k_in=pack, k_out=2 * pack, support=26
+    )
+    out = _unpack(F.conv1d(_pack(x, pack), wp, padding=wp.shape[-1] // 2), 2 * pack, channels)
+    assert out.shape == ref.shape
+    edge = 2 * pack * (wp.shape[-1] // 2 + 1)  # samples the zero-vs-replicate end padding can reach
+    assert torch.allclose(out[..., edge:-edge], ref[..., edge:-edge], atol=1e-4, rtol=1e-4)
+    assert _psnr(ref, out) > 40, "end padding difference dominates the whole clip"
+
+
+@pytest.mark.parametrize(("channels", "pack"), BANDS)
+def test_packed_downsample_matches_interior(channels, pack):
+    torch.manual_seed(2)
+    taps = kaiser_taps()
+    k_in = 2 * pack
+    t = 64 * k_in
+    x = torch.randn(1, channels, t)
+    ref = downsample2x_ref(taps, channels)(x.double()).float()
+    wp = packed_weight(
+        downsample2x_ref(taps, channels), c_in=channels, c_out=channels, k_in=k_in, k_out=pack, support=26
+    )
+    out = _unpack(F.conv1d(_pack(x, k_in), wp, padding=wp.shape[-1] // 2), pack, channels)
+    assert out.shape == ref.shape
+    edge = pack * (wp.shape[-1] // 2 + 1)
+    assert torch.allclose(out[..., edge:-edge], ref[..., edge:-edge], atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize(("channels", "pack"), BANDS)
+def test_packed_kernel_widths(channels, pack):
+    """The packed kernels stay short: this is what keeps the dense form's FLOPs at today's padded-conv level."""
+    widths = {}
+    for kernel, dilation in [(3, 1), (7, 1), (11, 1), (3, 3), (7, 3), (11, 3), (3, 5), (7, 5), (11, 5)]:
+        wp = packed_weight(
+            conv1d_same(torch.ones(channels, channels, kernel), dilation),
+            c_in=channels,
+            c_out=channels,
+            k_in=pack,
+            k_out=pack,
+            support=(kernel - 1) * dilation + 1,
+        )
+        widths[(kernel, dilation)] = wp.shape[-1]
+        assert wp.shape[-1] == 2 * math.ceil((kernel - 1) * dilation / 2 / pack) + 1
+    up = packed_weight(
+        upsample2x_ref(kaiser_taps(), channels), c_in=channels, c_out=channels, k_in=pack, k_out=2 * pack, support=26
+    )
+    down = packed_weight(
+        downsample2x_ref(kaiser_taps(), channels), c_in=channels, c_out=channels, k_in=2 * pack, k_out=pack, support=26
+    )
+    print(f"C={channels} k={pack}: conv taps {widths}, up {up.shape}, down {down.shape}")


### PR DESCRIPTION
## MiniMax-H3 audio decoder: time-packed late bands, cheaper split modes, host-edge fixes (4x8, T-shard factor 8)

Follow-up to the audio decoder timing analysis (branch `rouzbeh/audio-decoder-benchmark`): the traced decode of a
15 s clip on a 4x8 Galaxy at T-shard factor 8 was 0.53 s, ~5,400 device ops per chip, with the late bands (8 and 16
channels) running every op at a few GB/s on 32- and 64-byte DRAM pages. This PR squeezes that without changing
main's accuracy, adds cheaper precision modes as options, and documents what did not work.

All numbers: traced decode wall (best of 3 after a warm eager call), PSNR against the pinned CPU reference decode
(`AutoencoderKLMiniMaxH3Audio`, fp32) of the same latents. Harness in
`models/tt_dit/tests/models/minimax_h3/test_audio_decode_squeeze.py`.

### Results

15 s clip, 600 latents, batch 1 (main = `split_mode="full"`, 0.528 s, 67.4 dB):

| accuracy | configuration | traced s | vs main |
|---|---|---|---|
| 67 dB (main's) | full split + packed bands 5-6 + host edges (**default on this branch**) | 0.414 | 1.28x |
| 65 dB | same, packed resamplers without the split (`MINIMAX_H3_AUDIO_RESAMPLER_SPLIT=off`) | 0.343 | 1.54x |
| 60 dB | activation-only split (`split_mode="act"`) + packed + host edges | 0.348 | 1.52x |
| 53 dB | no split + packed + host edges | 0.248 | 2.13x |

The pipeline's own shape (600 latents, stereo as batch 2): main 0.958 s -> packed 0.802 s (67.3 dB), 0.658 s at 65 dB,
0.473 s at 53 dB. The 5 s batch-2 clip (tile-floor padding path) tracks these within a few percent.

### Measured end to end: fox 16:9 15 s t2va (4x8, T-shard factor 8, `test_t2va_end_to_end`)

"Audio decode" stage of the timed second pass (the first pass is kernel compilation). The pipeline calls the decoder
eagerly, so this stage is the eager stereo (batch 2) decode plus ~0.35 s of host work around it.

| configuration | Audio decode stage | CLIP | host |
|---|---|---|---|
| main's split, packing off (same code otherwise) | **1.4 s** | 35.67 | c03u08 |
| packed bands 5-6, main's split (branch default, 67 dB) | **1.3 s** | 35.67 | c03u08 |
| packed bands 5-6, no split (`MINIMAX_H3_AUDIO_SPLIT=off`, 53 dB) | **1.0 s** | 35.67 | c03u02 |
| packed + resamplers without the split (65 dB) | not run end to end (harness: 0.66 s traced, stereo) | | |
| activation-only split + packed (59 dB) | not run end to end (harness: 0.67 s traced, stereo) | | |

Reference: the same stage measured 1.5 s on main on 09-04. CLIP scores the video and is unchanged throughout. The
eager stage only shows the op-count saving; the traced harness numbers above are where the device-time gain appears
(PR #55877 traces the pipeline's audio decode). Video and audio of the packed and no-split runs are kept under
`main_build_logs/h3_audio_samples/`.

### What changed

- **`layers/audio_pack.py`: time-packed late bands.** `Vocoder(pack_bands={5: 2, 6: 4})` runs a band's AMP blocks on
  `(T/k, k*C)` rows (128-byte pages). Every op in the block is shift-invariant with an integer rate, so each has an exact
  packed form as a dense conv over packed rows: the dilated convs become 3-15 tap convs on 32 -> 32 channels, the 2x
  anti-alias upsampler a 3-tap conv 32 -> 64, the downsampler 3-tap 64 -> 32, and SnakeBeta's parameters are tiled.
  The packed weights are read off the reference ops' impulse responses (`packed_weight`), checked by 24 CPU tests
  (`tests/unit/test_audio_pack.py`). At `k*C = 32` the conv3d FLOPs are unchanged (conv3d already padded C to 32) and
  each 6-op depthwise resampler chain becomes one conv3d. PSNR unchanged (88.6 dB against the unpacked output).
- **Split modes.** `split_mode="act"` (activation-only, 2 conv3d) and `"stack"` (the full split as one conv3d over
  stacked operands; measured slower, kept as an option). `resampler_split_mode` lets the packed resamplers use a
  cheaper mode than the convs. All part of the device-weight cache key (`weights_variant`).
- **bf16-rounded weights for no-residual convs.** The FPU truncates an fp32 weight operand; the same conv measured
  60.8 dB with the raw fp32 weight and 65.1 dB with the bf16-rounded one, so `prepare_conv3d_weight_state` now rounds.
- **Host edges.** The latent projection (`dec_in_proj`, k=1) stays on device and feeds the vocoder graph directly (its
  zero pad rows masked back to zero, since a k=1 conv with a bias projects them to the bias); the mono waveform is
  carried as `(T/32, 32)` rows through the clamp, T gather and readback instead of 4-byte rows. -33 ms at every precision.
- **Pipeline switches.** `MINIMAX_H3_AUDIO_PACK` (default `5:2,6:4`, `0` restores main's decoder),
  `MINIMAX_H3_AUDIO_RESAMPLER_SPLIT` (default `same`) and `MINIMAX_H3_AUDIO_SPLIT` (conv split mode when the caller
  passes none, default `full`).
- **Tools.** Squeeze harness (recipes x clips, PSNR vs CPU reference), `sqz_reference.py` (cached reference clips),
  `tools/layout_tax_probe.py` (per-op time vs row packing), `tools/tracy_audio_decode_sqz_harness.py`.

### What was learned

- The fp32 hi/lo split is two separate error floors: weight-only split = no split (51 dB), activation-only 60 dB,
  both 67 dB. No 2-conv variant reaches main's accuracy.
- Layout tax (band-6 tensor, 1.9 MB): `(60000, 8)` -> `(15000, 32)` rows makes add/snake/untilize/halo/concat 1.6-3x
  cheaper at equal conv3d cost; packing 8+ steps per row makes the dense conv FLOPs explode.
- Measured and rejected: stacked-operand split (slower: conv3d time grows with input-channel blocks), dense resamplers
  in bands 3-4 (slower at 32/64 channels), packing beyond 4 steps per row.
- Profile of the packed decode (Tracy, per chip): 5,617 ops, 468 ms device time (581 before); the split's extra
  conv3d launches, adds and typecasts are ~245 ms of it, spread over all bands. Note: this main's Tracy launcher no
  longer sets `TTNN_OP_PROFILER=1`; without it the C++ report has no op names.

### Toward 200 ms

At main's accuracy the remaining lever is an fp32-faithful conv3d kernel (the three bf16 MAC passes inside one
launch) worth most of the ~245 ms; then tracing the pipeline's decode (#55877) and packing the last late-band ops
(transposed convs, `act_post`, `conv_post`). At 65 dB the same steps land around 0.2 s per mono channel.

### Test

- `tests/unit/test_audio_pack.py`: 24/24 (CPU).
- `test_audio_decode_squeeze.py` on 4x8 (c02u08 / c03u08): every recipe above, three clips.
- `test_pipeline_minimax_h3.py::test_t2va_end_to_end[4x8-16x9_15s]`: pass with packing off, on, and on with the
  split off; CLIP 35.67 in all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
