### PR TITLE
[Cleanup] Data movement single-device tests modernization

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -14,7 +15,6 @@
 #include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -56,9 +56,7 @@ struct AllFromAllConfig {
 /// @param mesh_device The mesh device on which the test is executed.
 /// @param test_config Configuration of the test, defined by a specific struct.
 /// @return Status of the test execution (e.g., success or failure).
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFromAllConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
+bool run_dm(distributed::MeshDevice& mesh_device, const AllFromAllConfig& test_config) {
     /* ================ SETUP ================ */
 
     // Program
@@ -97,7 +95,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
 
     vector<uint32_t> sub_worker_coordinates = {};
     for (auto& sub_logical_core : corerange_to_cores(sub_logical_core_set)) {
-        CoreCoord sub_worker_core = device->worker_core_from_logical_core(sub_logical_core);
+        CoreCoord sub_worker_core = mesh_device.worker_core_from_logical_core(sub_logical_core);
         sub_worker_coordinates.push_back(sub_worker_core.x);
         sub_worker_coordinates.push_back(sub_worker_core.y);
     }
@@ -129,7 +127,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
     const uint32_t num_coord_varargs = (uint32_t)(num_subordinates * 2);
 
     DataMovementHardwareConfig requestor_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         requestor_hw_config = DataMovementGen2Config{};
     } else {
         requestor_hw_config = DataMovementGen1Config{
@@ -157,7 +155,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
         }},
     };
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     ProgramRunArgs run_params;
     ProgramRunArgs::KernelRunArgs requestor_run_params{.kernel = requestor_spec.unique_id};
@@ -190,8 +188,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
     vector<uint32_t> packed_golden = packed_input;
 
     for (auto& sub_logical_core : corerange_to_cores(sub_logical_core_set)) {
-        detail::WriteToDeviceL1(device, sub_logical_core, sub_l1_base_address, packed_input);
-        MetalContext::instance().get_cluster().l1_barrier(device->id());
+        slow_dispatch::WriteToL1(mesh_device, sub_logical_core, sub_l1_base_address, packed_input);
+        MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
     }
 
     // LAUNCH PROGRAM - Use mesh workload approach
@@ -201,7 +199,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
@@ -210,7 +208,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
     bool is_equal = false;
 
     for (auto& mst_logical_core : corerange_to_cores(mst_logical_core_set)) {
-        detail::ReadFromDeviceL1(device, mst_logical_core, mst_l1_base_address, bytes_per_transaction, packed_output);
+        slow_dispatch::ReadFromL1(
+            mesh_device, mst_logical_core, mst_l1_base_address, bytes_per_transaction, packed_output);
 
         // Results comparison
         is_equal = (packed_output == packed_golden);
@@ -228,7 +227,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
 }
 
 void directed_ideal_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
@@ -269,7 +268,7 @@ void directed_ideal_test(
 }
 
 void packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
@@ -283,12 +282,11 @@ void packet_sizes_test(
     /* Running the Test */
 
     uint32_t max_transactions_per_subordinate = 256;
-    uint32_t max_reservable_pages_per_transaction = mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE
-                                                        ? 1024
-                                                        : 2048;  // Max total transaction size == 64 KB
+    uint32_t max_reservable_pages_per_transaction =
+        mesh_device.arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     // Cap sweep on Quasar emulator to avoid timeouts.
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         max_transactions_per_subordinate = 1;
         max_reservable_pages_per_transaction = 1;
     }
@@ -329,8 +327,7 @@ void packet_sizes_test(
     }
 }
 
-void virtual_channels_test(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_case_id) {
-    IDevice* device = mesh_device->impl().get_device(0);
+void virtual_channels_test(distributed::MeshDevice& mesh_device, uint32_t test_case_id) {
     // Physical Constraints
     auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
         unit_tests::dm::compute_physical_constraints(mesh_device);
@@ -338,8 +335,8 @@ void virtual_channels_test(const shared_ptr<distributed::MeshDevice>& mesh_devic
     // Parameters for literal all-to-all (use the full grid for both master and subordinate)
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = mesh_device.compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     std::uint32_t max_num_pages_per_transaction = 1 << 12;
     std::uint32_t num_of_transactions = 256;  // Constant value
@@ -381,7 +378,7 @@ void virtual_channels_test(const shared_ptr<distributed::MeshDevice>& mesh_devic
 }
 
 void custom_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
@@ -419,7 +416,7 @@ void custom_test(
 }
 
 void grid_packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
@@ -431,10 +428,9 @@ void grid_packet_sizes_test(
         unit_tests::dm::compute_physical_constraints(mesh_device);
 
     uint32_t max_transactions_per_subordinate = 256;
-    uint32_t max_reservable_pages_per_transaction =
-        mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE ? 1024 : 2048;
+    uint32_t max_reservable_pages_per_transaction = mesh_device.arch() == ARCH::BLACKHOLE ? 1024 : 2048;
 
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         max_transactions_per_subordinate = 1;
         max_reservable_pages_per_transaction = 1;
     }
@@ -476,8 +472,6 @@ void grid_packet_sizes_test(
 /* ======== DIRECTED IDEAL ======== */
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
     uint32_t test_case_id = 320;
 
     /* Parameters */
@@ -485,30 +479,27 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllDirectedIdeal) {
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     unit_tests::dm::all_from_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== PACKET SIZES ======== */
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllPacketSizes) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     uint32_t test_case_id = 321;
 
     /* Parameters */
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     unit_tests::dm::all_from_all::packet_sizes_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 2x2 to 1x1 ======== */
@@ -523,7 +514,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll2x2From1x1Direct
     CoreCoord sub_grid_size = {1, 1};
 
     unit_tests::dm::all_from_all::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 4x4 to 1x1 ======== */
@@ -538,7 +529,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll4x4From1x1Direct
     CoreCoord sub_grid_size = {1, 1};
 
     unit_tests::dm::all_from_all::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 1x1 to 2x2 ======== */
@@ -553,7 +544,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll1x1From2x2Direct
     CoreCoord sub_grid_size = {2, 2};
 
     unit_tests::dm::all_from_all::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 1x1 to 4x4 ======== */
@@ -568,7 +559,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll1x1From4x4Direct
     CoreCoord sub_grid_size = {4, 4};
 
     unit_tests::dm::all_from_all::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 2x2 to 2x2 ======== */
@@ -583,7 +574,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll2x2From2x2Direct
     CoreCoord sub_grid_size = {2, 2};
 
     unit_tests::dm::all_from_all::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== VIRTUAL CHANNELS ======== */
@@ -592,28 +583,25 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllVirtualChannels)
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 327;
 
-    unit_tests::dm::all_from_all::virtual_channels_test(get_mesh_device(), test_case_id);
+    unit_tests::dm::all_from_all::virtual_channels_test(this->device(), test_case_id);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllCustom) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 328;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     // Parameters
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     uint32_t num_of_transactions_per_subordinate = 256;
     uint32_t pages_per_transaction = 1;
     uint32_t num_virtual_channels = 4;
 
     unit_tests::dm::all_from_all::custom_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         mst_start_coord,
         sub_start_coord,
@@ -625,18 +613,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllCustom) {
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllPacketSizes2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
     uint32_t test_case_id = 329;
 
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     // On Quasar emulator, clamp to a 1x1 single-shot to fit the budget.
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         if (mst_grid_size.x < 1 || mst_grid_size.y < 1) {
             GTEST_SKIP() << "Skipping: Quasar emulator grid too small";
         }
@@ -645,23 +630,21 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllPacketSizes2_0) 
     }
 
     unit_tests::dm::all_from_all::packet_sizes_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllDirectedIdeal_2_0) {
     uint32_t test_id = 330;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-    auto arch_ = device->arch();
+    auto arch_ = this->device().arch();
 
     auto [bytes_per_page, max_reservable_bytes, max_reservable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     uint32_t num_of_transactions_per_subordinate = 1;
     uint32_t pages_reservable_per_transaction = max_reservable_pages / num_of_transactions_per_subordinate / 2;
@@ -689,19 +672,18 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllDirectedIdeal_2_
         .noc_id = NOC::NOC_1,
     };
 
-    EXPECT_TRUE(unit_tests::dm::all_from_all::run_dm(mesh_device, test_config));
+    EXPECT_TRUE(unit_tests::dm::all_from_all::run_dm(this->device(), test_config));
 }
 
 namespace {
 void all_from_all_grid_directed_ideal_2_0(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
     CoreCoord mst_grid_size,
     CoreCoord sub_grid_size) {
-    auto* device = mesh_device->impl().get_device(0);
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = mesh_device.compute_with_storage_grid_size();
     uint32_t required_x = std::max(mst_start_coord.x + mst_grid_size.x, sub_start_coord.x + sub_grid_size.x);
     uint32_t required_y = std::max(mst_start_coord.y + mst_grid_size.y, sub_start_coord.y + sub_grid_size.y);
     if (grid.x < required_x || grid.y < required_y) {
@@ -714,31 +696,29 @@ void all_from_all_grid_directed_ideal_2_0(
 }  // namespace
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll2x2From1x1DirectedIdeal_2_0) {
-    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 331, {0, 0}, {4, 4}, {2, 2}, {1, 1});
+    all_from_all_grid_directed_ideal_2_0(this->device(), 331, {0, 0}, {4, 4}, {2, 2}, {1, 1});
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll4x4From1x1DirectedIdeal_2_0) {
-    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 332, {0, 0}, {0, 0}, {4, 4}, {1, 1});
+    all_from_all_grid_directed_ideal_2_0(this->device(), 332, {0, 0}, {0, 0}, {4, 4}, {1, 1});
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll1x1From2x2DirectedIdeal_2_0) {
-    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 333, {0, 0}, {4, 4}, {1, 1}, {2, 2});
+    all_from_all_grid_directed_ideal_2_0(this->device(), 333, {0, 0}, {4, 4}, {1, 1}, {2, 2});
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll1x1From4x4DirectedIdeal_2_0) {
-    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 334, {0, 0}, {0, 0}, {1, 1}, {4, 4});
+    all_from_all_grid_directed_ideal_2_0(this->device(), 334, {0, 0}, {0, 0}, {1, 1}, {4, 4});
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAll2x2From2x2DirectedIdeal_2_0) {
-    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 335, {0, 0}, {0, 0}, {2, 2}, {2, 2});
+    all_from_all_grid_directed_ideal_2_0(this->device(), 335, {0, 0}, {0, 0}, {2, 2}, {2, 2});
 }
 
 /* ======== GRID + PACKET SIZE SWEEP ======== */
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllGridSweepPacketSizes2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = this->device().compute_with_storage_grid_size();
 
     uint32_t test_case_id = 336;
 
@@ -774,7 +754,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllFromAllGridSweepPacketS
         }
 
         unit_tests::dm::all_from_all::grid_packet_sizes_test(
-            mesh_device, test_case_id, mst_start_coord, sub_start_coord, gc.mst_grid, gc.sub_grid);
+            this->device(), test_case_id, mst_start_coord, sub_start_coord, gc.mst_grid, gc.sub_grid);
     }
 }
 

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -14,7 +15,6 @@
 #include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -54,9 +54,7 @@ struct AllToAllConfig {
 /// @param mesh_device The mesh device on which the test is executed.
 /// @param test_config Configuration of the test, defined by a specific struct.
 /// @return Status of the test execution (e.g., success or failure).
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToAllConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
+bool run_dm(distributed::MeshDevice& mesh_device, const AllToAllConfig& test_config) {
     /* ================ SETUP ================ */
 
     // Initialize core sets //
@@ -94,7 +92,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
 
     vector<uint32_t> sub_worker_coordinates = {};
     for (auto& sub_logical_core : corerange_to_cores(sub_logical_core_set)) {
-        CoreCoord sub_worker_core = device->worker_core_from_logical_core(sub_logical_core);
+        CoreCoord sub_worker_core = mesh_device.worker_core_from_logical_core(sub_logical_core);
         sub_worker_coordinates.push_back(sub_worker_core.x);
         sub_worker_coordinates.push_back(sub_worker_core.y);
     }
@@ -135,7 +133,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
     const uint32_t num_coord_varargs = (uint32_t)(num_subordinates * 2);
 
     DataMovementHardwareConfig sender_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         sender_hw_config = DataMovementGen2Config{};
     } else {
         sender_hw_config = DataMovementGen1Config{
@@ -163,7 +161,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
         }},
     };
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     ProgramRunArgs run_params;
     ProgramRunArgs::KernelRunArgs sender_run_params{.kernel = sender_spec.unique_id};
@@ -198,8 +196,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
 
     // Generate random input data for each master core
     for (auto& mst_logical_core : corerange_to_cores(mst_logical_core_set)) {
-        detail::WriteToDeviceL1(device, mst_logical_core, mst_l1_base_address, packed_input);
-        MetalContext::instance().get_cluster().l1_barrier(device->id());
+        slow_dispatch::WriteToL1(mesh_device, mst_logical_core, mst_l1_base_address, packed_input);
+        MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
     }
 
     // LAUNCH PROGRAM - Use mesh workload approach
@@ -209,7 +207,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
@@ -219,7 +217,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
     bool is_equal = false;
 
     for (auto& sub_logical_core : corerange_to_cores(sub_logical_core_set)) {
-        detail::ReadFromDeviceL1(device, sub_logical_core, sub_l1_base_address, bytes_per_transaction, packed_output);
+        slow_dispatch::ReadFromL1(
+            mesh_device, sub_logical_core, sub_l1_base_address, bytes_per_transaction, packed_output);
 
         // Results comparison
         is_equal = (packed_output == packed_golden);
@@ -237,7 +236,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
 }
 
 void directed_ideal_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
@@ -278,7 +277,7 @@ void directed_ideal_test(
 }
 
 void packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
@@ -292,12 +291,11 @@ void packet_sizes_test(
     /* Running the Test */
 
     uint32_t max_transactions_per_master = 256;
-    uint32_t max_reservable_pages_per_transaction = mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE
-                                                        ? 1024
-                                                        : 2048;  // Max total transaction size == 64 KB
+    uint32_t max_reservable_pages_per_transaction =
+        mesh_device.arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     // Cap sweep on Quasar emulator to avoid timeouts.
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         max_transactions_per_master = 1;
         max_reservable_pages_per_transaction = 1;
     }
@@ -337,8 +335,7 @@ void packet_sizes_test(
     }
 }
 
-void virtual_channels_test(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_case_id) {
-    auto* device = mesh_device->impl().get_device(0);
+void virtual_channels_test(distributed::MeshDevice& mesh_device, uint32_t test_case_id) {
     // Physical Constraints
     auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
         unit_tests::dm::compute_physical_constraints(mesh_device);
@@ -346,8 +343,8 @@ void virtual_channels_test(const shared_ptr<distributed::MeshDevice>& mesh_devic
     // Parameters for literal all-to-all (use the full grid for both master and subordinate)
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = mesh_device.compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     std::uint32_t max_num_pages_per_transaction = 1 << 12;
     std::uint32_t num_of_transactions = 256;  // Constant value
@@ -390,13 +387,11 @@ void virtual_channels_test(const shared_ptr<distributed::MeshDevice>& mesh_devic
 }
 
 void custom_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     uint32_t num_of_transactions,
     uint32_t pages_per_transaction,
     uint32_t num_virtual_channels) {
-    auto* device = mesh_device->impl().get_device(0);
-
     // Physical Constraints
     auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
         unit_tests::dm::compute_physical_constraints(mesh_device);
@@ -404,8 +399,8 @@ void custom_test(
     // Parameters for literal all-to-all (use the full grid for both master and subordinate)
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = mesh_device.compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     // Test config
     unit_tests::dm::all_to_all::AllToAllConfig test_config = {
@@ -427,7 +422,7 @@ void custom_test(
 }
 
 void grid_packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
@@ -439,10 +434,9 @@ void grid_packet_sizes_test(
         unit_tests::dm::compute_physical_constraints(mesh_device);
 
     uint32_t max_transactions_per_master = 256;
-    uint32_t max_reservable_pages_per_transaction =
-        mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE ? 1024 : 2048;
+    uint32_t max_reservable_pages_per_transaction = mesh_device.arch() == ARCH::BLACKHOLE ? 1024 : 2048;
 
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         max_transactions_per_master = 1;
         max_reservable_pages_per_transaction = 1;
     }
@@ -484,39 +478,33 @@ void grid_packet_sizes_test(
 
 /* ======== All to All ======== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     uint32_t test_case_id = 300;
 
     /* Parameters */
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     unit_tests::dm::all_to_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== PACKET SIZES ======== */
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllPacketSizes) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     uint32_t test_case_id = 301;
 
     /* Parameters */
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     unit_tests::dm::all_to_all::packet_sizes_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 2x2 to 1x1 ======== */
@@ -531,7 +519,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll2x2To1x1DirectedId
     CoreCoord sub_grid_size = {1, 1};
 
     unit_tests::dm::all_to_all::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 4x4 to 1x1 ======== */
@@ -546,7 +534,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll4x4To1x1DirectedId
     CoreCoord sub_grid_size = {1, 1};
 
     unit_tests::dm::all_to_all::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 1x1 to 2x2 ======== */
@@ -561,7 +549,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll1x1To2x2DirectedId
     CoreCoord sub_grid_size = {2, 2};
 
     unit_tests::dm::all_to_all::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 1x1 to 4x4 ======== */
@@ -576,7 +564,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll1x1To4x4DirectedId
     CoreCoord sub_grid_size = {4, 4};
 
     unit_tests::dm::all_to_all::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 2x2 to 2x2 ======== */
@@ -591,7 +579,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll2x2To2x2DirectedId
     CoreCoord sub_grid_size = {2, 2};
 
     unit_tests::dm::all_to_all::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== VIRTUAL CHANNELS ======== */
@@ -601,7 +589,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllVirtualChannels) {
 
     uint32_t test_case_id = 307;
 
-    unit_tests::dm::all_to_all::virtual_channels_test(get_mesh_device(), test_case_id);
+    unit_tests::dm::all_to_all::virtual_channels_test(this->device(), test_case_id);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllCustom) {
@@ -615,22 +603,19 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllCustom) {
     uint32_t num_virtual_channels = 4;
 
     unit_tests::dm::all_to_all::custom_test(
-        get_mesh_device(), test_case_id, num_of_transactions, pages_per_transaction, num_virtual_channels);
+        this->device(), test_case_id, num_of_transactions, pages_per_transaction, num_virtual_channels);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllPacketSizes2_0) {
     uint32_t test_id = 309;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     // On Quasar emulator, clamp to a 1x1 single-shot to fit the budget.
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         if (mst_grid_size.x < 1 || mst_grid_size.y < 1) {
             GTEST_SKIP() << "Skipping: Quasar emulator grid too small";
         }
@@ -639,23 +624,21 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllPacketSizes2_0) {
     }
 
     unit_tests::dm::all_to_all::packet_sizes_test(
-        mesh_device, test_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        this->device(), test_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllDirectedIdeal_2_0) {
     uint32_t test_id = 310;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-    auto arch_ = device->arch();
+    auto arch_ = this->device().arch();
 
     auto [bytes_per_page, max_reservable_bytes, max_reservable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
+    CoreCoord sub_grid_size = mst_grid_size;
 
     uint32_t num_of_transactions_per_master = 1;
     uint32_t pages_reservable_per_transaction = max_reservable_pages / num_of_transactions_per_master / 2;
@@ -683,19 +666,18 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllDirectedIdeal_2_0)
         .noc_id = NOC::NOC_0,
     };
 
-    EXPECT_TRUE(unit_tests::dm::all_to_all::run_dm(mesh_device, test_config));
+    EXPECT_TRUE(unit_tests::dm::all_to_all::run_dm(this->device(), test_config));
 }
 
 namespace {
 void all_to_all_grid_directed_ideal_2_0(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
     CoreCoord mst_grid_size,
     CoreCoord sub_grid_size) {
-    auto* device = mesh_device->impl().get_device(0);
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = mesh_device.compute_with_storage_grid_size();
     uint32_t required_x = std::max(mst_start_coord.x + mst_grid_size.x, sub_start_coord.x + sub_grid_size.x);
     uint32_t required_y = std::max(mst_start_coord.y + mst_grid_size.y, sub_start_coord.y + sub_grid_size.y);
     if (grid.x < required_x || grid.y < required_y) {
@@ -708,31 +690,29 @@ void all_to_all_grid_directed_ideal_2_0(
 }  // namespace
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll2x2To1x1DirectedIdeal_2_0) {
-    all_to_all_grid_directed_ideal_2_0(get_mesh_device(), 311, {0, 0}, {4, 4}, {2, 2}, {1, 1});
+    all_to_all_grid_directed_ideal_2_0(this->device(), 311, {0, 0}, {4, 4}, {2, 2}, {1, 1});
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll4x4To1x1DirectedIdeal_2_0) {
-    all_to_all_grid_directed_ideal_2_0(get_mesh_device(), 312, {0, 0}, {0, 0}, {4, 4}, {1, 1});
+    all_to_all_grid_directed_ideal_2_0(this->device(), 312, {0, 0}, {0, 0}, {4, 4}, {1, 1});
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll1x1To2x2DirectedIdeal_2_0) {
-    all_to_all_grid_directed_ideal_2_0(get_mesh_device(), 313, {0, 0}, {4, 4}, {1, 1}, {2, 2});
+    all_to_all_grid_directed_ideal_2_0(this->device(), 313, {0, 0}, {4, 4}, {1, 1}, {2, 2});
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll1x1To4x4DirectedIdeal_2_0) {
-    all_to_all_grid_directed_ideal_2_0(get_mesh_device(), 314, {0, 0}, {0, 0}, {1, 1}, {4, 4});
+    all_to_all_grid_directed_ideal_2_0(this->device(), 314, {0, 0}, {0, 0}, {1, 1}, {4, 4});
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal_2_0) {
-    all_to_all_grid_directed_ideal_2_0(get_mesh_device(), 315, {0, 0}, {0, 0}, {2, 2}, {2, 2});
+    all_to_all_grid_directed_ideal_2_0(this->device(), 315, {0, 0}, {0, 0}, {2, 2}, {2, 2});
 }
 
 /* ======== GRID + PACKET SIZE SWEEP ======== */
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllGridSweepPacketSizes2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = this->device().compute_with_storage_grid_size();
 
     uint32_t test_case_id = 316;
 
@@ -768,7 +748,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementAllToAllGridSweepPacketSiz
         }
 
         unit_tests::dm::all_to_all::grid_packet_sizes_test(
-            mesh_device, test_case_id, mst_start_coord, sub_start_coord, gc.mst_grid, gc.sub_grid);
+            this->device(), test_case_id, mst_start_coord, sub_start_coord, gc.mst_grid, gc.sub_grid);
     }
 }
 

--- a/tests/tt_metal/tt_metal/data_movement/atomics/test_atomic_semaphore_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/atomics/test_atomic_semaphore_bandwidth.cpp
@@ -5,6 +5,7 @@
 #include "device_fixture.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "../dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 
