### PR TITLE
[CI] Bump Wan2.2-T2V e2e timeouts (bh_quietbox_2 pytest, bh_sc4 job budget)

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -357,7 +357,7 @@ models:
     bh_quietbox_2: 390
     bh_galaxy: 78
     bh_sc1: 335
-    bh_sc4: 120
+    bh_sc4: 160
   e2e_tier2:
     wh_llmbox_perf: 266
     wh_n150: 45

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -1362,11 +1362,11 @@
     unset HF_HUB_OFFLINE
     export NO_PROMPT=1 TT_DIT_CACHE_DIR=/tmp/TT_DIT_CACHE VBENCH_CACHE_DIR=/mnt/MLPerf/vbench TORCH_HOME=/mnt/MLPerf/vbench/torch_hub
     fail=0
-    pytest --timeout 3000 models/tt_dit/tests/models/wan2_2/test_performance_wan.py \
+    pytest --timeout 3500 models/tt_dit/tests/models/wan2_2/test_performance_wan.py \
       -k "resolution_480p and t2v" || fail=1
-    pytest --timeout 3000 models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py \
+    pytest --timeout 3500 models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py \
       -k "(4x8sp1tp0nl4_ring_is_fsdp1 and resolution_720p) or (2x2sp0tp1nl2_linear_is_fsdp1 and resolution_480p)" || fail=1
-    pytest --timeout 1200 models/tt_dit/tests/models/wan2_2/test_performance_wan.py \
+    pytest --timeout 1700 models/tt_dit/tests/models/wan2_2/test_performance_wan.py \
       -k "wh_4x8_sp1tp0 and resolution_720p and t2v" || fail=1
     exit $fail
   model: wan-2.2-t2v
@@ -1420,7 +1420,7 @@
   model_family: Wan
   skus:
     bh_sc4:
-      timeout: 40
+      timeout: 80
       tier: 1
       release_ready: true
   owner_id: U0ATR08RCQ0 # James Lee


### PR DESCRIPTION
## Problem

The Tier-1 **Wan2.2-T2V-A14B** e2e legs have been failing on two *distinct* timeout constraints (diagnosed from run [34547375974](https://github.com/tenstorrent/tt-metal/actions/runs/34547375974)):

- **`bh_quietbox_2`** — the 480p perf/pipeline tests hit their **per-test `pytest --timeout`**: two attempts died with `Failed: Timeout (>3000.0s) from pytest-timeout` at ~3009s. The job budget was never close to being hit. (The test passes normally in ~46 min — [green baseline run](https://github.com/tenstorrent/tt-metal/actions/runs/34554649533/job/103126449906).)
- **`bh_sc4` multihost quad** — the perf test *passed* (~29:33), but the step was killed by the **40-min job `timeout-minutes` budget** while the second (pipeline) test was mid-run. The `pytest --timeout` is already 10000s, so pytest was never the constraint. The **I2V sibling** runs the same two-test shape and [passes at `timeout: 80`](https://github.com/tenstorrent/tt-metal/actions/runs/34547375974/job/103380284593).

## Change (Wan2.2-T2V only)

- **`bh_quietbox_2`**: pytest timeouts `3000 -> 3500` (480p perf + pipeline) and `1200 -> 1700` (720p perf). **Job budget stays 115 min** — it already covers the worst realistic run (~58m 480p hang + ~11m pipeline + overhead ~= 68 min; measured step time with the 480p test hanging was ~60 min), so the shared `models/bh_quietbox_2` e2e_tier1 pool stays within its 390-min cap (389/390).
- **`bh_sc4`**: job budget `40 -> 80` to match the passing I2V sibling. The `models/bh_sc4` e2e_tier1 pool is now `T2V 80 + I2V 80 = 160`, which no longer fits the old 120-min cap, so **`time_budget.yaml` `models/e2e_tier1/bh_sc4` is raised 120 -> 160** (this pool serves only these two Wan multihost tests).

Verified with `.github/scripts/utils/verify_time_budget.py` for `e2e` tiers 1/2/3 — all pass.

## Passing reference runs (evidence)

- `bh_quietbox_2` Wan2.2-T2V green baseline (normal ~46 min run): https://github.com/tenstorrent/tt-metal/actions/runs/34554649533/job/103126449906
- `bh_sc4` Wan2.2-**I2V** sibling passing at `timeout: 80` (same two-test shape as T2V): https://github.com/tenstorrent/tt-metal/actions/runs/34547375974/job/103380284593

## CI verification runs (this branch)

Dispatched "(Tier 1) Models E2E" against this branch, one per changed SKU:

- `bh_quietbox_2`: https://github.com/tenstorrent/tt-metal/actions/runs/34652229391
- `bh_sc4`: https://github.com/tenstorrent/tt-metal/actions/runs/34659099702 (re-run; a first attempt [34652232067](https://github.com/tenstorrent/tt-metal/actions/runs/34652232067) died on a runner-provisioning infra flake before any test ran)

## Caveats

- The `bh_quietbox_2` 480p perf test hung at *exactly* ~3009s on two separate runners, which reads more like a genuine hang than "500s too slow." If it is a true hang, this bump only delays the failure — a real investigation is still warranted.
- The `bh_sc4` "Connection mismatch" cluster-validation abort seen in the logs was a pre-test check that **retried and recovered**; it was not the fatal cause. The only thing that failed that job was the 40-min budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jameslee/bump-wan22-t2v-qb2-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jameslee/bump-wan22-t2v-qb2-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jameslee/bump-wan22-t2v-qb2-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jameslee/bump-wan22-t2v-qb2-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jameslee/bump-wan22-t2v-qb2-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jameslee/bump-wan22-t2v-qb2-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jameslee/bump-wan22-t2v-qb2-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jameslee/bump-wan22-t2v-qb2-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jameslee/bump-wan22-t2v-qb2-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jameslee/bump-wan22-t2v-qb2-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jameslee/bump-wan22-t2v-qb2-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jameslee/bump-wan22-t2v-qb2-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jameslee/bump-wan22-t2v-qb2-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jameslee/bump-wan22-t2v-qb2-timeouts)
