### PR TITLE
[Feature]: Add Blackhole Tensor Prefetcher traffic priority

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -679,7 +679,7 @@ TEST_F(DramKernelFixture, DramKernelDRISCRTensixParallelDRAMReads) {
     }
 }
 
-TEST_F(DramKernelFixture, DISABLED_MpfePriorityWeightBenchmark) {
+TEST_F(DramKernelFixture, MpfePriorityWeightBenchmark) {
     if (std::getenv("TT_METAL_RUN_BH_MPFE_BENCHMARK") == nullptr) {
         GTEST_SKIP() << "Set TT_METAL_RUN_BH_MPFE_BENCHMARK=1 to run the MPFE weight sweep";
     }
@@ -757,6 +757,22 @@ TEST_F(DramKernelFixture, DISABLED_MpfePriorityWeightBenchmark) {
 
         const uint64_t drisc_cycles = read_timing_cycles(drisc_virtual, drisc_l1_noc_addr_ + bytes_per_iter);
         const uint64_t ordinary_cycles = read_timing_cycles(tensix_virtual, tensix_l1_base_ + bytes_per_iter);
+        const size_t elements_per_iter = bytes_per_iter / sizeof(uint32_t);
+        std::vector<uint32_t> drisc_result(elements_per_iter);
+        std::vector<uint32_t> ordinary_result(elements_per_iter);
+        MetalContext::instance().get_cluster().read_core(
+            drisc_result.data(),
+            bytes_per_iter,
+            tt_cxy_pair(mesh_device_->build_id(), drisc_virtual),
+            drisc_l1_noc_addr_);
+        MetalContext::instance().get_cluster().read_core(
+            ordinary_result.data(),
+            bytes_per_iter,
+            tt_cxy_pair(mesh_device_->build_id(), tensix_virtual),
+            tensix_l1_base_);
+        EXPECT_TRUE(std::equal(drisc_result.begin(), drisc_result.end(), data.begin()));
+        EXPECT_TRUE(std::equal(ordinary_result.begin(), ordinary_result.end(), data.end() - elements_per_iter));
+
         log_info(
             LogTest,
             "BH MPFE benchmark case={} weights={}/{}/{} active_port=P{} ordinary_port=P{} "

--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -136,11 +136,7 @@ protected:
             "tests/tt_metal/tt_metal/test_kernels/misc/drisc_gddr_mc_priority.cpp",
             logical_dram_core,
             DramConfig{.noc = NOC::NOC_0});
-        SetRuntimeArgs(
-            program,
-            kernel,
-            logical_dram_core,
-            {weights[0], weights[1], weights[2], drisc_l1_base_});
+        SetRuntimeArgs(program, kernel, logical_dram_core, {weights[0], weights[1], weights[2], drisc_l1_base_});
         run_workload(std::move(program));
 
         std::array<uint32_t, 3> readback{};
@@ -727,10 +723,8 @@ TEST_F(DramKernelFixture, DISABLED_MpfePriorityWeightBenchmark) {
     }
 
     const CoreCoord tensix_logical{0, 0};
-    const CoreCoord drisc_virtual =
-        mesh_device_->virtual_core_from_logical_core(active_sender, CoreType::DRAM);
-    const CoreCoord tensix_virtual =
-        mesh_device_->virtual_core_from_logical_core(tensix_logical, CoreType::WORKER);
+    const CoreCoord drisc_virtual = mesh_device_->virtual_core_from_logical_core(active_sender, CoreType::DRAM);
+    const CoreCoord tensix_virtual = mesh_device_->virtual_core_from_logical_core(tensix_logical, CoreType::WORKER);
     const uint32_t clk_hz =
         MetalContext::instance().get_cluster().get_device_aiclk(mesh_device_->build_id()) * 1000000u;
 
@@ -743,11 +737,7 @@ TEST_F(DramKernelFixture, DISABLED_MpfePriorityWeightBenchmark) {
                 "tests/tt_metal/tt_metal/test_kernels/misc/drisc_l1_dram_dma.cpp",
                 active_sender,
                 DramConfig{.noc = NOC::NOC_0});
-            SetRuntimeArgs(
-                program,
-                drisc_kernel,
-                active_sender,
-                {dram_addr, drisc_l1_base_, bytes_per_iter, iters});
+            SetRuntimeArgs(program, drisc_kernel, active_sender, {dram_addr, drisc_l1_base_, bytes_per_iter, iters});
 
             const auto tensix_kernel = CreateKernel(
                 program,
@@ -758,20 +748,15 @@ TEST_F(DramKernelFixture, DISABLED_MpfePriorityWeightBenchmark) {
                     .noc = NOC::NOC_0,
                     .defines = {{"WRITE_TIMING", "1"}}});
             SetRuntimeArgs(
-                program,
-                tensix_kernel,
-                tensix_logical,
-                {bank_id, dram_addr, tensix_l1_base_, bytes_per_iter, iters});
+                program, tensix_kernel, tensix_logical, {bank_id, dram_addr, tensix_l1_base_, bytes_per_iter, iters});
             run_workload(std::move(program));
         } catch (...) {
             (void)set_mpfe_weights(bank_id, {0, 0, 0});
             throw;
         }
 
-        const uint64_t drisc_cycles =
-            read_timing_cycles(drisc_virtual, drisc_l1_noc_addr_ + bytes_per_iter);
-        const uint64_t ordinary_cycles =
-            read_timing_cycles(tensix_virtual, tensix_l1_base_ + bytes_per_iter);
+        const uint64_t drisc_cycles = read_timing_cycles(drisc_virtual, drisc_l1_noc_addr_ + bytes_per_iter);
+        const uint64_t ordinary_cycles = read_timing_cycles(tensix_virtual, tensix_l1_base_ + bytes_per_iter);
         log_info(
             LogTest,
             "BH MPFE benchmark case={} weights={}/{}/{} active_port=P{} ordinary_port=P{} "

--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <array>
+#include <cstdlib>
 #include <cstdint>
 #include <vector>
 #include <chrono>
@@ -42,6 +44,27 @@ static CoreCoord logical_dram_endpoint_for_noc(const metal_SocDescriptor& soc_de
     }
     TT_FATAL(false, "Preferred DRAM endpoint ({}, {}) for bank {} not found", pref.x, pref.y, dram_view);
     return {};
+}
+
+static uint32_t mpfe_port_for_logical_dram_core(
+    const metal_SocDescriptor& soc_desc, uint32_t dram_view, const CoreCoord& logical_core) {
+    constexpr uint32_t kFirstMpfePort = 1;
+    const CoreCoord physical_core = soc_desc.get_physical_dram_core_from_logical(logical_core);
+    const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(dram_view));
+    const uint32_t num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
+    for (uint32_t subchannel = 0; subchannel < num_subchannels; ++subchannel) {
+        const tt::umd::CoreCoord subchannel_core = soc_desc.get_dram_core_for_channel(
+            static_cast<int>(channel), static_cast<int>(subchannel), tt::CoordSystem::TRANSLATED);
+        if (subchannel_core.x == physical_core.x && subchannel_core.y == physical_core.y) {
+            return kFirstMpfePort + subchannel;
+        }
+    }
+    TT_THROW(
+        "Could not map logical DRAM core ({}, {}) in view {} to an MPFE port",
+        logical_core.x,
+        logical_core.y,
+        dram_view);
+    return 0;
 }
 
 // Fixture for DRISC/DRAM-kernel tests
