### PR TITLE
Bug fix: bias_gelu computes the approximate GELU with no way to opt out

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -327,6 +327,34 @@ def test_bias_gelu_fp32(device, ttnn_function):
     assert status
 
 
+@pytest.mark.parametrize("scalar_bias", [False, True], ids=["tensor_bias", "scalar_bias"])
+def test_bias_gelu_fp32_defaults_to_accurate(device, scalar_bias):
+    # bias_gelu compiled the approximate gelu on every surface while ttnn.gelu defaulted to the
+    # accurate one, so fusing the bias silently changed the numerics with no way to opt out.
+    # The tensor-scalar and tensor-tensor overloads reached it by different routes, so both are
+    # covered here.
+    x_torch = torch.linspace(-5.0, 5.0, 1024, dtype=torch.float32).reshape(32, 32)
+    bias = 0.5
+    expected = torch.nn.functional.gelu(x_torch.double() + bias)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    bias_arg = (
+        bias
+        if scalar_bias
+        else ttnn.from_torch(torch.full_like(x_torch, bias), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    )
+
+    accurate_err = (ttnn.to_torch(ttnn.bias_gelu(x_tt, bias_arg)).double() - expected).abs().max()
+    approx_err = (
+        (ttnn.to_torch(ttnn.bias_gelu(x_tt, bias_arg, fast_and_approximate_mode=True)).double() - expected).abs().max()
+    )
+
+    # The default tracks ttnn.gelu's accurate path, which lands near 1e-06 over this range.
+    assert accurate_err < 1e-5
+    # The flag still has to reach the lookup table, or it is not wired up at all.
+    assert approx_err > 1e-3
+
+
 @pytest.mark.parametrize(
     "ttnn_function",
     [

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -327,6 +327,23 @@ def test_bias_gelu_fp32(device, ttnn_function):
     assert status
 
 
+def test_bias_gelu_inplace_fp32_defaults_to_accurate(device):
+    # bias_gelu_ reaches BIAS_GELU through TTNN_BINARY_OP_INPLACE_INVOKE_IMPL, which pins the mode
+    # separately from the out-of-place overloads, so it needs its own fence. It exposes no
+    # fast_and_approximate_mode argument, so only the default is asserted here.
+    x_torch = torch.linspace(-5.0, 5.0, 1024, dtype=torch.float32).reshape(32, 32)
+    bias = 0.5
+    expected = torch.nn.functional.gelu(x_torch.double() + bias)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    bias_tt = ttnn.from_torch(
+        torch.full_like(x_torch, bias), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    ttnn.bias_gelu_(x_tt, bias_tt)
+
+    assert (ttnn.to_torch(x_tt).double() - expected).abs().max() < 1e-5
+
+
 @pytest.mark.parametrize("scalar_bias", [False, True], ids=["tensor_bias", "scalar_bias"])
 def test_bias_gelu_fp32_defaults_to_accurate(device, scalar_bias):
     # bias_gelu compiled the approximate gelu on every surface while ttnn.gelu defaulted to the

--- a/tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
@@ -17,8 +17,8 @@ pytestmark = pytest.mark.use_module_device
 def run_elt_binary_test_range(device, h, w, ttnn_function, low, high, *, pcc=0.9999, exact=False):
     """Run a binary eltwise op on bf16 inputs in [low, high) and assert vs the torch golden.
 
-    Defaults to ``assert_with_pcc(pcc)`` for composite math (ldexp/logaddexp/xlogy/bias_gelu) where
-    the expected error exceeds the ULP <= 5 policy. Callers set ``exact=True`` for ops whose output
+    Defaults to ``assert_with_pcc(pcc)`` for composite math (ldexp/logaddexp/xlogy) where the
+    expected error exceeds the ULP <= 5 policy. Callers set ``exact=True`` for ops whose output
     is a bit-exact selection or boolean (maximum/minimum, logical_and/or/xor)."""
     torch.manual_seed(0)
     low = low

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -97,7 +97,8 @@ Tensor bias_gelu(
     ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
     ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt,
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt);
 
 Tensor bias_gelu(
     const ttnn::Tensor& input_tensor_a,
@@ -109,7 +110,8 @@ Tensor bias_gelu(
     ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
     ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt,
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt);
 
 Tensor fmod(
     const Tensor& input_a,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -94,6 +94,9 @@ constexpr auto kAdditiveFastApproxPostNote =
 constexpr auto kMultiplyFastApproxPostNote =
     R"doc(When :attr:`fast_and_approximate_mode` is `True` for bfloat16 datatype, the operation uses FPU implementation for better performance.
         When :attr:`fast_and_approximate_mode` is `False` for bfloat16 datatype, the operation uses SFPU with the result rounded to nearest even (RNE).)doc";
+constexpr auto kBiasGeluFastApproxPostNote =
+    R"doc(When :attr:`fast_and_approximate_mode` is `True`, the gelu is computed with the fast lookup-table approximation.
+        When it is `False` (default), the accurate gelu is used, matching the default of :attr:`ttnn.gelu`.)doc";
 constexpr auto kDivideFastApproxPostNote =
     R"doc(When :attr:`fast_and_approximate_mode` is `True`, operation assumes that :attr:`input_tensor_b` is not zero.
         When :attr:`fast_and_approximate_mode` is `False` (default), operation properly handles division by zero.
@@ -1341,6 +1344,62 @@ Tensor multiply_fast_approx_tensor_tensor(
         sub_device_id);
 }
 
+Tensor bias_gelu_fast_approx_tensor_scalar(
+    const Tensor& input_tensor_a,
+    unary::ScalarVariant value,
+    bool fast_and_approximate_mode,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_a_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_b_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt) {
+    return ttnn::bias_gelu(
+        input_tensor_a,
+        value,
+        dtype,
+        memory_config,
+        output_tensor,
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(activations.data(), activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_a_activations.data(), input_tensor_a_activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_b_activations.data(), input_tensor_b_activations.size()),
+        sub_core_grids,
+        sub_device_id,
+        fast_and_approximate_mode);
+}
+
+Tensor bias_gelu_fast_approx_tensor_tensor(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    bool fast_and_approximate_mode,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_a_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_b_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt) {
+    return ttnn::bias_gelu(
+        input_tensor_a,
+        input_tensor_b,
+        dtype,
+        memory_config,
+        output_tensor,
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(activations.data(), activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_a_activations.data(), input_tensor_a_activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_b_activations.data(), input_tensor_b_activations.size()),
+        sub_core_grids,
+        sub_device_id,
+        fast_and_approximate_mode);
+}
+
 Tensor divide_fast_approx_tensor_scalar(
     const Tensor& input_tensor_a,
     unary::ScalarVariant value,
@@ -2072,15 +2131,15 @@ void py_module(nb::module_& mod) {
         detail::kArithmeticFpuDtypes,
         detail::kMixedFloatFamilyFootnote);
 
-    detail::bind_binary_operation<"bias_gelu">(
+    detail::bind_binary_operation_with_fast_approx<"bias_gelu">(
         mod,
         R"doc(Computes bias_gelu of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{output\_tensor}} = \verb|bias_gelu|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
-        static_cast<detail::BinaryOpTensorScalarFn>(&ttnn::bias_gelu),
-        static_cast<detail::BinaryOpTensorTensorFn>(&ttnn::bias_gelu),
-        ". ",
+        &detail::bias_gelu_fast_approx_tensor_scalar,
+        &detail::bias_gelu_fast_approx_tensor_tensor,
         detail::kFloatOnlyDtypes,
-        detail::kSameDtypeRequiredFootnote);
+        detail::kSameDtypeRequiredFootnote,
+        detail::kBiasGeluFastApproxPostNote);
 
     detail::bind_binary_operation_with_fast_approx<"multiply">(
         mod,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -1116,7 +1116,8 @@ Tensor bias_gelu(
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    const std::optional<bool>& fast_and_approximate_mode) {
     return ttnn::detail::invoke_binary_ng(
         input_tensor_a_arg,
         input_tensor_b_arg,
@@ -1127,7 +1128,7 @@ Tensor bias_gelu(
         post_activations,
         lhs_activations,
         rhs_activations,
-        /*fast_and_approximate_mode=*/std::nullopt,
+        fast_and_approximate_mode.value_or(false),
         sub_core_grids,
         sub_device_id);
 }
@@ -1142,7 +1143,8 @@ Tensor bias_gelu(
     ttsl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/,
     ttsl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    const std::optional<bool>& fast_and_approximate_mode) {
     // Resolve sub_device_id to sub_core_grids so both add and gelu use the same core restriction
     auto resolved_sub_core_grids = sub_core_grids;
     if (sub_device_id.has_value()) {
@@ -1174,7 +1176,7 @@ Tensor bias_gelu(
             {},
             /*fast_and_approximate_mode*/ std::nullopt,
             resolved_sub_core_grids),
-        true,
+        fast_and_approximate_mode.value_or(false),
         memory_config,
         gelu_output,
         resolved_sub_core_grids);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -735,6 +735,10 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         std::nullopt,
         std::nullopt};
 
+    operation_attributes.gelu_fast_and_approximate =
+        binary_op_type == ttnn::operations::binary_ng::BinaryOpType::BIAS_GELU &&
+        fast_and_approximate_mode.value_or(false);
+
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, input_tensor_b, output_tensor};
     const auto output_spec = OperationType::compute_output_specs(operation_attributes, tensor_args);
     const auto shard_volumes = ttnn::operations::binary_ng::get_shard_volumes(
@@ -831,6 +835,10 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         std::nullopt,
         std::nullopt,
         std::nullopt};
+
+    operation_attributes.gelu_fast_and_approximate =
+        binary_op_type == ttnn::operations::binary_ng::BinaryOpType::BIAS_GELU &&
+        fast_and_approximate_mode.value_or(false);
 
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, std::nullopt, output_tensor};
     // Skip the output-spec computation on the interleaved fast path. output_tensor is tested separately:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -64,6 +64,8 @@ struct BinaryNgDeviceOperation {
         // Sharded output's shape in pages on the accessor path. The inputs' equivalent rides in
         // tensor_args_t::to_hash(); the output has no Tensor at hash time, so it is carried here.
         std::optional<tt::tt_metal::Shape> c_tensor_shape_in_pages;
+        // Selects the gelu variant BIAS_GELU compiles into its postprocess activation.
+        bool gelu_fast_and_approximate = false;
 
         DataType get_dtype() const;
 
@@ -92,7 +94,8 @@ struct BinaryNgDeviceOperation {
             "a_shard_volume",
             "b_shard_volume",
             "c_shard_volume",
-            "c_tensor_shape_in_pages");
+            "c_tensor_shape_in_pages",
+            "gelu_fast_and_approximate");
 
         auto attribute_values() const {
             return std::make_tuple(
@@ -116,7 +119,8 @@ struct BinaryNgDeviceOperation {
                 a_shard_volume,
                 b_shard_volume,
                 c_shard_volume,
-                c_tensor_shape_in_pages);
+                c_tensor_shape_in_pages,
+                binary_op_type == BinaryOpType::BIAS_GELU ? gelu_fast_and_approximate : false);
         }
     };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -891,8 +891,10 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
 
     // TODO: when handling mixed types, we must identify the appropriate dtype and pass it here to define the respective
     // LLK APIs
-    const auto op_config = is_sfpu_op ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype)
-                                      : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype);
+    const auto gelu_fast_and_approximate = operation_attributes.gelu_fast_and_approximate;
+    const auto op_config =
+        is_sfpu_op ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype, gelu_fast_and_approximate)
+                   : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype, gelu_fast_and_approximate);
 
     auto compute_kernel_defines = op_config.as_defines(a_dtype);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -149,7 +149,10 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_w
 //  EnumT can either be FpuBinaryOp or SfpuBinaryOp
 template <class EnumT>
 OpConfig::OpConfig(
-    BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, [[maybe_unused]] std::optional<DataType> dtype) :
+    BinaryOpType binary_op_type,
+    std::in_place_type_t<EnumT>,
+    [[maybe_unused]] std::optional<DataType> dtype,
+    [[maybe_unused]] bool gelu_fast_and_approximate) :
     binary_op(EnumT::SUB) {
     switch (binary_op_type) {
         case BinaryOpType::ADD: binary_op = EnumT::ADD; break;
@@ -223,7 +226,10 @@ OpConfig::OpConfig(
         // gelu(a+b)
         case BinaryOpType::BIAS_GELU:
             binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::GELU;
+            // The parameter is required: without it this reaches gelu_tile's default template
+            // argument, which is the approximate variant, where ttnn.gelu defaults to exact.
+            postprocess =
+                unary::EltwiseUnaryWithParam{unary::UnaryOpType::GELU, gelu_fast_and_approximate ? 1.0f : 0.0f};
             break;
         case BinaryOpType::LOGICAL_AND:
             process_lhs = unary::UnaryOpType::NEZ;
@@ -707,8 +713,10 @@ uint32_t pack_scalar_runtime_arg(const unary::ScalarVariant scalar, const DataTy
         scalar);
 }
 
-template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<FpuBinaryOp>, std::optional<DataType>);
-template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<SfpuBinaryOp>, std::optional<DataType>);
+template OpConfig::OpConfig(
+    BinaryOpType binary_op_type, std::in_place_type_t<FpuBinaryOp>, std::optional<DataType>, bool);
+template OpConfig::OpConfig(
+    BinaryOpType binary_op_type, std::in_place_type_t<SfpuBinaryOp>, std::optional<DataType>, bool);
 
 tt::tt_metal::ShardSpec adjust_to_shape(
     const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -91,13 +91,19 @@ struct OpConfig {
     };
 
     template <class EnumT>
-    OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std::optional<DataType> dtype = std::nullopt);
+    OpConfig(
+        BinaryOpType binary_op_type,
+        std::in_place_type_t<EnumT>,
+        std::optional<DataType> dtype = std::nullopt,
+        bool gelu_fast_and_approximate = false);
 
     std::map<std::string, std::string> as_defines(DataType dtype) const;
 
     std::optional<unary::UnaryOpType> process_lhs;
     std::optional<unary::UnaryOpType> process_rhs;
