### PR TITLE
[skip ci] [Bug fix] Correct Copilot Garage cache prefix and secret diagnostics

### DIFF
--- a/.github/instructions/copilot-cloud.instructions.md
+++ b/.github/instructions/copilot-cloud.instructions.md
@@ -73,9 +73,12 @@ you pass go straight through to `build_metal.sh`:
 `--enable-ccache` is always applied for you. Build the narrowest thing that
 actually exercises your change; do not reach for `--build-all`.
 
-If the wrapper warns that Garage credentials are missing, you are building
-against a cold cache and it will most likely not finish. Say so in the PR
-rather than burning the session on it.
+If the wrapper warns that Garage credentials are missing, remote-cache
+acceleration is unavailable; the session's local cache can still be used.
+Missing credentials or a cold cache alone are not reasons to skip a required
+build. Run the narrowest appropriate build and monitor its progress against
+the remaining session time. If it cannot finish, report the command, progress,
+and actual limitation in the PR.
 
 ## What to do about a build
 
@@ -85,9 +88,9 @@ rather than burning the session on it.
   a compile error you could have caught.
 - **Did not need a build** (see the table above) — say which check you ran
   instead, e.g. that it is a docs-only change.
-- **Genuinely cannot build** (cold cache, docker unavailable, environment
-  problem) — open the PR anyway, and state in the description that the change
-  is **unverified**, and why.
+- **Cannot complete a build** (Docker unavailable, an environment failure,
+  or an observed timeout or resource limit) — open the PR anyway, and state
+  in the description that the change is **unverified**, and why.
 
 Do not claim you ran anything you did not run.
 

--- a/.github/instructions/copilot-cloud.instructions.md
+++ b/.github/instructions/copilot-cloud.instructions.md
@@ -73,12 +73,6 @@ you pass go straight through to `build_metal.sh`:
 `--enable-ccache` is always applied for you. Build the narrowest thing that
 actually exercises your change; do not reach for `--build-all`.
 
-If the wrapper warns that Garage credentials are missing, remote-cache
-acceleration is unavailable; the session's local cache can still be used.
-Missing credentials or a cold cache alone are not reasons to skip a required
-build. Run the narrowest appropriate build and monitor its progress against
-the remaining session time. If it cannot finish, report the command, progress,
-and actual limitation in the PR.
 
 ## What to do about a build
 

--- a/.github/scripts/copilot-build.sh
+++ b/.github/scripts/copilot-build.sh
@@ -36,6 +36,8 @@ DOCKER_ARGS=(
   -e CCACHE_DIR=/ccache
   -e CCACHE_COMPRESS=true
   -e CCACHE_COMPRESSLEVEL=3
+  # Match the path normalization used by build-artifact.yaml.
+  -e CCACHE_BASEDIR=/work
 )
 
 # Credentials arrive as *Agents* secrets, which the platform exposes to the agent
@@ -46,11 +48,12 @@ if [[ -n "${GARAGE_S3_ACCESS_KEY:-}" && -n "${GARAGE_S3_SECRET_KEY:-}" ]]; then
   # trusted CI builds later consume. Within a session, repeated builds are
   # served by the local cache mounted at /ccache above.
   #
-  # NOTE: this flag is a guardrail, not a boundary - it is client-side, and the
-  # agent holds the credentials in its own environment. A genuinely read-only
-  # Garage key is the real fix; none exists yet (only one read-write pair is
-  # provisioned). Tracked in the PR discussion.
-  export CCACHE_REMOTE_STORAGE="s3://ccache|region=garage|prefix=tt-metal|endpoint_url=${GARAGE_ENDPOINT}|read-only=true"
+  # The Agents secrets must contain a Garage key with server-side read-only
+  # access: read-only=true is only a client-side guardrail.
+  #
+  # ccache 4.14 requires @ for storage-helper attributes. Without it, prefix
+  # is discarded and the helper reads the bucket root instead of CI's cache.
+  export CCACHE_REMOTE_STORAGE="s3://ccache|@region=garage|@prefix=tt-metal|@endpoint_url=${GARAGE_ENDPOINT}|read-only=true"
   export AWS_ACCESS_KEY_ID="${GARAGE_S3_ACCESS_KEY}"
   export AWS_SECRET_ACCESS_KEY="${GARAGE_S3_SECRET_KEY}"
   export AWS_DEFAULT_REGION=garage
@@ -64,11 +67,10 @@ if [[ -n "${GARAGE_S3_ACCESS_KEY:-}" && -n "${GARAGE_S3_SECRET_KEY:-}" ]]; then
     -e AWS_DEFAULT_REGION
     -e AWS_ENDPOINT_URL_S3
   )
-  echo "[copilot-build] remote ccache enabled (read-only)"
+  echo "[copilot-build] remote ccache enabled (read-only): ${GARAGE_ENDPOINT}/ccache/tt-metal"
 else
   echo "[copilot-build] WARNING: GARAGE_S3_ACCESS_KEY / GARAGE_S3_SECRET_KEY not set." >&2
