### PR TITLE
Use a single-device mesh for compile-time/runtime-arg API tests

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_blaze_named_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_blaze_named_runtime_args.cpp
@@ -29,7 +29,7 @@
 
 using namespace tt;
 using namespace tt::tt_metal;
-using NamedArgsTest = GenericMeshDeviceFixture;
+using NamedArgsTest = MeshDevice1x1Fixture;
 
 TEST_F(NamedArgsTest, TensixTestNamedCommonAndPerCoreRuntimeArgs) {
     auto mesh_device = get_mesh_device();

--- a/tests/tt_metal/tt_metal/api/test_compile_time_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compile_time_args.cpp
@@ -30,7 +30,7 @@ class IDevice;
 
 using namespace tt;
 using namespace tt::tt_metal;
-using CompileTimeArgsTest = GenericMeshDeviceFixture;
+using CompileTimeArgsTest = MeshDevice1x1Fixture;
 
 TEST_F(MeshDeviceFixture, TensixTestTwentyThousandCompileTimeArgs) {
     for (const auto& mesh_device : this->devices_) {


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Follow-up to #56191. `test_blaze_named_runtime_args.cpp` and `test_compile_time_args.cpp` were using `GenericMeshDeviceFixture`, which opens a `MeshDevice` even though every test in both files only reads back from only one device via`get_devices()[0]`.

Swapped existing `GenericMeshDeviceFixture` to `MeshDevice1x1Fixture`

Benchmarked on an 32-chip Wormhole reservation (`--gtest_filter='NamedArgsTest.*:CompileTimeArgsTest.*'`, 11 tests):

| | real | user | sys |
|---|---|---|---|
| Before (`GenericMeshDeviceFixture`) | 37.303s | 23.310s | 10.958s |
| After (`MeshDevice1x1Fixture`) | 11.495s | 3.797s | 3.246s |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anirudhsathiyaTT/unit-mesh-api-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anirudhsathiyaTT/unit-mesh-api-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anirudhsathiyaTT/unit-mesh-api-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anirudhsathiyaTT/unit-mesh-api-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anirudhsathiyaTT/unit-mesh-api-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anirudhsathiyaTT/unit-mesh-api-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anirudhsathiyaTT/unit-mesh-api-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anirudhsathiyaTT/unit-mesh-api-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anirudhsathiyaTT/unit-mesh-api-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anirudhsathiyaTT/unit-mesh-api-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anirudhsathiyaTT/unit-mesh-api-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anirudhsathiyaTT/unit-mesh-api-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anirudhsathiyaTT/unit-mesh-api-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anirudhsathiyaTT/unit-mesh-api-tests)