-    std::optional<unary::UnaryOpType> postprocess;
+    // Carries a parameter: a bare UnaryOpType reaches get_op_init_and_func_default, which emits the
+    // paramless form and so inherits the compute API's default template argument.
+    std::optional<unary::EltwiseUnaryWithParam> postprocess;
     std::variant<FpuBinaryOp, SfpuBinaryOp> binary_op;
     bool is_sfpu_op() const;
 };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary_composite.hpp
@@ -97,7 +97,8 @@ Tensor bias_gelu(
     ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
     ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt,
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt);
 
 Tensor bias_gelu(
     const ttnn::Tensor& input_tensor_a,
@@ -109,7 +110,8 @@ Tensor bias_gelu(
     ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
     ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt,
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt);
 
 Tensor fmod(
     const Tensor& input_a,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/binary_nanobind.cpp
@@ -1077,6 +1077,62 @@ void bind_div(
 }
 
 // Free functions for multiply and divide with fast_and_approximate_mode
+Tensor bias_gelu_fast_approx_tensor_scalar(
+    const Tensor& input_tensor_a,
+    unary::ScalarVariant value,
+    bool fast_and_approximate_mode,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_a_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_b_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt) {
+    return bias_gelu(
+        input_tensor_a,
+        value,
+        dtype,
+        memory_config,
+        output_tensor,
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(activations.data(), activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_a_activations.data(), input_tensor_a_activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_b_activations.data(), input_tensor_b_activations.size()),
+        sub_core_grids,
+        sub_device_id,
+        fast_and_approximate_mode);
+}
+
+Tensor bias_gelu_fast_approx_tensor_tensor(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    bool fast_and_approximate_mode,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output_tensor,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_a_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> input_tensor_b_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt) {
+    return bias_gelu(
+        input_tensor_a,
+        input_tensor_b,
+        dtype,
+        memory_config,
+        output_tensor,
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(activations.data(), activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_a_activations.data(), input_tensor_a_activations.size()),
+        ttsl::Span<const unary::EltwiseUnaryWithParam>(
+            input_tensor_b_activations.data(), input_tensor_b_activations.size()),
+        sub_core_grids,
+        sub_device_id,
+        fast_and_approximate_mode);
+}
+
 Tensor multiply_fast_approx_tensor_scalar(
     const Tensor& input_tensor_a,
     unary::ScalarVariant value,
@@ -1826,14 +1882,15 @@ void py_module(nb::module_& mod) {
         ". ",
         R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32, UINT16)doc");
 
-    detail::bind_binary_operation<"bias_gelu">(
+    detail::bind_binary_operation_with_fast_approx<"bias_gelu">(
         mod,
         R"doc(Computes bias_gelu of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{output\_tensor}} = \verb|bias_gelu|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
-        static_cast<detail::BinaryOpTensorScalarFn>(&bias_gelu),
-        static_cast<detail::BinaryOpTensorTensorFn>(&bias_gelu),
-        ". ",
-        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+        &detail::bias_gelu_fast_approx_tensor_scalar,
+        &detail::bias_gelu_fast_approx_tensor_tensor,
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc",
+        R"doc(When :attr:`fast_and_approximate_mode` is `True`, the gelu uses the fast lookup-table approximation.
+        When it is `False` (default), the accurate gelu is used, matching the default of :attr:`ttnn.gelu`.)doc");
 
     detail::bind_binary_operation_with_fast_approx<"multiply">(
         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/binary_composite_op.cpp
@@ -782,7 +782,8 @@ Tensor bias_gelu(
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    const std::optional<bool>& fast_and_approximate_mode) {
     return ttnn::operations::experimental::quasar::binary::detail::invoke_binary_ng(
         input_tensor_a_arg,
         input_tensor_b_arg,
@@ -793,7 +794,7 @@ Tensor bias_gelu(
         post_activations,
         lhs_activations,
         rhs_activations,
-        /*fast_and_approximate_mode=*/std::nullopt,
+        fast_and_approximate_mode.value_or(false),
         sub_core_grids,
         sub_device_id);
 }
@@ -808,7 +809,8 @@ Tensor bias_gelu(
     ttsl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/,
     ttsl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    const std::optional<bool>& fast_and_approximate_mode) {
     // Resolve sub_device_id to sub_core_grids so both add and gelu use the same core restriction
     auto resolved_sub_core_grids = sub_core_grids;
     if (sub_device_id.has_value()) {
@@ -828,7 +830,7 @@ Tensor bias_gelu(
             {},
             {},
             resolved_sub_core_grids),
-        true,
+        fast_and_approximate_mode.value_or(false),
         memory_config,
         optional_output_tensor,
         resolved_sub_core_grids);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
@@ -918,6 +918,10 @@ ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation::tens
         input_tensor_b.layout(),
         output_layout};
 
+    operation_attributes.gelu_fast_and_approximate =
+        binary_op_type == ttnn::operations::experimental::quasar::binary_ng::BinaryOpType::BIAS_GELU &&
+        fast_and_approximate_mode.value_or(false);
+
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, input_tensor_b, output_tensor};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
@@ -992,6 +996,10 @@ ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation::tens
         input_tensor_a.layout(),
         Layout::INVALID,
         output_layout};
+
+    operation_attributes.gelu_fast_and_approximate =
+        binary_op_type == ttnn::operations::experimental::quasar::binary_ng::BinaryOpType::BIAS_GELU &&
+        fast_and_approximate_mode.value_or(false);
 
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, std::nullopt, output_tensor};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
@@ -55,6 +55,8 @@ struct BinaryNgDeviceOperation {
         Layout input_layout_a = Layout::TILE;
         Layout input_layout_b = Layout::TILE;
         Layout output_layout = Layout::TILE;
+        // Selects the gelu variant BIAS_GELU compiles into its postprocess activation.
+        bool gelu_fast_and_approximate = false;
 
         // `worker_grid` is hashed because get_worker_grid resolves it from MUTABLE device state, so
         // unhashed a cache hit could reuse a program placed on a different core set. `sub_device_id`
@@ -79,7 +81,8 @@ struct BinaryNgDeviceOperation {
             "equal_nan",
             "scalar",
             "rtol",
-            "atol");
+            "atol",
+            "gelu_fast_and_approximate");
         auto attribute_values() const {
             return std::make_tuple(
                 binary_op_type,
@@ -101,7 +104,8 @@ struct BinaryNgDeviceOperation {
                 equal_nan,
                 scalar,
                 rtol,
-                atol);
+                atol,
+                binary_op_type == BinaryOpType::BIAS_GELU ? gelu_fast_and_approximate : false);
         }
         DataType get_dtype() const;
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
@@ -422,8 +422,9 @@ ProgramArtifacts create_no_bcast_artifacts(
     const uint32_t c_tile_bytes = static_cast<uint32_t>(c_tile.get_tile_size(c_df));
 
     // --- OpConfig + compute defines (mirrors the descriptor factory). ---
-    OpConfig op_config = is_sfpu ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype)
-                                 : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype);
+    const auto gelu_fa = op.gelu_fast_and_approximate;
+    OpConfig op_config = is_sfpu ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype, gelu_fa)
+                                 : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype, gelu_fa);
     std::map<std::string, std::string> compute_defines = op_config.as_defines(a_dtype);
 
     // ISCLOSE: the DFB SFPU kernel reads rtol/atol as named args (args::rtol_bits/atol_bits), so the

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_program_factory.cpp
@@ -446,8 +446,9 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
 
     // TODO: when handling mixed types, we must identify the appropriate dtype and pass it here to define the respective
     // LLK APIs