@@ -102,6 +125,33 @@ protected:
         return usable.front();
     }
 
+    std::array<uint32_t, 3> set_mpfe_weights(uint32_t bank, const std::array<uint32_t, 3>& weights) {
+        const CoreCoord logical_dram_core{bank, first_usable_dram_endpoint(bank)};
+        const CoreCoord virtual_dram_core =
+            mesh_device_->virtual_core_from_logical_core(logical_dram_core, CoreType::DRAM);
+
+        Program program = CreateProgram();
+        const auto kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/misc/drisc_gddr_mc_priority.cpp",
+            logical_dram_core,
+            DramConfig{.noc = NOC::NOC_0});
+        SetRuntimeArgs(
+            program,
+            kernel,
+            logical_dram_core,
+            {weights[0], weights[1], weights[2], drisc_l1_base_});
+        run_workload(std::move(program));
+
+        std::array<uint32_t, 3> readback{};
+        MetalContext::instance().get_cluster().read_core(
+            readback.data(),
+            sizeof(readback),
+            tt_cxy_pair(mesh_device_->build_id(), virtual_dram_core),
+            drisc_l1_noc_addr_);
+        return readback;
+    }
+
     distributed::MeshDevice* mesh_device_{};
     distributed::MeshCoordinateRange device_range_{distributed::MeshCoordinate(0, 0)};
     uint32_t drisc_l1_base_{};
@@ -137,6 +187,19 @@ TEST_F(DramKernelFixture, DramKernelWriteToL1) {
         result.data(), sizeof(uint32_t), tt_cxy_pair(mesh_device_->build_id(), virtual_dram_core), drisc_l1_noc_addr_);
 
     EXPECT_EQ(result[0], kMagicValue);
+}
+
+TEST_F(DramKernelFixture, GddrMcMpfeRoundRobinWeights) {
+    constexpr std::array<std::array<uint32_t, 3>, 4> kWeightSequence = {
+        std::array<uint32_t, 3>{7, 7, 7},
+        std::array<uint32_t, 3>{0, 0, 0},
+        std::array<uint32_t, 3>{7, 7, 7},
+        std::array<uint32_t, 3>{0, 0, 0},
+    };
+
+    for (const auto& weights : kWeightSequence) {
+        EXPECT_EQ(set_mpfe_weights(/*bank=*/0, weights), weights);
+    }
 }
 
 // Run the same kernel across multiple DRAM cores.
@@ -617,6 +680,114 @@ TEST_F(DramKernelFixture, DramKernelDRISCRTensixParallelDRAMReads) {
                 tensix_l1_base_);
             EXPECT_EQ(result, data) << "Data mismatch on core (" << col << ", " << row << ")";
         }