-  echo "[copilot-build]          Building with a COLD cache. A full cold build takes" >&2
-  echo "[copilot-build]          over an hour and will most likely not finish." >&2
+  echo "[copilot-build]          Remote cache disabled; only the session's local cache is available." >&2
   echo "[copilot-build]          They must be repository *Agents* secrets, not Actions secrets." >&2
 fi
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -85,28 +85,26 @@ jobs:
           docker image inspect "$IMG" --format 'image ready: {{.Id}} ({{.Created}})' 2>/dev/null || true
 
       - name: Check ccache credentials
-        # A cold build will not finish inside a session, so surface this loudly.
+        # The secrets context belongs to this job: Actions in a validation run,
+        # Agents in a Copilot session. It does not identify the runtime's env.
         # Referenced at step level: job-level env resolves empty for agent runs.
         env:
-          ACTIONS_GARAGE_ACCESS_KEY: ${{ secrets.GARAGE_S3_ACCESS_KEY }}
-          ACTIONS_GARAGE_SECRET_KEY: ${{ secrets.GARAGE_S3_SECRET_KEY }}
+          GARAGE_S3_ACCESS_KEY: ${{ secrets.GARAGE_S3_ACCESS_KEY }}
+          GARAGE_S3_SECRET_KEY: ${{ secrets.GARAGE_S3_SECRET_KEY }}
         run: |
           # Both halves are required: copilot-build.sh enables the remote cache
           # only when the pair is present, so reporting on one key alone would
           # claim a warm cache while the build silently ran cold.
           if [ -n "${GARAGE_S3_ACCESS_KEY:-}" ] && [ -n "${GARAGE_S3_SECRET_KEY:-}" ]; then
-            echo "Agents secrets present - remote ccache will be used (read-only)."
+            echo "Garage credentials are available to this setup job."
           elif [ -n "${GARAGE_S3_ACCESS_KEY:-}" ] || [ -n "${GARAGE_S3_SECRET_KEY:-}" ]; then
-            echo "::error::Only one of GARAGE_S3_ACCESS_KEY / GARAGE_S3_SECRET_KEY is set as an"
-            echo "::error::Agents secret. The remote cache needs both; the agent would build cold."
+            echo "::error::Only one of GARAGE_S3_ACCESS_KEY / GARAGE_S3_SECRET_KEY is available"
+            echo "::error::to this setup job. Both are required for remote cache access."
             exit 1
-          elif [ -n "${ACTIONS_GARAGE_ACCESS_KEY:-}" ] && [ -n "${ACTIONS_GARAGE_SECRET_KEY:-}" ]; then
-            echo "::notice::Actions secrets found (this validation run), but Copilot cannot read them."
-            echo "::notice::Add GARAGE_S3_ACCESS_KEY / GARAGE_S3_SECRET_KEY under Settings ->"
-            echo "::notice::Secrets and variables -> Agents for the agent to get a warm cache."
           else
-            echo "::warning::No Garage credentials from either source. The agent would build COLD."
+            echo "::notice::No Garage credentials are available to this setup job."
           fi
+          echo "copilot-build.sh checks the agent's injected credentials at build time."
 
       - name: Install gh-aw extension
         # Must match the gh-aw version the repo's .lock.yml files were compiled


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Copilot's build wrapper supplied `prefix=tt-metal`, which ccache 4.14 discards because storage-helper attributes require `@`. CI masks the same syntax problem with its `CCACHE_S3_PREFIX` environment fallback; Copilot has no fallback and reads from the bucket root. The reported session had 0/1423 remote hits, while an earlier Release CI build of the same commit had 1751/1810 (96.74%).

Use `@region`, `@prefix`, and `@endpoint_url` so the helper reads `ccache/tt-metal/`, retaining `read-only=true`. Also pass CI's `CCACHE_BASEDIR=/work`, and correct the setup diagnostic: availability in a job's secrets context does not establish that the agent lacks Agents secrets. Remove the stale claims that no read-only key exists and a cold build cannot finish.

Closes #56315.

### Notes for reviewers

- Reproduced with the official ccache 4.14 binary: the old configuration sends `CRSH_NUM_ATTR=0`; the corrected configuration sends all three attributes, including `prefix=tt-metal`.
- Checked the installed S3 helper v0.1.7's prefix fallback and the actual Copilot log's `AgentSecrets` source and runtime injection of both Garage variables.
- Validation passed: Bash syntax, repository yamllint configuration, `git diff --check`, all four setup credential combinations, and a Docker-stub execution of the wrapper verifying read-only configuration, path normalization, and passing credentials by environment-variable name rather than value.
- A fresh Copilot build is still needed to measure the resulting Garage hit rate. Build options and generated paths also affect reuse; this PR does not claim they all match CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/copilot-garage-cache-prefix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/copilot-garage-cache-prefix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/copilot-garage-cache-prefix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/copilot-garage-cache-prefix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/copilot-garage-cache-prefix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/copilot-garage-cache-prefix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/copilot-garage-cache-prefix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/copilot-garage-cache-prefix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/copilot-garage-cache-prefix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/copilot-garage-cache-prefix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/copilot-garage-cache-prefix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/copilot-garage-cache-prefix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/copilot-garage-cache-prefix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/copilot-garage-cache-prefix)