@@ -31,11 +32,7 @@ struct AtomicSemaphoreConfig {
 /// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test
 /// @return true if test passes, false otherwise
-bool run_atomic_semaphore_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, const AtomicSemaphoreConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
-
+bool run_atomic_semaphore_test(distributed::MeshDevice& mesh_device, const AtomicSemaphoreConfig& test_config) {
     std::cerr << "Sender core location X,Y: " << test_config.sender_core_coord.x << ","
               << test_config.sender_core_coord.y << std::endl;
     std::cerr << "Receiver core location X,Y: " << test_config.receiver_core_coord.x << ","
@@ -73,7 +70,7 @@ bool run_atomic_semaphore_test(
     uint32_t l1_base_address = sender_l1_info.base_address;
 
     // Physical Core Coordinates
-    CoreCoord physical_receiver_core = device->worker_core_from_logical_core(test_config.receiver_core_coord);
+    CoreCoord physical_receiver_core = mesh_device.worker_core_from_logical_core(test_config.receiver_core_coord);
     uint32_t packed_receiver_core_coordinates = physical_receiver_core.x << 16 | (physical_receiver_core.y & 0xFFFF);
 
     // Compile-time arguments for sender kernel
@@ -128,13 +125,19 @@ bool run_atomic_semaphore_test(
 
     // Initialize semaphores to zero on both cores
     vector<uint32_t> zero_semaphore = {0};
-    detail::WriteToDeviceL1(
-        device, test_config.sender_core_coord, l1_base_address + test_config.semaphore_addr_offset, zero_semaphore);
-    detail::WriteToDeviceL1(
-        device, test_config.receiver_core_coord, l1_base_address + test_config.semaphore_addr_offset, zero_semaphore);
+    slow_dispatch::WriteToL1(
+        mesh_device,
+        test_config.sender_core_coord,
+        l1_base_address + test_config.semaphore_addr_offset,
+        zero_semaphore);
+    slow_dispatch::WriteToL1(
+        mesh_device,
+        test_config.receiver_core_coord,
+        l1_base_address + test_config.semaphore_addr_offset,
+        zero_semaphore);
 
     // Barrier to ensure initialization is complete
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     // Launch the program using mesh workload approach
     auto mesh_workload = distributed::MeshWorkload();
@@ -142,7 +145,7 @@ bool run_atomic_semaphore_test(
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
@@ -150,14 +153,14 @@ bool run_atomic_semaphore_test(
 
     // Read final semaphore values for verification
     vector<uint32_t> sender_semaphore_result, receiver_semaphore_result;
-    detail::ReadFromDeviceL1(
-        device,
+    slow_dispatch::ReadFromL1(
+        mesh_device,
         test_config.sender_core_coord,
         l1_base_address + test_config.semaphore_addr_offset,
         sizeof(uint32_t),
         sender_semaphore_result);
-    detail::ReadFromDeviceL1(
-        device,
+    slow_dispatch::ReadFromL1(
+        mesh_device,
         test_config.receiver_core_coord,
         l1_base_address + test_config.semaphore_addr_offset,
         sizeof(uint32_t),
@@ -187,7 +190,7 @@ bool run_atomic_semaphore_test(
 
 /// @brief Bandwidth sweep test that varies transaction sizes and counts
 void increment_value_sweep_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord sender_core = {0, 1},
     CoreCoord receiver_core = {0, 0}) {
@@ -227,7 +230,7 @@ void increment_value_sweep_test(
 
 /// @brief Directed performance test with optimal parameters
 void directed_performance_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     uint32_t atomic_inc_value = 1,
     CoreCoord sender_core = {0, 0},
@@ -261,7 +264,7 @@ TEST_F(UnitMeshFastDispatchFixture, AtomicSemaphoreAdjacentIncrementValueSweep) 
     uint32_t test_id = 340;
 
     unit_tests::dm::atomics::increment_value_sweep_test(
-        get_mesh_device(),
+        this->device(),
         test_id,
         CoreCoord(0, 1),  // Sender core
         CoreCoord(0, 0)   // Receiver core
@@ -271,7 +274,7 @@ TEST_F(UnitMeshFastDispatchFixture, AtomicSemaphoreAdjacentIncrementValueSweep) 
 TEST_F(UnitMeshFastDispatchFixture, AtomicSemaphoreNonAdjacentIncrementValueSweep) {
     uint32_t test_id = 341;
 
-    auto logical_grid_size = get_mesh_device()->logical_grid_size();
+    auto logical_grid_size = this->device().logical_grid_size();
 
     TT_FATAL(logical_grid_size.x > 2 && logical_grid_size.y > 2, "Test assumes grid size is at least 3x3");
 
@@ -279,7 +282,7 @@ TEST_F(UnitMeshFastDispatchFixture, AtomicSemaphoreNonAdjacentIncrementValueSwee
     auto sender_core = CoreCoord(logical_grid_size.x - 2, logical_grid_size.y - 2);
 
     unit_tests::dm::atomics::increment_value_sweep_test(
-        get_mesh_device(),
+        this->device(),
         test_id,
         sender_core,     // Sender core
         CoreCoord(0, 0)  // Receiver core

--- a/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
@@ -7,9 +7,9 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -40,9 +40,7 @@ struct CoreBidirectionalConfig {
 /// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const CoreBidirectionalConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
+bool run_dm(distributed::MeshDevice& mesh_device, const CoreBidirectionalConfig& test_config) {
     /* ================ SETUP ================ */
 
     // Program
@@ -67,7 +65,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const CoreBi
     uint32_t l1_base_read_address = l1_base_write_address + (master_l1_info.size / 2);
 
     // Physical Core Coordinates
-    CoreCoord physical_subordinate_core = device->worker_core_from_logical_core(test_config.subordinate_core_coord);
+    CoreCoord physical_subordinate_core = mesh_device.worker_core_from_logical_core(test_config.subordinate_core_coord);
     uint32_t packed_subordinate_core_coordinates =
         physical_subordinate_core.x << 16 | (physical_subordinate_core.y & 0xFFFF);
 
@@ -158,9 +156,9 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const CoreBi
     std::vector<uint32_t> packed_golden = packed_input;
 
     // Write Input to Master L1
-    tt_metal::detail::WriteToDeviceL1(device, test_config.master_core_coord, l1_base_write_address, packed_input);
-    tt_metal::detail::WriteToDeviceL1(device, test_config.subordinate_core_coord, l1_base_read_address, packed_input);
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    slow_dispatch::WriteToL1(mesh_device, test_config.master_core_coord, l1_base_write_address, packed_input);
+    slow_dispatch::WriteToL1(mesh_device, test_config.subordinate_core_coord, l1_base_read_address, packed_input);
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
@@ -168,17 +166,25 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const CoreBi
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
     // Record Output from Subordinate L1
     std::vector<uint32_t> packed_sender_output;
     std::vector<uint32_t> packed_requestor_output;
-    tt_metal::detail::ReadFromDeviceL1(
-        device, test_config.subordinate_core_coord, l1_base_write_address, bytes_per_transaction, packed_sender_output);
-    tt_metal::detail::ReadFromDeviceL1(
-        device, test_config.master_core_coord, l1_base_read_address, bytes_per_transaction, packed_requestor_output);
+    slow_dispatch::ReadFromL1(
+        mesh_device,
+        test_config.subordinate_core_coord,
+        l1_base_write_address,
+        bytes_per_transaction,
+        packed_sender_output);
+    slow_dispatch::ReadFromL1(
+        mesh_device,
+        test_config.master_core_coord,
+        l1_base_read_address,
+        bytes_per_transaction,
+        packed_requestor_output);
 
     // Compare output with golden vector
     bool is_equal;
@@ -200,7 +206,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const CoreBi
 }
 
 void directed_ideal_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {0, 1},
@@ -232,7 +238,7 @@ void directed_ideal_test(
 }
 
 void same_vc_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {0, 1},
@@ -243,7 +249,7 @@ void same_vc_test(
 }
 
 void packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {1, 1},
@@ -253,10 +259,9 @@ void packet_sizes_test(
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     // Parameters
-    IDevice* device = mesh_device->impl().get_device(0);
     uint32_t max_transactions = 256;
     uint32_t max_pages_per_transaction =
-        device->arch() == tt::ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+        mesh_device.arch() == tt::ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t pages_per_transaction = 1; pages_per_transaction <= max_pages_per_transaction;
@@ -298,7 +303,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalDirectedI
     uint32_t write_vc = 0;
 
     unit_tests::dm::core_to_and_from_core::directed_ideal_test(
-        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
+        this->device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalDirectedIdealDifferentKernels) {
@@ -312,7 +317,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalDirectedI
     uint32_t write_vc = 0;
 
     unit_tests::dm::core_to_and_from_core::directed_ideal_test(
-        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
+        this->device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
 }
 
 // ========== Same VC Tests ==========
@@ -327,7 +332,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalSameVCSam
     CoreCoord subordinate_core_coord = {0, 1};
 
     unit_tests::dm::core_to_and_from_core::same_vc_test(
-        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
+        this->device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalSameVCDifferentKernels) {
@@ -340,7 +345,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalSameVCDif
     CoreCoord subordinate_core_coord = {0, 1};
 
     unit_tests::dm::core_to_and_from_core::same_vc_test(
-        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
+        this->device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
 }
 
 // ========== Write VC Sweep Tests ==========
@@ -359,7 +364,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalWriteVCSw
         uint32_t test_id = test_id_base + write_vc;
 
         unit_tests::dm::core_to_and_from_core::directed_ideal_test(
-            get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
+            this->device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
     }
 }
 
@@ -377,7 +382,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalWriteVCSw
         uint32_t test_id = test_id_base + write_vc;
 
         unit_tests::dm::core_to_and_from_core::directed_ideal_test(
-            get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
+            this->device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
     }
 }
 
@@ -391,7 +396,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalPacketSiz
     CoreCoord subordinate_core_coord = {1, 1};
 
     unit_tests::dm::core_to_and_from_core::packet_sizes_test(
-        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
+        this->device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalPacketSizesDifferentKernels) {
@@ -402,7 +407,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalPacketSiz
     CoreCoord subordinate_core_coord = {1, 1};
 
     unit_tests::dm::core_to_and_from_core::packet_sizes_test(
-        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
+        this->device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
 }
 
 // ========== Custom Test Case ==========
@@ -418,7 +423,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementCoreBidirectionalCustom) {
     uint32_t write_vc = 0;
 
     unit_tests::dm::core_to_and_from_core::directed_ideal_test(
-        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
+        this->device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
@@ -66,11 +66,12 @@ void sync_debug_servers_before_teardown() {
 }  // namespace
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
-    TT_FATAL(this->device().is_mmio_capable(), "Host hugepage test requires an MMIO-capable device");
+    IDevice* device = this->device().get_devices()[0];
+    TT_FATAL(device->is_mmio_capable(), "Host hugepage test requires an MMIO-capable device");
 
     auto& cluster = MetalContext::instance().get_cluster();
-    const ChipId mmio_device_id = cluster.get_associated_mmio_device(this->device().get_device_ids().front());
-    const uint16_t channel = cluster.get_assigned_channel_for_device(this->device().get_device_ids().front());
+    const ChipId mmio_device_id = cluster.get_associated_mmio_device(device->id());
+    const uint16_t channel = cluster.get_assigned_channel_for_device(device->id());
 
     void* host_hugepage_base = cluster.host_dma_address(0, mmio_device_id, channel);
     ASSERT_NE(host_hugepage_base, nullptr) << "Host hugepage is not mapped for this device";
@@ -79,12 +80,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
     ASSERT_GE(channel_size, kHostDstOffset + kTransferSizeBytes) << "Host channel too small for test buffers";
 
     // Device-side PCIe byte offsets mirror host hugepage offsets (see SimulationSysmemManager mapping).
-    const uint64_t pcie_base = cluster.get_pcie_base_addr_from_device(this->device().get_device_ids().front());
+    const uint64_t pcie_base = cluster.get_pcie_base_addr_from_device(device->id());
     const uint32_t host_src_pcie_addr = static_cast<uint32_t>(pcie_base + kHostSrcOffset);
     const uint32_t host_dst_pcie_addr = static_cast<uint32_t>(pcie_base + kHostDstOffset);
 
     const experimental::NodeCoord node{0, 0};
-    const uint32_t l1_base = this->device().allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
     const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
     const uint32_t l1_staging_addr = l1_base + l1_alignment * 8;
 

--- a/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
@@ -66,12 +66,11 @@ void sync_debug_servers_before_teardown() {
 }  // namespace
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
-    IDevice* device = this->device().get_devices()[0];
-    TT_FATAL(device->is_mmio_capable(), "Host hugepage test requires an MMIO-capable device");
+    TT_FATAL(this->device().is_mmio_capable(), "Host hugepage test requires an MMIO-capable device");
 
     auto& cluster = MetalContext::instance().get_cluster();
-    const ChipId mmio_device_id = cluster.get_associated_mmio_device(device->id());
-    const uint16_t channel = cluster.get_assigned_channel_for_device(device->id());
+    const ChipId mmio_device_id = cluster.get_associated_mmio_device(this->device().get_device_ids().front());
+    const uint16_t channel = cluster.get_assigned_channel_for_device(this->device().get_device_ids().front());
 
     void* host_hugepage_base = cluster.host_dma_address(0, mmio_device_id, channel);
     ASSERT_NE(host_hugepage_base, nullptr) << "Host hugepage is not mapped for this device";
@@ -80,12 +79,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
     ASSERT_GE(channel_size, kHostDstOffset + kTransferSizeBytes) << "Host channel too small for test buffers";
 
     // Device-side PCIe byte offsets mirror host hugepage offsets (see SimulationSysmemManager mapping).
-    const uint64_t pcie_base = cluster.get_pcie_base_addr_from_device(device->id());
+    const uint64_t pcie_base = cluster.get_pcie_base_addr_from_device(this->device().get_device_ids().front());
     const uint32_t host_src_pcie_addr = static_cast<uint32_t>(pcie_base + kHostSrcOffset);
     const uint32_t host_dst_pcie_addr = static_cast<uint32_t>(pcie_base + kHostDstOffset);
 
     const experimental::NodeCoord node{0, 0};
-    const uint32_t l1_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_base = this->device().allocator()->get_base_allocator_addr(HalMemType::L1);
     const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
     const uint32_t l1_staging_addr = l1_base + l1_alignment * 8;
 

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -5,9 +5,9 @@
 #include <tt-logger/tt-logger.hpp>
 #include "device_fixture.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -38,11 +38,7 @@ struct DirectWriteConfig {
 /// @param mesh_device MeshDevice to run on
 /// @param test_config Test configuration
 /// @return Success status
-bool run_dm(
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, const DirectWriteConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
-
+bool run_dm(distributed::MeshDevice& mesh_device, const DirectWriteConfig& test_config) {
     // Program
     Program program = CreateProgram();
 
@@ -75,9 +71,10 @@ bool run_dm(
     std::unordered_map<std::string, uint32_t> sender_compile_args;
 
     if (test_config.use_multicast) {
-        CoreCoord sub_worker_start_coord = device->worker_core_from_logical_core(test_config.receiver_core_coords[0]);
-        CoreCoord sub_worker_end_coord =
-            device->worker_core_from_logical_core(test_config.receiver_core_coords[test_config.num_subordinates - 1]);
+        CoreCoord sub_worker_start_coord =
+            mesh_device.worker_core_from_logical_core(test_config.receiver_core_coords[0]);
+        CoreCoord sub_worker_end_coord = mesh_device.worker_core_from_logical_core(
+            test_config.receiver_core_coords[test_config.num_subordinates - 1]);
 
         sender_compile_args = {
             {"test_id", test_config.test_id},
@@ -95,7 +92,8 @@ bool run_dm(
 
     } else {
         // Physical Core Coordinates
-        CoreCoord physical_receiver_core = device->worker_core_from_logical_core(test_config.receiver_core_coords[0]);
+        CoreCoord physical_receiver_core =
+            mesh_device.worker_core_from_logical_core(test_config.receiver_core_coords[0]);
         uint32_t packed_receiver_core_coordinates =
             physical_receiver_core.x << 16 | (physical_receiver_core.y & 0xFFFF);
 
@@ -145,9 +143,9 @@ bool run_dm(
     uint32_t init_words = test_config.same_destination ? 1 : test_config.num_writes;
     std::vector<uint32_t> init_data(init_words, 0x00000000);  // Initialize to zero
     for (int i = 0; i < test_config.num_subordinates; i++) {
-        tt_metal::detail::WriteToDeviceL1(device, test_config.receiver_core_coords[i], l1_base_address, init_data);
+        slow_dispatch::WriteToL1(mesh_device, test_config.receiver_core_coords[i], l1_base_address, init_data);
     }
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     // Launch the program - Use mesh workload approach
     auto mesh_workload = distributed::MeshWorkload();
@@ -155,7 +153,7 @@ bool run_dm(
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0));  // Single device at (0,0)
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
@@ -165,8 +163,8 @@ bool run_dm(
         // Read back and validate results
         std::vector<uint32_t> output_data;
         uint32_t read_bytes = init_words * sizeof(uint32_t);
-        tt_metal::detail::ReadFromDeviceL1(
-            device, test_config.receiver_core_coords[i], l1_base_address, read_bytes, output_data);
+        slow_dispatch::ReadFromL1(
+            mesh_device, test_config.receiver_core_coords[i], l1_base_address, read_bytes, output_data);
 
         if (test_config.same_destination) {
             // All writes went to same location
@@ -228,7 +226,7 @@ bool run_dm(
 }
 
 void performance_comparison_test(
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord sender_core = {0, 0},
     CoreCoord receiver_core = {1, 1}) {
@@ -255,7 +253,7 @@ void performance_comparison_test(
 }
 
 void address_pattern_test(
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord sender_core = {0, 0},
     CoreCoord receiver_core = {1, 1}) {
@@ -284,13 +282,8 @@ void address_pattern_test(
     }
 }
 
-void multicast_test(
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
-    uint32_t test_id,
-    CoreCoord sender_core = {0, 0}) {
-    IDevice* device = mesh_device->impl().get_device(0);
-
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+void multicast_test(distributed::MeshDevice& mesh_device, uint32_t test_id, CoreCoord sender_core = {0, 0}) {
+    auto compute_with_storage_grid_size = mesh_device.compute_with_storage_grid_size();
     uint32_t max_x = compute_with_storage_grid_size.x;
     uint32_t max_y = compute_with_storage_grid_size.y;
 
@@ -323,26 +316,26 @@ void multicast_test(
 }  // namespace unit_tests::dm::direct_write
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDirectWritePerformanceComparison) {
-    if (get_mesh_device()->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         GTEST_SKIP()
             << "Skipping on Quasar emulator: direct-write kernel executes but destination L1 remains unchanged";
     }
     uint32_t test_id = 500;
-    unit_tests::dm::direct_write::performance_comparison_test(get_mesh_device(), test_id);
+    unit_tests::dm::direct_write::performance_comparison_test(this->device(), test_id);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDirectWriteAddressPatterns) {
-    if (get_mesh_device()->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         GTEST_SKIP()
             << "Skipping on Quasar emulator: direct-write kernel executes but destination L1 remains unchanged";
     }
     uint32_t test_id = 501;
-    unit_tests::dm::direct_write::address_pattern_test(get_mesh_device(), test_id);
+    unit_tests::dm::direct_write::address_pattern_test(this->device(), test_id);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDirectWriteMulticast) {
     uint32_t test_id = 507;
-    unit_tests::dm::direct_write::multicast_test(get_mesh_device(), test_id);
+    unit_tests::dm::direct_write::multicast_test(this->device(), test_id);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
@@ -6,6 +6,7 @@
 #include "hal_types.hpp"
 #include <tt-metalium/mesh_device.hpp>
 #include <tuple>
+#include "impl/context/metal_context.hpp"
 #include "impl/emulation/emule_live_ranges.hpp"
 #include "impl/emulation/host_sanitizers.hpp"
 

--- a/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dm_common.hpp"
-#include "device_fixture.hpp"
 #include "hal_types.hpp"
 #include <tt-metalium/mesh_device.hpp>
 #include <tuple>
-#include <distributed/mesh_device_impl.hpp>
 #include "impl/emulation/emule_live_ranges.hpp"
 #include "impl/emulation/host_sanitizers.hpp"
 
@@ -22,15 +20,12 @@ uint32_t runtime_host_id = 0;
 // Static function for internal use only
 static uint32_t obtain_page_size_bytes(ARCH arch) { return (arch == ARCH::BLACKHOLE) ? 64 : 32; }
 
-L1AddressInfo get_l1_address_and_size(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const CoreCoord& core_coord) {
+L1AddressInfo get_l1_address_and_size(distributed::MeshDevice& mesh_device, const CoreCoord& core_coord) {
     // Obtaining L1 address and size for a specific core //
-    const IDevice* device = mesh_device->impl().get_device(0);
-
-    CoreCoord physical_core = device->worker_core_from_logical_core(core_coord);
+    CoreCoord physical_core = mesh_device.worker_core_from_logical_core(core_coord);
 
     const auto& hal = MetalContext::instance().hal();
-    HalProgrammableCoreType core_type = device->get_programmable_core_type(physical_core);
+    HalProgrammableCoreType core_type = mesh_device.get_programmable_core_type(physical_core);
     uint64_t core_l1_base_address = hal.get_dev_addr(core_type, HalL1MemAddrType::DEFAULT_UNRESERVED);
     uint64_t core_l1_size = hal.get_dev_size(core_type, HalL1MemAddrType::DEFAULT_UNRESERVED);
 
@@ -43,7 +38,7 @@ L1AddressInfo get_l1_address_and_size(
     if constexpr (emule::kEmuleAsanBuild) {
         if (emule::emule_asan_enabled()) {
             emule::LiveL1HostPokeRanges::add(
-                device->id(),
+                mesh_device.get_device_ids().front(),
                 static_cast<uint32_t>(core_l1_base_address),
                 static_cast<uint32_t>(core_l1_base_address + core_l1_size));
         }
@@ -61,10 +56,8 @@ DramAddressInfo get_dram_address_and_size() {
     return {dram_base_address, dram_size};
 }
 
-std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    const IDevice* device = mesh_device->impl().get_device(0);
-    ARCH arch = device->arch();
+std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(distributed::MeshDevice& mesh_device) {
+    ARCH arch = mesh_device.arch();
 
     // Use core {0,0} as representative core for computing physical constraints
     CoreCoord representative_core = {0, 0};

--- a/tests/tt_metal/tt_metal/data_movement/dm_common.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/dm_common.hpp
@@ -23,8 +23,7 @@ struct L1AddressInfo {
 };
 
 // Function to get L1 address and size
-L1AddressInfo get_l1_address_and_size(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const CoreCoord& core_coord = {0, 0});
+L1AddressInfo get_l1_address_and_size(distributed::MeshDevice& mesh_device, const CoreCoord& core_coord = {0, 0});
 
 struct DramAddressInfo {
     uint64_t base_address;
@@ -35,8 +34,7 @@ struct DramAddressInfo {
 DramAddressInfo get_dram_address_and_size();
 
 // Function to compute physical constraints
-std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device);
+std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(distributed::MeshDevice& mesh_device);
 
 }  // namespace tt::tt_metal::unit_tests::dm
 

--- a/tests/tt_metal/tt_metal/data_movement/dram_neighbour/test_dram_neighbour.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_neighbour/test_dram_neighbour.cpp
@@ -7,11 +7,11 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
-#include <distributed/mesh_device_impl.hpp>
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
@@ -66,8 +66,7 @@ void print_detailed_comparison(const vector<uint32_t>& packed_golden, const vect
 /// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test
 /// @return true if test passes
-bool run_dm_neighbour(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramNeighbourConfig& test_config) {
-    IDevice* device = mesh_device->impl().get_device(0);
+bool run_dm_neighbour(distributed::MeshDevice& mesh_device, const DramNeighbourConfig& test_config) {
     Program program = CreateProgram();
 
     uint32_t num_pages = test_config.num_banks * test_config.pages_per_bank;
@@ -104,8 +103,7 @@ bool run_dm_neighbour(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         .shard_orientation = ShardOrientation::ROW_MAJOR,
     };
 
-    auto mesh_buffer =
-        distributed::MeshBuffer::create(sharded_buffer_config, per_device_buffer_config, mesh_device.get());
+    auto mesh_buffer = distributed::MeshBuffer::create(sharded_buffer_config, per_device_buffer_config, &mesh_device);
     uint32_t input_buffer_address = mesh_buffer->address();  // need to read from different dram starting point
 
     // Generate input
@@ -145,7 +143,7 @@ bool run_dm_neighbour(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     // We only use the coordinator's semaphore - all cores increment it via NOC and poll until num_cores.
     // Creating on all cores ensures get_semaphore(id) works correctly on every core.
     CoreCoord coordinator_core = worker_cores[0];
-    CoreCoord coordinator_phys = device->worker_core_from_logical_core(coordinator_core);
+    CoreCoord coordinator_phys = mesh_device.worker_core_from_logical_core(coordinator_core);
 
     uint32_t reader_barrier_sem_id = 0;
     reader_barrier_sem_id = CreateSemaphore(program, core_range_set, 0);
@@ -178,7 +176,7 @@ bool run_dm_neighbour(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     program.set_runtime_id(runtime_host_id++);
 
     // LAUNCH PROGRAM - Use mesh workload approach
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueWriteMeshBuffer(cq, mesh_buffer, packed_input);
 
     auto mesh_workload = distributed::MeshWorkload();
@@ -202,7 +200,7 @@ bool run_dm_neighbour(const shared_ptr<distributed::MeshDevice>& mesh_device, co
             packed_output.push_back(packed_golden[j]);
         }
 
-        detail::ReadFromDeviceL1(device, worker_cores[i], l1_addr[i], per_core_output_size_bytes, cur_output);
+        slow_dispatch::ReadFromL1(mesh_device, worker_cores[i], l1_addr[i], per_core_output_size_bytes, cur_output);
 
         // Verify results
         bool is_equal = (packed_output == cur_output);
@@ -234,11 +232,10 @@ bool run_dm_neighbour(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     return true;
 }
 
-std::map<uint32_t, uint32_t> core_dram_mapping_ideal(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t num_dram_banks) {
+std::map<uint32_t, uint32_t> core_dram_mapping_ideal(distributed::MeshDevice& mesh_device, uint32_t num_dram_banks) {
     map<uint32_t, uint32_t> mapping;
     const vector<CoreCoord> dram_bank2core_coords =
-        mesh_device->get_optimal_dram_bank_to_logical_worker_assignment(tt::tt_metal::NOC::RISCV_0_default);
+        mesh_device.get_optimal_dram_bank_to_logical_worker_assignment(tt::tt_metal::NOC::RISCV_0_default);
 
     for (uint32_t i = 0; i < dram_bank2core_coords.size(); i++) {
         if (i == num_dram_banks) {
@@ -275,9 +272,9 @@ std::map<uint32_t, IndexRange> get_golden_index_ranges(
 }
 
 std::map<uint32_t, uint32_t> add_neighbour_cores_dram_mapping(
-    const std::map<uint32_t, uint32_t>& core_dram_map, const shared_ptr<distributed::MeshDevice>& mesh_device) {
+    const std::map<uint32_t, uint32_t>& core_dram_map, distributed::MeshDevice& mesh_device) {
     std::map<uint32_t, uint32_t> updated_map = core_dram_map;
-    CoreCoord grid_size = mesh_device->logical_grid_size();
+    CoreCoord grid_size = mesh_device.logical_grid_size();
 
     const auto& dispatch_cores =
         tt::tt_metal::MetalContext::instance().get_dispatch_query_manager().get_logical_dispatch_cores_on_user_chips();
@@ -307,9 +304,9 @@ std::map<uint32_t, uint32_t> add_neighbour_cores_dram_mapping(
     return updated_map;
 }
 
-std::map<uint32_t, uint32_t> add_single_row_cores_dram_mapping(const shared_ptr<distributed::MeshDevice>& mesh_device) {
+std::map<uint32_t, uint32_t> add_single_row_cores_dram_mapping(distributed::MeshDevice& mesh_device) {
     std::map<uint32_t, uint32_t> mapping = core_dram_mapping_ideal(mesh_device, 1);
-    CoreCoord grid_size = mesh_device->logical_grid_size();
+    CoreCoord grid_size = mesh_device.logical_grid_size();
 
     const auto& dispatch_cores =
         tt::tt_metal::MetalContext::instance().get_dispatch_query_manager().get_logical_dispatch_cores_on_user_chips();
@@ -334,7 +331,7 @@ std::map<uint32_t, uint32_t> add_single_row_cores_dram_mapping(const shared_ptr<
 }
 
 bool run_single_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     uint32_t num_of_transactions,
     uint32_t num_banks,
@@ -359,7 +356,7 @@ bool run_single_test(
 }
 
 bool run_sweep_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     uint32_t max_transactions,
     uint32_t num_banks,
@@ -384,7 +381,7 @@ bool run_sweep_test(
 }
 
 bool run_bank_sweep_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     uint32_t max_transactions,
     uint32_t max_num_banks,
@@ -419,19 +416,17 @@ using unit_tests::dm::dram_neighbour::run_single_test;
 using unit_tests::dm::dram_neighbour::run_sweep_test;
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourDirectedIdeal) {
-    shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
-
     uint32_t test_id = 502;
     uint32_t num_of_transactions = 1;
-    uint32_t num_banks = mesh_device->num_dram_channels();
+    uint32_t num_banks = this->device().num_dram_channels();
     uint32_t pages_per_bank = 1;
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
     std::map<uint32_t, uint32_t> core_dram_map =
-        add_neighbour_cores_dram_mapping(core_dram_mapping_ideal(mesh_device, num_banks), mesh_device);
+        add_neighbour_cores_dram_mapping(core_dram_mapping_ideal(this->device(), num_banks), this->device());
 
     EXPECT_TRUE(run_single_test(
-        mesh_device,
+        this->device(),
         test_id,
         num_of_transactions,
         num_banks,
@@ -442,19 +437,17 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourDirectedIdeal
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourNumPagesSweep) {
-    shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
-
     uint32_t test_id = 503;
-    uint32_t num_banks = mesh_device->num_dram_channels();
+    uint32_t num_banks = this->device().num_dram_channels();
     uint32_t max_num_pages = 32;
     uint32_t max_transactions = 256;
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
     std::map<uint32_t, uint32_t> core_dram_map =
-        add_neighbour_cores_dram_mapping(core_dram_mapping_ideal(mesh_device, num_banks), mesh_device);
+        add_neighbour_cores_dram_mapping(core_dram_mapping_ideal(this->device(), num_banks), this->device());
 
     EXPECT_TRUE(run_sweep_test(
-        mesh_device,
+        this->device(),
         test_id,
         max_transactions,
         num_banks,
@@ -465,22 +458,18 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourNumPagesSweep
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourNumBankSweep) {
-    shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
-
     uint32_t test_id = 504;
-    uint32_t max_num_banks = mesh_device->num_dram_channels();
+    uint32_t max_num_banks = this->device().num_dram_channels();
     uint32_t num_pages = 32;
     uint32_t max_transactions = 256;
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
 
     EXPECT_TRUE(run_bank_sweep_test(
-        mesh_device, test_id, max_transactions, max_num_banks, num_pages, page_size_bytes, l1_data_format));
+        this->device(), test_id, max_transactions, max_num_banks, num_pages, page_size_bytes, l1_data_format));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourSingleRowSweep) {
-    shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
-
     uint32_t test_id = 505;
     uint32_t num_banks = 1;
     uint32_t max_num_pages = 32;
@@ -488,10 +477,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourSingleRowSwee
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
 
-    std::map<uint32_t, uint32_t> core_dram_map = add_single_row_cores_dram_mapping(mesh_device);
+    std::map<uint32_t, uint32_t> core_dram_map = add_single_row_cores_dram_mapping(this->device());
 
     EXPECT_TRUE(run_sweep_test(
-        mesh_device,
+        this->device(),
         test_id,
         max_transactions,
         num_banks,
@@ -502,9 +491,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourSingleRowSwee
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourOneHopSweep) {
-    shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    auto logical_grid_size = device->logical_grid_size();
+    auto logical_grid_size = this->device().logical_grid_size();
 
     uint32_t test_id = 508;
     uint32_t num_banks = 1;
@@ -512,14 +499,14 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourOneHopSweep) 
     uint32_t max_transactions = 256;
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
-    std::map<uint32_t, uint32_t> core_dram_map = core_dram_mapping_ideal(mesh_device, num_banks);
+    std::map<uint32_t, uint32_t> core_dram_map = core_dram_mapping_ideal(this->device(), num_banks);
     CoreCoord singleCore = CoreCoord{core_dram_map.begin()->first >> 16, core_dram_map.begin()->first & 0xFFFF};
     core_dram_map
         [(static_cast<uint32_t>((singleCore.x + 1) % logical_grid_size.x) << 16) |
          static_cast<uint32_t>(singleCore.y)] = core_dram_map.begin()->second;
 
     EXPECT_TRUE(run_sweep_test(
-        mesh_device,
+        this->device(),
         test_id,
         max_transactions,
         num_banks,
@@ -530,9 +517,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourOneHopSweep) 
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourLoopBackSweep) {
-    shared_ptr<distributed::MeshDevice> mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    auto logical_grid_size = device->logical_grid_size();
+    auto logical_grid_size = this->device().logical_grid_size();
 
     uint32_t test_id = 509;
     uint32_t num_banks = 1;
@@ -540,14 +525,14 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDramNeighbourLoopBackSweep
     uint32_t max_transactions = 256;
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
-    std::map<uint32_t, uint32_t> core_dram_map = core_dram_mapping_ideal(mesh_device, num_banks);
+    std::map<uint32_t, uint32_t> core_dram_map = core_dram_mapping_ideal(this->device(), num_banks);
     CoreCoord singleCore = CoreCoord{core_dram_map.begin()->first >> 16, core_dram_map.begin()->first & 0xFFFF};
     core_dram_map
         [(static_cast<uint32_t>((singleCore.x == 0) ? logical_grid_size.x - 2 : singleCore.x - 1) << 16) |
          static_cast<uint32_t>(singleCore.y)] = core_dram_map.begin()->second;
 
     EXPECT_TRUE(run_sweep_test(
-        mesh_device,
+        this->device(),
         test_id,
         max_transactions,
         num_banks,

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -16,7 +17,6 @@
 #include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -42,10 +42,7 @@ struct DramShardedConfig {
 /// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramShardedConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
-
+bool run_dm(distributed::MeshDevice& mesh_device, const DramShardedConfig& test_config) {
     uint32_t num_pages = test_config.num_banks * test_config.pages_per_bank;
     const size_t total_size_bytes = num_pages * test_config.page_size_bytes;
 
@@ -71,8 +68,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
         .shard_orientation = ShardOrientation::ROW_MAJOR,
     };
 
-    auto mesh_buffer =
-        distributed::MeshBuffer::create(sharded_buffer_config, per_device_buffer_config, mesh_device.get());
+    auto mesh_buffer = distributed::MeshBuffer::create(sharded_buffer_config, per_device_buffer_config, &mesh_device);
     uint32_t input_buffer_address = mesh_buffer->address();
 
     // Input
@@ -107,7 +103,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
     std::vector<std::string> named_rtas = {"src_addr", "l1_addr"};
 
     DataMovementHardwareConfig reader_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         reader_hw_config = DataMovementGen2Config{};
     } else {
         reader_hw_config = DataMovementGen1Config{
@@ -134,7 +130,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
         }},
     };
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     ProgramRunArgs run_params;
     ProgramRunArgs::KernelRunArgs reader_run_params{.kernel = reader_spec.unique_id};
@@ -157,7 +153,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
     // Launch program and record outputs
     vector<uint32_t> packed_output;
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueWriteMeshBuffer(cq, mesh_buffer, packed_input);
 
     auto mesh_workload = distributed::MeshWorkload();
@@ -169,8 +165,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
-    detail::ReadFromDeviceL1(
-        device, corerange_to_cores(test_config.cores)[0], l1_addr, total_size_bytes, packed_output);
+    slow_dispatch::ReadFromL1(
+        mesh_device, corerange_to_cores(test_config.cores)[0], l1_addr, total_size_bytes, packed_output);
 
     // Results comparison
     bool is_equal = (packed_output == packed_golden);
@@ -189,7 +185,6 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
 
 /* ========== Directed Ideal Test Case; Test id = 84 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
     const uint32_t test_id = 84;
 
     // Parameters
@@ -205,24 +200,22 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadDirectedIde
     unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
         .test_id = test_id,
         .num_of_transactions = num_of_transactions,
-        .num_banks = mesh_device->num_dram_channels(),
+        .num_banks = this->device().num_dram_channels(),
         .pages_per_bank = 32,
         .page_size_bytes = page_size_bytes,
         .l1_data_format = l1_data_format,
         .cores = core_range_set};
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
 /* ========== Sweep over varying number of tiles per DRAM bank; Test id = 85 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTileNumbers) {
-    auto mesh_device = get_mesh_device();
-
     // Parameters
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
-    uint32_t num_banks = mesh_device->num_dram_channels();
+    uint32_t num_banks = this->device().num_dram_channels();
     uint32_t max_num_pages = 32;
     uint32_t max_transactions = 256;
 
@@ -243,19 +236,17 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTileNumbers
                 .cores = core_range_set};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 /* ========== Sweep over varying number of DRAM banks; Test id = 86 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadBankNumbers) {
-    auto mesh_device = get_mesh_device();
-
     // Parameters
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
-    uint32_t max_num_banks = mesh_device->num_dram_channels();
+    uint32_t max_num_banks = this->device().num_dram_channels();
     uint32_t num_pages = 32;
     uint32_t max_transactions = 256;
 
@@ -276,15 +267,13 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadBankNumbers
                 .cores = core_range_set};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 /* ========== Directed Ideal Test Case with Transaction IDs; Test id = 87 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTridDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-
     // Parameters
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
@@ -298,7 +287,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTridDirecte
     unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
         .test_id = 87,
         .num_of_transactions = num_of_transactions,
-        .num_banks = mesh_device->num_dram_channels(),
+        .num_banks = this->device().num_dram_channels(),
         .pages_per_bank = 32,
         .page_size_bytes = page_size_bytes,
         .l1_data_format = l1_data_format,
@@ -307,12 +296,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTridDirecte
         .num_of_trids = 16};
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadDirectedIdeal2_0) {
-    auto mesh_device = get_mesh_device();
-
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
 
@@ -325,23 +312,21 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadDirectedIde
     unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
         .test_id = 94,
         .num_of_transactions = num_of_transactions,
-        .num_banks = mesh_device->num_dram_channels(),
+        .num_banks = this->device().num_dram_channels(),
         .pages_per_bank = 32,
         .page_size_bytes = page_size_bytes,
         .l1_data_format = l1_data_format,
         .cores = core_range_set,
     };
 
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTileNumbers2_0) {
-    auto mesh_device = get_mesh_device();
-
     // Parameters
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
-    uint32_t num_banks = mesh_device->num_dram_channels();
+    uint32_t num_banks = this->device().num_dram_channels();
 
     // Cap sweep on Quasar emulator to avoid timeouts.
     const bool is_quasar = MetalContext::instance().get_cluster().arch() == ARCH::QUASAR;
@@ -366,17 +351,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTileNumbers
             };
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadBankNumbers2_0) {
-    auto mesh_device = get_mesh_device();
-
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
-    uint32_t max_num_banks = mesh_device->num_dram_channels();
+    uint32_t max_num_banks = this->device().num_dram_channels();
     uint32_t num_pages = 32;
 
     const bool is_quasar = MetalContext::instance().get_cluster().arch() == ARCH::QUASAR;
@@ -397,14 +380,12 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadBankNumbers
                 .cores = core_range_set,
             };
 
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTridDirectedIdeal_2_0) {
-    auto mesh_device = get_mesh_device();
-
     // Parameters
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
@@ -418,7 +399,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTridDirecte
     unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
         .test_id = 97,
         .num_of_transactions = num_of_transactions,
-        .num_banks = mesh_device->num_dram_channels(),
+        .num_banks = this->device().num_dram_channels(),
         .pages_per_bank = 32,
         .page_size_bytes = page_size_bytes,
         .l1_data_format = l1_data_format,
@@ -428,7 +409,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMShardedReadTridDirecte
     };
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -15,7 +15,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
-#include <distributed/mesh_device_impl.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -41,8 +41,7 @@ struct DramConfig {
 /// @param test_config - Configuration of the test -- see struct
 /// @param fixture - DispatchFixture pointer for dispatch-aware operations
 /// @return
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramConfig& test_config) {
-    IDevice* device = mesh_device->impl().get_device(0);
+bool run_dm(distributed::MeshDevice& mesh_device, const DramConfig& test_config) {
     // SETUP
 
     const size_t total_size_bytes = test_config.pages_per_transaction * test_config.bytes_per_page;
@@ -92,7 +91,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
     };
 
     DataMovementHardwareConfig reader_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         reader_hw_config = DataMovementGen2Config{};
     } else {
         reader_hw_config = DataMovementGen1Config{
@@ -115,7 +114,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
     };
 
     DataMovementHardwareConfig writer_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         writer_hw_config = DataMovementGen2Config{};
     } else {
         writer_hw_config = DataMovementGen1Config{
@@ -148,7 +147,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
         }},
     };
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     ProgramRunArgs run_params;
     ProgramRunArgs::KernelRunArgs reader_run{.kernel = reader_spec.unique_id};
@@ -187,8 +186,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
     vector<uint32_t> packed_golden = packed_input;
 
     // Write Input to DRAM
-    detail::WriteToDeviceDRAMChannel(device, test_config.dram_channel, input_dram_address, packed_input);
-    MetalContext::instance().get_cluster().dram_barrier(device->id());
+    slow_dispatch::WriteToDRAMChannel(mesh_device, test_config.dram_channel, input_dram_address, packed_input);
+    MetalContext::instance().get_cluster().dram_barrier(mesh_device.get_device_ids().front());
 
     // LAUNCH PROGRAM - Use mesh workload approach
     auto mesh_workload = distributed::MeshWorkload();
@@ -196,18 +195,19 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
     // Read Intermediate Output from L1 (for debugging purposes)
     vector<uint32_t> packed_intermediate_output;
-    detail::ReadFromDeviceL1(device, test_config.core_coord, l1_address, total_size_bytes, packed_intermediate_output);
+    slow_dispatch::ReadFromL1(
+        mesh_device, test_config.core_coord, l1_address, total_size_bytes, packed_intermediate_output);
 
     // Read Output from DRAM
     vector<uint32_t> packed_output;
-    detail::ReadFromDeviceDRAMChannel(
-        device, test_config.dram_channel, output_dram_address, total_size_bytes, packed_output);
+    slow_dispatch::ReadFromDRAMChannel(
+        mesh_device, test_config.dram_channel, output_dram_address, total_size_bytes, packed_output);
 
     // Results comparison
     bool is_equal = (packed_output == packed_golden);
@@ -224,7 +224,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
 }
 
 void directed_ideal_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     CoreCoord core_coord = {0, 0},
     uint32_t dram_channel = 0,
@@ -236,7 +236,7 @@ void directed_ideal_test(
     // Parameters
     uint32_t num_of_transactions = 256;
     uint32_t pages_per_transaction = max_transmittable_pages;
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         num_of_transactions = 4;
         pages_per_transaction = 4;
     }
@@ -258,7 +258,7 @@ void directed_ideal_test(
 }
 
 void packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     CoreCoord core_coord = {0, 0},
     uint32_t dram_channel = 0) {
@@ -299,7 +299,7 @@ void packet_sizes_test(
 /* ========== Test case for varying transaction numbers and sizes; Test id = 0 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMPacketSizes) {
     unit_tests::dm::dram::packet_sizes_test(
-        get_mesh_device(),
+        this->device(),
         0,      // Test case ID
         {0, 0}  // Core coordinates (default)
     );
@@ -309,21 +309,18 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMPacketSizes) {
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMCoreLocations) {
     uint32_t test_case_id = 1;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     CoreCoord core_coord;
     uint32_t dram_channel = 0;
 
     // Cores
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     log_info(LogTest, "Grid size x: {}, y: {}", grid_size.x, grid_size.y);
 
     for (unsigned int x = 0; x < grid_size.x; x++) {
         for (unsigned int y = 0; y < grid_size.y; y++) {
             core_coord = {x, y};
 
-            unit_tests::dm::dram::directed_ideal_test(mesh_device, test_case_id, core_coord, dram_channel);
+            unit_tests::dm::dram::directed_ideal_test(this->device(), test_case_id, core_coord, dram_channel);
         }
     }
 }
@@ -334,24 +331,20 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMCoreLocations) {
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMChannels) {
     uint32_t test_case_id = 2;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     CoreCoord core_coord = {0, 0};
 
-    for (unsigned int dram_channel = 0; dram_channel < device->num_dram_channels(); dram_channel++) {
+    for (unsigned int dram_channel = 0; dram_channel < this->device().num_dram_channels(); dram_channel++) {
         for (unsigned int vc = 0; vc < 4; vc++) {
-            unit_tests::dm::dram::directed_ideal_test(mesh_device, test_case_id, core_coord, dram_channel, vc);
+            unit_tests::dm::dram::directed_ideal_test(this->device(), test_case_id, core_coord, dram_channel, vc);
         }
     }
 }
 
 /* ========== Directed ideal test case; Test id = 3 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::dram::DramConfig test_config = {
             .test_id = 3,
             .num_of_transactions = 4,
@@ -360,23 +353,22 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMDirectedIdeal) {
             .l1_data_format = DataFormat::Float16_b,
             .core_coord = {0, 0},
             .dram_channel = 0};
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
     // Test ID (Arbitrary)
     uint32_t test_id = 3;
-    unit_tests::dm::dram::directed_ideal_test(mesh_device, test_id);
+    unit_tests::dm::dram::directed_ideal_test(this->device(), test_id);
 }
 
 /* ========== Test case for varying transaction numbers and sizes with 2.0 API; Test id = 40 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMPacketSizes2_0) {
-    auto mesh_device = get_mesh_device();
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // Quasar emulator: full sweep is too slow (same as legacy
         // TensixDataMovementDRAMPacketSizes timed out). Run a single small config to
         // exercise the Metal 2.0 host path + DRAM read/write+ semaphore handshake.
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::dram::DramConfig test_config = {
             .test_id = 40,
             .num_of_transactions = 4,
@@ -387,17 +379,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMPacketSizes2_0) {
             .dram_channel = 0,
             .virtual_channel = 0,
         };
-        EXPECT_TRUE(unit_tests::dm::dram::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::dram::run_dm(this->device(), test_config));
         return;
     }
-    unit_tests::dm::dram::packet_sizes_test(mesh_device, 40, {0, 0}, 0);
+    unit_tests::dm::dram::packet_sizes_test(this->device(), 40, {0, 0}, 0);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMDirectedIdeal2_0) {
-    auto mesh_device = get_mesh_device();
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::dram::DramConfig test_config = {
             .test_id = 41,
             .num_of_transactions = 4,
@@ -408,41 +399,35 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMDirectedIdeal2_0) {
             .dram_channel = 0,
             .virtual_channel = 0,
         };
-        EXPECT_TRUE(unit_tests::dm::dram::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::dram::run_dm(this->device(), test_config));
         return;
     }
-    unit_tests::dm::dram::directed_ideal_test(mesh_device, 41, {0, 0}, 0, 0);
+    unit_tests::dm::dram::directed_ideal_test(this->device(), 41, {0, 0}, 0, 0);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMCoreLocations2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
-    if (device->arch() == ARCH::QUASAR) {
-        unit_tests::dm::dram::directed_ideal_test(mesh_device, 42, {0, 0}, 0, 0);
+    if (this->device().arch() == ARCH::QUASAR) {
+        unit_tests::dm::dram::directed_ideal_test(this->device(), 42, {0, 0}, 0, 0);
         return;
     }
 
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     for (unsigned int x = 0; x < grid_size.x; x++) {
         for (unsigned int y = 0; y < grid_size.y; y++) {
-            unit_tests::dm::dram::directed_ideal_test(mesh_device, 42, {x, y}, 0, 0);
+            unit_tests::dm::dram::directed_ideal_test(this->device(), 42, {x, y}, 0, 0);
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMChannels2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
-    if (device->arch() == ARCH::QUASAR) {
-        unit_tests::dm::dram::directed_ideal_test(mesh_device, 43, {0, 0}, 0, 0);
+    if (this->device().arch() == ARCH::QUASAR) {
+        unit_tests::dm::dram::directed_ideal_test(this->device(), 43, {0, 0}, 0, 0);
         return;
     }
 
-    for (unsigned int dram_channel = 0; dram_channel < device->num_dram_channels(); dram_channel++) {
+    for (unsigned int dram_channel = 0; dram_channel < this->device().num_dram_channels(); dram_channel++) {
         for (unsigned int vc = 0; vc < 4; vc++) {
-            unit_tests::dm::dram::directed_ideal_test(mesh_device, 43, {0, 0}, dram_channel, vc);
+            unit_tests::dm::dram::directed_ideal_test(this->device(), 43, {0, 0}, dram_channel, vc);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -7,10 +7,10 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -37,24 +37,21 @@ struct InterleavedConfig {
 /// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const InterleavedConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
-
+bool run_dm(distributed::MeshDevice& mesh_device, const InterleavedConfig& test_config) {
     // Program
     Program program = CreateProgram();
 
     const size_t total_size_bytes = test_config.num_pages * test_config.page_size_bytes;
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::ReplicatedBufferConfig global_config{.size = total_size_bytes};
     distributed::DeviceLocalBufferConfig local_config{
         .page_size = test_config.page_size_bytes,
         .buffer_type = test_config.is_dram ? BufferType::DRAM : BufferType::L1};
-    auto input_buffer = distributed::MeshBuffer::create(global_config, local_config, mesh_device.get());
+    auto input_buffer = distributed::MeshBuffer::create(global_config, local_config, &mesh_device);
     uint32_t input_buffer_address = input_buffer->address();
 
-    auto output_buffer = distributed::MeshBuffer::create(global_config, local_config, mesh_device.get());
+    auto output_buffer = distributed::MeshBuffer::create(global_config, local_config, &mesh_device);
     uint32_t output_buffer_address = output_buffer->address();
 
     TT_FATAL(input_buffer_address != output_buffer_address, "Input and output buffer addresses must be different");
@@ -156,13 +153,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Interl
     if (test_config.read_kernel) {
         distributed::EnqueueWriteMeshBuffer(cq, input_buffer, packed_input, /*blocking=*/true);
         if (test_config.is_dram) {
-            MetalContext::instance().get_cluster().dram_barrier(device->id());
+            MetalContext::instance().get_cluster().dram_barrier(mesh_device.get_device_ids().front());
         } else {
-            MetalContext::instance().get_cluster().l1_barrier(device->id());
+            MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
         }
     } else {
-        detail::WriteToDeviceL1(device, corerange_to_cores(test_config.cores)[0], l1_addr, packed_input);
-        MetalContext::instance().get_cluster().l1_barrier(device->id());
+        slow_dispatch::WriteToL1(mesh_device, corerange_to_cores(test_config.cores)[0], l1_addr, packed_input);
+        MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
     }
 
     auto mesh_workload = distributed::MeshWorkload();
@@ -178,8 +175,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Interl
         distributed::ReadShard(
             cq, packed_output, output_buffer, distributed::MeshCoordinate(coord_data), /*blocking=*/true);
     } else {
-        detail::ReadFromDeviceL1(
-            device, corerange_to_cores(test_config.cores)[0], l1_addr, total_size_bytes, packed_output);
+        slow_dispatch::ReadFromL1(
+            mesh_device, corerange_to_cores(test_config.cores)[0], l1_addr, total_size_bytes, packed_output);
     }
 
     // Results comparison
@@ -201,11 +198,9 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Interl
 
 /* ========== Test case for varying number of pages; Test id = 61 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageNumbers) {
-    auto mesh_device = get_mesh_device();
-
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -235,7 +230,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageNumbers
                 .cores = core_range_set};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
@@ -250,9 +245,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageCoreLoc
     uint32_t num_of_transactions = 16;
 
     // Cores
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     log_info(tt::LogTest, "Grid size x: {}, y: {}", grid_size.x, grid_size.y);
     for (unsigned int x = 0; x < grid_size.x; x++) {
         for (unsigned int y = 0; y < grid_size.y; y++) {
@@ -268,17 +261,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageCoreLoc
                 .cores = core_range_set};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 /* ========== Test noc_async_read_page kernel only; Test id = 63 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageReadNumbers) {
-    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -311,17 +303,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageReadNum
                 .write_kernel = false};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 /* ========== Test noc_async_write_page kernel only; Test id = 64 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageWriteNumbers) {
-    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -354,17 +345,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageWriteNu
                 .write_kernel = true};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 /* ========== Directed Ideal Test Case; Test id = 65 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t num_pages = 16;
@@ -384,17 +374,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageDirecte
         .cores = core_range_set};
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
 /* ========== Test noc_async_read_page kernel only with swapped noc; Test id = 72 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageReadNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
-    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -428,7 +417,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageReadNoc
                 .default_noc = false};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
@@ -437,10 +426,9 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageReadNoc
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageWriteNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
-    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -474,7 +462,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageWriteNo
                 .default_noc = false};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
@@ -483,10 +471,9 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementDRAMInterleavedPageWriteNo
 
 /* ========== Test case for varying number of pages using interleaved L1; Test id = 66 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageNumbers) {
-    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -517,7 +504,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageNumbers) 
                 .is_dram = false};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
@@ -531,9 +518,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageCoreLocat
     uint32_t page_size_bytes = 32 * 32 * 2;  // = tile
 
     // Cores
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     log_info(tt::LogTest, "Grid size x: {}, y: {}", grid_size.x, grid_size.y);
     for (unsigned int x = 0; x < grid_size.x; x++) {
         for (unsigned int y = 0; y < grid_size.y; y++) {
@@ -550,17 +535,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageCoreLocat
                 .is_dram = false};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 /* ========== Test noc_async_read_page only; Test id = 68 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageReadNumbers) {
-    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -593,16 +577,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageReadNumbe
                 .write_kernel = false};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 /* ========== Test noc_async_write_page only; Test id = 69 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageWriteNumbers) {
-    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -635,17 +618,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageWriteNumb
                 .write_kernel = true};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 /* ========== Directed Ideal Test Case; Test id = 71 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t num_pages = 16;
@@ -666,17 +648,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageDirectedI
         .is_dram = false};
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
 /* ========== Test noc_async_read_page only with swapped noc; Test id = 74 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageReadNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
-    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -710,7 +691,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageReadNocSw
                 .default_noc = false};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
@@ -718,10 +699,9 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageReadNocSw
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageWriteNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
-    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -755,7 +735,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementL1InterleavedPageWriteNocS
                 .default_noc = false};
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -15,7 +15,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
-#include <distributed/mesh_device_impl.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -48,9 +48,7 @@ struct LoopbackConfig {
 /// @param test_config - Configuration of the test -- see struct
 /// @param fixture - DispatchFixture pointer for dispatch-aware operations
 /// @return
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const LoopbackConfig& test_config) {
-    IDevice* device = mesh_device->impl().get_device(0);
-
+bool run_dm(distributed::MeshDevice& mesh_device, const LoopbackConfig& test_config) {
     // Buffer Parameters
     const uint32_t transaction_size_bytes = test_config.transaction_size_pages * test_config.page_size_bytes;
 
@@ -72,7 +70,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
     uint32_t subordinate_l1_byte_address =
         master_l1_info.base_address + transaction_size_bytes;  // Offset for subordinate data
 
-    CoreCoord worker = device->worker_core_from_logical_core(test_config.master_core_coord);
+    CoreCoord worker = mesh_device.worker_core_from_logical_core(test_config.master_core_coord);
 
     using namespace tt::tt_metal::experimental;
 
@@ -88,7 +86,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
     };
 
     DataMovementHardwareConfig sender_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         sender_hw_config = DataMovementGen2Config{};
     } else {
         sender_hw_config = DataMovementGen1Config{
@@ -121,7 +119,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
         }},
     };
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     ProgramRunArgs run_params;
     ProgramRunArgs::KernelRunArgs sender_run_params{.kernel = sender_spec.unique_id};
@@ -153,8 +151,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
     vector<uint32_t> packed_golden = packed_input;
 
     // Write Input to Master L1
-    detail::WriteToDeviceL1(device, test_config.master_core_coord, master_l1_byte_address, packed_input);
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    slow_dispatch::WriteToL1(mesh_device, test_config.master_core_coord, master_l1_byte_address, packed_input);
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     // Launch program and record outputs
     auto mesh_workload = distributed::MeshWorkload();
@@ -162,14 +160,14 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
     // Record Output from Subordinate L1 (same core, different address)
     vector<uint32_t> packed_output;
-    detail::ReadFromDeviceL1(
-        device, test_config.master_core_coord, subordinate_l1_byte_address, transaction_size_bytes, packed_output);
+    slow_dispatch::ReadFromL1(
+        mesh_device, test_config.master_core_coord, subordinate_l1_byte_address, transaction_size_bytes, packed_output);
 
     // Results comparison
     bool is_equal = (packed_output == packed_golden);
@@ -186,8 +184,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
 
 /* ========== Test case for loopback data movement; ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackPacketSizes) {
-    auto mesh_device = get_mesh_device();
-    auto arch_ = mesh_device->impl().get_device(0)->arch();
+    auto arch_ = this->device().arch();
 
     if (arch_ == ARCH::QUASAR) {
         // Single run to validate the Quasar code path within emulator 3-min timeout
@@ -200,7 +197,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackPacketSizes) {
             .l1_data_format = DataFormat::Float16_b,
             .noc_id = NOC::NOC_0,
         };
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
 
@@ -227,19 +224,18 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackPacketSizes) {
             };
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-    auto arch_ = mesh_device->impl().get_device(0)->arch();
+    auto arch_ = this->device().arch();
 
     uint32_t test_id = 55;
 
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
     // Use reduced params for Quasar emulator to fit within 3-min timeout
     uint32_t num_of_transactions = arch_ == ARCH::QUASAR ? 4 : 128;
@@ -259,13 +255,12 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackDirectedIdeal) {
         .noc_id = noc_id};
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
 /* ========== Metal 2.0 variants ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackPacketSizes_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto arch_ = mesh_device->impl().get_device(0)->arch();
+    auto arch_ = this->device().arch();
 
     if (arch_ == ARCH::QUASAR) {
         // Single small config on Quasar emulator to fit within 3-min timeout while still
@@ -279,7 +274,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackPacketSizes_2_0) {
             .l1_data_format = DataFormat::Float16_b,
             .noc_id = NOC::NOC_0,
         };
-        EXPECT_TRUE(unit_tests::dm::core_loopback::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_loopback::run_dm(this->device(), test_config));
         return;
     }
 
@@ -302,19 +297,18 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackPacketSizes_2_0) {
                 .l1_data_format = DataFormat::Float16_b,
                 .noc_id = noc_id,
             };
-            EXPECT_TRUE(unit_tests::dm::core_loopback::run_dm(mesh_device, test_config));
+            EXPECT_TRUE(unit_tests::dm::core_loopback::run_dm(this->device(), test_config));
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackDirectedIdeal_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto arch_ = mesh_device->impl().get_device(0)->arch();
+    auto arch_ = this->device().arch();
 
     uint32_t test_id = 45;
 
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
     uint32_t num_of_transactions = arch_ == ARCH::QUASAR ? 4 : 128;
     uint32_t transaction_size_pages = max_transmittable_pages / (num_of_transactions * 2);
@@ -329,7 +323,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementLoopbackDirectedIdeal_2_0)
         .noc_id = NOC::NOC_0,
     };
 
-    EXPECT_TRUE(unit_tests::dm::core_loopback::run_dm(mesh_device, test_config));
+    EXPECT_TRUE(unit_tests::dm::core_loopback::run_dm(this->device(), test_config));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d.cpp
@@ -7,11 +7,11 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
-#include <distributed/mesh_device_impl.hpp>
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
@@ -29,11 +29,9 @@ uint32_t runtime_host_id = 0;
 
 /// @brief 1D matmul: column 0 is the fixed in0 sender, row 0 is the fixed in1 sender
 ///        (reads its full column from DRAM once, then K-loop multicasts down the column).
-bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, const MatmulTestConfig& test_config) {
-    IDevice* device = mesh_device->impl().get_device(0);
-
+bool run_dm_1d_matmul(distributed::MeshDevice& mesh_device, const MatmulTestConfig& test_config) {
     // Check that the requested grid fits within the device's compute grid.
-    auto compute_grid = device->compute_with_storage_grid_size();
+    auto compute_grid = mesh_device.compute_with_storage_grid_size();
     if (test_config.end_logical_core.x >= compute_grid.x || test_config.end_logical_core.y >= compute_grid.y) {
         log_info(
             tt::LogTest,
@@ -76,8 +74,8 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     CoreRangeSet in0_cores({CoreRange(in0_logical_start_coord, in0_logical_end_coord)});
     vector<CoreCoord> in0_cores_list = corerange_to_cores(in0_cores);
 
-    CoreCoord matmul_physical_start_coord = device->worker_core_from_logical_core(test_config.start_logical_core);
-    CoreCoord matmul_physical_end_coord = device->worker_core_from_logical_core(test_config.end_logical_core);
+    CoreCoord matmul_physical_start_coord = mesh_device.worker_core_from_logical_core(test_config.start_logical_core);
+    CoreCoord matmul_physical_end_coord = mesh_device.worker_core_from_logical_core(test_config.end_logical_core);
 
     uint32_t in0_pages = (test_config.num_subblocks_r_dim * test_config.subblock_r_dim) *
                          (test_config.num_subblocks_k_dim * test_config.subblock_k_dim);
@@ -106,7 +104,7 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         }
         dim_r_to_in0_pages_map[in0_cores_list[i].y] =
             vector<uint32_t>(in0_per_core_pages.begin(), in0_per_core_pages.end());
-        detail::WriteToDeviceL1(device, in0_cores_list[i], l1_base_address, in0_per_core_pages);
+        slow_dispatch::WriteToL1(mesh_device, in0_cores_list[i], l1_base_address, in0_per_core_pages);
         in0_per_core_pages.clear();
     }
 
@@ -115,8 +113,8 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
 
     DramAddressInfo dram_info = unit_tests::dm::get_dram_address_and_size();
     uint32_t input_dram_address = dram_info.base_address;
-    detail::WriteToDeviceDRAMChannel(device, test_config.dram_bank_id, input_dram_address, in1_input);
-    MetalContext::instance().get_cluster().dram_barrier(device->id());
+    slow_dispatch::WriteToDRAMChannel(mesh_device, test_config.dram_bank_id, input_dram_address, in1_input);
+    MetalContext::instance().get_cluster().dram_barrier(mesh_device.get_device_ids().front());
 
     uint32_t in1_per_core_read_size_bytes = in1_pages_bytes / test_config.num_subblocks_c_dim;
     vector<uint32_t> in1_per_core_read_addr;
@@ -151,7 +149,7 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     uint32_t risc1_barrier_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc1_barrier_done_sem_id = CreateSemaphore(program, matmul_cores, 0);
 
-    CoreCoord barrier_coordinator_phys = device->worker_core_from_logical_core(matmul_cores_list[0]);
+    CoreCoord barrier_coordinator_phys = mesh_device.worker_core_from_logical_core(matmul_cores_list[0]);
     uint32_t num_cores = matmul_cores_list.size();
 
     uint32_t risc0_local_barrier_addr = (in1_mcast_output_addr + in1_per_core_read_size_bytes + 15) & ~15U;
@@ -240,14 +238,13 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
     for (auto & i : matmul_cores_list) {
         vector<uint32_t> in0_read_output;
-        detail::ReadFromDeviceL1(
-            device, i, in0_mcast_output_addr, pages_per_core_size_bytes, in0_read_output);
+        slow_dispatch::ReadFromL1(mesh_device, i, in0_mcast_output_addr, pages_per_core_size_bytes, in0_read_output);
         const vector<uint32_t>& expected_in0_read_output = dim_r_to_in0_pages_map[i.y];
         bool is_equal = (expected_in0_read_output == in0_read_output);
         if (!is_equal) {
@@ -266,7 +263,7 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     uint32_t total_in1_read_elements = in1_per_core_read_size_bytes / sizeof(uint32_t);
     for (auto & i : matmul_cores_list) {
         vector<uint32_t> in1_read_output;
-        detail::ReadFromDeviceL1(device, i, in1_mcast_output_addr, in1_per_core_read_size_bytes, in1_read_output);
+        slow_dispatch::ReadFromL1(mesh_device, i, in1_mcast_output_addr, in1_per_core_read_size_bytes, in1_read_output);
         uint32_t cur_c_dim = i.x - test_config.start_logical_core.x;
         for (uint32_t j = 0; j < total_in1_read_elements; j++) {
             golden_in1_read_output.push_back(in1_input[cur_c_dim * total_in1_read_elements + j]);
@@ -290,7 +287,7 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     return true;
 }
 
-bool run_single_test(const shared_ptr<distributed::MeshDevice>& mesh_device, MatmulTestConfig test_config) {
+bool run_single_test(distributed::MeshDevice& mesh_device, MatmulTestConfig test_config) {
     test_config.test_id += unit_tests::dm::matmul::MATMUL_1D_TEST_ID_OFFSET;
     test_config.page_size_bytes = 2048;
     test_config.end_logical_core = CoreCoord(
@@ -299,7 +296,7 @@ bool run_single_test(const shared_ptr<distributed::MeshDevice>& mesh_device, Mat
     return run_dm_1d_matmul(mesh_device, test_config);
 }
 
-bool run_multiple_test(const shared_ptr<distributed::MeshDevice>& mesh_device, const MatmulTestConfig& test_config) {
+bool run_multiple_test(distributed::MeshDevice& mesh_device, const MatmulTestConfig& test_config) {
     auto or_scalar = [](const std::vector<uint32_t>& v, uint32_t scalar) {
         return v.empty() ? std::vector<uint32_t>{scalar} : v;
     };
@@ -338,7 +335,7 @@ bool run_multiple_test(const shared_ptr<distributed::MeshDevice>& mesh_device, c
 }  // namespace unit_tests::dm::one_d_matmul
 
 TEST_P(Matmul1DParamFixture, Test1DMatmul) {
-    EXPECT_TRUE(unit_tests::dm::one_d_matmul::run_multiple_test(get_mesh_device(), GetParam()));
+    EXPECT_TRUE(unit_tests::dm::one_d_matmul::run_multiple_test(this->device(), GetParam()));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d_v2.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d_v2.cpp
@@ -7,11 +7,11 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
-#include <distributed/mesh_device_impl.hpp>
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
@@ -29,11 +29,9 @@ uint32_t runtime_host_id = 0;
 
 /// @brief 1D matmul v2: in0 senders rotate round-robin across columns; in1 keeps the
 ///        v1 row-0 fixed-sender DRAM-read path.
-bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device, const MatmulTestConfig& test_config) {
-    IDevice* device = mesh_device->impl().get_device(0);
-
+bool run_dm_1d_matmul_v2(distributed::MeshDevice& mesh_device, const MatmulTestConfig& test_config) {
     // Check that the requested grid fits within the device's compute grid.
-    auto compute_grid = device->compute_with_storage_grid_size();
+    auto compute_grid = mesh_device.compute_with_storage_grid_size();
     if (test_config.end_logical_core.x >= compute_grid.x || test_config.end_logical_core.y >= compute_grid.y) {
         log_info(
             tt::LogTest,
@@ -70,13 +68,13 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     CoreRangeSet matmul_cores({CoreRange(test_config.start_logical_core, test_config.end_logical_core)});
     vector<CoreCoord> matmul_cores_list = corerange_to_cores(matmul_cores);
 
-    CoreCoord matmul_physical_start_coord = device->worker_core_from_logical_core(test_config.start_logical_core);
-    CoreCoord matmul_physical_end_coord = device->worker_core_from_logical_core(test_config.end_logical_core);
+    CoreCoord matmul_physical_start_coord = mesh_device.worker_core_from_logical_core(test_config.start_logical_core);
+    CoreCoord matmul_physical_end_coord = mesh_device.worker_core_from_logical_core(test_config.end_logical_core);
 
     vector<uint32_t> col_phys_x(grid_cols);
     for (uint32_t c = 0; c < grid_cols; c++) {
         CoreCoord logical_col_core(test_config.start_logical_core.x + c, test_config.start_logical_core.y);
-        CoreCoord phys = device->worker_core_from_logical_core(logical_col_core);
+        CoreCoord phys = mesh_device.worker_core_from_logical_core(logical_col_core);
         col_phys_x[c] = phys.x;
     }
 
@@ -138,7 +136,7 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
         }
 
         if (!core_in0_data.empty()) {
-            detail::WriteToDeviceL1(device, core_idx, l1_base_address, core_in0_data);
+            slow_dispatch::WriteToL1(mesh_device, core_idx, l1_base_address, core_in0_data);
         }
     }
 
@@ -147,8 +145,8 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
 
     DramAddressInfo dram_info = unit_tests::dm::get_dram_address_and_size();
     uint32_t input_dram_address = dram_info.base_address;
-    detail::WriteToDeviceDRAMChannel(device, test_config.dram_bank_id, input_dram_address, in1_input);
-    MetalContext::instance().get_cluster().dram_barrier(device->id());
+    slow_dispatch::WriteToDRAMChannel(mesh_device, test_config.dram_bank_id, input_dram_address, in1_input);
+    MetalContext::instance().get_cluster().dram_barrier(mesh_device.get_device_ids().front());
 
     vector<uint32_t> in1_per_core_read_addr;
     in1_per_core_read_addr.reserve(C);
@@ -169,7 +167,7 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t risc1_barrier_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc1_barrier_done_sem_id = CreateSemaphore(program, matmul_cores, 0);
 
-    CoreCoord barrier_coordinator_phys = device->worker_core_from_logical_core(matmul_cores_list[0]);
+    CoreCoord barrier_coordinator_phys = mesh_device.worker_core_from_logical_core(matmul_cores_list[0]);
     uint32_t num_cores = matmul_cores_list.size();
 
     uint32_t risc0_local_barrier_addr = (in1_mcast_output_addr + in1_per_core_read_size_bytes + 15) & ~15U;
@@ -271,15 +269,14 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
     // Each core should hold all K subblocks for its row, in order.
     for (auto & i : matmul_cores_list) {
         vector<uint32_t> in0_read_output;
-        detail::ReadFromDeviceL1(
-            device, i, in0_mcast_output_addr, in0_output_total_bytes, in0_read_output);
+        slow_dispatch::ReadFromL1(mesh_device, i, in0_mcast_output_addr, in0_output_total_bytes, in0_read_output);
         const vector<uint32_t>& expected_in0_read_output = dim_r_to_in0_pages_map[i.y];
         bool is_equal = (expected_in0_read_output == in0_read_output);
         if (!is_equal) {
@@ -297,7 +294,7 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t total_in1_read_elements = in1_per_core_read_size_bytes / sizeof(uint32_t);
     for (auto & i : matmul_cores_list) {
         vector<uint32_t> in1_read_output;
-        detail::ReadFromDeviceL1(device, i, in1_mcast_output_addr, in1_per_core_read_size_bytes, in1_read_output);
+        slow_dispatch::ReadFromL1(mesh_device, i, in1_mcast_output_addr, in1_per_core_read_size_bytes, in1_read_output);
         uint32_t cur_c_dim = i.x - test_config.start_logical_core.x;
         for (uint32_t j = 0; j < total_in1_read_elements; j++) {
             golden_in1_read_output.push_back(in1_input[cur_c_dim * total_in1_read_elements + j]);
@@ -320,7 +317,7 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     return true;
 }
 
-bool run_single_test(const shared_ptr<distributed::MeshDevice>& mesh_device, MatmulTestConfig test_config) {
+bool run_single_test(distributed::MeshDevice& mesh_device, MatmulTestConfig test_config) {
     test_config.test_id += unit_tests::dm::matmul::MATMUL_1D_V2_TEST_ID_OFFSET;
     test_config.page_size_bytes = 2048;
     test_config.end_logical_core = CoreCoord(
@@ -329,7 +326,7 @@ bool run_single_test(const shared_ptr<distributed::MeshDevice>& mesh_device, Mat
     return run_dm_1d_matmul_v2(mesh_device, test_config);
 }
 
-bool run_multiple_test(const shared_ptr<distributed::MeshDevice>& mesh_device, const MatmulTestConfig& test_config) {
+bool run_multiple_test(distributed::MeshDevice& mesh_device, const MatmulTestConfig& test_config) {
     auto or_scalar = [](const std::vector<uint32_t>& v, uint32_t scalar) {
         return v.empty() ? std::vector<uint32_t>{scalar} : v;
     };
@@ -368,7 +365,7 @@ bool run_multiple_test(const shared_ptr<distributed::MeshDevice>& mesh_device, c
 }  // namespace unit_tests::dm::one_d_matmul_v2
 
 TEST_P(Matmul1DV2ParamFixture, Test1DMatmulV2) {
-    EXPECT_TRUE(unit_tests::dm::one_d_matmul_v2::run_multiple_test(get_mesh_device(), GetParam()));
+    EXPECT_TRUE(unit_tests::dm::one_d_matmul_v2::run_multiple_test(this->device(), GetParam()));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_2d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_2d.cpp
@@ -7,11 +7,11 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
-#include <distributed/mesh_device_impl.hpp>
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
@@ -29,11 +29,9 @@ uint32_t runtime_host_id = 0;
 
 /// @brief 2D matmul: rotating sender on both axes (in0 round-robin across columns,
 ///        in1 round-robin across rows). No DRAM — host writes all data to L1.
-bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, const MatmulTestConfig& test_config) {
-    IDevice* device = mesh_device->impl().get_device(0);
-
+bool run_dm_2d_matmul(distributed::MeshDevice& mesh_device, const MatmulTestConfig& test_config) {
     // Check that the requested grid fits within the device's compute grid.
-    auto compute_grid = device->compute_with_storage_grid_size();
+    auto compute_grid = mesh_device.compute_with_storage_grid_size();
     if (test_config.end_logical_core.x >= compute_grid.x || test_config.end_logical_core.y >= compute_grid.y) {
         log_info(
             tt::LogTest,
@@ -70,20 +68,20 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     CoreRangeSet matmul_cores({CoreRange(test_config.start_logical_core, test_config.end_logical_core)});
     vector<CoreCoord> matmul_cores_list = corerange_to_cores(matmul_cores);
 
-    CoreCoord matmul_physical_start_coord = device->worker_core_from_logical_core(test_config.start_logical_core);
-    CoreCoord matmul_physical_end_coord = device->worker_core_from_logical_core(test_config.end_logical_core);
+    CoreCoord matmul_physical_start_coord = mesh_device.worker_core_from_logical_core(test_config.start_logical_core);
+    CoreCoord matmul_physical_end_coord = mesh_device.worker_core_from_logical_core(test_config.end_logical_core);
 
     vector<uint32_t> col_phys_x(grid_cols);
     for (uint32_t c = 0; c < grid_cols; c++) {
         CoreCoord logical_col_core(test_config.start_logical_core.x + c, test_config.start_logical_core.y);
-        CoreCoord phys = device->worker_core_from_logical_core(logical_col_core);
+        CoreCoord phys = mesh_device.worker_core_from_logical_core(logical_col_core);
         col_phys_x[c] = phys.x;
     }
 
     vector<uint32_t> row_phys_y(grid_rows);
     for (uint32_t r = 0; r < grid_rows; r++) {
         CoreCoord logical_row_core(test_config.start_logical_core.x, test_config.start_logical_core.y + r);
-        CoreCoord phys = device->worker_core_from_logical_core(logical_row_core);
+        CoreCoord phys = mesh_device.worker_core_from_logical_core(logical_row_core);
         row_phys_y[r] = phys.y;
     }
 
@@ -161,7 +159,7 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
             }
         }
         if (!core_in0_data.empty()) {
-            detail::WriteToDeviceL1(device, core, l1_base_address, core_in0_data);
+            slow_dispatch::WriteToL1(mesh_device, core, l1_base_address, core_in0_data);
         }
 
         vector<uint32_t> core_in1_data;
@@ -173,7 +171,7 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
             }
         }
         if (!core_in1_data.empty()) {
-            detail::WriteToDeviceL1(device, core, in1_source_addr, core_in1_data);
+            slow_dispatch::WriteToL1(mesh_device, core, in1_source_addr, core_in1_data);
         }
     }
 
@@ -190,7 +188,7 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     uint32_t risc1_barrier_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc1_barrier_done_sem_id = CreateSemaphore(program, matmul_cores, 0);
 
-    CoreCoord barrier_coordinator_phys = device->worker_core_from_logical_core(matmul_cores_list[0]);
+    CoreCoord barrier_coordinator_phys = mesh_device.worker_core_from_logical_core(matmul_cores_list[0]);
     uint32_t num_cores = matmul_cores_list.size();
 
     vector<uint32_t> risc0_compile_args = {
@@ -297,14 +295,14 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
     // Each core should hold all K subblocks for its row, in order.
     for (const auto& core : matmul_cores_list) {
         vector<uint32_t> in0_read_output;
-        detail::ReadFromDeviceL1(device, core, in0_mcast_output_addr, in0_output_total_bytes, in0_read_output);
+        slow_dispatch::ReadFromL1(mesh_device, core, in0_mcast_output_addr, in0_output_total_bytes, in0_read_output);
         const vector<uint32_t>& expected_in0 = dim_r_to_in0_pages_map[core.y];
         bool is_equal = (expected_in0 == in0_read_output);
         if (!is_equal) {
@@ -320,7 +318,7 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     // Each core should hold all K subblocks for its column, in order.
     for (const auto& core : matmul_cores_list) {
         vector<uint32_t> in1_read_output;
-        detail::ReadFromDeviceL1(device, core, in1_mcast_output_addr, in1_output_total_bytes, in1_read_output);
+        slow_dispatch::ReadFromL1(mesh_device, core, in1_mcast_output_addr, in1_output_total_bytes, in1_read_output);
         const vector<uint32_t>& expected_in1 = dim_c_to_in1_pages_map[core.x];
         bool is_equal = (expected_in1 == in1_read_output);
         if (!is_equal) {
@@ -336,7 +334,7 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     return true;
 }
 
-bool run_single_test(const shared_ptr<distributed::MeshDevice>& mesh_device, MatmulTestConfig test_config) {
+bool run_single_test(distributed::MeshDevice& mesh_device, MatmulTestConfig test_config) {
     test_config.test_id += unit_tests::dm::matmul::MATMUL_2D_TEST_ID_OFFSET;
     test_config.page_size_bytes = 2048;
     test_config.end_logical_core = CoreCoord(
@@ -345,7 +343,7 @@ bool run_single_test(const shared_ptr<distributed::MeshDevice>& mesh_device, Mat
     return run_dm_2d_matmul(mesh_device, test_config);
 }
 
-bool run_multiple_test(const shared_ptr<distributed::MeshDevice>& mesh_device, const MatmulTestConfig& test_config) {
+bool run_multiple_test(distributed::MeshDevice& mesh_device, const MatmulTestConfig& test_config) {
     auto or_scalar = [](const std::vector<uint32_t>& v, uint32_t scalar) {
         return v.empty() ? std::vector<uint32_t>{scalar} : v;
     };
@@ -384,7 +382,7 @@ bool run_multiple_test(const shared_ptr<distributed::MeshDevice>& mesh_device, c
 }  // namespace unit_tests::dm::two_d_matmul
 
 TEST_P(Matmul2DParamFixture, Test2DMatmul) {
-    EXPECT_TRUE(unit_tests::dm::two_d_matmul::run_multiple_test(get_mesh_device(), GetParam()));
+    EXPECT_TRUE(unit_tests::dm::two_d_matmul::run_multiple_test(this->device(), GetParam()));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -7,10 +7,10 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -36,16 +36,13 @@ struct MultiInterleavedConfig {
 /// @param mesh_device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiInterleavedConfig& test_config) {
+bool run_dm(distributed::MeshDevice& mesh_device, const MultiInterleavedConfig& test_config) {
     log_info(
         tt::LogTest,
         "num transaction {}, num pages: {}, page size bytes: {}",
         test_config.num_of_transactions,
         test_config.num_pages,
         test_config.page_size_bytes);
-
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
 
     // Program
     Program program = CreateProgram();
@@ -54,14 +51,14 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
     const size_t per_core_size_bytes = test_config.num_pages * test_config.page_size_bytes;
     const size_t total_buffer_size_bytes = num_cores * per_core_size_bytes;
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::ReplicatedBufferConfig global_config{.size = total_buffer_size_bytes};
     distributed::DeviceLocalBufferConfig local_config{
         .page_size = test_config.page_size_bytes, .buffer_type = BufferType::DRAM};
-    auto input_buffer = distributed::MeshBuffer::create(global_config, local_config, mesh_device.get());
+    auto input_buffer = distributed::MeshBuffer::create(global_config, local_config, &mesh_device);
     uint32_t input_buffer_address = input_buffer->address();
 
-    auto output_buffer = distributed::MeshBuffer::create(global_config, local_config, mesh_device.get());
+    auto output_buffer = distributed::MeshBuffer::create(global_config, local_config, &mesh_device);
     uint32_t output_buffer_address = output_buffer->address();
 
     TT_FATAL(input_buffer_address != output_buffer_address, "Input and output buffer addresses must be different");
@@ -132,7 +129,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
     // We only use the coordinator's semaphore - all cores increment it via NOC and poll until num_cores.
     // Creating on all cores ensures get_semaphore(id) works correctly on every core.
     CoreCoord coordinator_core = core_list[0];
-    CoreCoord coordinator_phys = device->worker_core_from_logical_core(coordinator_core);
+    CoreCoord coordinator_phys = mesh_device.worker_core_from_logical_core(coordinator_core);
 
     uint32_t reader_barrier_sem_id = 0;
     uint32_t writer_barrier_sem_id = 0;
@@ -213,16 +210,16 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
 
     if (test_config.read_kernel) {
         distributed::EnqueueWriteMeshBuffer(cq, input_buffer, packed_input, /*blocking=*/true);
-        MetalContext::instance().get_cluster().dram_barrier(device->id());
+        MetalContext::instance().get_cluster().dram_barrier(mesh_device.get_device_ids().front());
     } else {
         // If not reading, write each core's slice to L1 directly
         const size_t per_core_words = per_core_size_bytes / sizeof(uint32_t);
         for (size_t i = 0; i < num_cores; ++i) {
             vector<uint32_t> core_input(
                 packed_input.begin() + i * per_core_words, packed_input.begin() + (i + 1) * per_core_words);
-            detail::WriteToDeviceL1(device, core_list[i], l1_addrs[i], core_input);
+            slow_dispatch::WriteToL1(mesh_device, core_list[i], l1_addrs[i], core_input);
         }
-        MetalContext::instance().get_cluster().l1_barrier(device->id());
+        MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
     }
 
     auto mesh_workload = distributed::MeshWorkload();
@@ -252,7 +249,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
         // Each core reads different pages, verify each core's L1 against its slice
         const size_t per_core_words = per_core_size_bytes / sizeof(uint32_t);
         for (size_t i = 0; i < num_cores; ++i) {
-            detail::ReadFromDeviceL1(device, core_list[i], l1_addrs[i], per_core_size_bytes, packed_output);
+            slow_dispatch::ReadFromL1(mesh_device, core_list[i], l1_addrs[i], per_core_size_bytes, packed_output);
             vector<uint32_t> core_golden(
                 packed_golden.begin() + i * per_core_words, packed_golden.begin() + (i + 1) * per_core_words);
             is_equal = (packed_output == core_golden);
@@ -270,7 +267,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
 }
 
 void directed_ideal_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord mst_grid_size,
@@ -307,7 +304,7 @@ void directed_ideal_test(
 }
 
 void packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord mst_grid_size,
@@ -355,17 +352,14 @@ void packet_sizes_test(
     }
 }
 
-void grid_packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_case_id, bool read, bool write) {
-    auto* device = mesh_device->impl().get_device(0);
-
+void grid_packet_sizes_test(distributed::MeshDevice& mesh_device, uint32_t test_case_id, bool read, bool write) {
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;
     uint32_t max_num_pages = 256;
 
-    CoreCoord full_grid = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord full_grid = mesh_device.compute_with_storage_grid_size();
     std::vector<CoreCoord> grid_sizes = {{2, 2}, {6, 6}, full_grid};
 
     for (auto& grid_size : grid_sizes) {
@@ -406,74 +400,56 @@ void grid_packet_sizes_test(
 
 /* ========== Full grid directed ideal ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     uint32_t test_case_id = 110;
     CoreCoord mst_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
     unit_tests::dm::multi_interleaved::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, mst_grid_size, true, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
 /* ========== Full grid packet sizes sweep ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedSizes) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     uint32_t test_case_id = 111;
     CoreCoord mst_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
     unit_tests::dm::multi_interleaved::packet_sizes_test(
-        mesh_device, test_case_id, mst_start_coord, mst_grid_size, true, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
 /* ========== Full grid read kernel directed ideal ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedReadDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     uint32_t test_case_id = 112;
     CoreCoord mst_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
     unit_tests::dm::multi_interleaved::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, mst_grid_size, true, false);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
 /* ========== Full grid read kernel packet sizes sweep ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedReadSizes) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     uint32_t test_case_id = 113;
     CoreCoord mst_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
     unit_tests::dm::multi_interleaved::packet_sizes_test(
-        mesh_device, test_case_id, mst_start_coord, mst_grid_size, true, false);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
 /* ========== Full grid write kernel directed ideal ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedWriteDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     uint32_t test_case_id = 114;
     CoreCoord mst_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
     unit_tests::dm::multi_interleaved::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, mst_grid_size, false, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
 /* ========== Full grid write kernel packet sizes sweep ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedWriteSizes) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     uint32_t test_case_id = 115;
     CoreCoord mst_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = this->device().compute_with_storage_grid_size();
     unit_tests::dm::multi_interleaved::packet_sizes_test(
-        mesh_device, test_case_id, mst_start_coord, mst_grid_size, false, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
 /* ========== 2x2 CORE TESTS ========== */
@@ -483,7 +459,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedDirecte
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
     unit_tests::dm::multi_interleaved::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedSizes) {
@@ -491,7 +467,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedSizes) 
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
     unit_tests::dm::multi_interleaved::packet_sizes_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedReadDirectedIdeal) {
@@ -499,7 +475,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedReadDir
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
     unit_tests::dm::multi_interleaved::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedReadSizes) {
@@ -507,7 +483,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedReadSiz
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
     unit_tests::dm::multi_interleaved::packet_sizes_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedWriteDirectedIdeal) {
@@ -515,7 +491,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedWriteDi
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
     unit_tests::dm::multi_interleaved::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedWriteSizes) {
@@ -523,7 +499,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement2x2MultiInterleavedWriteSi
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {2, 2};
     unit_tests::dm::multi_interleaved::packet_sizes_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
 /* ========== 6x6 CORE TESTS ========== */
@@ -533,7 +509,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedDirecte
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
     unit_tests::dm::multi_interleaved::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedSizes) {
@@ -541,7 +517,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedSizes) 
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
     unit_tests::dm::multi_interleaved::packet_sizes_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedReadDirectedIdeal) {
@@ -549,7 +525,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedReadDir
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
     unit_tests::dm::multi_interleaved::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedReadSizes) {
@@ -557,7 +533,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedReadSiz
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
     unit_tests::dm::multi_interleaved::packet_sizes_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedWriteDirectedIdeal) {
@@ -565,7 +541,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedWriteDi
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
     unit_tests::dm::multi_interleaved::directed_ideal_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedWriteSizes) {
@@ -573,24 +549,24 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovement6x6MultiInterleavedWriteSi
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord mst_grid_size = {6, 6};
     unit_tests::dm::multi_interleaved::packet_sizes_test(
-        get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
+        this->device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
 /* ========== GRID SWEEP TESTS ========== */
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedGridSweepSizes) {
     uint32_t test_case_id = 128;
-    unit_tests::dm::multi_interleaved::grid_packet_sizes_test(get_mesh_device(), test_case_id, true, true);
+    unit_tests::dm::multi_interleaved::grid_packet_sizes_test(this->device(), test_case_id, true, true);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedReadGridSweepSizes) {
     uint32_t test_case_id = 129;
-    unit_tests::dm::multi_interleaved::grid_packet_sizes_test(get_mesh_device(), test_case_id, true, false);
+    unit_tests::dm::multi_interleaved::grid_packet_sizes_test(this->device(), test_case_id, true, false);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementMultiInterleavedWriteGridSweepSizes) {
     uint32_t test_case_id = 130;
-    unit_tests::dm::multi_interleaved::grid_packet_sizes_test(get_mesh_device(), test_case_id, false, true);
+    unit_tests::dm::multi_interleaved::grid_packet_sizes_test(this->device(), test_case_id, false, true);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
@@ -5,6 +5,7 @@
 #include "device_fixture.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "../dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -36,9 +37,7 @@ struct MulticastAtomicConfig {
 /// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test
 /// @return true if test passes, false otherwise
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MulticastAtomicConfig& test_config) {
-    IDevice* device = mesh_device->get_device(0);
-
+bool run_dm(distributed::MeshDevice& mesh_device, const MulticastAtomicConfig& test_config) {
     uint32_t num_senders = test_config.sender_cores.size();
     uint32_t num_dests = test_config.dst_grid_size.x * test_config.dst_grid_size.y;
     uint32_t expected_value = num_senders * test_config.num_of_transactions * test_config.atomic_inc_value;
@@ -51,8 +50,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Multic
         test_config.dst_grid_start.y + test_config.dst_grid_size.y - 1};
 
     // Get physical coordinates for destination grid
-    CoreCoord physical_dst_start = device->worker_core_from_logical_core(test_config.dst_grid_start);
-    CoreCoord physical_dst_end = device->worker_core_from_logical_core(dst_grid_end);
+    CoreCoord physical_dst_start = mesh_device.worker_core_from_logical_core(test_config.dst_grid_start);
+    CoreCoord physical_dst_end = mesh_device.worker_core_from_logical_core(dst_grid_end);
 
     vector<CoreCoord> dst_cores;
     for (uint32_t y = test_config.dst_grid_start.y; y <= dst_grid_end.y; y++) {
@@ -99,7 +98,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Multic
         {"test_id", (uint32_t)test_config.test_id}};
 
     DataMovementHardwareConfig sender_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         sender_hw_config = DataMovementGen2Config{};
     } else {
         sender_hw_config = DataMovementGen1Config{
@@ -125,7 +124,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Multic
         {"expected_value", (uint32_t)expected_value}, {"test_id", (uint32_t)test_config.test_id}};
 
     DataMovementHardwareConfig receiver_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         receiver_hw_config = DataMovementGen2Config{};
     } else {
         receiver_hw_config = DataMovementGen1Config{
@@ -162,7 +161,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Multic
             },
     };
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     ProgramRunArgs run_params;
     ProgramRunArgs::KernelRunArgs sender_run_params{.kernel = sender_spec.unique_id};
@@ -196,7 +195,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Multic
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
@@ -217,10 +216,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Multic
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSource) {
     uint32_t test_id = 342;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -234,16 +230,13 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSource) {
         .atomic_inc_value = 1,
         .noc_id = NOC::NOC_0};
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSource) {
     uint32_t test_id = 343;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -257,16 +250,13 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSource) {
         .atomic_inc_value = 1,
         .noc_id = NOC::NOC_0};
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSourceNOC1) {
     uint32_t test_id = 344;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -280,16 +270,13 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSourceNOC1) {
         .atomic_inc_value = 1,
         .noc_id = NOC::NOC_1};
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSourceNOC1) {
     uint32_t test_id = 345;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -303,16 +290,13 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSourceNOC1) {
         .atomic_inc_value = 1,
         .noc_id = NOC::NOC_1};
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrement) {
     uint32_t test_id = 346;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -328,16 +312,13 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrement) {
         .atomic_inc_value = 5,
         .noc_id = NOC::NOC_0};
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrementNOC1) {
     uint32_t test_id = 347;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -353,7 +334,7 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrementNOC1) {
         .atomic_inc_value = 5,
         .noc_id = NOC::NOC_1};
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 /* ========== NOC 2.0 API TEST CASES ========== */
@@ -361,10 +342,7 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrementNOC1) {
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSource_2_0) {
     uint32_t test_id = 348;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -379,16 +357,13 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSource_2_0) {
         .noc_id = NOC::NOC_0,
     };
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrement_2_0) {
     uint32_t test_id = 349;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -405,16 +380,13 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrement_2_0) {
         .noc_id = NOC::NOC_0,
     };
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSource_2_0) {
     uint32_t test_id = 350;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -429,16 +401,13 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSource_2_0) {
         .noc_id = NOC::NOC_0,
     };
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSourceNOC1_2_0) {
     uint32_t test_id = 351;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -453,16 +422,13 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicSingleSourceNOC1_2_0) {
         .noc_id = NOC::NOC_1,
     };
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSourceNOC1_2_0) {
     uint32_t test_id = 352;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -477,16 +443,13 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicMultiSourceNOC1_2_0) {
         .noc_id = NOC::NOC_1,
     };
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrementNOC1_2_0) {
     uint32_t test_id = 353;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
-
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = this->device().compute_with_storage_grid_size();
     if (grid_size.x < 5 || grid_size.y < 4) {
         GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
     }
@@ -501,7 +464,7 @@ TEST_F(UnitMeshFastDispatchFixture, MulticastAtomicLargerIncrementNOC1_2_0) {
         .noc_id = NOC::NOC_1,
     };
 
-    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(mesh_device, config));
+    EXPECT_TRUE(unit_tests::dm::multicast_atomics::run_dm(this->device(), config));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
@@ -5,6 +5,7 @@
 #include "kernel_types.hpp"
 #include "device_fixture.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -47,11 +48,7 @@ struct NocApiLatencyConfig {
 /// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test -- see struct
 /// @return true if test passes
-bool run_noc_api_latency_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, const NocApiLatencyConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
-
+bool run_noc_api_latency_test(distributed::MeshDevice& mesh_device, const NocApiLatencyConfig& test_config) {
     /* ================ SETUP ================ */
 
     // (Logical) Core coordinates and ranges
@@ -71,12 +68,12 @@ bool run_noc_api_latency_test(
     uint32_t l1_base_address = source_l1_info.base_address;
 
     // Physical Core Coordinates
-    CoreCoord physical_dest_core = device->worker_core_from_logical_core(test_config.dest_core_coord);
+    CoreCoord physical_dest_core = mesh_device.worker_core_from_logical_core(test_config.dest_core_coord);
     uint32_t packed_dest_core_coordinates = physical_dest_core.x << 16 | (physical_dest_core.y & 0xFFFF);
 
     // For multicast tests, use configured multicast rectangle
-    CoreCoord physical_mcast_dest_start = device->worker_core_from_logical_core(test_config.mcast_dest_core_start);
-    CoreCoord physical_mcast_dest_end = device->worker_core_from_logical_core(test_config.mcast_dest_core_end);
+    CoreCoord physical_mcast_dest_start = mesh_device.worker_core_from_logical_core(test_config.mcast_dest_core_start);
+    CoreCoord physical_mcast_dest_end = mesh_device.worker_core_from_logical_core(test_config.mcast_dest_core_end);
     uint32_t packed_dest_core_end_coordinates = physical_mcast_dest_end.x << 16 | (physical_mcast_dest_end.y & 0xFFFF);
 
     // For non-multicast tests, override with unicast destination
@@ -134,7 +131,7 @@ bool run_noc_api_latency_test(
     }
 
     DataMovementHardwareConfig noc_kernel_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         noc_kernel_hw_config = DataMovementGen2Config{};
     } else {
         noc_kernel_hw_config = DataMovementGen1Config{
@@ -155,7 +152,7 @@ bool run_noc_api_latency_test(
                 static_cast<uint32_t>(test_config.source_core_coord.x),
                 static_cast<uint32_t>(test_config.source_core_coord.y)}}}};
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     // Assign unique id
     log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
@@ -163,14 +160,14 @@ bool run_noc_api_latency_test(
 
     /* ================ RUNNING THE PROGRAM ================ */
 
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
@@ -180,15 +177,13 @@ bool run_noc_api_latency_test(
 }
 
 // Sweep test for unicast write and read
-void unicast_sweep_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id, KernelType kernel_type) {
-    auto* device = mesh_device->get_device(0);
+void unicast_sweep_test(distributed::MeshDevice& mesh_device, uint32_t test_id, KernelType kernel_type) {
     for (uint32_t transaction_size = 32; transaction_size <= 4096; transaction_size *= 2) {
         for (uint32_t num_transactions = 1; num_transactions <= 256; num_transactions *= 2) {
             NocApiLatencyConfig test_config = {
                 .test_id = test_id,
                 .source_core_coord = {0, 0},
-                .dest_core_coord = {0, device->compute_with_storage_grid_size().y - 1},
+                .dest_core_coord = {0, mesh_device.compute_with_storage_grid_size().y - 1},
                 .num_transactions = num_transactions,
                 .transaction_size = transaction_size,
                 .kernel_type = kernel_type,
@@ -201,11 +196,7 @@ void unicast_sweep_test(
 
 // Sweep test for multicast write with configurable grid
 void multicast_write_sweep_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
-    uint32_t test_id,
-    CoreCoord mcast_start,
-    CoreCoord mcast_end,
-    bool loopback) {
+    distributed::MeshDevice& mesh_device, uint32_t test_id, CoreCoord mcast_start, CoreCoord mcast_end, bool loopback) {
     for (uint32_t transaction_size = 32; transaction_size <= 4096; transaction_size *= 2) {
         for (uint32_t num_transactions = 1; num_transactions <= 256; num_transactions *= 2) {
             NocApiLatencyConfig test_config = {
@@ -232,51 +223,50 @@ TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyUnicastWrite) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 700;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
-        this->get_mesh_device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_WRITE);
+        this->device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_WRITE);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyUnicastRead) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 701;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
-        this->get_mesh_device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_READ);
+        this->device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_READ);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyStatefulWrite) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 702;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
-        this->get_mesh_device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_WRITE);
+        this->device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_WRITE);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyStatefulRead) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 703;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
-        this->get_mesh_device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_READ);
+        this->device(), test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_READ);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyMulticastWrite2x2) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 704;
     tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
-        this->get_mesh_device(), test_case_id, {0, 1}, {1, 2}, false);
+        this->device(), test_case_id, {0, 1}, {1, 2}, false);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyMulticastWrite5x5) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 705;
     tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
-        this->get_mesh_device(), test_case_id, {0, 1}, {4, 5}, false);
+        this->device(), test_case_id, {0, 1}, {4, 5}, false);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixNocApiLatencyMulticastWriteAll) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 706;
-    auto* device = this->get_mesh_device()->get_device(0);
-    CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreCoord grid_size = this->device().compute_with_storage_grid_size();
     tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
-        this->get_mesh_device(), test_case_id, {0, 0}, {grid_size.x - 1, grid_size.y - 1}, true);
+        this->device(), test_case_id, {0, 0}, {grid_size.x - 1, grid_size.y - 1}, true);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -7,11 +7,11 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include <distributed/mesh_device_impl.hpp>
 #include <algorithm>
 
 namespace tt::tt_metal {
@@ -162,13 +162,13 @@ static vector<uint32_t> make_reader_compile_args(
     };
 }
 
-static void execute_program(const shared_ptr<distributed::MeshDevice>& mesh_device, Program program) {
+static void execute_program(distributed::MeshDevice& mesh_device, Program program) {
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 }
@@ -182,8 +182,7 @@ static vector<uint32_t> make_test_data(size_t bytes) {
 // ============ PATTERN-SPECIFIC RUN FUNCTIONS ============
 
 // Handles ONE_TO_ONE (write) and ONE_FROM_ONE (read)
-static bool run_single_core(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
-    IDevice* device = mesh_device->impl().get_device(0);
+static bool run_single_core(distributed::MeshDevice& mesh_device, const NocEstimatorConfig& cfg) {
     Program program = CreateProgram();
 
     const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
@@ -205,7 +204,7 @@ static bool run_single_core(const shared_ptr<distributed::MeshDevice>& mesh_devi
     }
     uint32_t l1_base = master_l1.base_address;
 
-    CoreCoord phys_sub = device->worker_core_from_logical_core(sub_coord);
+    CoreCoord phys_sub = mesh_device.worker_core_from_logical_core(sub_coord);
     uint32_t packed_sub = (phys_sub.x << 16) | (phys_sub.y & 0xFFFF);
 
     bool is_write = is_write_pattern(cfg.pattern);
@@ -240,19 +239,19 @@ static bool run_single_core(const shared_ptr<distributed::MeshDevice>& mesh_devi
     auto packed_golden = packed_input;
 
     if (is_write) {
-        detail::WriteToDeviceL1(device, master_coord, l1_base, packed_input);
+        slow_dispatch::WriteToL1(mesh_device, master_coord, l1_base, packed_input);
     } else {
-        detail::WriteToDeviceL1(device, sub_coord, l1_base, packed_input);
+        slow_dispatch::WriteToL1(mesh_device, sub_coord, l1_base, packed_input);
     }
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     execute_program(mesh_device, std::move(program));
 
     vector<uint32_t> packed_output;
     if (is_write) {
-        detail::ReadFromDeviceL1(device, sub_coord, l1_base, bytes_per_txn, packed_output);
+        slow_dispatch::ReadFromL1(mesh_device, sub_coord, l1_base, bytes_per_txn, packed_output);
     } else {
-        detail::ReadFromDeviceL1(device, master_coord, l1_base, bytes_per_txn, packed_output);
+        slow_dispatch::ReadFromL1(mesh_device, master_coord, l1_base, bytes_per_txn, packed_output);
     }
 
     bool is_equal = (packed_output == packed_golden);
@@ -263,8 +262,7 @@ static bool run_single_core(const shared_ptr<distributed::MeshDevice>& mesh_devi
 }
 
 // Handles ONE_TO_ALL (write, unicast/multicast) and ONE_FROM_ALL (read)
-static bool run_one_to_many(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
-    IDevice* device = mesh_device->impl().get_device(0);
+static bool run_one_to_many(distributed::MeshDevice& mesh_device, const NocEstimatorConfig& cfg) {
     Program program = CreateProgram();
 
     const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
@@ -315,8 +313,8 @@ static bool run_one_to_many(const shared_ptr<distributed::MeshDevice>& mesh_devi
         if (is_multicast) {
             writer_mode = (cfg.mechanism == NocMechanism::MULTICAST_LINKED) ? WRITER_MODE_MULTICAST_LINKED
                                                                             : WRITER_MODE_MULTICAST;
-            CoreCoord sub_phys_start = device->worker_core_from_logical_core(sub_start);
-            CoreCoord sub_phys_end = device->worker_core_from_logical_core(sub_end);
+            CoreCoord sub_phys_start = mesh_device.worker_core_from_logical_core(sub_start);
+            CoreCoord sub_phys_end = mesh_device.worker_core_from_logical_core(sub_end);
 
             auto compile_args = make_writer_compile_args(
                 cfg,
@@ -352,7 +350,7 @@ static bool run_one_to_many(const shared_ptr<distributed::MeshDevice>& mesh_devi
 
             vector<uint32_t> rt_args;
             for (auto& core : sub_core_list) {
-                CoreCoord phys = device->worker_core_from_logical_core(core);
+                CoreCoord phys = mesh_device.worker_core_from_logical_core(core);
                 rt_args.push_back((phys.x << 16) | (phys.y & 0xFFFF));
             }
             SetRuntimeArgs(program, kernel, mst_set, rt_args);
@@ -372,7 +370,7 @@ static bool run_one_to_many(const shared_ptr<distributed::MeshDevice>& mesh_devi
 
         vector<uint32_t> rt_args;
         for (auto& core : sub_core_list) {
-            CoreCoord phys = device->worker_core_from_logical_core(core);
+            CoreCoord phys = mesh_device.worker_core_from_logical_core(core);
             rt_args.push_back(phys.x);
             rt_args.push_back(phys.y);
         }
@@ -386,20 +384,20 @@ static bool run_one_to_many(const shared_ptr<distributed::MeshDevice>& mesh_devi
     auto packed_golden = packed_input;
 
     if (is_write) {
-        detail::WriteToDeviceL1(device, mst_coord, mst_l1_addr, packed_input);
+        slow_dispatch::WriteToL1(mesh_device, mst_coord, mst_l1_addr, packed_input);
     } else {
         for (auto& core : sub_core_list) {
-            detail::WriteToDeviceL1(device, core, mst_l1.base_address, packed_input);
+            slow_dispatch::WriteToL1(mesh_device, core, mst_l1.base_address, packed_input);
         }
     }
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     execute_program(mesh_device, std::move(program));
 
     if (is_write) {
         for (auto& core : sub_core_list) {
             vector<uint32_t> packed_output;
-            detail::ReadFromDeviceL1(device, core, sub_l1_addr, bytes_per_txn, packed_output);
+            slow_dispatch::ReadFromL1(mesh_device, core, sub_l1_addr, bytes_per_txn, packed_output);
             if (packed_output != packed_golden) {
                 log_error(LogTest, "Equality Check failed for test_id {}", cfg.test_id);
                 return false;
@@ -407,7 +405,7 @@ static bool run_one_to_many(const shared_ptr<distributed::MeshDevice>& mesh_devi
         }
     } else {
         vector<uint32_t> packed_output;
-        detail::ReadFromDeviceL1(device, mst_coord, mst_l1.base_address, bytes_per_txn, packed_output);
+        slow_dispatch::ReadFromL1(mesh_device, mst_coord, mst_l1.base_address, bytes_per_txn, packed_output);
         if (packed_output != packed_golden) {
             log_error(LogTest, "Equality Check failed for test_id {}", cfg.test_id);
             return false;
@@ -417,8 +415,7 @@ static bool run_one_to_many(const shared_ptr<distributed::MeshDevice>& mesh_devi
 }
 
 // Handles ALL_TO_ALL (write) and ALL_FROM_ALL (read)
-static bool run_all_pattern(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
-    IDevice* device = mesh_device->impl().get_device(0);
+static bool run_all_pattern(distributed::MeshDevice& mesh_device, const NocEstimatorConfig& cfg) {
     Program program = CreateProgram();
 
     const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
@@ -449,7 +446,7 @@ static bool run_all_pattern(const shared_ptr<distributed::MeshDevice>& mesh_devi
     // Subordinate physical coordinates
     vector<uint32_t> sub_worker_coords;
     for (auto& core : sub_core_list) {
-        CoreCoord phys = device->worker_core_from_logical_core(core);
+        CoreCoord phys = mesh_device.worker_core_from_logical_core(core);
         if (is_write) {
             sub_worker_coords.push_back((phys.x << 16) | (phys.y & 0xFFFF));
         } else {
@@ -491,23 +488,23 @@ static bool run_all_pattern(const shared_ptr<distributed::MeshDevice>& mesh_devi
     if (is_write) {
         // Write source data to master cores at mst_l1_addr
         for (auto& core : mst_core_list) {
-            detail::WriteToDeviceL1(device, core, mst_l1_addr, packed_input);
+            slow_dispatch::WriteToL1(mesh_device, core, mst_l1_addr, packed_input);
         }
     } else {
         // Write source data to subordinate cores at mst_l1_addr
         // (reader kernel reads from local_addr = mst_l1_addr on remote cores)
         for (auto& core : sub_core_list) {
-            detail::WriteToDeviceL1(device, core, mst_l1_addr, packed_input);
+            slow_dispatch::WriteToL1(mesh_device, core, mst_l1_addr, packed_input);
         }
     }
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     execute_program(mesh_device, std::move(program));
 
     if (is_write) {
         for (auto& core : sub_core_list) {
             vector<uint32_t> packed_output;
-            detail::ReadFromDeviceL1(device, core, sub_l1_addr, bytes_per_txn, packed_output);
+            slow_dispatch::ReadFromL1(mesh_device, core, sub_l1_addr, bytes_per_txn, packed_output);
             if (packed_output != packed_golden) {
                 log_error(LogTest, "Equality Check failed for test_id {}", cfg.test_id);
                 return false;
@@ -517,7 +514,7 @@ static bool run_all_pattern(const shared_ptr<distributed::MeshDevice>& mesh_devi
         // Reader writes to local_addr = mst_l1_addr on each master core
         for (auto& core : mst_core_list) {
             vector<uint32_t> packed_output;
-            detail::ReadFromDeviceL1(device, core, mst_l1_addr, bytes_per_txn, packed_output);
+            slow_dispatch::ReadFromL1(mesh_device, core, mst_l1_addr, bytes_per_txn, packed_output);
             if (packed_output != packed_golden) {
                 log_error(LogTest, "Equality Check failed for test_id {}", cfg.test_id);
                 return false;
@@ -530,9 +527,7 @@ static bool run_all_pattern(const shared_ptr<distributed::MeshDevice>& mesh_devi
 // Handles ROW_TO_ROW / COLUMN_TO_COLUMN with multicast:
 // All masters in the row/column multicast to the same rectangle (the row/column).
 // Masters and subordinates overlap; loopback should be true (INCLUDE_SRC).
-static bool run_many_to_many_multicast(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
-    IDevice* device = mesh_device->impl().get_device(0);
+static bool run_many_to_many_multicast(distributed::MeshDevice& mesh_device, const NocEstimatorConfig& cfg) {
     Program program = CreateProgram();
 
     const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
@@ -563,8 +558,8 @@ static bool run_many_to_many_multicast(
     uint32_t writer_mode =
         (cfg.mechanism == NocMechanism::MULTICAST_LINKED) ? WRITER_MODE_MULTICAST_LINKED : WRITER_MODE_MULTICAST;
 
-    CoreCoord sub_phys_start = device->worker_core_from_logical_core(sub_start);
-    CoreCoord sub_phys_end = device->worker_core_from_logical_core(sub_end);
+    CoreCoord sub_phys_start = mesh_device.worker_core_from_logical_core(sub_start);
+    CoreCoord sub_phys_end = mesh_device.worker_core_from_logical_core(sub_end);
 
     auto compile_args = make_writer_compile_args(
         cfg,
@@ -594,16 +589,16 @@ static bool run_many_to_many_multicast(
 
     // Write source data to all master cores
     for (auto& core : mst_core_list) {
-        detail::WriteToDeviceL1(device, core, mst_l1_addr, packed_input);
+        slow_dispatch::WriteToL1(mesh_device, core, mst_l1_addr, packed_input);
     }
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     execute_program(mesh_device, std::move(program));
 
     // Verify all subordinate cores
     for (auto& core : sub_core_list) {
         vector<uint32_t> packed_output;
-        detail::ReadFromDeviceL1(device, core, sub_l1_addr, bytes_per_txn, packed_output);
+        slow_dispatch::ReadFromL1(mesh_device, core, sub_l1_addr, bytes_per_txn, packed_output);
         if (packed_output != packed_golden) {
             log_error(LogTest, "Equality Check failed for test_id {}", cfg.test_id);
             return false;
@@ -619,25 +614,24 @@ enum class DramDirection { READ, WRITE };
 // For interleaved mode: each core cycles through all banks via sequential page IDs.
 // For sharded mode: each core reads/writes only the page(s) mapping to its dedicated bank.
 static bool run_dram_accessor(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     const NocEstimatorConfig& cfg,
     const vector<CoreCoord>& cores,
     const vector<uint32_t>& bank_assignments,
     DramDirection direction) {
-    IDevice* device = mesh_device->impl().get_device(0);
     Program program = CreateProgram();
 
     const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
-    uint32_t num_dram_banks = (uint32_t)device->num_dram_channels();
+    uint32_t num_dram_banks = (uint32_t)mesh_device.num_dram_channels();
     uint32_t num_cores = (uint32_t)cores.size();
 
     uint32_t num_pages = num_dram_banks;
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     auto dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = (size_t)num_pages * bytes_per_txn},
         {.page_size = (uint32_t)bytes_per_txn, .buffer_type = BufferType::DRAM},
-        mesh_device.get());
+        &mesh_device);
 
     std::set<CoreRange> core_ranges;
     for (const auto& c : cores) {
@@ -650,7 +644,7 @@ static bool run_dram_accessor(
 
     uint32_t barrier_sem_id = CreateSemaphore(program, core_set, 0);
 
-    CoreCoord coordinator_phys = device->worker_core_from_logical_core(cores[0]);
+    CoreCoord coordinator_phys = mesh_device.worker_core_from_logical_core(cores[0]);
     uint32_t local_scratch_addr = l1_addr + (uint32_t)bytes_per_txn;
 
     uint32_t mem_type = (uint32_t)cfg.memory_type;
@@ -704,7 +698,7 @@ static bool run_dram_accessor(
         full_input.insert(full_input.end(), page_data.begin(), page_data.end());
     }
     distributed::EnqueueWriteMeshBuffer(cq, dram_buffer, full_input, /*blocking=*/true);
-    MetalContext::instance().get_cluster().dram_barrier(device->id());
+    MetalContext::instance().get_cluster().dram_barrier(mesh_device.get_device_ids().front());
 
     execute_program(mesh_device, std::move(program));
 
@@ -713,7 +707,7 @@ static bool run_dram_accessor(
 
 // ============ DISPATCH ============
 
-static bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
+static bool run_dm(distributed::MeshDevice& mesh_device, const NocEstimatorConfig& cfg) {
     switch (cfg.pattern) {
         case NocPattern::ONE_TO_ONE:
         case NocPattern::ONE_FROM_ONE: return run_single_core(mesh_device, cfg);
@@ -740,16 +734,15 @@ static bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const
 
 // Returns NOC packet size: 8KB for WH, 16KB for BH
 // Stateful unicast writes are only valid for transfers smaller than one packet
-static uint32_t get_noc_packet_size(IDevice* device) {
-    return device->arch() == ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
+static uint32_t get_noc_packet_size(distributed::MeshDevice& mesh_device) {
+    return mesh_device.arch() == ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
 }
 
-static void packet_sizes_sweep(const shared_ptr<distributed::MeshDevice>& mesh_device, NocEstimatorConfig base_cfg) {
+static void packet_sizes_sweep(distributed::MeshDevice& mesh_device, NocEstimatorConfig base_cfg) {
     auto [bytes_per_page, max_bytes, max_pages] = unit_tests::dm::compute_physical_constraints(mesh_device);
-    IDevice* device = mesh_device->impl().get_device(0);
 
     uint32_t max_transactions = 256;
-    uint32_t max_pages_per_txn = device->arch() == ARCH::BLACKHOLE ? 1024 : 2048;
+    uint32_t max_pages_per_txn = mesh_device.arch() == ARCH::BLACKHOLE ? 1024 : 2048;
 
     base_cfg.bytes_per_page = bytes_per_page;
 
@@ -765,17 +758,15 @@ static void packet_sizes_sweep(const shared_ptr<distributed::MeshDevice>& mesh_d
     }
 
     // Flush profiler DRAM buffer to prevent overflow across many sweep iterations
-    ReadMeshDeviceProfilerResults(*mesh_device);
+    ReadMeshDeviceProfilerResults(mesh_device);
 }
 
 // Stateful sweep for unicast writes - constrained to packets smaller than max stateful size
-static void packet_sizes_sweep_stateful_write(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, NocEstimatorConfig base_cfg) {
+static void packet_sizes_sweep_stateful_write(distributed::MeshDevice& mesh_device, NocEstimatorConfig base_cfg) {
     auto [bytes_per_page, max_bytes, max_pages] = unit_tests::dm::compute_physical_constraints(mesh_device);
-    IDevice* device = mesh_device->impl().get_device(0);
 
     uint32_t max_transactions = 256;
-    uint32_t noc_packet_size = get_noc_packet_size(device);
+    uint32_t noc_packet_size = get_noc_packet_size(mesh_device);
     uint32_t max_stateful_pages = noc_packet_size / bytes_per_page;
 
     base_cfg.bytes_per_page = bytes_per_page;
@@ -793,12 +784,12 @@ static void packet_sizes_sweep_stateful_write(
     }
 
     // Flush profiler DRAM buffer to prevent overflow across many sweep iterations
-    ReadMeshDeviceProfilerResults(*mesh_device);
+    ReadMeshDeviceProfilerResults(mesh_device);
 }
 
 // ============ SWEEP FUNCTIONS ============
 
-static void sweep_one_to_one(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+static void sweep_one_to_one(distributed::MeshDevice& mesh_device, uint32_t test_id) {
     for (bool same_axis : {true, false}) {
         for (bool stateful : {true, false}) {
             NocEstimatorConfig cfg = {
@@ -814,7 +805,7 @@ static void sweep_one_to_one(const shared_ptr<distributed::MeshDevice>& mesh_dev
     }
 }
 
-static void sweep_one_from_one(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+static void sweep_one_from_one(distributed::MeshDevice& mesh_device, uint32_t test_id) {
     for (bool same_axis : {true, false}) {
         for (bool stateful : {true, false}) {
             NocEstimatorConfig cfg = {
@@ -830,9 +821,8 @@ static void sweep_one_from_one(const shared_ptr<distributed::MeshDevice>& mesh_d
     }
 }
 
-static void sweep_one_to_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
-    IDevice* device = mesh_device->impl().get_device(0);
-    CoreCoord device_grid = device->compute_with_storage_grid_size();
+static void sweep_one_to_all(distributed::MeshDevice& mesh_device, uint32_t test_id) {
+    CoreCoord device_grid = mesh_device.compute_with_storage_grid_size();
 
     struct GridConfig {
         CoreCoord size;
@@ -906,9 +896,8 @@ static void sweep_one_to_all(const shared_ptr<distributed::MeshDevice>& mesh_dev
     }
 }
 
-static void sweep_one_from_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
-    IDevice* device = mesh_device->impl().get_device(0);
-    CoreCoord device_grid = device->compute_with_storage_grid_size();
+static void sweep_one_from_all(distributed::MeshDevice& mesh_device, uint32_t test_id) {
+    CoreCoord device_grid = mesh_device.compute_with_storage_grid_size();
 
     // Sweep stateful for reads (reads can always use stateful with UNICAST)
     for (bool stateful : {false, true}) {
@@ -925,9 +914,8 @@ static void sweep_one_from_all(const shared_ptr<distributed::MeshDevice>& mesh_d
     }
 }
 
-static void sweep_all_to_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
-    IDevice* device = mesh_device->impl().get_device(0);
-    CoreCoord device_grid = device->compute_with_storage_grid_size();
+static void sweep_all_to_all(distributed::MeshDevice& mesh_device, uint32_t test_id) {
+    CoreCoord device_grid = mesh_device.compute_with_storage_grid_size();
 
     vector<CoreCoord> grid_sizes = {{2, 2}, {3, 3}, {5, 5}, {8, 8}};
     // Add the full device grid if not already included
@@ -957,9 +945,8 @@ static void sweep_all_to_all(const shared_ptr<distributed::MeshDevice>& mesh_dev
     }
 }
 
-static void sweep_all_from_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
-    IDevice* device = mesh_device->impl().get_device(0);
-    CoreCoord device_grid = device->compute_with_storage_grid_size();
+static void sweep_all_from_all(distributed::MeshDevice& mesh_device, uint32_t test_id) {
+    CoreCoord device_grid = mesh_device.compute_with_storage_grid_size();
 
     vector<CoreCoord> grid_sizes = {{2, 2}, {3, 3}, {5, 5}, {8, 8}};
     // Add the full device grid if not already included
@@ -994,7 +981,7 @@ static void sweep_all_from_all(const shared_ptr<distributed::MeshDevice>& mesh_d
 // Helper: run a DRAM accessor sweep with the given cores, bank assignments, and direction.
 // Sweeps both NOC_0 and NOC_1 for each configuration.
 static void dram_accessor_sweep(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     NocPattern pattern,
     MemoryType memory_type,
@@ -1028,16 +1015,13 @@ static void dram_accessor_sweep(
         }
     }
 
-    ReadMeshDeviceProfilerResults(*mesh_device);
+    ReadMeshDeviceProfilerResults(mesh_device);
 }
 
 static void get_all_cores(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
-    vector<CoreCoord>& cores,
-    vector<uint32_t>& bank_assignments) {
-    IDevice* device = mesh_device->impl().get_device(0);
-    CoreCoord device_grid = device->compute_with_storage_grid_size();
-    uint32_t num_dram_banks = (uint32_t)device->num_dram_channels();
+    distributed::MeshDevice& mesh_device, vector<CoreCoord>& cores, vector<uint32_t>& bank_assignments) {
+    CoreCoord device_grid = mesh_device.compute_with_storage_grid_size();
+    uint32_t num_dram_banks = (uint32_t)mesh_device.num_dram_channels();
     for (uint32_t y = 0; y < device_grid.y; y++) {
         for (uint32_t x = 0; x < device_grid.x; x++) {
             cores.push_back(CoreCoord(x, y));
@@ -1048,7 +1032,7 @@ static void get_all_cores(
 
 // ---- READ sweeps ----
 
-static void sweep_dram_sharded_one_from_one(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+static void sweep_dram_sharded_one_from_one(distributed::MeshDevice& mesh_device, uint32_t test_id) {
     vector<CoreCoord> cores = {{0, 0}};
     vector<uint32_t> bank_assignments = {0};
     dram_accessor_sweep(
@@ -1061,7 +1045,7 @@ static void sweep_dram_sharded_one_from_one(const shared_ptr<distributed::MeshDe
         DramDirection::READ);
 }
 
-static void sweep_dram_sharded_all_from_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+static void sweep_dram_sharded_all_from_all(distributed::MeshDevice& mesh_device, uint32_t test_id) {
     vector<CoreCoord> cores;
     vector<uint32_t> bank_assignments;
     get_all_cores(mesh_device, cores, bank_assignments);
@@ -1075,8 +1059,7 @@ static void sweep_dram_sharded_all_from_all(const shared_ptr<distributed::MeshDe
         DramDirection::READ);
 }
 
-static void sweep_dram_interleaved_one_from_all(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+static void sweep_dram_interleaved_one_from_all(distributed::MeshDevice& mesh_device, uint32_t test_id) {
     vector<CoreCoord> cores = {{0, 0}};
     vector<uint32_t> bank_assignments = {0};
     dram_accessor_sweep(
@@ -1089,8 +1072,7 @@ static void sweep_dram_interleaved_one_from_all(
         DramDirection::READ);
 }
 
-static void sweep_dram_interleaved_all_from_all(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+static void sweep_dram_interleaved_all_from_all(distributed::MeshDevice& mesh_device, uint32_t test_id) {
     vector<CoreCoord> cores;
     vector<uint32_t> bank_assignments;
     get_all_cores(mesh_device, cores, bank_assignments);
@@ -1106,7 +1088,7 @@ static void sweep_dram_interleaved_all_from_all(
 
 // ---- WRITE sweeps ----
 
-static void sweep_dram_sharded_one_to_one(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+static void sweep_dram_sharded_one_to_one(distributed::MeshDevice& mesh_device, uint32_t test_id) {
     vector<CoreCoord> cores = {{0, 0}};
     vector<uint32_t> bank_assignments = {0};
     dram_accessor_sweep(
@@ -1119,7 +1101,7 @@ static void sweep_dram_sharded_one_to_one(const shared_ptr<distributed::MeshDevi
         DramDirection::WRITE);
 }
 
-static void sweep_dram_sharded_all_to_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+static void sweep_dram_sharded_all_to_all(distributed::MeshDevice& mesh_device, uint32_t test_id) {
     vector<CoreCoord> cores;
     vector<uint32_t> bank_assignments;
     get_all_cores(mesh_device, cores, bank_assignments);
@@ -1133,8 +1115,7 @@ static void sweep_dram_sharded_all_to_all(const shared_ptr<distributed::MeshDevi
         DramDirection::WRITE);
 }
 
-static void sweep_dram_interleaved_one_to_all(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+static void sweep_dram_interleaved_one_to_all(distributed::MeshDevice& mesh_device, uint32_t test_id) {
     vector<CoreCoord> cores = {{0, 0}};
     vector<uint32_t> bank_assignments = {0};
     dram_accessor_sweep(
@@ -1147,8 +1128,7 @@ static void sweep_dram_interleaved_one_to_all(
         DramDirection::WRITE);
 }
 
-static void sweep_dram_interleaved_all_to_all(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+static void sweep_dram_interleaved_all_to_all(distributed::MeshDevice& mesh_device, uint32_t test_id) {
     vector<CoreCoord> cores;
     vector<uint32_t> bank_assignments;
     get_all_cores(mesh_device, cores, bank_assignments);
@@ -1164,9 +1144,8 @@ static void sweep_dram_interleaved_all_to_all(
 
 // ============ ROW / COLUMN SWEEP FUNCTIONS ============
 
-static void sweep_one_to_row(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
-    IDevice* device = mesh_device->impl().get_device(0);
-    CoreCoord device_grid = device->compute_with_storage_grid_size();
+static void sweep_one_to_row(distributed::MeshDevice& mesh_device, uint32_t test_id) {
+    CoreCoord device_grid = mesh_device.compute_with_storage_grid_size();
 
     // Unicast: master at (0, 0), sends individually to each core in the row
     {
@@ -1220,9 +1199,8 @@ static void sweep_one_to_row(const shared_ptr<distributed::MeshDevice>& mesh_dev
     }
 }
 
-static void sweep_row_to_row(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
-    IDevice* device = mesh_device->impl().get_device(0);
-    CoreCoord device_grid = device->compute_with_storage_grid_size();
+static void sweep_row_to_row(distributed::MeshDevice& mesh_device, uint32_t test_id) {
+    CoreCoord device_grid = mesh_device.compute_with_storage_grid_size();
 
     // Unicast: every core in the row sends individually to every core in the row
     {
@@ -1275,9 +1253,8 @@ static void sweep_row_to_row(const shared_ptr<distributed::MeshDevice>& mesh_dev
     }
 }
 
-static void sweep_one_to_column(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
-    IDevice* device = mesh_device->impl().get_device(0);
-    CoreCoord device_grid = device->compute_with_storage_grid_size();
+static void sweep_one_to_column(distributed::MeshDevice& mesh_device, uint32_t test_id) {
+    CoreCoord device_grid = mesh_device.compute_with_storage_grid_size();
 
     // Unicast: master at (0, 0), sends individually to each core in the column
     {
@@ -1331,9 +1308,8 @@ static void sweep_one_to_column(const shared_ptr<distributed::MeshDevice>& mesh_
     }
 }
 
-static void sweep_column_to_column(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
-    IDevice* device = mesh_device->impl().get_device(0);
-    CoreCoord device_grid = device->compute_with_storage_grid_size();
+static void sweep_column_to_column(distributed::MeshDevice& mesh_device, uint32_t test_id) {
+    CoreCoord device_grid = mesh_device.compute_with_storage_grid_size();
 
     // Unicast: every core in the column sends individually to every core in the column
     {
@@ -1392,77 +1368,77 @@ static void sweep_column_to_column(const shared_ptr<distributed::MeshDevice>& me
 
 // ---- L1 tests (800-809) ----
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneToOne) {
-    unit_tests::dm::noc_estimator::sweep_one_to_one(get_mesh_device(), 800);
+    unit_tests::dm::noc_estimator::sweep_one_to_one(this->device(), 800);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneFromOne) {
-    unit_tests::dm::noc_estimator::sweep_one_from_one(get_mesh_device(), 801);
+    unit_tests::dm::noc_estimator::sweep_one_from_one(this->device(), 801);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneToAll) {
-    unit_tests::dm::noc_estimator::sweep_one_to_all(get_mesh_device(), 802);
+    unit_tests::dm::noc_estimator::sweep_one_to_all(this->device(), 802);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneFromAll) {
-    unit_tests::dm::noc_estimator::sweep_one_from_all(get_mesh_device(), 803);
+    unit_tests::dm::noc_estimator::sweep_one_from_all(this->device(), 803);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1AllToAll) {
-    unit_tests::dm::noc_estimator::sweep_all_to_all(get_mesh_device(), 804);
+    unit_tests::dm::noc_estimator::sweep_all_to_all(this->device(), 804);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1AllFromAll) {
-    unit_tests::dm::noc_estimator::sweep_all_from_all(get_mesh_device(), 805);
+    unit_tests::dm::noc_estimator::sweep_all_from_all(this->device(), 805);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneToRow) {
-    unit_tests::dm::noc_estimator::sweep_one_to_row(get_mesh_device(), 806);
+    unit_tests::dm::noc_estimator::sweep_one_to_row(this->device(), 806);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1RowToRow) {
-    unit_tests::dm::noc_estimator::sweep_row_to_row(get_mesh_device(), 807);
+    unit_tests::dm::noc_estimator::sweep_row_to_row(this->device(), 807);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1OneToColumn) {
-    unit_tests::dm::noc_estimator::sweep_one_to_column(get_mesh_device(), 808);
+    unit_tests::dm::noc_estimator::sweep_one_to_column(this->device(), 808);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorL1ColumnToColumn) {
-    unit_tests::dm::noc_estimator::sweep_column_to_column(get_mesh_device(), 809);
+    unit_tests::dm::noc_estimator::sweep_column_to_column(this->device(), 809);
 }
 
 // ---- DRAM Read tests (810-813) ----
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMShardedOneFromOne) {
-    unit_tests::dm::noc_estimator::sweep_dram_sharded_one_from_one(get_mesh_device(), 810);
+    unit_tests::dm::noc_estimator::sweep_dram_sharded_one_from_one(this->device(), 810);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMShardedAllFromAll) {
-    unit_tests::dm::noc_estimator::sweep_dram_sharded_all_from_all(get_mesh_device(), 811);
+    unit_tests::dm::noc_estimator::sweep_dram_sharded_all_from_all(this->device(), 811);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMInterleavedOneFromAll) {
-    unit_tests::dm::noc_estimator::sweep_dram_interleaved_one_from_all(get_mesh_device(), 812);
+    unit_tests::dm::noc_estimator::sweep_dram_interleaved_one_from_all(this->device(), 812);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMInterleavedAllFromAll) {
-    unit_tests::dm::noc_estimator::sweep_dram_interleaved_all_from_all(get_mesh_device(), 813);
+    unit_tests::dm::noc_estimator::sweep_dram_interleaved_all_from_all(this->device(), 813);
 }
 
 // ---- DRAM Write tests (814-817) ----
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMShardedOneToOne) {
-    unit_tests::dm::noc_estimator::sweep_dram_sharded_one_to_one(get_mesh_device(), 814);
+    unit_tests::dm::noc_estimator::sweep_dram_sharded_one_to_one(this->device(), 814);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMShardedAllToAll) {
-    unit_tests::dm::noc_estimator::sweep_dram_sharded_all_to_all(get_mesh_device(), 815);
+    unit_tests::dm::noc_estimator::sweep_dram_sharded_all_to_all(this->device(), 815);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMInterleavedOneToAll) {
-    unit_tests::dm::noc_estimator::sweep_dram_interleaved_one_to_all(get_mesh_device(), 816);
+    unit_tests::dm::noc_estimator::sweep_dram_interleaved_one_to_all(this->device(), 816);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, NocEstimatorDRAMInterleavedAllToAll) {
-    unit_tests::dm::noc_estimator::sweep_dram_interleaved_all_to_all(get_mesh_device(), 817);
+    unit_tests::dm::noc_estimator::sweep_dram_interleaved_all_to_all(this->device(), 817);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -14,7 +14,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
-#include <distributed/mesh_device_impl.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -48,8 +48,7 @@ struct OneFromAllConfig {
 /// @param test_config - Configuration of the test -- see struct
 /// @param fixture - DispatchFixture pointer for dispatch-aware operations
 /// @return
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFromAllConfig& test_config) {
-    IDevice* device = mesh_device->impl().get_device(0);
+bool run_dm(distributed::MeshDevice& mesh_device, const OneFromAllConfig& test_config) {
     // Sharded L1 buffers
     CoreRangeSet master_core_set({CoreRange(test_config.master_core_coord)});
 
@@ -91,7 +90,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
     vector<uint32_t> subordinate_phys_coords;
     subordinate_phys_coords.reserve(total_subordinate_cores * 2);
     for (auto& core : sub_core_list) {
-        CoreCoord physical_core = device->worker_core_from_logical_core(core);
+        CoreCoord physical_core = mesh_device.worker_core_from_logical_core(core);
         subordinate_phys_coords.push_back(physical_core.x);
         subordinate_phys_coords.push_back(physical_core.y);
     }
@@ -107,7 +106,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
     const uint32_t num_coord_varargs = (uint32_t)(total_subordinate_cores * 2);
 
     DataMovementHardwareConfig gatherer_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         gatherer_hw_config = DataMovementGen2Config{};
     } else {
         gatherer_hw_config = DataMovementGen1Config{
@@ -135,7 +134,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
         }},
     };
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     ProgramRunArgs run_params;
     ProgramRunArgs::KernelRunArgs gatherer_run_params{.kernel = gatherer_spec.unique_id};
@@ -165,25 +164,24 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
     // Golden output
     vector<uint32_t> packed_golden = packed_input;
 
-    // Launch program and record outputs
     for (size_t i = 0; i < total_subordinate_cores; i++) {
-        detail::WriteToDeviceL1(device, sub_core_list[i], l1_base_address, packed_input);
+        slow_dispatch::WriteToL1(mesh_device, sub_core_list[i], l1_base_address, packed_input);
     }
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
-    // LAUNCH PROGRAM - Use mesh workload approach
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
-    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
+    auto target_devices =
+        distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
     vector<uint32_t> packed_output;
-    detail::ReadFromDeviceL1(
-        device, test_config.master_core_coord, l1_base_address, transaction_size_bytes, packed_output);
+    slow_dispatch::ReadFromL1(
+        mesh_device, test_config.master_core_coord, l1_base_address, transaction_size_bytes, packed_output);
 
     // Results comparison
     bool is_equal = (packed_output == packed_golden);
@@ -200,7 +198,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
 }
 
 void directed_ideal_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_start_coord,
@@ -236,7 +234,7 @@ void directed_ideal_test(
 }
 
 void packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_start_coord,
@@ -248,9 +246,8 @@ void packet_sizes_test(
 
     // Parameters
     uint32_t max_transactions = 256;
-    uint32_t max_transaction_size_pages = mesh_device->impl().get_device(0)->arch() == tt::ARCH::BLACKHOLE
-                                              ? 1024
-                                              : 2048;  // Max total transaction size == 64 KB
+    uint32_t max_transaction_size_pages =
+        mesh_device.arch() == tt::ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
@@ -279,7 +276,7 @@ void packet_sizes_test(
 }
 
 void virtual_channels_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_start_coord,
@@ -288,7 +285,7 @@ void virtual_channels_test(
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
-    const bool is_quasar = mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR;
+    const bool is_quasar = mesh_device.arch() == ARCH::QUASAR;
     std::uint32_t max_num_pages_per_transaction = is_quasar ? 4u : (1u << 12);
     std::uint32_t num_of_transactions = is_quasar ? 4u : 256u;
     std::uint32_t max_num_virtual_channels = is_quasar ? 2u : 4u;
@@ -329,7 +326,7 @@ void virtual_channels_test(
 }
 
 void custom_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_start_coord,
@@ -371,16 +368,15 @@ void custom_test(
 
 /* ========== Test case for one from all data movement; Test id = 15 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllPacketSizes) {
-    auto mesh_device = get_mesh_device();
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // sub_grid_size {2, 1} requires at least 2 columns in the compute grid
-        if (mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x < 2) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: sub_grid_size {2, 1} requires >= 2 columns, but grid has "
-                         << mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x
+                         << this->device().compute_with_storage_grid_size().x
                          << " column(s). Use emu-quasar-2x3 or larger.";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_from_all::OneFromAllConfig test_config = {
             .test_id = 15,
             .master_core_coord = {0, 0},
@@ -390,31 +386,28 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllPacketSizes) {
             .transaction_size_pages = 1,
             .page_size_bytes = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b};
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
     uint32_t test_id = 15;
-    auto* device = mesh_device->impl().get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
-    CoreCoord subordinate_grid_size = {
-        device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord subordinate_grid_size = this->device().compute_with_storage_grid_size();
     unit_tests::dm::core_from_all::packet_sizes_test(
-        mesh_device, test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
+        this->device(), test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
 }
 
 /* ========== Test case for one from all data movement; Test id = 30 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // sub_grid_size {2, 1} requires at least 2 columns in the compute grid
-        if (mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x < 2) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: sub_grid_size {2, 1} requires >= 2 columns, but grid has "
-                         << mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x
+                         << this->device().compute_with_storage_grid_size().x
                          << " column(s). Use emu-quasar-2x3 or larger.";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_from_all::OneFromAllConfig test_config = {
             .test_id = 30,
             .master_core_coord = {0, 0},
@@ -424,17 +417,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllDirectedIdeal) {
             .transaction_size_pages = 1,
             .page_size_bytes = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b};
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
     uint32_t test_id = 30;
-    auto* device = mesh_device->impl().get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
-    CoreCoord subordinate_grid_size = {
-        device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord subordinate_grid_size = this->device().compute_with_storage_grid_size();
     unit_tests::dm::core_from_all::directed_ideal_test(
-        mesh_device, test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
+        this->device(), test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllVirtualChannels) {
@@ -442,29 +433,21 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllVirtualChannels)
 
     // Test ID (Arbitrary)
     uint32_t test_id = 156;
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
-    CoreCoord subordinate_grid_size = {
-        device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord subordinate_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_from_all::virtual_channels_test(
-        get_mesh_device(), test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
+        this->device(), test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllCustom) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_id = 157;
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
-    CoreCoord subordinate_grid_size = {
-        device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord subordinate_grid_size = this->device().compute_with_storage_grid_size();
 
     // Parameters
     uint32_t num_of_transactions = 256;
@@ -472,7 +455,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllCustom) {
     uint32_t num_virtual_channels = 4;
 
     unit_tests::dm::core_from_all::custom_test(
-        get_mesh_device(),
+        this->device(),
         test_id,
         master_core_coord,
         subordinate_start_coord,
@@ -484,18 +467,17 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllCustom) {
 
 /* ========== Metal 2.0 variants ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllPacketSizes_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    auto arch_ = device->arch();
+    auto arch_ = this->device().arch();
 
     if (arch_ == ARCH::QUASAR) {
         // sub_grid_size {2, 1} requires at least 2 columns in the compute grid.
-        if (device->compute_with_storage_grid_size().x < 2) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: sub_grid_size {2, 1} requires >= 2 columns, but grid has "
-                         << device->compute_with_storage_grid_size().x << " column(s). Use emu-quasar-2x3 or larger.";
+                         << this->device().compute_with_storage_grid_size().x
+                         << " column(s). Use emu-quasar-2x3 or larger.";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_from_all::OneFromAllConfig test_config = {
             .test_id = 162,
             .master_core_coord = {0, 0},
@@ -506,7 +488,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllPacketSizes_2_0)
             .page_size_bytes = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b,
         };
-        EXPECT_TRUE(unit_tests::dm::core_from_all::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_from_all::run_dm(this->device(), test_config));
         return;
     }
 
@@ -514,11 +496,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllPacketSizes_2_0)
     uint32_t test_id = 162;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
-    CoreCoord subordinate_grid_size = {
-        device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord subordinate_grid_size = this->device().compute_with_storage_grid_size();
 
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     uint32_t max_transactions = 256;
     uint32_t max_transaction_size_pages = arch_ == ARCH::BLACKHOLE ? 1024 : 2048;
@@ -541,22 +522,20 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllPacketSizes_2_0)
                 .l1_data_format = DataFormat::Float16_b,
                 .noc_id = noc_id,
             };
-            EXPECT_TRUE(unit_tests::dm::core_from_all::run_dm(mesh_device, test_config));
+            EXPECT_TRUE(unit_tests::dm::core_from_all::run_dm(this->device(), test_config));
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllDirectedIdeal_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    auto arch_ = device->arch();
+    auto arch_ = this->device().arch();
 
     if (arch_ == ARCH::QUASAR) {
-        if (device->compute_with_storage_grid_size().x < 2) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: sub_grid_size {2, 1} requires >= 2 columns.";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_from_all::OneFromAllConfig test_config = {
             .test_id = 163,
             .master_core_coord = {0, 0},
@@ -567,7 +546,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllDirectedIdeal_2_
             .page_size_bytes = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b,
         };
-        EXPECT_TRUE(unit_tests::dm::core_from_all::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_from_all::run_dm(this->device(), test_config));
         return;
     }
 
@@ -575,11 +554,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllDirectedIdeal_2_
     uint32_t test_id = 163;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
-    CoreCoord subordinate_grid_size = {
-        device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord subordinate_grid_size = this->device().compute_with_storage_grid_size();
 
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
     size_t total_subordinate_cores = subordinate_grid_size.x * subordinate_grid_size.y;
     uint32_t num_of_transactions = 1;
     uint32_t transaction_size_pages = max_transmittable_pages / (num_of_transactions * total_subordinate_cores);
@@ -595,19 +573,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllDirectedIdeal_2_
         .l1_data_format = DataFormat::Float16_b,
         .noc_id = NOC::RISCV_1_default,
     };
-    EXPECT_TRUE(unit_tests::dm::core_from_all::run_dm(mesh_device, test_config));
+    EXPECT_TRUE(unit_tests::dm::core_from_all::run_dm(this->device(), test_config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllVirtualChannels_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
-    if (device->arch() == ARCH::QUASAR) {
-        if (device->compute_with_storage_grid_size().x < 2) {
+    if (this->device().arch() == ARCH::QUASAR) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: sub_grid_size {2, 1} requires >= 2 columns.";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_from_all::OneFromAllConfig test_config = {
             .test_id = 164,
             .master_core_coord = {0, 0},
@@ -620,36 +595,29 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllVirtualChannels_
             .noc_id = NOC::NOC_0,
             .num_virtual_channels = 2,
         };
-        EXPECT_TRUE(unit_tests::dm::core_from_all::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_from_all::run_dm(this->device(), test_config));
         return;
     }
 
     unit_tests::dm::core_from_all::virtual_channels_test(
-        mesh_device,
-        164,
-        {0, 0},
-        {0, 0},
-        {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y});
+        this->device(), 164, {0, 0}, {0, 0}, this->device().compute_with_storage_grid_size());
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromAllCustom_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
-    if (device->arch() == ARCH::QUASAR) {
-        if (device->compute_with_storage_grid_size().x < 2) {
+    if (this->device().arch() == ARCH::QUASAR) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: sub_grid_size {2, 1} requires >= 2 columns.";
         }
-        unit_tests::dm::core_from_all::custom_test(mesh_device, 165, {0, 0}, {0, 0}, {2, 1}, 4, 1, 2, NOC::NOC_0);
+        unit_tests::dm::core_from_all::custom_test(this->device(), 165, {0, 0}, {0, 0}, {2, 1}, 4, 1, 2, NOC::NOC_0);
         return;
     }
 
     unit_tests::dm::core_from_all::custom_test(
-        mesh_device,
+        this->device(),
         165,
         {0, 0},
         {0, 0},
-        {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y},
+        this->device().compute_with_storage_grid_size(),
         256,
         1,
         4,

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -14,7 +14,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
-#include <distributed/mesh_device_impl.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -41,8 +41,7 @@ struct OneFromOneConfig {
 /// @param test_config - Configuration of the test -- see struct
 /// @param fixture - DispatchFixture pointer for dispatch-aware operations
 /// @return
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFromOneConfig& test_config) {
-    IDevice* device = mesh_device->impl().get_device(0);
+bool run_dm(distributed::MeshDevice& mesh_device, const OneFromOneConfig& test_config) {
     const size_t transaction_size_bytes = test_config.transaction_size_pages * test_config.page_size_bytes;
 
     // (Logical) Core Coordinates and ranges
@@ -71,7 +70,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
     const std::string requestor_kernel_path =
         "tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor_2_0.cpp";
 
-    CoreCoord physical_subordinate_core = device->worker_core_from_logical_core(test_config.subordinate_core_coord);
+    CoreCoord physical_subordinate_core = mesh_device.worker_core_from_logical_core(test_config.subordinate_core_coord);
 
     using namespace tt::tt_metal::experimental;
 
@@ -81,7 +80,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
         {"num_vc", (uint32_t)test_config.num_virtual_channels}};
 
     DataMovementHardwareConfig requestor_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         requestor_hw_config = DataMovementGen2Config{};
     } else {
         requestor_hw_config = DataMovementGen1Config{
@@ -111,7 +110,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
         }},
     };
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     ProgramRunArgs run_params;
     ProgramRunArgs::KernelRunArgs requestor_run_params{.kernel = requestor_spec.unique_id};
@@ -142,20 +141,20 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
     vector<uint32_t> packed_golden = packed_input;
 
     // Launch program and record outputs
-    detail::WriteToDeviceL1(device, test_config.subordinate_core_coord, l1_base_address, packed_input);
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    slow_dispatch::WriteToL1(mesh_device, test_config.subordinate_core_coord, l1_base_address, packed_input);
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
     vector<uint32_t> packed_output;
-    detail::ReadFromDeviceL1(
-        device, test_config.master_core_coord, l1_base_address, transaction_size_bytes, packed_output);
+    slow_dispatch::ReadFromL1(
+        mesh_device, test_config.master_core_coord, l1_base_address, transaction_size_bytes, packed_output);
 
     // Results comparison
     bool is_equal = (packed_output == packed_golden);
@@ -172,7 +171,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
 }
 
 void directed_ideal_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_core_coord,
@@ -203,12 +202,11 @@ void directed_ideal_test(
 }
 
 void packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_core_coord,
     NOC noc_id = NOC::RISCV_1_default) {
-    IDevice* device = mesh_device->impl().get_device(0);
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
         unit_tests::dm::compute_physical_constraints(mesh_device);
@@ -216,7 +214,7 @@ void packet_sizes_test(
     // Parameters
     uint32_t max_transactions = 256;
     uint32_t max_transaction_size_pages =
-        device->arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+        mesh_device.arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
@@ -244,7 +242,7 @@ void packet_sizes_test(
 }
 
 void virtual_channels_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {1, 1}) {
@@ -290,7 +288,7 @@ void virtual_channels_test(
 }
 
 void custom_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_core_coord,
@@ -329,16 +327,15 @@ void custom_test(
 /* ========== TEST CASES ========== */
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOnePacketSizes) {
-    auto mesh_device = get_mesh_device();
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // subordinate_core_coord {1, 0} requires at least 2 columns in the compute grid
-        if (mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x < 2) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: subordinate core {1, 0} requires >= 2 columns, but grid has "
-                         << mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x
+                         << this->device().compute_with_storage_grid_size().x
                          << " column(s). Use emu-quasar-2x3 or larger.";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_from_core::OneFromOneConfig test_config = {
             .test_id = 5,
             .master_core_coord = {0, 0},
@@ -347,26 +344,26 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOnePacketSizes) {
             .transaction_size_pages = 4,
             .page_size_bytes = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b};
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
     uint32_t test_id = 5;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {1, 1};
-    unit_tests::dm::core_from_core::packet_sizes_test(mesh_device, test_id, master_core_coord, subordinate_core_coord);
+    unit_tests::dm::core_from_core::packet_sizes_test(
+        this->device(), test_id, master_core_coord, subordinate_core_coord);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // subordinate_core_coord {1, 0} requires at least 2 columns in the compute grid
-        if (mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x < 2) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: subordinate core {1, 0} requires >= 2 columns, but grid has "
-                         << mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x
+                         << this->device().compute_with_storage_grid_size().x
                          << " column(s). Use emu-quasar-2x3 or larger.";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_from_core::OneFromOneConfig test_config = {
             .test_id = 51,
             .master_core_coord = {0, 0},
@@ -375,14 +372,14 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneDirectedIdeal) {
             .transaction_size_pages = 1,
             .page_size_bytes = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b};
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
     uint32_t test_id = 51;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {0, 1};
     unit_tests::dm::core_from_core::directed_ideal_test(
-        mesh_device, test_id, master_core_coord, subordinate_core_coord);
+        this->device(), test_id, master_core_coord, subordinate_core_coord);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneVirtualChannels) {
@@ -391,7 +388,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneVirtualChannels)
     uint32_t test_id = 152;
 
     unit_tests::dm::core_from_core::virtual_channels_test(
-        get_mesh_device(),
+        this->device(),
         test_id,
         CoreCoord(0, 0),  // Master Core
         CoreCoord(0, 1)   // Subordinate Core
@@ -408,7 +405,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneCustom) {
     uint32_t num_virtual_channels = 4;
 
     unit_tests::dm::core_from_core::custom_test(
-        get_mesh_device(),
+        this->device(),
         test_id,
         CoreCoord(0, 0),  // Master Core
         CoreCoord(0, 1),  // Subordinate Core
@@ -418,12 +415,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneCustom) {
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOnePacketSizes2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // Quasar emulator (1x3 or 2x3): pick a subordinate that exists on the grid
         // and run a single small config. Full sweep is too large for emulator.
-        auto grid = device->compute_with_storage_grid_size();
+        auto grid = this->device().compute_with_storage_grid_size();
         CoreCoord subordinate;
         if (grid.x >= 2) {
             subordinate = {1, 0};
@@ -433,7 +428,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOnePacketSizes2_0) 
             GTEST_SKIP() << "Skipping: need at least a 1x2 or 2x1 grid, got " << grid.x << "x" << grid.y;
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_from_core::OneFromOneConfig test_config = {
             .test_id = 159,
             .master_core_coord = {0, 0},
@@ -443,18 +438,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOnePacketSizes2_0) 
             .page_size_bytes = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b,
         };
-        EXPECT_TRUE(unit_tests::dm::core_from_core::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_from_core::run_dm(this->device(), test_config));
         return;
     }
     uint32_t test_id = 159;
-    unit_tests::dm::core_from_core::packet_sizes_test(mesh_device, test_id, CoreCoord(0, 0), CoreCoord(1, 1));
+    unit_tests::dm::core_from_core::packet_sizes_test(this->device(), test_id, CoreCoord(0, 0), CoreCoord(1, 1));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneDirectedIdeal2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    if (device->arch() == ARCH::QUASAR) {
-        auto grid = device->compute_with_storage_grid_size();
+    if (this->device().arch() == ARCH::QUASAR) {
+        auto grid = this->device().compute_with_storage_grid_size();
         CoreCoord subordinate;
         if (grid.x >= 2) {
             subordinate = {1, 0};
@@ -464,7 +457,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneDirectedIdeal2_0
             GTEST_SKIP() << "Skipping: need at least a 1x2 or 2x1 grid, got " << grid.x << "x" << grid.y;
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_from_core::OneFromOneConfig test_config = {
             .test_id = 161,
             .master_core_coord = {0, 0},
@@ -474,11 +467,11 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneFromOneDirectedIdeal2_0
             .page_size_bytes = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b,
         };
-        EXPECT_TRUE(unit_tests::dm::core_from_core::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_from_core::run_dm(this->device(), test_config));
         return;
     }
     unit_tests::dm::core_from_core::directed_ideal_test(
-        mesh_device, 161, CoreCoord(0, 0), CoreCoord(0, 1), NOC::RISCV_1_default);
+        this->device(), 161, CoreCoord(0, 0), CoreCoord(0, 1), NOC::RISCV_1_default);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -14,7 +15,6 @@
 #include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -37,9 +37,7 @@ struct OnePacketConfig {
 /// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePacketConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
+bool run_dm(distributed::MeshDevice& mesh_device, const OnePacketConfig& test_config) {
     // (Logical) Core Coordinates and ranges
     CoreRangeSet master_core_set({CoreRange(test_config.master_core_coord)});
 
@@ -68,7 +66,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
     const std::string kernel_path = std::string("tests/tt_metal/tt_metal/data_movement/one_packet/kernels/") +
                                     (test_config.read ? "read_one_packet_2_0" : "write_one_packet_2_0") + ".cpp";
 
-    CoreCoord physical_subordinate_core = device->worker_core_from_logical_core(test_config.subordinate_core_coord);
+    CoreCoord physical_subordinate_core = mesh_device.worker_core_from_logical_core(test_config.subordinate_core_coord);
 
     using namespace tt::tt_metal::experimental;
 
@@ -79,7 +77,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
     const NOC noc = test_config.read ? NOC::RISCV_1_default : NOC::RISCV_0_default;
 
     DataMovementHardwareConfig kspec_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         kspec_hw_config = DataMovementGen2Config{};
     } else {
         kspec_hw_config = DataMovementGen1Config{
@@ -115,7 +113,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
         }},
     };
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     ProgramRunArgs run_params;
     ProgramRunArgs::KernelRunArgs krp{.kernel = kspec.unique_id};
@@ -150,24 +148,27 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
 
     // Launch program and record outputs
     if (test_config.read) {
-        detail::WriteToDeviceL1(device, test_config.subordinate_core_coord, subordinate_l1_address, packed_input);
-        MetalContext::instance().get_cluster().l1_barrier(device->id());
-
+        slow_dispatch::WriteToL1(mesh_device, test_config.subordinate_core_coord, subordinate_l1_address, packed_input);
+        MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
         auto mesh_workload = distributed::MeshWorkload();
         vector<uint32_t> coord_data = {0, 0};
         auto target_devices =
             distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
         mesh_workload.add_program(target_devices, std::move(program));
 
-        auto& cq = mesh_device->mesh_command_queue();
+        auto& cq = mesh_device.mesh_command_queue();
         distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
         Finish(cq);
 
-        detail::ReadFromDeviceL1(
-            device, test_config.master_core_coord, master_l1_address, test_config.packet_size_bytes, packed_output);
+        slow_dispatch::ReadFromL1(
+            mesh_device,
+            test_config.master_core_coord,
+            master_l1_address,
+            test_config.packet_size_bytes,
+            packed_output);
     } else {
-        detail::WriteToDeviceL1(device, test_config.master_core_coord, master_l1_address, packed_input);
-        MetalContext::instance().get_cluster().l1_barrier(device->id());
+        slow_dispatch::WriteToL1(mesh_device, test_config.master_core_coord, master_l1_address, packed_input);
+        MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
         auto mesh_workload = distributed::MeshWorkload();
         vector<uint32_t> coord_data = {0, 0};
@@ -175,12 +176,12 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
             distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
         mesh_workload.add_program(target_devices, std::move(program));
 
-        auto& cq = mesh_device->mesh_command_queue();
+        auto& cq = mesh_device.mesh_command_queue();
         distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
         Finish(cq);
 
-        detail::ReadFromDeviceL1(
-            device,
+        slow_dispatch::ReadFromL1(
+            mesh_device,
             test_config.subordinate_core_coord,
             subordinate_l1_address,
             test_config.packet_size_bytes,
@@ -204,17 +205,16 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
 
 /* ========== Test case for reading varying number of packets and packet sizes; Test id = 80 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadSizes) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // subordinate_core_coord {1, 0} requires at least 2 columns in the compute grid
-        if (device->compute_with_storage_grid_size().x < 2) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: subordinate core {1, 0} requires >= 2 columns, but grid has "
-                         << device->compute_with_storage_grid_size().x << " column(s). Use emu-quasar-2x3 or larger.";
+                         << this->device().compute_with_storage_grid_size().x
+                         << " column(s). Use emu-quasar-2x3 or larger.";
         }
         // Single run to validate the Quasar code path within emulator timeout
         unit_tests::dm::one_packet::OnePacketConfig test_config = {
@@ -225,13 +225,13 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadSizes) {
             .packet_size_bytes = page_size_bytes,
             .read = true,
         };
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
 
     // Parameters
     uint32_t max_packet_size_bytes =
-        device->arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;  // 16 kB for BH, 8 kB for WH
+        this->device().arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;  // 16 kB for BH, 8 kB for WH
     uint32_t max_packets = 256;
 
     // Cores
@@ -252,25 +252,23 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadSizes) {
             };
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 /* ========== Test case for writing varying number of packets and packet sizes; Test id = 81 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteSizes) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // subordinate_core_coord {1, 0} requires at least 2 columns in the compute grid
-        if (device->compute_with_storage_grid_size().x < 2) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: subordinate core {1, 0} requires >= 2 columns, but grid has "
-                         << device->compute_with_storage_grid_size().x << " column(s). Use emu-quasar-2x3 or larger.";
+                         << this->device().compute_with_storage_grid_size().x
+                         << " column(s). Use emu-quasar-2x3 or larger.";
         }
         // Single run to validate the Quasar code path within emulator timeout
         unit_tests::dm::one_packet::OnePacketConfig test_config = {
@@ -281,13 +279,13 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteSizes) {
             .packet_size_bytes = page_size_bytes,
             .read = false,
         };
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
 
     // Parameters
     uint32_t max_packet_size_bytes =
-        device->arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;  // 16 kB for BH, 8 kB for WH
+        this->device().arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;  // 16 kB for BH, 8 kB for WH
     uint32_t max_packets = 256;
     // Cores
     CoreCoord master_core_coord = {0, 0};
@@ -307,16 +305,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteSizes) {
             };
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
 
 /* ========== Directed Ideal Test Case; Test id = 82 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
     // Parameters
     uint32_t packet_size_bytes = page_size_bytes * 256;  // max packet size = 256 flits
@@ -341,14 +338,13 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadDirectedIdeal
     };
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
 /* ========== Directed Ideal Test Case; Test id = 83 ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
     // Parameters
     uint32_t packet_size_bytes = page_size_bytes * 256;  // max packet size = 256 flits
@@ -373,17 +369,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteDirectedIdea
     };
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadSizes_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
-    if (device->arch() == ARCH::QUASAR) {
-        auto grid = device->compute_with_storage_grid_size();
+    if (this->device().arch() == ARCH::QUASAR) {
+        auto grid = this->device().compute_with_storage_grid_size();
         CoreCoord subordinate;
         if (grid.x >= 2) {
             subordinate = {1, 0};
@@ -400,12 +394,12 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadSizes_2_0) {
             .packet_size_bytes = page_size_bytes,
             .read = true,
         };
-        EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(this->device(), test_config));
         return;
     }
 
     // WH/BH: full sweep with Metal 2.0 host path.
-    uint32_t max_packet_size_bytes = device->arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
+    uint32_t max_packet_size_bytes = this->device().arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
     uint32_t max_packets = 256;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {0, 1};
@@ -421,19 +415,17 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadSizes_2_0) {
                 .packet_size_bytes = packet_size_bytes,
                 .read = true,
             };
-            EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(mesh_device, test_config));
+            EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(this->device(), test_config));
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteSizes_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
-    if (device->arch() == ARCH::QUASAR) {
-        auto grid = device->compute_with_storage_grid_size();
+    if (this->device().arch() == ARCH::QUASAR) {
+        auto grid = this->device().compute_with_storage_grid_size();
         CoreCoord subordinate;
         if (grid.x >= 2) {
             subordinate = {1, 0};
@@ -450,12 +442,12 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteSizes_2_0) {
             .packet_size_bytes = page_size_bytes,
             .read = false,
         };
-        EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(this->device(), test_config));
         return;
     }
 
     // WH/BH: full sweep with Metal 2.0 host path.
-    uint32_t max_packet_size_bytes = device->arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
+    uint32_t max_packet_size_bytes = this->device().arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
     uint32_t max_packets = 257;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {0, 1};
@@ -471,22 +463,20 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteSizes_2_0) {
                 .packet_size_bytes = packet_size_bytes,
                 .read = false,
             };
-            EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(mesh_device, test_config));
+            EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(this->device(), test_config));
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadDirectedIdeal_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {0, 1};
 
-    if (device->arch() == ARCH::QUASAR) {
-        auto grid = device->compute_with_storage_grid_size();
+    if (this->device().arch() == ARCH::QUASAR) {
+        auto grid = this->device().compute_with_storage_grid_size();
         if (grid.x >= 2) {
             subordinate_core_coord = {1, 0};
         } else if (grid.y >= 2) {
@@ -502,7 +492,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadDirectedIdeal
             .packet_size_bytes = page_size_bytes,
             .read = true,
         };
-        EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(this->device(), test_config));
         return;
     }
 
@@ -517,20 +507,18 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketReadDirectedIdeal
         .packet_size_bytes = packet_size_bytes,
         .read = true,
     };
-    EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(mesh_device, test_config));
+    EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(this->device(), test_config));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteDirectedIdeal_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {0, 1};
 
-    if (device->arch() == ARCH::QUASAR) {
-        auto grid = device->compute_with_storage_grid_size();
+    if (this->device().arch() == ARCH::QUASAR) {
+        auto grid = this->device().compute_with_storage_grid_size();
         if (grid.x >= 2) {
             subordinate_core_coord = {1, 0};
         } else if (grid.y >= 2) {
@@ -546,7 +534,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteDirectedIdea
             .packet_size_bytes = page_size_bytes,
             .read = false,
         };
-        EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(this->device(), test_config));
         return;
     }
 
@@ -561,7 +549,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOnePacketWriteDirectedIdea
         .packet_size_bytes = packet_size_bytes,
         .read = false,
     };
-    EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(mesh_device, test_config));
+    EXPECT_TRUE(unit_tests::dm::one_packet::run_dm(this->device(), test_config));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
@@ -8,7 +8,6 @@
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
 #include "test_one_to_all.hpp"
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -18,11 +17,9 @@ using namespace test_utils;
 
 namespace unit_tests::dm::core_to_all::multicast_schemes {
 
-uint32_t determine_max_grid_dimension(const shared_ptr<distributed::MeshDevice>& mesh_device) {
-    uint32_t smaller_dimension =
-        min(mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x,
-            mesh_device->impl().get_device(0)->compute_with_storage_grid_size().y);
-    return (smaller_dimension - 1);
+uint32_t determine_max_grid_dimension(distributed::MeshDevice& mesh_device) {
+    CoreCoord grid_size = mesh_device.compute_with_storage_grid_size();
+    return min(grid_size.x, grid_size.y) - 1;
 }
 
 enum class MulticastSchemeType {
@@ -98,7 +95,7 @@ pair<CoreCoord, CoreCoord> get_coordinates(uint32_t sub_grid_dimension_size, Mul
 }
 
 void test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     uint32_t sub_grid_dimension_size,
     NOC noc_id,
@@ -125,8 +122,7 @@ void test(
         static_cast<uint32_t>(multicast_scheme_type));
 }
 
-void run_all_tests(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_case_id, bool loopback = true) {
+void run_all_tests(distributed::MeshDevice& mesh_device, uint32_t test_case_id, bool loopback = true) {
     vector<NOC> noc_ids = {NOC::NOC_0, NOC::NOC_1};
     uint32_t starting_sub_grid_dimension_size = 2;  // Minimum size for sub-grid dimension
     uint32_t sub_grid_dimension_limit = determine_max_grid_dimension(mesh_device);
@@ -165,7 +161,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastSchemesLo
     uint32_t test_case_id = 100;
     bool loopback = true;
 
-    unit_tests::dm::core_to_all::multicast_schemes::run_all_tests(get_mesh_device(), test_case_id, loopback);
+    unit_tests::dm::core_to_all::multicast_schemes::run_all_tests(this->device(), test_case_id, loopback);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastSchemesNoLoopback) {
@@ -174,14 +170,14 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastSchemesNo
     uint32_t test_case_id = 101;
     bool loopback = false;
 
-    unit_tests::dm::core_to_all::multicast_schemes::run_all_tests(get_mesh_device(), test_case_id, loopback);
+    unit_tests::dm::core_to_all::multicast_schemes::run_all_tests(this->device(), test_case_id, loopback);
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastSchemesNoLoopback2_0) {
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 10;
     bool loopback = false;
 
-    unit_tests::dm::core_to_all::multicast_schemes::run_all_tests(get_mesh_device(), test_case_id, loopback);
+    unit_tests::dm::core_to_all::multicast_schemes::run_all_tests(this->device(), test_case_id, loopback);
 }
 
 /* ============================================================= */
@@ -210,17 +206,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastSchemeSin
 
     uint32_t test_case_id = 102;
 
-    auto mesh_device = get_mesh_device();
-
     bool loopback = false;
     NOC noc_id = NOC::NOC_0;
     uint32_t sub_grid_dimension_size =
-        mesh_device->impl().get_device(0)->arch() == ARCH::WORMHOLE_B0 ? 7 : 9;  // Adjust based on architecture
+        this->device().arch() == ARCH::WORMHOLE_B0 ? 7 : 9;  // Adjust based on architecture
     unit_tests::dm::core_to_all::multicast_schemes::MulticastSchemeType multicast_scheme =
         unit_tests::dm::core_to_all::multicast_schemes::MulticastSchemeType::SenderInGridTopRight;
 
     unit_tests::dm::core_to_all::multicast_schemes::test(
-        mesh_device, test_case_id, sub_grid_dimension_size, noc_id, multicast_scheme, loopback);
+        this->device(), test_case_id, sub_grid_dimension_size, noc_id, multicast_scheme, loopback);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -17,8 +17,8 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "test_one_to_all.hpp"
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -56,8 +56,7 @@ struct OneToAllConfig {
     //  response packets) (60, 45, 23, vs 60, 60, 60 at posted)
 };
 
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToAllConfig& test_config) {
-    IDevice* device = mesh_device->impl().get_device(0);
+bool run_dm(distributed::MeshDevice& mesh_device, const OneToAllConfig& test_config) {
     /* ================ SETUP ================ */
 
     // Program
@@ -79,7 +78,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
 
     // Master Logical
     CoreRangeSet mst_logical_core_set({CoreRange(test_config.mst_core_coord)});
-    auto mst_core_physical = device->worker_core_from_logical_core(test_config.mst_core_coord);
+    auto mst_core_physical = mesh_device.worker_core_from_logical_core(test_config.mst_core_coord);
     uint32_t mst_core_coord_packed = (mst_core_physical.x << 16) | (mst_core_physical.y & 0xFFFF);
 
     // Subordinate Logical
@@ -96,11 +95,11 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
     auto sub_core_list = corerange_to_cores(sub_logical_core_set);
 
     // Subordinate Physical (only needed for unicast)
-    CoreCoord sub_worker_start_coord = device->worker_core_from_logical_core(sub_logical_start_coord);
-    CoreCoord sub_worker_end_coord = device->worker_core_from_logical_core(sub_logical_end_coord);
+    CoreCoord sub_worker_start_coord = mesh_device.worker_core_from_logical_core(sub_logical_start_coord);
+    CoreCoord sub_worker_end_coord = mesh_device.worker_core_from_logical_core(sub_logical_end_coord);
     vector<uint32_t> sub_worker_coordinates = {};
     for (auto& sub_logical_core : sub_core_list) {
-        CoreCoord sub_worker_core = device->worker_core_from_logical_core(sub_logical_core);
+        CoreCoord sub_worker_core = mesh_device.worker_core_from_logical_core(sub_logical_core);
         uint32_t sub_worker_core_packed =
             (sub_worker_core.x << 16) | (sub_worker_core.y & 0xFFFF);  // Pack coordinates into a single uint32_t
         sub_worker_coordinates.push_back(sub_worker_core_packed);
@@ -241,7 +240,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
         const uint32_t num_coord_varargs = test_config.is_multicast ? 0u : (uint32_t)sub_worker_coordinates.size();
 
         DataMovementHardwareConfig sender_hw_config;
-        if (device->arch() == tt::ARCH::QUASAR) {
+        if (mesh_device.arch() == tt::ARCH::QUASAR) {
             sender_hw_config = DataMovementGen2Config{};
         } else {
             sender_hw_config = DataMovementGen1Config{
@@ -269,7 +268,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
             }},
         };
 
-        program = MakeProgramFromSpec(*mesh_device, spec);
+        program = MakeProgramFromSpec(mesh_device, spec);
 
         ProgramRunArgs run_params;
         ProgramRunArgs::KernelRunArgs sender_run_params{.kernel = sender_spec.unique_id};
@@ -348,8 +347,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
     vector<uint32_t> packed_golden = packed_input;
 
     // Write input to master L1 buffer
-    detail::WriteToDeviceL1(device, test_config.mst_core_coord, mst_l1_base_address, packed_input);
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    slow_dispatch::WriteToL1(mesh_device, test_config.mst_core_coord, mst_l1_base_address, packed_input);
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     // LAUNCH THE PROGRAM
     auto mesh_workload = distributed::MeshWorkload();
@@ -357,7 +356,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
@@ -365,7 +364,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
     vector<uint32_t> packed_output;
 
     for (auto& sub_logical_core : sub_core_list) {
-        detail::ReadFromDeviceL1(device, sub_logical_core, sub_l1_base_address, bytes_per_transaction, packed_output);
+        slow_dispatch::ReadFromL1(
+            mesh_device, sub_logical_core, sub_l1_base_address, bytes_per_transaction, packed_output);
 
         // Results comparison
         bool is_equal = (packed_output == packed_golden);
@@ -385,7 +385,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
 /* TEST TYPES */
 
 void directed_ideal_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     bool is_multicast,
     bool is_linked,
@@ -440,7 +440,7 @@ void directed_ideal_test(
 }
 
 void packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     bool is_multicast,
     bool is_linked,
@@ -459,7 +459,7 @@ void packet_sizes_test(
 
     uint32_t max_transactions = 256;
     uint32_t max_pages_reservable_per_transaction =
-        mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE
+        mesh_device.arch() == ARCH::BLACKHOLE
             ? 1024 * max_pages_override_factor
             : 2048 * max_pages_override_factor;  // Max total transaction size == 64 KB
 
@@ -502,7 +502,7 @@ void packet_sizes_test(
 }
 
 void virtual_channels_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     bool is_multicast,
     bool is_linked,
@@ -564,7 +564,7 @@ void virtual_channels_test(
 }
 
 void custom_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     bool is_multicast,
     bool is_linked,
@@ -633,9 +633,8 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllUnicast2x2
     CoreCoord sub_start_core_coord = {0, 0};
     CoreCoord sub_grid_size = {2, 2};
 
-    auto mesh_device = get_mesh_device();
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== 5x5 ========== */
@@ -650,9 +649,8 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllUnicast5x5
     CoreCoord sub_start_core_coord = {0, 0};
     CoreCoord sub_grid_size = {5, 5};
 
-    auto mesh_device = get_mesh_device();
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== All ========== */
@@ -660,18 +658,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastPacketSizes
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 2;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     bool is_multicast = false;
     bool is_linked = false;
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== MULTICAST ========== */
@@ -681,8 +676,6 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast2
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 3;
 
-    auto mesh_device = get_mesh_device();
-
     bool is_multicast = true;
     bool is_linked = false;
 
@@ -691,15 +684,13 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast2
     CoreCoord sub_grid_size = {2, 2};
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== 5x5 ========== */
 TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast5x5PacketSizes) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 4;
-
-    auto mesh_device = get_mesh_device();
 
     bool is_multicast = true;
     bool is_linked = false;
@@ -709,7 +700,7 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast5
     CoreCoord sub_grid_size = {5, 5};
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== All ========== */
@@ -717,18 +708,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastPacketSiz
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 5;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     bool is_multicast = true;
     bool is_linked = false;
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== MULTICAST LINKED ========== */
@@ -738,8 +726,6 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastL
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 6;
 
-    auto mesh_device = get_mesh_device();
-
     bool is_multicast = true;
     bool is_linked = true;
 
@@ -748,15 +734,13 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastL
     CoreCoord sub_grid_size = {2, 2};
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== 5x5 ========== */
 TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLinked5x5PacketSizes) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 7;
-
-    auto mesh_device = get_mesh_device();
 
     bool is_multicast = true;
     bool is_linked = true;
@@ -766,7 +750,7 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastL
     CoreCoord sub_grid_size = {5, 5};
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== 11x10 ========== */
@@ -774,18 +758,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedPac
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 8;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     bool is_multicast = true;
     bool is_linked = true;
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== MULTICAST LINKED WITH SEMAPHORE ========== */
@@ -795,8 +776,6 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSem
 
     // Parameters
     uint32_t test_case_id = 24;
-
-    auto mesh_device = get_mesh_device();
 
     bool is_multicast = true;
     bool is_linked = true;
@@ -808,7 +787,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSem
     CoreCoord sub_grid_size = {2, 2};
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,
@@ -826,8 +805,6 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSem
     // Parameters
     uint32_t test_case_id = 25;
 
-    auto mesh_device = get_mesh_device();
-
     bool is_multicast = true;
     bool is_linked = true;
     bool use_semaphore = true;
@@ -838,7 +815,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSem
     CoreCoord sub_grid_size = {5, 5};
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,
@@ -856,9 +833,6 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSem
     // Parameters
     uint32_t test_case_id = 26;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     bool is_multicast = true;
     bool is_linked = true;
     bool use_semaphore = true;
@@ -866,10 +840,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSem
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,
@@ -884,17 +858,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSem
 
 /* ========== UNICAST ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // sub_grid_size {2, 1} requires at least 2 columns in the compute grid
-        if (device->compute_with_storage_grid_size().x < 2) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: sub_grid_size {2, 1} requires >= 2 columns, but grid has "
-                         << device->compute_with_storage_grid_size().x << " column(s). Use emu-quasar-2x3 or larger.";
+                         << this->device().compute_with_storage_grid_size().x
+                         << " column(s). Use emu-quasar-2x3 or larger.";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_to_all::OneToAllConfig test_config = {
             .test_id = 52,
             .mst_core_coord = {0, 0},
@@ -906,7 +878,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastDirectedIde
             .l1_data_format = DataFormat::Float16_b,
             .loopback = true,
             .is_multicast = false};
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
 
@@ -921,10 +893,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastDirectedIde
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_to_all::directed_ideal_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,
@@ -941,9 +913,6 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastDirectedI
     // Parameters
     uint32_t test_case_id = 53;  // Arbitrary test id
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     bool loopback = true;
     NOC noc_id = NOC::NOC_0;
 
@@ -952,10 +921,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastDirectedI
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_to_all::directed_ideal_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,
@@ -972,9 +941,6 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedDir
     // Parameters
     uint32_t test_case_id = 54;  // Arbitrary test id
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     bool loopback = true;
     NOC noc_id = NOC::NOC_0;
 
@@ -983,10 +949,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedDir
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_to_all::directed_ideal_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,
@@ -1003,9 +969,6 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSem
     // Parameters
     uint32_t test_case_id = 56;  // Arbitrary test id
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     bool loopback = true;
     NOC noc_id = NOC::NOC_0;
 
@@ -1016,10 +979,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedSem
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_to_all::directed_ideal_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,
@@ -1040,9 +1003,6 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastVirtualChan
     // Parameters
     uint32_t test_case_id = 154;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     // These should always be false
     bool is_multicast = false;
     bool is_linked = false;
@@ -1050,13 +1010,13 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastVirtualChan
     // Grid Parameters
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     // Loopback
     bool loopback = true;
 
     unit_tests::dm::core_to_all::virtual_channels_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,
@@ -1072,9 +1032,6 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastCustom) {
     // Parameters
     uint32_t test_case_id = 155;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     // These should always be false
     bool is_multicast = false;
     bool is_linked = false;
@@ -1082,7 +1039,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastCustom) {
     // Grid Parameters
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     // Custom Parameters
     bool loopback = true;
@@ -1091,7 +1048,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastCustom) {
     uint32_t num_virtual_channels = 4;
 
     unit_tests::dm::core_to_all::custom_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,
@@ -1118,9 +1075,8 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllUnicast2x2
     CoreCoord sub_start_core_coord = {0, 0};
     CoreCoord sub_grid_size = {2, 2};
 
-    auto mesh_device = get_mesh_device();
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== 5x5 ========== */
@@ -1135,9 +1091,8 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllUnicast5x5
     CoreCoord sub_start_core_coord = {0, 0};
     CoreCoord sub_grid_size = {5, 5};
 
-    auto mesh_device = get_mesh_device();
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== All ========== */
@@ -1145,24 +1100,21 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastPacketSizes
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 2;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     bool is_multicast = false;
     bool is_linked = false;
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     // Quasar emulator: full packet-size sweep across the whole grid times-out. Run a single
     // small config to exercise the Metal 2.0 host path + sender_unicast_2_0 kernel.
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         if (sub_grid_size.x < 2 && sub_grid_size.y < 1) {
             GTEST_SKIP() << "Skipping: emulator grid too small for one_to_all unicast 2_0";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_to_all::OneToAllConfig test_config = {
             .test_id = test_case_id,
             .mst_core_coord = mst_core_coord,
@@ -1177,12 +1129,12 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastPacketSizes
             .is_multicast = false,
             .is_linked = false,
         };
-        EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(this->device(), test_config));
         return;
     }
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== MULTICAST 2.0 ========== */
@@ -1192,8 +1144,6 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast2
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 3;
 
-    auto mesh_device = get_mesh_device();
-
     bool is_multicast = true;
     bool is_linked = false;
 
@@ -1202,15 +1152,13 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast2
     CoreCoord sub_grid_size = {2, 2};
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== 5x5 ========== */
 TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast5x5PacketSizes2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 4;
-
-    auto mesh_device = get_mesh_device();
 
     bool is_multicast = true;
     bool is_linked = false;
@@ -1220,7 +1168,7 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticast5
     CoreCoord sub_grid_size = {5, 5};
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== All ========== */
@@ -1228,24 +1176,21 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastPacketSiz
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 5;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     bool is_multicast = true;
     bool is_linked = false;
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     // Quasar emulator: full packet-size sweep across the whole grid times-out. Run a single
     // small config to exercise the Metal 2.0 host path + sender_multicast_2_0 kernel.
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         if (sub_grid_size.x < 2 || sub_grid_size.y < 1) {
             GTEST_SKIP() << "Skipping: emulator grid too small for one_to_all multicast 2_0";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_to_all::OneToAllConfig test_config = {
             .test_id = test_case_id,
             .mst_core_coord = mst_core_coord,
@@ -1260,12 +1205,12 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastPacketSiz
             .is_multicast = true,
             .is_linked = false,
         };
-        EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(this->device(), test_config));
         return;
     }
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== MULTICAST LINKED ========== */
@@ -1275,8 +1220,6 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastL
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 6;
 
-    auto mesh_device = get_mesh_device();
-
     bool is_multicast = true;
     bool is_linked = true;
 
@@ -1285,15 +1228,13 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastL
     CoreCoord sub_grid_size = {2, 2};
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== 5x5 ========== */
 TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastLinked5x5PacketSizes2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 7;
-
-    auto mesh_device = get_mesh_device();
 
     bool is_multicast = true;
     bool is_linked = true;
@@ -1303,7 +1244,7 @@ TEST_F(UnitMeshFastDispatchFixture, NIGHTLY_TensixDataMovementOneToAllMulticastL
     CoreCoord sub_grid_size = {5, 5};
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== 11x10 ========== */
@@ -1311,24 +1252,21 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedPac
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 8;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     bool is_multicast = true;
     bool is_linked = true;
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     // Quasar emulator: full packet-size sweep across the whole grid times-out. Run a single
     // small config to exercise the Metal 2.0 host path + sender_multicast_2_0 kernel (linked).
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         if (sub_grid_size.x < 2 || sub_grid_size.y < 1) {
             GTEST_SKIP() << "Skipping: emulator grid too small for one_to_all multicast linked 2_0";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_to_all::OneToAllConfig test_config = {
             .test_id = test_case_id,
             .mst_core_coord = mst_core_coord,
@@ -1343,21 +1281,18 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedPac
             .is_multicast = true,
             .is_linked = true,
         };
-        EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(this->device(), test_config));
         return;
     }
 
     unit_tests::dm::core_to_all::packet_sizes_test(
-        mesh_device, test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
+        this->device(), test_case_id, is_multicast, is_linked, mst_core_coord, sub_start_core_coord, sub_grid_size);
 }
 
 /* ========== MULTICAST LINKED WITH LOOPBACK ========== */
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedDirectedIdeal2_0) {
     // Parameters
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 9;
-
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
 
     bool loopback = true;
     NOC noc_id = NOC::NOC_0;
@@ -1367,10 +1302,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedDir
 
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_to_all::directed_ideal_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,
@@ -1385,16 +1320,14 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastLinkedDir
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastDirectedIdeal_2_0) {
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 11;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
-    if (device->arch() == ARCH::QUASAR) {
-        if (device->compute_with_storage_grid_size().x < 2) {
+    if (this->device().arch() == ARCH::QUASAR) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: sub_grid_size {2, 1} requires >= 2 columns, but grid has "
-                         << device->compute_with_storage_grid_size().x << " column(s). Use emu-quasar-2x3 or larger.";
+                         << this->device().compute_with_storage_grid_size().x
+                         << " column(s). Use emu-quasar-2x3 or larger.";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_to_all::OneToAllConfig test_config = {
             .test_id = test_case_id,
             .mst_core_coord = {0, 0},
@@ -1407,7 +1340,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastDirectedIde
             .loopback = true,
             .is_multicast = false,
         };
-        EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(this->device(), test_config));
         return;
     }
 
@@ -1417,10 +1350,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastDirectedIde
     bool is_linked = false;
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_to_all::directed_ideal_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,
@@ -1435,15 +1368,12 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllUnicastDirectedIde
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastDirectedIdeal_2_0) {
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 12;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
-    if (device->arch() == ARCH::QUASAR) {
-        if (device->compute_with_storage_grid_size().x < 2) {
+    if (this->device().arch() == ARCH::QUASAR) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: emulator grid too small for multicast directed ideal _2_0";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_to_all::OneToAllConfig test_config = {
             .test_id = test_case_id,
             .mst_core_coord = {0, 0},
@@ -1458,7 +1388,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastDirectedI
             .is_multicast = true,
             .is_linked = false,
         };
-        EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_to_all::run_dm(this->device(), test_config));
         return;
     }
 
@@ -1468,10 +1398,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToAllMulticastDirectedI
     bool is_linked = false;
     CoreCoord mst_core_coord = {0, 0};
     CoreCoord sub_start_core_coord = {0, 0};
-    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = this->device().compute_with_storage_grid_size();
 
     unit_tests::dm::core_to_all::directed_ideal_test(
-        mesh_device,
+        this->device(),
         test_case_id,
         is_multicast,
         is_linked,

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.hpp
@@ -11,7 +11,7 @@ constexpr uint32_t START_ID = 6;
 constexpr uint32_t START_ID_2_0 = 170;
 
 void directed_ideal_test(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_case_id,
     bool is_multicast,
     bool is_linked,

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -14,7 +15,6 @@
 #include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -41,10 +41,7 @@ struct OneToOneConfig {
 /// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToOneConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
-
+bool run_dm(distributed::MeshDevice& mesh_device, const OneToOneConfig& test_config) {
     /* ================ SETUP ================ */
 
     // Buffer Parameters
@@ -83,7 +80,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToO
     uint32_t l1_base_address = master_l1_info.base_address;
 
     // Physical Core Coordinates
-    CoreCoord physical_subordinate_core = device->worker_core_from_logical_core(test_config.subordinate_core_coord);
+    CoreCoord physical_subordinate_core = mesh_device.worker_core_from_logical_core(test_config.subordinate_core_coord);
     uint32_t packed_subordinate_core_coordinates =
         physical_subordinate_core.x << 16 | (physical_subordinate_core.y & 0xFFFF);
 
@@ -100,7 +97,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToO
     KernelSpec::CompileTimeArgs cta_bindings(cta_bindings_map);
 
     DataMovementHardwareConfig sender_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         sender_hw_config = DataMovementGen2Config{};
     } else {
         sender_hw_config = DataMovementGen1Config{
@@ -127,7 +124,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToO
         }},
     };
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     ProgramRunArgs run_params;
     ProgramRunArgs::KernelRunArgs sender_run_params{.kernel = sender_spec.unique_id};
@@ -158,8 +155,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToO
     vector<uint32_t> packed_golden = packed_input;
 
     // Write Input to Master L1
-    detail::WriteToDeviceL1(device, test_config.master_core_coord, l1_base_address, packed_input);
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    slow_dispatch::WriteToL1(mesh_device, test_config.master_core_coord, l1_base_address, packed_input);
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     // LAUNCH THE PROGRAM - Use mesh workload approach
     auto mesh_workload = distributed::MeshWorkload();
@@ -168,14 +165,14 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToO
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
     // Record Output from Subordinate L1
     vector<uint32_t> packed_output;
-    detail::ReadFromDeviceL1(
-        device, test_config.subordinate_core_coord, l1_base_address, bytes_per_transaction, packed_output);
+    slow_dispatch::ReadFromL1(
+        mesh_device, test_config.subordinate_core_coord, l1_base_address, bytes_per_transaction, packed_output);
 
     // Compare output with golden vector
     bool is_equal = (packed_output == packed_golden);
@@ -192,7 +189,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToO
 }
 
 void directed_ideal_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {0, 1},
@@ -226,7 +223,7 @@ void directed_ideal_test(
 }
 
 void virtual_channels_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {1, 1}) {
@@ -270,11 +267,10 @@ void virtual_channels_test(
 }
 
 void packet_sizes_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {1, 1}) {
-    IDevice* device = mesh_device->impl().get_device(0);
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
         unit_tests::dm::compute_physical_constraints(mesh_device);
@@ -282,7 +278,7 @@ void packet_sizes_test(
     // Parameters
     uint32_t max_transactions = 256;
     uint32_t max_pages_per_transaction =
-        device->arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+        mesh_device.arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t pages_per_transaction = 1; pages_per_transaction <= max_pages_per_transaction;
@@ -310,7 +306,7 @@ void packet_sizes_test(
 }
 
 void custom_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {1, 1},
@@ -341,16 +337,15 @@ void custom_test(
 /* ========== TEST CASES ========== */
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOnePacketSizes) {
-    auto mesh_device = get_mesh_device();
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // subordinate_core_coord {1, 0} requires at least 2 columns in the compute grid
-        if (mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x < 2) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: subordinate core {1, 0} requires >= 2 columns, but grid has "
-                         << mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x
+                         << this->device().compute_with_storage_grid_size().x
                          << " column(s). Use emu-quasar-2x3 or larger.";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_to_core::OneToOneConfig test_config = {
             .test_id = 4,
             .master_core_coord = {0, 0},
@@ -359,12 +354,12 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOnePacketSizes) {
             .pages_per_transaction = 4,
             .bytes_per_page = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b};
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
     // Test ID
     uint32_t test_id = 4;
-    unit_tests::dm::core_to_core::packet_sizes_test(mesh_device, test_id);
+    unit_tests::dm::core_to_core::packet_sizes_test(this->device(), test_id);
 }
 
 /*
@@ -375,16 +370,15 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOnePacketSizes) {
 */
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneDirectedIdeal) {
-    auto mesh_device = get_mesh_device();
-    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // subordinate_core_coord {1, 0} requires at least 2 columns in the compute grid
-        if (mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x < 2) {
+        if (this->device().compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: subordinate core {1, 0} requires >= 2 columns, but grid has "
-                         << mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x
+                         << this->device().compute_with_storage_grid_size().x
                          << " column(s). Use emu-quasar-2x3 or larger.";
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_to_core::OneToOneConfig test_config = {
             .test_id = 50,
             .master_core_coord = {0, 0},
@@ -393,13 +387,13 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneDirectedIdeal) {
             .pages_per_transaction = 1,
             .bytes_per_page = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b};
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
     // Test ID (Arbitrary)
     uint32_t test_id = 50;
     unit_tests::dm::core_to_core::directed_ideal_test(
-        mesh_device,
+        this->device(),
         test_id,
         CoreCoord(0, 0),  // Master Core
         CoreCoord(0, 1)   // Subordinate Core
@@ -412,7 +406,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneVirtualChannels) {
     uint32_t test_id = 150;
 
     unit_tests::dm::core_to_core::virtual_channels_test(
-        get_mesh_device(),
+        this->device(),
         test_id,
         CoreCoord(0, 0),  // Master Core
         CoreCoord(0, 1)   // Subordinate Core
@@ -429,7 +423,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneCustom) {
     uint32_t num_virtual_channels = 4;
 
     unit_tests::dm::core_to_core::custom_test(
-        get_mesh_device(),
+        this->device(),
         test_id,
         CoreCoord(0, 0),  // Master Core
         CoreCoord(0, 1),  // Subordinate Core
@@ -439,13 +433,11 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneCustom) {
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOnePacketSizes2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // Quasar emulator (1x3 or 2x3): pick a subordinate that exists on the grid
         // and run a single small config. The full sweep is too large for the
         // emulator; this config still exercises MakeProgramFromSpec + varargs.
-        auto grid = device->compute_with_storage_grid_size();
+        auto grid = this->device().compute_with_storage_grid_size();
         CoreCoord subordinate;
         if (grid.x >= 2) {
             subordinate = {1, 0};  // 2x3 layout: adjacent core in next column
@@ -455,7 +447,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOnePacketSizes2_0) {
             GTEST_SKIP() << "Skipping: need at least a 1x2 or 2x1 grid, got " << grid.x << "x" << grid.y;
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_to_core::OneToOneConfig test_config = {
             .test_id = 158,
             .master_core_coord = {0, 0},
@@ -465,18 +457,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOnePacketSizes2_0) {
             .bytes_per_page = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b,
         };
-        EXPECT_TRUE(unit_tests::dm::core_to_core::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_to_core::run_dm(this->device(), test_config));
         return;
     }
     uint32_t test_id = 158;
-    unit_tests::dm::core_to_core::packet_sizes_test(mesh_device, test_id, CoreCoord(0, 0), CoreCoord(1, 1));
+    unit_tests::dm::core_to_core::packet_sizes_test(this->device(), test_id, CoreCoord(0, 0), CoreCoord(1, 1));
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneDirectedIdeal2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    if (device->arch() == ARCH::QUASAR) {
-        auto grid = device->compute_with_storage_grid_size();
+    if (this->device().arch() == ARCH::QUASAR) {
+        auto grid = this->device().compute_with_storage_grid_size();
         CoreCoord subordinate;
         if (grid.x >= 2) {
             subordinate = {1, 0};
@@ -486,7 +476,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneDirectedIdeal2_0) 
             GTEST_SKIP() << "Skipping: need at least a 1x2 or 2x1 grid, got " << grid.x << "x" << grid.y;
         }
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-            unit_tests::dm::compute_physical_constraints(mesh_device);
+            unit_tests::dm::compute_physical_constraints(this->device());
         unit_tests::dm::core_to_core::OneToOneConfig test_config = {
             .test_id = 160,
             .master_core_coord = {0, 0},
@@ -496,10 +486,10 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementOneToOneDirectedIdeal2_0) 
             .bytes_per_page = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b,
         };
-        EXPECT_TRUE(unit_tests::dm::core_to_core::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::core_to_core::run_dm(this->device(), test_config));
         return;
     }
-    unit_tests::dm::core_to_core::directed_ideal_test(mesh_device, 160, CoreCoord(0, 0), CoreCoord(0, 1), 1);
+    unit_tests::dm::core_to_core::directed_ideal_test(this->device(), 160, CoreCoord(0, 0), CoreCoord(0, 1), 1);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/test_pcie_read_bw.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/test_pcie_read_bw.cpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include "dm_common.hpp"
-#include <distributed/mesh_device_impl.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <chrono>
 
 namespace tt::tt_metal {
@@ -36,10 +36,8 @@ struct PCIeReadBwConfig {
 /// @param mesh_device Mesh device for execution
 /// @param test_config Configuration for the test
 /// @return true if test passes, false otherwise
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const PCIeReadBwConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
-    auto device_id = device->id();
+bool run_dm(distributed::MeshDevice& mesh_device, const PCIeReadBwConfig& test_config) {
+    auto device_id = mesh_device.get_device_ids().front();
 
     // Program
     Program program = CreateProgram();
@@ -68,7 +66,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const PCIeRe
     uint64_t pcie_offset = PCIE_OFFSET_BYTES;
     uint64_t pcie_l1_local_addr = dev_pcie_base + pcie_offset;
 
-    uint32_t clock_freq_mhz = device->get_clock_rate_mhz();
+    uint32_t clock_freq_mhz = mesh_device.get_clock_rate_mhz();
 
     std::string kernel_path = "tests/tt_metal/tt_metal/data_movement/pcie_read_bw/kernels/pcie_read_bw.cpp";
 
@@ -96,7 +94,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const PCIeRe
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate({0, 0}));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
 
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     distributed::Finish(cq);
@@ -104,8 +102,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const PCIeRe
     return true;
 }
 
-void pcie_read_bw_test(
-    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id, CoreCoord master_core_coord = {0, 0}) {
+void pcie_read_bw_test(distributed::MeshDevice& mesh_device, uint32_t test_id, CoreCoord master_core_coord = {0, 0}) {
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
@@ -132,20 +129,17 @@ TEST_F(UnitMeshFastDispatchFixture, PCIeReadBandwidth) {
     uint32_t test_id = 603;
     CoreCoord master_core_coord = {0, 0};
 
-    unit_tests::dm::pcie_read_bw::pcie_read_bw_test(get_mesh_device(), test_id, master_core_coord);
+    unit_tests::dm::pcie_read_bw::pcie_read_bw_test(this->device(), test_id, master_core_coord);
 }
 
 /* ========== Sweep 1M transactions with varying transaction sizes; Test id = 605 ========== */
 TEST_F(UnitMeshFastDispatchFixture, PCIeReadBandwidthSweep) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
     // Max transaction size: 16 kB for BH, 8 kB for WH (NOC max packet size)
-    uint32_t max_transaction_size_bytes = device->arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
+    uint32_t max_transaction_size_bytes = this->device().arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
 
     // Cap to L1 available size
     max_transaction_size_bytes = std::min(max_transaction_size_bytes, max_transmittable_bytes);
@@ -167,7 +161,7 @@ TEST_F(UnitMeshFastDispatchFixture, PCIeReadBandwidthSweep) {
             .noc_id = NOC::RISCV_0_default,
         };
 
-        EXPECT_TRUE(unit_tests::dm::pcie_read_bw::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::pcie_read_bw::run_dm(this->device(), test_config));
     }
 }
 
@@ -175,9 +169,8 @@ TEST_F(UnitMeshFastDispatchFixture, PCIeReadBandwidthSweep) {
 TEST_F(UnitMeshFastDispatchFixture, PCIeHostReadBandwidthSweep) {
     // Remove GTEST_SKIP to run the test
     GTEST_SKIP() << "Skipping: CLI timeout with large iteration count";
-    auto mesh_device = get_mesh_device();
     auto device_coord = distributed::MeshCoordinate(0, 0);
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = this->device().mesh_command_queue();
 
     constexpr uint32_t page_size = 4096;
     constexpr uint32_t num_iterations = 100000;
@@ -189,7 +182,7 @@ TEST_F(UnitMeshFastDispatchFixture, PCIeHostReadBandwidthSweep) {
             distributed::ReplicatedBufferConfig{.size = buf_size},
             distributed::DeviceLocalBufferConfig{
                 .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false},
-            mesh_device.get());
+            &this->device());
 
         // Seed device buffer
         vector<uint32_t> src(buf_size / sizeof(uint32_t), 0xDEADBEEF);

--- a/tests/tt_metal/tt_metal/data_movement/pcie_write_bw/test_pcie_write_bw.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_write_bw/test_pcie_write_bw.cpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include "dm_common.hpp"
-#include <distributed/mesh_device_impl.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <chrono>
 
 namespace tt::tt_metal {
@@ -35,10 +35,8 @@ struct PCIeWriteBwConfig {
 /// @param mesh_device Mesh device for execution
 /// @param test_config Configuration for the test
 /// @return true if test passes, false otherwise
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const PCIeWriteBwConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
-    auto device_id = device->id();
+bool run_dm(distributed::MeshDevice& mesh_device, const PCIeWriteBwConfig& test_config) {
+    auto device_id = mesh_device.get_device_ids().front();
 
     // Program
     Program program = CreateProgram();
@@ -66,7 +64,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const PCIeWr
     uint64_t pcie_l1_local_addr = dev_pcie_base + pcie_offset;
 
     // Compile-time arguments for kernels
-    uint32_t clock_freq_mhz = device->get_clock_rate_mhz();
+    uint32_t clock_freq_mhz = mesh_device.get_clock_rate_mhz();
     vector<uint32_t> compile_args = {
         (uint32_t)test_config.num_of_transactions,
         (uint32_t)test_config.bytes_per_transaction,
@@ -97,7 +95,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const PCIeWr
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate({0, 0}));
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
 
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     distributed::Finish(cq);
@@ -109,15 +107,12 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const PCIeWr
 
 /* ========== Sweep 1M transactions with varying transaction sizes; Test id = 604 ========== */
 TEST_F(UnitMeshFastDispatchFixture, PCIeWriteBandwidthSweep) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(this->device());
 
     // Max transaction size: 16 kB for BH, 8 kB for WH (NOC max packet size)
-    uint32_t max_transaction_size_bytes = device->arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
+    uint32_t max_transaction_size_bytes = this->device().arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
 
     // Cap to L1 available size
     max_transaction_size_bytes = std::min(max_transaction_size_bytes, max_transmittable_bytes);
@@ -136,7 +131,7 @@ TEST_F(UnitMeshFastDispatchFixture, PCIeWriteBandwidthSweep) {
             .noc_id = NOC::RISCV_0_default,
         };
 
-        EXPECT_TRUE(unit_tests::dm::pcie_write_bw::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::pcie_write_bw::run_dm(this->device(), test_config));
     }
 }
 
@@ -144,9 +139,8 @@ TEST_F(UnitMeshFastDispatchFixture, PCIeWriteBandwidthSweep) {
 TEST_F(UnitMeshFastDispatchFixture, PCIeHostWriteBandwidthSweep) {
     // Remove GTEST_SKIP to run the test
     GTEST_SKIP() << "Skipping: CLI timeout with large iteration count";
-    auto mesh_device = get_mesh_device();
     auto device_coord = distributed::MeshCoordinate(0, 0);
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = this->device().mesh_command_queue();
 
     constexpr uint32_t page_size = 4096;
     constexpr uint32_t num_iterations = 1000000;
@@ -158,7 +152,7 @@ TEST_F(UnitMeshFastDispatchFixture, PCIeHostWriteBandwidthSweep) {
             distributed::ReplicatedBufferConfig{.size = buf_size},
             distributed::DeviceLocalBufferConfig{
                 .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false},
-            mesh_device.get());
+            &this->device());
 
         vector<uint32_t> src(buf_size / sizeof(uint32_t), 0xDEADBEEF);
 

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -14,7 +15,6 @@
 #include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
-#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -46,10 +46,7 @@ struct TransactionIdConfig {
 /// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const TransactionIdConfig& test_config) {
-    // Get the actual device for this single-device test
-    IDevice* device = mesh_device->impl().get_device(0);
-
+bool run_dm(distributed::MeshDevice& mesh_device, const TransactionIdConfig& test_config) {
     /* ================ SETUP ================ */
 
     // Buffer Parameters
@@ -82,9 +79,9 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Transa
     uint32_t l1_base_address = master_l1_info.base_address;
 
     // Physical Core Coordinates
-    CoreCoord physical_sub0_core = device->worker_core_from_logical_core(test_config.sub0_core_coord);
+    CoreCoord physical_sub0_core = mesh_device.worker_core_from_logical_core(test_config.sub0_core_coord);
     uint32_t packed_sub0_core_coordinates = physical_sub0_core.x << 16 | (physical_sub0_core.y & 0xFFFF);
-    CoreCoord physical_sub1_core = device->worker_core_from_logical_core(test_config.sub1_core_coord);
+    CoreCoord physical_sub1_core = mesh_device.worker_core_from_logical_core(test_config.sub1_core_coord);
     uint32_t packed_sub1_core_coordinates = physical_sub1_core.x << 16 | (physical_sub1_core.y & 0xFFFF);
 
     string kernel_path = "tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/";
@@ -110,7 +107,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Transa
         {"sub1_coords", packed_sub1_core_coordinates}};
 
     DataMovementHardwareConfig sender_hw_config;
-    if (device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         sender_hw_config = DataMovementGen2Config{};
     } else {
         sender_hw_config = DataMovementGen1Config{
@@ -140,7 +137,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Transa
         }},
     };
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     ProgramRunArgs run_params;
     ProgramRunArgs::KernelRunArgs sender_run_params{.kernel = sender_spec.unique_id};
@@ -181,9 +178,9 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Transa
     vector<uint32_t> packed_golden_sub1 = packed_input_sub1;
 
     // Write Input to Master and Sub1 L1
-    detail::WriteToDeviceL1(device, test_config.master_core_coord, l1_base_address, packed_input_master);
-    detail::WriteToDeviceL1(device, test_config.sub1_core_coord, l1_base_address, packed_input_sub1);
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    slow_dispatch::WriteToL1(mesh_device, test_config.master_core_coord, l1_base_address, packed_input_master);
+    slow_dispatch::WriteToL1(mesh_device, test_config.sub1_core_coord, l1_base_address, packed_input_sub1);
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids().front());
 
     // LAUNCH THE PROGRAM - Use mesh workload approach
     auto mesh_workload = distributed::MeshWorkload();
@@ -192,18 +189,18 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Transa
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
     // Record Output from Master and Sub0 L1
     vector<uint32_t> packed_output_master;
-    detail::ReadFromDeviceL1(
-        device, test_config.sub0_core_coord, l1_base_address, bytes_per_transaction, packed_output_master);
+    slow_dispatch::ReadFromL1(
+        mesh_device, test_config.sub0_core_coord, l1_base_address, bytes_per_transaction, packed_output_master);
 
     vector<uint32_t> packed_output_sub1;
-    detail::ReadFromDeviceL1(
-        device, test_config.master_core_coord, l1_base_address, bytes_per_transaction, packed_output_sub1);
+    slow_dispatch::ReadFromL1(
+        mesh_device, test_config.master_core_coord, l1_base_address, bytes_per_transaction, packed_output_sub1);
 
     // Compare output with golden vector
     bool is_equal = (packed_output_master == packed_golden_master);
@@ -228,23 +225,20 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Transa
 /* ========== TEST CASES ========== */
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrite) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     // Cores
     CoreCoord master_core_coord = {0, 0};
 
     // Furthest cores from master
-    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
-    CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
+    CoreCoord sub0_core_coord = {0, this->device().compute_with_storage_grid_size().y - 1};
+    CoreCoord sub1_core_coord = {this->device().compute_with_storage_grid_size().x - 1, 0};
 
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         // Transaction ID test needs 3 distinct cores; skip if grid is too small
-        auto grid = device->compute_with_storage_grid_size();
+        auto grid = this->device().compute_with_storage_grid_size();
         if (grid.x * grid.y < 3) {
             GTEST_SKIP() << "Skipping: need 3 distinct cores but grid is only " << grid.x << "x" << grid.y;
         }
@@ -258,7 +252,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
             .bytes_per_page = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b,
         };
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
         return;
     }
 
@@ -267,7 +261,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
 
     // Parameters
     uint32_t max_pages_per_transaction =
-        device->arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+        this->device().arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_trids = 1; num_of_trids <= 16; num_of_trids *= 2) {  // Up to 0xF (16) transaction ids
         for (uint32_t pages_per_transaction = 1; pages_per_transaction <= max_pages_per_transaction;
@@ -289,7 +283,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
             };
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
@@ -298,19 +292,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
     // Test ID
     uint32_t test_id = 601;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     // Cores
     CoreCoord master_core_coord = {0, 0};
 
     // Furthest cores from master
-    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
-    CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
+    CoreCoord sub0_core_coord = {0, this->device().compute_with_storage_grid_size().y - 1};
+    CoreCoord sub1_core_coord = {this->device().compute_with_storage_grid_size().x - 1, 0};
 
     // Parameters
     uint32_t max_pages_per_transaction = 256;  // NOC_MAX_BURST_WORDS
@@ -336,7 +327,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
             };
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
@@ -345,19 +336,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
     // Test ID
     uint32_t test_id = 602;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     // Cores
     CoreCoord master_core_coord = {0, 0};
 
     // Furthest cores from master
-    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
-    CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
+    CoreCoord sub0_core_coord = {0, this->device().compute_with_storage_grid_size().y - 1};
+    CoreCoord sub1_core_coord = {this->device().compute_with_storage_grid_size().x - 1, 0};
 
     // Parameters
     uint32_t max_pages_per_transaction = 256;  // NOC_MAX_BURST_WORDS
@@ -384,7 +372,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
             };
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
@@ -393,24 +381,20 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRea
     // Test ID
     uint32_t test_id = 610;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     // Cores
     CoreCoord master_core_coord = {0, 0};
 
     // Furthest cores from master
-    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
-    CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
+    CoreCoord sub0_core_coord = {0, this->device().compute_with_storage_grid_size().y - 1};
+    CoreCoord sub1_core_coord = {this->device().compute_with_storage_grid_size().x - 1, 0};
 
     // Parameters
-    uint32_t max_pages_per_transaction = mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE
-                                             ? 1024
-                                             : 2048;  // Max total transaction size == 64 KB
+    uint32_t max_pages_per_transaction =
+        this->device().arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_trids = 1; num_of_trids <= 16; num_of_trids *= 2) {  // Up to 0xF (16) transaction ids
         for (uint32_t pages_per_transaction = 1; pages_per_transaction <= max_pages_per_transaction;
@@ -433,7 +417,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRea
             };
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
@@ -442,19 +426,16 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRea
     // Test ID
     uint32_t test_id = 611;
 
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     // Cores
     CoreCoord master_core_coord = {0, 0};
 
     // Furthest cores from master
-    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
-    CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
+    CoreCoord sub0_core_coord = {0, this->device().compute_with_storage_grid_size().y - 1};
+    CoreCoord sub1_core_coord = {this->device().compute_with_storage_grid_size().x - 1, 0};
 
     // Parameters
     uint32_t max_pages_per_transaction = 256;  // NOC_MAX_BURST_WORDS
@@ -482,7 +463,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRea
             };
 
             // Run
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
+            EXPECT_TRUE(run_dm(this->device(), test_config));
         }
     }
 }
@@ -491,27 +472,25 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRea
 
 namespace unit_tests::dm::transaction_id {
 // Helper: returns true if Quasar emulator can run a 3-core transaction_id test, otherwise GTEST_SKIP-ready.
-inline bool quasar_grid_ok(IDevice* device) {
-    auto grid = device->compute_with_storage_grid_size();
+inline bool quasar_grid_ok(distributed::MeshDevice& mesh_device) {
+    auto grid = mesh_device.compute_with_storage_grid_size();
     return grid.x * grid.y >= 3;
 }
 }  // namespace unit_tests::dm::transaction_id
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrite_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    auto arch_ = device->arch();
+    auto arch_ = this->device().arch();
 
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     CoreCoord master_core_coord = {0, 0};
-    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
-    CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
+    CoreCoord sub0_core_coord = {0, this->device().compute_with_storage_grid_size().y - 1};
+    CoreCoord sub1_core_coord = {this->device().compute_with_storage_grid_size().x - 1, 0};
 
     if (arch_ == ARCH::QUASAR) {
-        auto grid_dbg = device->compute_with_storage_grid_size();
-        if (!unit_tests::dm::transaction_id::quasar_grid_ok(device)) {
+        auto grid_dbg = this->device().compute_with_storage_grid_size();
+        if (!unit_tests::dm::transaction_id::quasar_grid_ok(this->device())) {
             GTEST_SKIP() << "Skipping: need 3 distinct cores but grid is only " << grid_dbg.x << "x" << grid_dbg.y;
         }
         unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
@@ -524,7 +503,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
             .bytes_per_page = bytes_per_page,
             .l1_data_format = DataFormat::Float16_b,
         };
-        EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(this->device(), test_config));
         return;
     }
 
@@ -546,25 +525,23 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
                 .bytes_per_page = bytes_per_page,
                 .l1_data_format = DataFormat::Float16_b,
             };
-            EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(mesh_device, test_config));
+            EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(this->device(), test_config));
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWriteOnePacket_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    auto arch_ = device->arch();
+    auto arch_ = this->device().arch();
 
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     CoreCoord master_core_coord = {0, 0};
-    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
-    CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
+    CoreCoord sub0_core_coord = {0, this->device().compute_with_storage_grid_size().y - 1};
+    CoreCoord sub1_core_coord = {this->device().compute_with_storage_grid_size().x - 1, 0};
 
     if (arch_ == ARCH::QUASAR) {
-        if (!unit_tests::dm::transaction_id::quasar_grid_ok(device)) {
+        if (!unit_tests::dm::transaction_id::quasar_grid_ok(this->device())) {
             GTEST_SKIP() << "Skipping: need 3 distinct cores on Quasar emulator";
         }
         unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
@@ -578,7 +555,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
             .l1_data_format = DataFormat::Float16_b,
             .one_packet = true,
         };
-        EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(this->device(), test_config));
         return;
     }
 
@@ -600,25 +577,23 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
                 .l1_data_format = DataFormat::Float16_b,
                 .one_packet = true,
             };
-            EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(mesh_device, test_config));
+            EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(this->device(), test_config));
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWriteOnePacketStateful_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    auto arch_ = device->arch();
+    auto arch_ = this->device().arch();
 
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     CoreCoord master_core_coord = {0, 0};
-    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
-    CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
+    CoreCoord sub0_core_coord = {0, this->device().compute_with_storage_grid_size().y - 1};
+    CoreCoord sub1_core_coord = {this->device().compute_with_storage_grid_size().x - 1, 0};
 
     if (arch_ == ARCH::QUASAR) {
-        if (!unit_tests::dm::transaction_id::quasar_grid_ok(device)) {
+        if (!unit_tests::dm::transaction_id::quasar_grid_ok(this->device())) {
             GTEST_SKIP() << "Skipping: need 3 distinct cores on Quasar emulator";
         }
         unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
@@ -633,7 +608,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
             .one_packet = true,
             .stateful = true,
         };
-        EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(this->device(), test_config));
         return;
     }
 
@@ -656,25 +631,23 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdReadAfterWrit
                 .one_packet = true,
                 .stateful = true,
             };
-            EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(mesh_device, test_config));
+            EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(this->device(), test_config));
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRead_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    auto arch_ = device->arch();
+    auto arch_ = this->device().arch();
 
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     CoreCoord master_core_coord = {0, 0};
-    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
-    CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
+    CoreCoord sub0_core_coord = {0, this->device().compute_with_storage_grid_size().y - 1};
+    CoreCoord sub1_core_coord = {this->device().compute_with_storage_grid_size().x - 1, 0};
 
     if (arch_ == ARCH::QUASAR) {
-        if (!unit_tests::dm::transaction_id::quasar_grid_ok(device)) {
+        if (!unit_tests::dm::transaction_id::quasar_grid_ok(this->device())) {
             GTEST_SKIP() << "Skipping: need 3 distinct cores on Quasar emulator";
         }
         unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
@@ -688,7 +661,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRea
             .l1_data_format = DataFormat::Float16_b,
             .read_after_write = false,
         };
-        EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(this->device(), test_config));
         return;
     }
 
@@ -710,25 +683,23 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRea
                 .l1_data_format = DataFormat::Float16_b,
                 .read_after_write = false,
             };
-            EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(mesh_device, test_config));
+            EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(this->device(), test_config));
         }
     }
 }
 
 TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterReadOnePacketStateful_2_0) {
-    auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->impl().get_device(0);
-    auto arch_ = device->arch();
+    auto arch_ = this->device().arch();
 
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        unit_tests::dm::compute_physical_constraints(mesh_device);
+        unit_tests::dm::compute_physical_constraints(this->device());
 
     CoreCoord master_core_coord = {0, 0};
-    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
-    CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
+    CoreCoord sub0_core_coord = {0, this->device().compute_with_storage_grid_size().y - 1};
+    CoreCoord sub1_core_coord = {this->device().compute_with_storage_grid_size().x - 1, 0};
 
     if (arch_ == ARCH::QUASAR) {
-        if (!unit_tests::dm::transaction_id::quasar_grid_ok(device)) {
+        if (!unit_tests::dm::transaction_id::quasar_grid_ok(this->device())) {
             GTEST_SKIP() << "Skipping: need 3 distinct cores on Quasar emulator";
         }
         unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
@@ -744,7 +715,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRea
             .stateful = true,
             .read_after_write = false,
         };
-        EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(mesh_device, test_config));
+        EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(this->device(), test_config));
         return;
     }
 
@@ -768,7 +739,7 @@ TEST_F(UnitMeshFastDispatchFixture, TensixDataMovementTransactionIdWriteAfterRea
                 .stateful = true,
                 .read_after_write = false,
             };
-            EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(mesh_device, test_config));
+            EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm(this->device(), test_config));
         }
     }
 }


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

We're deprecation legacy API related to `IDevice` and `Buffer`.
As one of the steps, usage of this API is replaced with mesh alternatives in data movement tests, in particular, we remove:
```c++
    IDevice* device = mesh_device->impl().get_device(0);
```

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-dm-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-dm-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-dm-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-dm-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-dm-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-dm-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-dm-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-dm-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-dm-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-dm-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-dm-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-dm-tests-modernize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-dm-tests-modernize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-dm-tests-modernize)