+    }
+}
+
+TEST_F(DramKernelFixture, DISABLED_MpfePriorityWeightBenchmark) {
+    if (std::getenv("TT_METAL_RUN_BH_MPFE_BENCHMARK") == nullptr) {
+        GTEST_SKIP() << "Set TT_METAL_RUN_BH_MPFE_BENCHMARK=1 to run the MPFE weight sweep";
+    }
+
+    constexpr uint32_t bank_id = 0;
+    constexpr uint32_t bytes_per_iter = 16 * 1024;
+    constexpr uint32_t iters = 128;
+    constexpr uint64_t total_bytes = static_cast<uint64_t>(bytes_per_iter) * iters;
+
+    const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(mesh_device_->build_id());
+    const CoreCoord active_sender{bank_id, first_usable_dram_endpoint(bank_id)};
+    const uint32_t active_port = mpfe_port_for_logical_dram_core(soc_desc, bank_id, active_sender);
+    const CoreCoord ordinary_endpoint = logical_dram_endpoint_for_noc(soc_desc, bank_id, NOC::NOC_0);
+    const uint32_t ordinary_port = mpfe_port_for_logical_dram_core(soc_desc, bank_id, ordinary_endpoint);
+    TT_FATAL(active_port != ordinary_port, "Active and ordinary-operation traffic map to the same MPFE port");
+    const uint32_t inactive_port = 1 + 2 + 3 - active_port - ordinary_port;
+
+    const uint32_t dram_channel = mesh_device_->dram_channel_from_logical_core({bank_id, 0});
+    auto dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = total_bytes},
+        {.page_size = total_bytes, .buffer_type = BufferType::DRAM},
+        mesh_device_);
+    const uint32_t dram_addr = dram_buffer->address();
+    const auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+    std::vector<uint32_t> data = create_random_vector_of_bfloat16(total_bytes, 1000.0f, seed);
+    slow_dispatch::WriteToDRAMChannel(*mesh_device_, dram_channel, dram_addr, data);
+
+    struct BenchmarkCase {
+        const char* name;
+        std::array<uint32_t, 3> weights;
+    };
+    std::vector<BenchmarkCase> cases;
+    cases.push_back({"equal_0", {0, 0, 0}});
+    cases.push_back({"equal_7", {7, 7, 7}});
+    for (uint32_t active_weight = 0; active_weight <= 7; ++active_weight) {
+        std::array<uint32_t, 3> weights{};
+        weights[active_port - 1] = active_weight;
+        weights[inactive_port - 1] = 7;
+        weights[ordinary_port - 1] = 7;
+        cases.push_back({"active_sweep", weights});
+    }
+
+    const CoreCoord tensix_logical{0, 0};
+    const CoreCoord drisc_virtual =
+        mesh_device_->virtual_core_from_logical_core(active_sender, CoreType::DRAM);
+    const CoreCoord tensix_virtual =
+        mesh_device_->virtual_core_from_logical_core(tensix_logical, CoreType::WORKER);
+    const uint32_t clk_hz =
+        MetalContext::instance().get_cluster().get_device_aiclk(mesh_device_->build_id()) * 1000000u;
+
+    for (const auto& benchmark_case : cases) {
+        ASSERT_EQ(set_mpfe_weights(bank_id, benchmark_case.weights), benchmark_case.weights);
+        try {
+            Program program = CreateProgram();
+            const auto drisc_kernel = CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/test_kernels/misc/drisc_l1_dram_dma.cpp",
+                active_sender,
+                DramConfig{.noc = NOC::NOC_0});
+            SetRuntimeArgs(
+                program,
+                drisc_kernel,
+                active_sender,
+                {dram_addr, drisc_l1_base_, bytes_per_iter, iters});
+
+            const auto tensix_kernel = CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/test_kernels/misc/tensix_dram_reads.cpp",
+                tensix_logical,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0,
+                    .noc = NOC::NOC_0,
+                    .defines = {{"WRITE_TIMING", "1"}}});
+            SetRuntimeArgs(
+                program,
+                tensix_kernel,
+                tensix_logical,
+                {bank_id, dram_addr, tensix_l1_base_, bytes_per_iter, iters});
+            run_workload(std::move(program));
+        } catch (...) {
+            (void)set_mpfe_weights(bank_id, {0, 0, 0});
+            throw;
+        }
+
+        const uint64_t drisc_cycles =
+            read_timing_cycles(drisc_virtual, drisc_l1_noc_addr_ + bytes_per_iter);
+        const uint64_t ordinary_cycles =
+            read_timing_cycles(tensix_virtual, tensix_l1_base_ + bytes_per_iter);
+        log_info(
+            LogTest,
+            "BH MPFE benchmark case={} weights={}/{}/{} active_port=P{} ordinary_port=P{} "
+            "drisc_dma={:.2f}GB/s ordinary_noc={:.2f}GB/s drisc_cycles={} ordinary_cycles={}",
+            benchmark_case.name,
+            benchmark_case.weights[0],
+            benchmark_case.weights[1],
+            benchmark_case.weights[2],
+            active_port,
+            ordinary_port,
+            compute_bw_gbs(total_bytes, drisc_cycles, clk_hz),
+            compute_bw_gbs(total_bytes, ordinary_cycles, clk_hz),
+            drisc_cycles,
+            ordinary_cycles);
+
+        EXPECT_EQ(set_mpfe_weights(bank_id, {0, 0, 0}), (std::array<uint32_t, 3>{0, 0, 0}));
     }
 }
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/drisc_gddr_mc_priority.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/drisc_gddr_mc_priority.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "internal/tt-1xx/blackhole/gddr_mc_regs.h"
+
+void kernel_main() {
+    const uint32_t result_l1_addr = get_arg_val<uint32_t>(3);
+    volatile tt_l1_ptr uint32_t* results = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(result_l1_addr);
+
+    for (uint32_t port = 1; port <= 3; ++port) {
+        gddr_mc_write_mpfe_weight(port, get_arg_val<uint32_t>(port - 1));
+        results[port - 1] = gddr_mc_read_mpfe_weight(port);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/tensix_dram_reads.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/tensix_dram_reads.cpp
@@ -19,9 +19,16 @@ void kernel_main() {
     AllocatorBank<AllocatorBankType::DRAM> bank;
     CoreLocalMem<uint32_t> dst(dst_l1_addr);
 
+#ifdef WRITE_TIMING
+    const uint64_t start = get_timestamp();
+#endif
     for (uint32_t i = 0; i < iters; i++) {
         noc.async_read(bank, dst, total_bytes, {.bank_id = src_dram_bank_id, .addr = src_dram_addr}, {});
         src_dram_addr += total_bytes;
         noc.async_read_barrier();
     }
+#ifdef WRITE_TIMING
+    CoreLocalMem<uint64_t> timing(dst_l1_addr);
+    timing[total_bytes / sizeof(uint64_t)] = get_timestamp() - start;
+#endif
 }

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -213,6 +213,25 @@ def test_validator_dram_sender(device, K, N, dtype, recv_per_bank, num_layers):
         )
 
 
+def test_validator_dram_sender_restart(device):
+    """Start/stop twice so the DRISC shutdown semaphore and MPFE defaults are re-established."""
+    K, N, dtype, recv_per_bank, num_layers = 448, 1792, ttnn.bfloat16, 1, 1
+    tt_weight, _, gcb, _, _, ring_size = _setup_weight_and_gcb_dram_sender(
+        device, K, N, dtype, recv_per_bank, num_layers
+    )
+
+    for _ in range(2):
+        with tensor_prefetcher_session(device):
+            ttnn.experimental.queue_tensor_prefetcher_request(device, [(tt_weight, ring_size)], global_cb=gcb)
+            ttnn.experimental.test_dram_prefetcher_validator(
+                device,
+                tt_weight,
+                num_layers=num_layers,
+                print_stride=max(1, ring_size // 4),
+                global_cb=gcb,
+            )
+
+
 @pytest.mark.parametrize("K,N,dtype,recv_per_bank", [(448, 1792, ttnn.bfloat16, 1)])
 def test_validator_dram_sender_multi_gcb_switching(device, K, N, dtype, recv_per_bank):
     """Two DRAM-sender GCBs share one prefetcher; interleave Queue(A) → Queue(B) → Queue(A)

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/gddr_mc_regs.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/gddr_mc_regs.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Curated DRISC-visible subset of the Blackhole GDDR memory-controller register
+// map. Source of truth:
+// ws-bh-soc/src/hardware/gddr_soc_logic/meta/registers/c/gddr_mc_reg.h
+// Do not include directly from public device APIs.
+
+#ifdef COMPILE_FOR_DRISC
+
+#include <stdint.h>
+
+#define GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_P1_REG_ADDR (0xFC105830u)
+#define GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_P2_REG_ADDR (0xFC105834u)
+#define GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_P3_REG_ADDR (0xFC105838u)
+
+#define GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_MASK (0x7u)
+#define GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_DEFAULT (0x0u)
+
+static inline uint32_t gddr_mc_mpfe_weight_reg_addr(uint32_t port) {
+    return GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_P1_REG_ADDR + (port - 1u) * sizeof(uint32_t);
+}
+
+static inline uint32_t gddr_mc_read_mpfe_weight(uint32_t port) {
+    return *reinterpret_cast<volatile uint32_t*>(gddr_mc_mpfe_weight_reg_addr(port)) &
+           GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_MASK;
+}
+
+static inline void gddr_mc_write_mpfe_weight(uint32_t port, uint32_t weight) {
+    volatile uint32_t* reg = reinterpret_cast<volatile uint32_t*>(gddr_mc_mpfe_weight_reg_addr(port));
+    const uint32_t current = *reg;
+    *reg = (current & ~GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_MASK) |
+           (weight & GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_MASK);
+}
+
+#endif  // COMPILE_FOR_DRISC

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/gddr_mc_regs.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/gddr_mc_regs.h
@@ -32,8 +32,7 @@ static inline uint32_t gddr_mc_read_mpfe_weight(uint32_t port) {
 static inline void gddr_mc_write_mpfe_weight(uint32_t port, uint32_t weight) {
     volatile uint32_t* reg = reinterpret_cast<volatile uint32_t*>(gddr_mc_mpfe_weight_reg_addr(port));
     const uint32_t current = *reg;
-    *reg = (current & ~GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_MASK) |
-           (weight & GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_MASK);
+    *reg = (current & ~GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_MASK) | (weight & GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_MASK);
 }
 
 #endif  // COMPILE_FOR_DRISC

--- a/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
+++ b/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
@@ -232,6 +232,8 @@ void kernel_main() {
     constexpr uint32_t cq_signal_l1_base = get_compile_time_arg_val(4);
     constexpr uint32_t cq_signal_slot_stride = get_compile_time_arg_val(5);
     constexpr uint32_t shutdown_semaphore_id = get_compile_time_arg_val(6);
+    constexpr uint64_t dram_l1_noc_offset =
+        static_cast<uint64_t>(get_compile_time_arg_val(7)) | (static_cast<uint64_t>(get_compile_time_arg_val(8)) << 32);
     constexpr uint32_t ring_half = stage_ring_size / 2;
     constexpr uint32_t stage_slot_a = stage_ring_base;
     constexpr uint32_t stage_slot_b = stage_ring_base + ring_half;
@@ -268,7 +270,10 @@ void kernel_main() {
     const uint32_t shutdown_semaphore_addr = get_semaphore(shutdown_semaphore_id);
     volatile tt_l1_ptr uint32_t* shutdown_semaphore =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(shutdown_semaphore_addr);
-    const uint64_t peer_shutdown_semaphore = get_noc_addr(peer_noc_x, peer_noc_y, shutdown_semaphore_addr);
+    const uint64_t peer_shutdown_semaphore = NOC_XY_ADDR(
+        DYNAMIC_NOC_X(noc_index, peer_noc_x),
+        DYNAMIC_NOC_Y(noc_index, peer_noc_y),
+        dram_l1_noc_offset + shutdown_semaphore_addr);
 
     RemoteSenderCBInterface& iface = get_remote_sender_cb_interface(remote_cb_id);
     bool has_loaded_sender_state = false;

--- a/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
+++ b/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
@@ -30,6 +30,7 @@
 #include "api/socket_api.h"
 #include "experimental/drisc_mode.h"
 #include "experimental/gddr_dma.h"
+#include "internal/tt-1xx/blackhole/gddr_mc_regs.h"
 #include "tt_metal/impl/buffers/dram_sender_state_block.hpp"
 #include "tt_metal/impl/buffers/tensor_prefetcher_request.hpp"
 
@@ -66,6 +67,14 @@ using tt::tt_metal::TensorPrefetcherTensorLayout;
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
 namespace {
+
+constexpr uint32_t kInactiveMpfeWeight = 7;
+constexpr uint32_t kActiveMpfeWeight = 0;
+
+FORCE_INLINE void set_mpfe_weight(uint32_t port, uint32_t weight) {
+    gddr_mc_write_mpfe_weight(port, weight);
+    ASSERT(gddr_mc_read_mpfe_weight(port) == weight, DebugAssertTripped);
+}
 
 template <bool single_row, bool single_page>
 FORCE_INLINE void prefetcher_write_chunk(
@@ -222,6 +231,7 @@ void kernel_main() {
     // its own dispatcher write, which only lands on an L1-aligned address.
     constexpr uint32_t cq_signal_l1_base = get_compile_time_arg_val(4);
     constexpr uint32_t cq_signal_slot_stride = get_compile_time_arg_val(5);
+    constexpr uint32_t shutdown_semaphore_id = get_compile_time_arg_val(6);
     constexpr uint32_t ring_half = stage_ring_size / 2;
     constexpr uint32_t stage_slot_a = stage_ring_base;
     constexpr uint32_t stage_slot_b = stage_ring_base + ring_half;
@@ -239,12 +249,27 @@ void kernel_main() {
     const uint32_t bank_id = get_arg_val<uint32_t>(rt_idx++);
     (void)bank_id;
     const uint32_t socket_config_addr = get_arg_val<uint32_t>(rt_idx++);
+    const uint32_t own_mpfe_port = get_arg_val<uint32_t>(rt_idx++);
+    const uint32_t ordinary_operation_mpfe_port = get_arg_val<uint32_t>(rt_idx++);
+    const bool is_coordinator = get_arg_val<uint32_t>(rt_idx++) != 0;
+    const uint32_t peer_noc_x = get_arg_val<uint32_t>(rt_idx++);
+    const uint32_t peer_noc_y = get_arg_val<uint32_t>(rt_idx++);
 
     // ---- Init ----
     SocketReceiverInterface socket = create_receiver_socket_interface(socket_config_addr);
     set_receiver_socket_page_size(socket, socket_page_size);
 
     experimental::drisc_set_stream_mode();
+    // While this sender is parked, give it the same grant length as ordinary
+    // operation traffic. A PREFETCH command lowers only this sender's own slot.
+    set_mpfe_weight(ordinary_operation_mpfe_port, kInactiveMpfeWeight);
+    set_mpfe_weight(own_mpfe_port, kInactiveMpfeWeight);
+
+    const uint32_t shutdown_semaphore_addr = get_semaphore(shutdown_semaphore_id);
+    volatile tt_l1_ptr uint32_t* shutdown_semaphore =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(shutdown_semaphore_addr);
+    const uint64_t peer_shutdown_semaphore = get_noc_addr(peer_noc_x, peer_noc_y, shutdown_semaphore_addr);
+
     RemoteSenderCBInterface& iface = get_remote_sender_cb_interface(remote_cb_id);
     bool has_loaded_sender_state = false;
 
@@ -275,6 +300,27 @@ void kernel_main() {
             }
             socket_pop_pages(socket, 1);
             socket_notify_sender(socket);
+
+            // Each sender owns its MPFE slot. The coordinator waits until its peer
+            // has also drained and restored before returning the shared ordinary-
+            // operation slot to the hardware default.
+            set_mpfe_weight(own_mpfe_port, GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_DEFAULT);
+            if (is_coordinator) {
+                noc_semaphore_wait(shutdown_semaphore, 1);
+                set_mpfe_weight(
+                    ordinary_operation_mpfe_port, GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_DEFAULT);
+                ASSERT(
+                    gddr_mc_read_mpfe_weight(1) == GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_DEFAULT &&
+                        gddr_mc_read_mpfe_weight(2) == GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_DEFAULT &&
+                        gddr_mc_read_mpfe_weight(3) == GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_DEFAULT,
+                    DebugAssertTripped);
+                noc_semaphore_inc(peer_shutdown_semaphore, 1);
+                noc_async_atomic_barrier();
+            } else {
+                noc_semaphore_inc(peer_shutdown_semaphore, 1);
+                noc_async_atomic_barrier();
+                noc_semaphore_wait(shutdown_semaphore, 1);
+            }
             break;
         }
         if (cmd_id == tt::tt_metal::DRAM_PREFETCHER_CMD_WAIT_CQ) {
@@ -290,6 +336,8 @@ void kernel_main() {
             continue;
         }
         // DRAM_PREFETCHER_CMD_PREFETCH
+        set_mpfe_weight(own_mpfe_port, kActiveMpfeWeight);
+
         const uint32_t req_num_entries = req->prefetch.num_entries;
         const uint32_t gcb_state_addr = req->prefetch.gcb_state_addr;
         volatile tt_l1_ptr DramSenderStateBlock* state =
@@ -799,6 +847,7 @@ void kernel_main() {
         // resumes at the right ring offset.
         store_sender_state(state, iface);
 
+        set_mpfe_weight(own_mpfe_port, kInactiveMpfeWeight);
         socket_pop_pages(socket, 1);
         socket_notify_sender(socket);
     }

--- a/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
+++ b/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
@@ -232,8 +232,6 @@ void kernel_main() {
     constexpr uint32_t cq_signal_l1_base = get_compile_time_arg_val(4);
     constexpr uint32_t cq_signal_slot_stride = get_compile_time_arg_val(5);
     constexpr uint32_t shutdown_semaphore_id = get_compile_time_arg_val(6);
-    constexpr uint64_t dram_l1_noc_offset =
-        static_cast<uint64_t>(get_compile_time_arg_val(7)) | (static_cast<uint64_t>(get_compile_time_arg_val(8)) << 32);
     constexpr uint32_t ring_half = stage_ring_size / 2;
     constexpr uint32_t stage_slot_a = stage_ring_base;
     constexpr uint32_t stage_slot_b = stage_ring_base + ring_half;
@@ -267,13 +265,13 @@ void kernel_main() {
     set_mpfe_weight(ordinary_operation_mpfe_port, kInactiveMpfeWeight);
     set_mpfe_weight(own_mpfe_port, kInactiveMpfeWeight);
 
-    const uint32_t shutdown_semaphore_addr = get_semaphore(shutdown_semaphore_id);
+    const uint32_t shutdown_semaphore_addr = get_semaphore<ProgrammableCoreType::DRAM>(shutdown_semaphore_id);
     volatile tt_l1_ptr uint32_t* shutdown_semaphore =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(shutdown_semaphore_addr);
+    // Both sender NIUs remain in stream mode through this handshake, so incoming
+    // NoC traffic terminates in DRISC L1 at the untagged local address.
     const uint64_t peer_shutdown_semaphore = NOC_XY_ADDR(
-        DYNAMIC_NOC_X(noc_index, peer_noc_x),
-        DYNAMIC_NOC_Y(noc_index, peer_noc_y),
-        dram_l1_noc_offset + shutdown_semaphore_addr);
+        DYNAMIC_NOC_X(noc_index, peer_noc_x), DYNAMIC_NOC_Y(noc_index, peer_noc_y), shutdown_semaphore_addr);
 
     RemoteSenderCBInterface& iface = get_remote_sender_cb_interface(remote_cb_id);
     bool has_loaded_sender_state = false;

--- a/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
+++ b/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
@@ -307,8 +307,7 @@ void kernel_main() {
             set_mpfe_weight(own_mpfe_port, GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_DEFAULT);
             if (is_coordinator) {
                 noc_semaphore_wait(shutdown_semaphore, 1);
-                set_mpfe_weight(
-                    ordinary_operation_mpfe_port, GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_DEFAULT);
+                set_mpfe_weight(ordinary_operation_mpfe_port, GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_DEFAULT);
                 ASSERT(
                     gddr_mc_read_mpfe_weight(1) == GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_DEFAULT &&
                         gddr_mc_read_mpfe_weight(2) == GDDR_MC_MPFE_CFG_ROUNDROBIN_WEIGHT_DEFAULT &&

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -44,10 +44,41 @@ namespace tt::tt_metal::distributed {
 namespace {
 
 constexpr uint32_t kRemoteCBId = 31;
+constexpr uint32_t kNumGddrSubchannelsPerBank = 3;
+constexpr uint32_t kFirstMpfePort = 1;
+constexpr uint32_t kMpfePortSum = 1 + 2 + 3;
 
 constexpr const char* kKernelPath = "tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp";
 
 inline uint32_t align_up(uint32_t a, uint32_t align) { return (a + align - 1) & ~(align - 1); }
+
+uint32_t get_mpfe_port(
+    const metal_SocDescriptor& soc_desc, uint32_t bank_id, const CoreCoord& sender_logical_core) {
+    const uint32_t num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
+    TT_FATAL(
+        num_subchannels == kNumGddrSubchannelsPerBank,
+        "Tensor prefetcher expected {} GDDR subchannels for bank {}, found {}",
+        kNumGddrSubchannelsPerBank,
+        bank_id,
+        num_subchannels);
+
+    const CoreCoord sender_physical = soc_desc.get_physical_dram_core_from_logical(sender_logical_core);
+    const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank_id));
+    for (uint32_t subchannel = 0; subchannel < num_subchannels; ++subchannel) {
+        const tt::umd::CoreCoord subchannel_physical = soc_desc.get_dram_core_for_channel(
+            static_cast<int>(channel), static_cast<int>(subchannel), tt::CoordSystem::TRANSLATED);
+        if (subchannel_physical.x == sender_physical.x && subchannel_physical.y == sender_physical.y) {
+            // MPFE P0 is the tied-off native port. GDDR subchannels 0..2 enter through P1..P3.
+            return kFirstMpfePort + subchannel;
+        }
+    }
+
+    TT_THROW(
+        "Tensor prefetcher could not map logical DRAM sender ({}, {}) in bank {} to an MPFE port",
+        sender_logical_core.x,
+        sender_logical_core.y,
+        bank_id);
+}
 
 // Largest `page` (multiple of tile_size, <= max_page_size) such that num_tiles*tile_size
 // is divisible by page. Returns (page_size, num_pages). Identical to the existing
@@ -506,9 +537,46 @@ void TensorPrefetcherManager::build_and_launch_programs(uint32_t stage_ring_base
     programs_.clear();
     for (uint32_t d = 0; d < devices_.size(); ++d) {
         auto program = std::make_unique<Program>();
+        const uint32_t shutdown_semaphore_id = CreateSemaphore(
+            *program,
+            CoreRangeSet(ttsl::Span<const CoreCoord>(sender_logical_cores_)),
+            /*initial_value=*/0,
+            CoreType::DRAM);
+        const auto& soc_desc =
+            MetalContext::instance(mesh_device_->impl().get_context_id()).get_cluster().get_soc_desc(devices_[d]->id());
 
         for (uint32_t s = 0; s < num_senders_; ++s) {
             const CoreCoord sender_logical = sender_logical_cores_[s];
+            const uint32_t bank_id = static_cast<uint32_t>(sender_logical.x);
+            const uint32_t bank_sender_base = 2 * bank_id;
+            TT_FATAL(
+                bank_sender_base + 1 < sender_logical_cores_.size() &&
+                    sender_logical_cores_[bank_sender_base].x == bank_id &&
+                    sender_logical_cores_[bank_sender_base + 1].x == bank_id,
+                "Tensor prefetcher sender slots for bank {} are not a contiguous pair",
+                bank_id);
+
+            const uint32_t first_sender_port =
+                get_mpfe_port(soc_desc, bank_id, sender_logical_cores_[bank_sender_base]);
+            const uint32_t second_sender_port =
+                get_mpfe_port(soc_desc, bank_id, sender_logical_cores_[bank_sender_base + 1]);
+            TT_FATAL(
+                first_sender_port != second_sender_port,
+                "Tensor prefetcher senders for bank {} both map to MPFE port {}",
+                bank_id,
+                first_sender_port);
+            const uint32_t own_mpfe_port = get_mpfe_port(soc_desc, bank_id, sender_logical);
+            const uint32_t ordinary_operation_mpfe_port = kMpfePortSum - first_sender_port - second_sender_port;
+            TT_FATAL(
+                ordinary_operation_mpfe_port >= 1 && ordinary_operation_mpfe_port <= 3,
+                "Tensor prefetcher senders for bank {} map to invalid MPFE ports {} and {}",
+                bank_id,
+                first_sender_port,
+                second_sender_port);
+
+            const bool is_coordinator = s == bank_sender_base;
+            const CoreCoord peer_logical = sender_logical_cores_[is_coordinator ? s + 1 : s - 1];
+            const CoreCoord peer_noc = devices_[d]->virtual_core_from_logical_core(peer_logical, CoreType::DRAM);
 
             std::vector<uint32_t> compile_args = {
                 stage_ring_base,
@@ -517,13 +585,22 @@ void TensorPrefetcherManager::build_and_launch_programs(uint32_t stage_ring_base
                 socket_page_size,
                 cq_signal_l1_addr_,
                 cq_signal_slot_stride_,
+                shutdown_semaphore_id,
             };
 
             KernelHandle kernel_id = CreateKernel(
                 *program, kKernelPath, sender_logical, DramConfig{.noc = NOC::NOC_0, .compile_args = compile_args});
 
             const uint32_t socket_addr = sockets_[d * num_senders_ + s]->get_config_buffer_address();
-            std::vector<uint32_t> rt_args = {/*bank_id=*/static_cast<uint32_t>(sender_logical.x), socket_addr};
+            std::vector<uint32_t> rt_args = {
+                bank_id,
+                socket_addr,
+                own_mpfe_port,
+                ordinary_operation_mpfe_port,
+                static_cast<uint32_t>(is_coordinator),
+                static_cast<uint32_t>(peer_noc.x),
+                static_cast<uint32_t>(peer_noc.y),
+            };
             SetRuntimeArgs(*program, kernel_id, sender_logical, rt_args);
         }
 

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -533,9 +533,6 @@ void TensorPrefetcherManager::build_and_launch_programs(uint32_t stage_ring_base
     const uint32_t pcie_alignment =
         MetalContext::instance(mesh_device_->impl().get_context_id()).hal().get_alignment(HalMemType::HOST);
     const uint32_t socket_page_size = align_up(kRequestPageBytes, pcie_alignment);
-    const uint64_t dram_l1_noc_offset = MetalContext::instance(mesh_device_->impl().get_context_id())
-                                            .hal()
-                                            .get_l1_noc_offset(HalProgrammableCoreType::DRAM);
 
     programs_.clear();
     for (uint32_t d = 0; d < devices_.size(); ++d) {
@@ -589,8 +586,6 @@ void TensorPrefetcherManager::build_and_launch_programs(uint32_t stage_ring_base
                 cq_signal_l1_addr_,
                 cq_signal_slot_stride_,
                 shutdown_semaphore_id,
-                static_cast<uint32_t>(dram_l1_noc_offset),
-                static_cast<uint32_t>(dram_l1_noc_offset >> 32),
             };
 
             KernelHandle kernel_id = CreateKernel(

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -78,6 +78,7 @@ uint32_t get_mpfe_port(
         sender_logical_core.x,
         sender_logical_core.y,
         bank_id);
+    return 0;
 }
 
 // Largest `page` (multiple of tile_size, <= max_page_size) such that num_tiles*tile_size

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -52,8 +52,7 @@ constexpr const char* kKernelPath = "tt_metal/impl/buffers/kernels/tensor_prefet
 
 inline uint32_t align_up(uint32_t a, uint32_t align) { return (a + align - 1) & ~(align - 1); }
 
-uint32_t get_mpfe_port(
-    const metal_SocDescriptor& soc_desc, uint32_t bank_id, const CoreCoord& sender_logical_core) {
+uint32_t get_mpfe_port(const metal_SocDescriptor& soc_desc, uint32_t bank_id, const CoreCoord& sender_logical_core) {
     const uint32_t num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
     TT_FATAL(
         num_subchannels == kNumGddrSubchannelsPerBank,

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -533,6 +533,9 @@ void TensorPrefetcherManager::build_and_launch_programs(uint32_t stage_ring_base
     const uint32_t pcie_alignment =
         MetalContext::instance(mesh_device_->impl().get_context_id()).hal().get_alignment(HalMemType::HOST);
     const uint32_t socket_page_size = align_up(kRequestPageBytes, pcie_alignment);
+    const uint64_t dram_l1_noc_offset = MetalContext::instance(mesh_device_->impl().get_context_id())
+                                            .hal()
+                                            .get_l1_noc_offset(HalProgrammableCoreType::DRAM);
 
     programs_.clear();
     for (uint32_t d = 0; d < devices_.size(); ++d) {
@@ -586,6 +589,8 @@ void TensorPrefetcherManager::build_and_launch_programs(uint32_t stage_ring_base
                 cq_signal_l1_addr_,
                 cq_signal_slot_stride_,
                 shutdown_semaphore_id,
+                static_cast<uint32_t>(dram_l1_noc_offset),
+                static_cast<uint32_t>(dram_l1_noc_offset >> 32),
             };
 
             KernelHandle kernel_id = CreateKernel(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### PR Category
Feature

### Summary
Relates to #49778.

Programs Blackhole GDDR MPFE round-robin weights from the Device-side Tensor Prefetcher. Each sender lowers only its own port from weight 7 to 0 while servicing a request, restores it when idle, and coordinates shutdown so the bank returns to the hardware-default `0/0/0` state before DRISC exit.

Adds a curated internal GDDR memory-controller register subset and derives MPFE port roles from each device's existing DRAM topology.

### Notes for reviewers
The MPFE register addresses and weight semantics come from the generated `ws-bh-soc` GDDR MC register map. No snapshot is retained: normal shutdown explicitly restores hardware defaults. The two sender DRISCs use a standard per-program DRAM semaphore to prevent early restoration of the shared ordinary-operation port.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c59a70d1-1556-4ba9-8743-363cedbc8f99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c59a70d1-1556-4ba9-8743-363cedbc8f99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cursor/blackhole-tensor-prefetch-priority-8f99)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cursor/blackhole-tensor-prefetch-priority-8f99)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cursor/blackhole-tensor-prefetch-priority-8f99)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cursor/blackhole-tensor-prefetch-priority-8f99)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cursor/blackhole-tensor-prefetch-priority-8f99)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cursor/blackhole-tensor-prefetch-priority-8f99)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cursor/blackhole-tensor-prefetch-priority-8f99)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cursor/blackhole-tensor-prefetch-priority-8f99)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cursor/blackhole-tensor-prefetch-priority-8f99)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cursor/blackhole-tensor-prefetch-priority-8f99)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cursor/blackhole-tensor-prefetch-priority-8f99)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cursor/blackhole-tensor-prefetch-priority-8f99)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cursor/blackhole-tensor-prefetch-priority-8f99)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cursor/blackhole-tensor-prefetch-priority-8f99)