### PR TITLE
[Performance] Reduce RISC-V kernel debug info to -g1

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -183,7 +183,7 @@ void JitBuildEnv::init(
     }
 
     if (rtoptions.get_riscv_debug_info_enabled()) {
-        common_flags += "-g ";
+        common_flags += "-g1 ";
     }
 
     this->cflags_ = common_flags;

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -742,7 +742,7 @@ public:
     bool get_jit_analytics_enabled() const { return jit_analytics_enabled; }
     void set_jit_analytics_enabled(bool enable) { jit_analytics_enabled = enable; }
 
-    // Whether to compile with -g to include DWARF debug info in the binary.
+    // Whether to compile with -g1 to include minimal DWARF debug info in the binary.
     bool get_riscv_debug_info_enabled() const { return riscv_debug_info_enabled; }
     void set_riscv_debug_info_enabled(bool enable) { riscv_debug_info_enabled = enable; }
 


### PR DESCRIPTION
### PR Category
Performance

### Summary
Use `-g1` instead of `-g` when RISC-V debug information is enabled, requesting minimal DWARF information for JIT-compiled kernels and firmware. Update the runtime-option comment to match.

### Notes for reviewers
The flag is shared by compilation and linking, and participates in the JIT build cache key. The existing `TT_METAL_RISCV_DEBUG_INFO` enable/disable behavior is unchanged.

Validation of tt-triage with reduced debug information is pending. No compile-time or binary-size improvement has been measured.

### Validation
- Passed: `pre-commit run --files tt_metal/jit_build/build.cpp tt_metal/llrt/rtoptions.hpp`.
- Passed: `git diff --check`.
- Local build unverified: `.github/scripts/copilot-build.sh` could not run because Docker is unavailable in this environment. Hardware tests require CI.
- Dispatched `(Debug) Triage Tests` on commit `b77acde6a8e8ecea04f99f8b4dc2f6997df55536`, with Wormhole and Blackhole enabled, Ubuntu 22.04, and a Release build:
  - [Core tt-triage tests](https://github.com/tenstorrent/tt-metal/actions/runs/34656655738) (`run-hang-report-test=false`).
  - [Hang-report test](https://github.com/tenstorrent/tt-metal/actions/runs/34656666831) (`run-hang-report-test=true`).
- Both CI runs are pending; these links are validation requests, not passing results.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano-tt/kernel-debug-g1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano-tt/kernel-debug-g1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano-tt/kernel-debug-g1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano-tt/kernel-debug-g1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano-tt/kernel-debug-g1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano-tt/kernel-debug-g1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano-tt/kernel-debug-g1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano-tt/kernel-debug-g1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano-tt/kernel-debug-g1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano-tt/kernel-debug-g1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano-tt/kernel-debug-g1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano-tt/kernel-debug-g1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano-tt/kernel-debug-g1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano-tt/kernel-debug-g1)