-    const auto op_config = is_sfpu_op ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype)
-                                      : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype);
+    const auto gelu_fa = operation_attributes.gelu_fast_and_approximate;
+    const auto op_config = is_sfpu_op ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype, gelu_fa)
+                                      : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype, gelu_fa);
 
     auto compute_kernel_defines = op_config.as_defines(a_dtype);
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_quasar_native_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_quasar_native_factory.cpp
@@ -491,8 +491,9 @@ ProgramArtifacts create_no_bcast_artifacts(
     const uint32_t c_tile_bytes = static_cast<uint32_t>(c_tile.get_tile_size(c_df));
 
     // --- OpConfig + compute defines (mirrors the descriptor factory). ---
-    OpConfig op_config = is_sfpu ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype)
-                                 : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype);
+    const auto gelu_fa = op.gelu_fast_and_approximate;
+    OpConfig op_config = is_sfpu ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype, gelu_fa)
+                                 : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype, gelu_fa);
     std::map<std::string, std::string> compute_defines = op_config.as_defines(a_dtype);
 
     // ISCLOSE: the DFB SFPU kernel reads rtol/atol as named args (args::rtol_bits/atol_bits), so the

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.cpp
@@ -154,7 +154,11 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_w
 
 //  EnumT can either be FpuBinaryOp or SfpuBinaryOp
 template <class EnumT>
-OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std::optional<DataType> dtype) :
+OpConfig::OpConfig(
+    BinaryOpType binary_op_type,
+    std::in_place_type_t<EnumT>,
+    std::optional<DataType> dtype,
+    [[maybe_unused]] bool gelu_fast_and_approximate) :
     binary_op(EnumT::SUB) {
     switch (binary_op_type) {
         case BinaryOpType::ADD: binary_op = EnumT::ADD; break;
@@ -228,7 +232,10 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
         // gelu(a+b)
         case BinaryOpType::BIAS_GELU:
             binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::GELU;
+            // The parameter is required: without it this reaches gelu_tile's default template
+            // argument, which is the approximate variant, where ttnn.gelu defaults to exact.
+            postprocess =
+                unary::EltwiseUnaryWithParam{unary::UnaryOpType::GELU, gelu_fast_and_approximate ? 1.0f : 0.0f};
             break;
         case BinaryOpType::LOGICAL_AND:
             process_lhs = unary::UnaryOpType::NEZ;
@@ -699,8 +706,10 @@ uint32_t pack_scalar_runtime_arg(const unary::ScalarVariant scalar, const DataTy
         scalar);
 }
 
-template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<FpuBinaryOp>, std::optional<DataType>);
-template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<SfpuBinaryOp>, std::optional<DataType>);
+template OpConfig::OpConfig(
+    BinaryOpType binary_op_type, std::in_place_type_t<FpuBinaryOp>, std::optional<DataType>, bool);
+template OpConfig::OpConfig(
+    BinaryOpType binary_op_type, std::in_place_type_t<SfpuBinaryOp>, std::optional<DataType>, bool);
 
 tt::tt_metal::ShardSpec adjust_to_shape(
     const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_utils.hpp
@@ -91,13 +91,19 @@ struct OpConfig {
     };
 
     template <class EnumT>
-    OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std::optional<DataType> dtype = std::nullopt);
+    OpConfig(
+        BinaryOpType binary_op_type,
+        std::in_place_type_t<EnumT>,
+        std::optional<DataType> dtype = std::nullopt,
+        bool gelu_fast_and_approximate = false);
 
     std::map<std::string, std::string> as_defines(DataType dtype) const;
 
     std::optional<unary::UnaryOpType> process_lhs;
     std::optional<unary::UnaryOpType> process_rhs;
