### PR TITLE
perf counters: drop the duplicated Blackhole INSTRN table

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/hw_counters.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/hw_counters.h
@@ -165,37 +165,6 @@ constexpr size_t NUM_L1_5_COUNTERS = l1_5_counters.size();
 constexpr std::uint32_t L1_MUX_MASK = 0x7 << 4;
 
 // BH INSTRN_THREAD: sel gaps at 9-11 (XSEARCH kick tied to 0).
-constexpr std::array<std::pair<PerfCounterType, std::uint16_t>, 59> instrn_counters = {
-    {{PerfCounterType::CFG_INSTRN_AVAILABLE_0, 0},     {PerfCounterType::CFG_INSTRN_AVAILABLE_1, 1},
-     {PerfCounterType::CFG_INSTRN_AVAILABLE_2, 2},     {PerfCounterType::SYNC_INSTRN_AVAILABLE_0, 3},
-     {PerfCounterType::SYNC_INSTRN_AVAILABLE_1, 4},    {PerfCounterType::SYNC_INSTRN_AVAILABLE_2, 5},
-     {PerfCounterType::THCON_INSTRN_AVAILABLE_0, 6},   {PerfCounterType::THCON_INSTRN_AVAILABLE_1, 7},
-     {PerfCounterType::THCON_INSTRN_AVAILABLE_2, 8},   {PerfCounterType::MOVE_INSTRN_AVAILABLE_0, 12},
-     {PerfCounterType::MOVE_INSTRN_AVAILABLE_1, 13},   {PerfCounterType::MOVE_INSTRN_AVAILABLE_2, 14},
-     {PerfCounterType::MATH_INSTRN_AVAILABLE_0, 15},    {PerfCounterType::MATH_INSTRN_AVAILABLE_1, 16},
-     {PerfCounterType::MATH_INSTRN_AVAILABLE_2, 17},    {PerfCounterType::UNPACK_INSTRN_AVAILABLE_0, 18},
-     {PerfCounterType::UNPACK_INSTRN_AVAILABLE_1, 19}, {PerfCounterType::UNPACK_INSTRN_AVAILABLE_2, 20},
-     {PerfCounterType::PACK_INSTRN_AVAILABLE_0, 21},   {PerfCounterType::PACK_INSTRN_AVAILABLE_1, 22},
-     {PerfCounterType::PACK_INSTRN_AVAILABLE_2, 23},   {PerfCounterType::THREAD_STALLS_0, 24},
-     {PerfCounterType::THREAD_STALLS_1, 25},           {PerfCounterType::THREAD_STALLS_2, 26},
-     {PerfCounterType::WAITING_FOR_SRCA_CLEAR, 27},    {PerfCounterType::WAITING_FOR_SRCB_CLEAR, 28},
-     {PerfCounterType::WAITING_FOR_SRCA_VALID, 29},    {PerfCounterType::WAITING_FOR_SRCB_VALID, 30},
-     {PerfCounterType::WAITING_FOR_THCON_IDLE_0, 31},  {PerfCounterType::WAITING_FOR_UNPACK_IDLE_0, 32},
-     {PerfCounterType::WAITING_FOR_PACK_IDLE_0, 33},   {PerfCounterType::WAITING_FOR_MATH_IDLE_0, 34},
-     {PerfCounterType::WAITING_FOR_NONZERO_SEM_0, 35}, {PerfCounterType::WAITING_FOR_NONFULL_SEM_0, 36},
-     {PerfCounterType::WAITING_FOR_MOVE_IDLE_0, 37},   {PerfCounterType::WAITING_FOR_CFG_IDLE_0, 38},
-     {PerfCounterType::WAITING_FOR_SFPU_IDLE_0, 39},   {PerfCounterType::WAITING_FOR_THCON_IDLE_1, 40},
-     {PerfCounterType::WAITING_FOR_UNPACK_IDLE_1, 41}, {PerfCounterType::WAITING_FOR_PACK_IDLE_1, 42},
-     {PerfCounterType::WAITING_FOR_MATH_IDLE_1, 43},   {PerfCounterType::WAITING_FOR_NONZERO_SEM_1, 44},
-     {PerfCounterType::WAITING_FOR_NONFULL_SEM_1, 45}, {PerfCounterType::WAITING_FOR_MOVE_IDLE_1, 46},
-     {PerfCounterType::WAITING_FOR_CFG_IDLE_1, 47},   {PerfCounterType::WAITING_FOR_SFPU_IDLE_1, 48},
-     {PerfCounterType::WAITING_FOR_THCON_IDLE_2, 49},  {PerfCounterType::WAITING_FOR_UNPACK_IDLE_2, 50},
-     {PerfCounterType::WAITING_FOR_PACK_IDLE_2, 51},   {PerfCounterType::WAITING_FOR_MATH_IDLE_2, 52},
-     {PerfCounterType::WAITING_FOR_NONZERO_SEM_2, 53}, {PerfCounterType::WAITING_FOR_NONFULL_SEM_2, 54},
-     {PerfCounterType::WAITING_FOR_MOVE_IDLE_2, 55},   {PerfCounterType::WAITING_FOR_CFG_IDLE_2, 56},
-     {PerfCounterType::WAITING_FOR_SFPU_IDLE_2, 57},   {PerfCounterType::THREAD_INSTRUCTIONS_0, 256},
-     {PerfCounterType::THREAD_INSTRUCTIONS_1, 264},    {PerfCounterType::THREAD_INSTRUCTIONS_2, 272},
-     {PerfCounterType::ANY_THREAD_STALL, 283}}};
 constexpr size_t NUM_INSTRN_COUNTERS = 59;
 constexpr std::array<std::pair<PerfCounterType, std::uint16_t>, NUM_INSTRN_COUNTERS> instrn_counters = {
     {{PerfCounterType::CFG_INSTRN_AVAILABLE_0, 0},     {PerfCounterType::CFG_INSTRN_AVAILABLE_1, 1},


### PR DESCRIPTION
### Problem
main does not compile the Blackhole counter tables. `tt_metal/hw/inc/internal/tt-1xx/blackhole/hw_counters.h` defines `instrn_counters` twice (line 168 and line 200), so any Blackhole build that includes `perf_counters.hpp` with counters enabled fails with `redefinition of 'instrn_counters'`. The duplicate came from my #55162 rebase fixup. Wormhole is unaffected.

### Fix
Drop the first copy and keep the `NUM_INSTRN_COUNTERS` version. Both lists were identical (59 entries), so no counter names or selectors change.

### Checklist
- [x] LLK Blackhole counter build of `perf_eltwise_binary.py` (86 variants): fails on main, passes here for both the no-counter and with-counter producers
- [x] Host syntax probe including `perf_counters.hpp` + `blackhole/hw_counters.h` compiles, `instrn_counters.size() == NUM_INSTRN_COUNTERS`
- [ ] Sanity CI: https://github.com/tenstorrent/tt-metal/actions/runs/34661085976 / Profiler CI: https://github.com/tenstorrent/tt-metal/actions/runs/34661088139