-    std::optional<unary::UnaryOpType> postprocess;
+    // Carries a parameter: a bare UnaryOpType reaches get_op_init_and_func_default, which emits the
+    // paramless form and so inherits the compute API's default template argument.
+    std::optional<unary::EltwiseUnaryWithParam> postprocess;
     std::variant<FpuBinaryOp, SfpuBinaryOp> binary_op;
     bool is_sfpu_op() const;
 };

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -610,10 +610,15 @@ def _golden_function_assign(
 ttnn.attach_golden_function(ttnn.assign, golden_function=_golden_function_assign)
 
 
-def _golden_function(a, b, *args, **kwargs):
+def _golden_function(a, b, *args, fast_and_approximate_mode=False, **kwargs):
     import torch
 
-    return torch.nn.functional.gelu(torch.add(a, b))
+    output_tensor = torch.nn.functional.gelu(torch.add(a, b))
+    if fast_and_approximate_mode:
+        # The device runs the lookup-table gelu here, which is deliberately outside the accurate
+        # reference's numerical contract, so comparing it against torch would always fail.
+        ttnn.decorators.set_golden_comparison_config(output_tensor, method="skip", scope="all")
+    return output_tensor
 
 
 ttnn.attach_golden_function(ttnn.bias_gelu, golden_function=_golden_function)


### PR DESCRIPTION
Closes #55130.

`ttnn.bias_gelu` computed the approximate GELU on every surface while `ttnn.gelu` defaults to the
accurate one, and it exposed no way to ask for the accurate form. Fusing the bias silently changed
the numerics.

FLOAT32 over `[-5, 5]`, max absolute error against `torch.nn.functional.gelu` in float64:

| | before | after |
|---|---|---|
| `ttnn.bias_gelu(a, b)` | 2.340797e-02 | 6.762832e-07 |
| `ttnn.gelu(ttnn.add(a, b))` | 6.762832e-07 | 6.762832e-07 |

## Root cause

Two independent mechanisms, one per surface. Neither is in `binary_op_utils.cpp`, which the issue
pointed at: its `BIAS_GELU` cases do spell `gelu_tile<0u>` (accurate), but
`binary::utils::get_defines` has no live callers and its consumer kernels are unreferenced, so that
spelling never reaches a compiled kernel.

**Tensor-scalar** decomposes on the host into `ttnn::gelu(ttnn::add(...), true, ...)`, where the
literal `true` is `fast_and_approximate_mode`. That is the same op chain as
`ttnn.gelu(x, fast_and_approximate_mode=True)`, which is why the two were bitwise equal.

**Tensor-tensor and in-place** run on `binary_ng`, where `OpConfig::postprocess` was
`std::optional<unary::UnaryOpType>` and structurally could not carry a parameter. A parameterless
activation reaches `get_op_init_and_func_default`, which emits `gelu_tile(i)` with no template
argument, inheriting the compute API default of `fast_and_approx = true`.

## Changes

- `postprocess` widened to `std::optional<unary::EltwiseUnaryWithParam>`; every other assignment
  site keeps compiling through the existing implicit conversion.
- `BIAS_GELU` attaches the parameter explicitly.
- The mode is carried on the op attributes so it reaches the program factory and the program cache
  hash, and is hashed only for `BIAS_GELU`.
- The tensor-scalar composite forwards the flag instead of hardcoding `true`.
- `fast_and_approximate_mode` exposed on the out-of-place overloads via
  `bind_binary_operation_with_fast_approx`, defaulting to `False`. Passing `True` reproduces the
  previous output exactly, so callers who want the old speed keep it.
- The golden skips its comparison when `fast_and_approximate_mode=True`, matching how `ttnn.gelu`
  and `ttnn.divide` handle their own approximate paths. Without this the lookup-table output would
  be compared against the accurate torch reference and always fail.

`ttnn.bias_gelu_` gets the corrected default but no knob: it shares
`TTNN_BINARY_OP_INPLACE_INVOKE_IMPL` with `logical_and_`, `logical_or_` and `logical_xor_`, none of
which expose the flag, and giving it one means a new macro variant since
`resolve_fast_and_approximate_mode` resolves an unset flag to `true`. That is left as a follow-up
rather than widened into this PR.
- The same fix is applied to the Quasar tree, which duplicates `binary_ng` and does not inherit any
  of the above.

## Verification

Built and run on Blackhole p150b and Wormhole n150 at `cd31427033e`.

All three surfaces (tensor-tensor, tensor-scalar, in-place) now match `ttnn.gelu`'s accurate default
exactly: 6.762832e-07 on Blackhole and 6.890377e-07 on Wormhole, each equal to that card's own
`ttnn.gelu` figure. On the two out-of-place surfaces `fast_and_approximate_mode=True` returns
2.340797e-02 on both cards, identical to the previous behaviour.

Interleaving the two modes five times in one process gives stable, distinct results in both
directions and leaves exactly four program-cache entries for two dtypes times two modes, so the new
attribute separates the modes without churning keys for anything else. The 225 tests covering every
other op that assigns `OpConfig::postprocess` (`squared_difference`, `logaddexp`, `logaddexp2`,
`logical_and`/`or`/`xor`, `ldexp`) pass unchanged on both cards.

The 18 existing `bias_gelu` tests pass unchanged on both cards, including
`test_bias_gelu_output_dtype`, which asserts the two overloads agree at `ulp_threshold=0` across
four dtype combinations, and `test_opt_output_bf8b`, which exercises the BFLOAT8_B path.

Added `test_bias_gelu_fp32_defaults_to_accurate`, parametrized over tensor and scalar bias because
they reach the op by different routes. It asserts the default stays under 1e-5 and that
`fast_and_approximate_mode=True` still exceeds 1e-3, so it pins both the default and the knob.
`test_bias_gelu_inplace_fp32_defaults_to_accurate` fences the in-place surface separately, since it
pins its mode at a different call site and its existing coverage runs at a 0.98 PCC floor that the
approximate output also clears.

Also removed `bias_gelu` from a comment in `test_elt_binary.py` listing ops "where the expected
error exceeds the ULP <= 5 policy", which described the defect rather than the op.

Quasar is pre-silicon, so its half is source-only and mirrors the Wormhole and Blackhole change.
