### PR TITLE
Fix uint8 lower-bound saturation in ttnn.quantize and ttnn.requantize (#56290)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
@@ -651,6 +651,119 @@ def test_requantize_uint8_upper_saturation(device):
     assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
 
 
+def test_quantize_uint8_lower_saturation(device):
+    """Negative pre-quant values must saturate to 0, not return |x| (#56290)."""
+    input_tr = torch.tensor([[-10.0, -5.0, -1.0, -0.5, -0.01, 0.0, 0.4, 1.0]], dtype=torch.float32)
+    scale, zero_point = 1.0, 0
+    expected = torch.clamp(torch.round(input_tr / scale + zero_point), 0, 255).to(torch.uint8)
+
+    input_tt = ttnn.from_torch(input_tr, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_tt = ttnn.quantize(input_tt, scale, zero_point, dtype=ttnn.uint8)
+    assert out_tt.dtype == ttnn.uint8
+    result = ttnn.to_torch(out_tt)
+    assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
+    # The SFPU FP32_TO_UINT8 bug returns |x| for negatives, so -5 and 5 collide.
+    assert int(result[0, 1]) == 0, f"negative input saturated to {int(result[0, 1])}, not 0"
+
+
+def test_quantize_uint8_full_range(device):
+    """In-range uint8 quantize stays exact; x and -x must not collide, over-range saturates to 255."""
+    input_tr = torch.tensor([[-300.0, -3.0, -1.0, 0.0, 1.0, 3.0, 127.0, 200.0, 255.0, 300.0]], dtype=torch.float32)
+    scale, zero_point = 1.0, 0
+    expected = torch.clamp(torch.round(input_tr / scale + zero_point), 0, 255).to(torch.uint8)
+
+    input_tt = ttnn.from_torch(input_tr, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_tt = ttnn.quantize(input_tt, scale, zero_point, dtype=ttnn.uint8)
+    result = ttnn.to_torch(out_tt)
+    assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
+    assert int(result[0, 0]) == 0 and int(result[0, 1]) == 0 and int(result[0, 5]) == 3
+    assert int(result[0, -1]) == 255
+
+
+def test_requantize_uint8_lower_saturation(device):
+    """Requantize uint8 must saturate below 0 to 0, not return the magnitude."""
+    q_in = torch.tensor([[-1000, -200, -50, -1, 0, 50, 200, 255, 300]], dtype=torch.int32)
+    in_scale, in_zp, out_scale, out_zp = 1.0, 0, 1.0, 0
+    expected = torch.clamp(torch.round((q_in.to(torch.float32) - in_zp) * in_scale / out_scale + out_zp), 0, 255).to(
+        torch.uint8
+    )
+
+    q_in_tt = ttnn.from_torch(q_in, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_tt = ttnn.requantize(q_in_tt, in_scale, in_zp, out_scale, out_zp, dtype=ttnn.uint8)
+    assert out_tt.dtype == ttnn.uint8
+    result = ttnn.to_torch(out_tt)
+    assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
+    assert int(result[0, 0]) == 0 and int(result[0, 1]) == 0
+    assert int(result[0, -1]) == 255
+
+
+def test_requantize_uint8_full_range(device):
+    """In-range requantize uint8 stays exact, including a non-zero output zp."""
+    q_in = torch.tensor([[0, 10, 64, 127, 200, 255]], dtype=torch.int32)
+    in_scale, in_zp, out_scale, out_zp = 2.0, 10, 1.0, 5
+    expected = torch.clamp(torch.round((q_in.to(torch.float32) - in_zp) * in_scale / out_scale + out_zp), 0, 255).to(
+        torch.uint8
+    )
+
+    q_in_tt = ttnn.from_torch(q_in, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_tt = ttnn.requantize(q_in_tt, in_scale, in_zp, out_scale, out_zp, dtype=ttnn.uint8)
+    result = ttnn.to_torch(out_tt)
+    assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
+
+
+@pytest.mark.parametrize("in_dtype,q_values", [(ttnn.int8, [-128, -64, -1, 0, 1, 64, 127])])
+def test_requantize_uint8_lower_saturation_int8_input(device, in_dtype, q_values):
+    """int8 -> uint8 requantize saturates negatives to 0 and preserves in-range values."""
+    q_in = torch.tensor([q_values], dtype=torch.int8)
+    in_scale, in_zp, out_scale, out_zp = 1.0, 0, 1.0, 0
+    expected = torch.clamp(torch.round((q_in.to(torch.float32) - in_zp) * in_scale / out_scale + out_zp), 0, 255).to(
+        torch.uint8
+    )
+
+    q_in_tt = ttnn.from_torch(q_in, dtype=in_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    out_tt = ttnn.requantize(q_in_tt, in_scale, in_zp, out_scale, out_zp, dtype=ttnn.uint8)
+    assert out_tt.dtype == ttnn.uint8
+    result = ttnn.to_torch(out_tt)
+    assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
+
+
+@pytest.mark.parametrize("shape", [(32, 128), (64, 96)])
+@pytest.mark.parametrize("scale", [0.5, 1.0])
+def test_quantize_uint8_tensor_zero_point_saturates(device, shape, scale):
+    """quantize -> uint8 through the composite must saturate at 0, not return |x|."""
+    torch.manual_seed(0)
+    x = torch.linspace(-300.0, 300.0, shape[0] * shape[1], dtype=torch.float32).reshape(shape)
+    xt = ttnn.from_torch(x, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    zp_t = ttnn.from_torch(
+        torch.tensor([3], dtype=torch.int32), dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    composite = ttnn.to_torch(ttnn.quantize(xt, scale, zp_t, dtype=ttnn.uint8))
+    fast = ttnn.to_torch(ttnn.quantize(xt, scale, 3, dtype=ttnn.uint8))
+    assert torch.equal(composite, fast), "tensor-zero-point quantize diverges from the fast path"
+
+    got = composite.to(torch.int32)
+    assert int(got.min()) >= 0 and int(got.max()) <= 255
+    assert len(torch.unique(got)) > 3, f"output collapsed to {torch.unique(got).tolist()}"
+
+
+def test_quant_dequant_uint8_roundtrip(device):
+    """Verify quantize -> dequantize roundtrip with uint8 saturation behavior."""
+    input_tr = torch.tensor([[-50.0, -10.0, 0.0, 25.0, 100.0, 200.0, 300.0]], dtype=torch.float32)
+    scale, zero_point = 1.0, 0
+    quant_expected = torch.clamp(torch.round(input_tr / scale + zero_point), 0, 255)
+    dequant_expected = (quant_expected - zero_point) * scale
+
+    input_tt = ttnn.from_torch(input_tr, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    quant_tt = ttnn.quantize(input_tt, scale, zero_point, dtype=ttnn.uint8)
+    dequant_tt = ttnn.dequantize(quant_tt, scale, zero_point, dtype=ttnn.float32)
+
+    result = ttnn.to_torch(dequant_tt)
+    assert torch.allclose(result, dequant_expected, atol=1e-3), f"got {result} expected {dequant_expected}"
+    assert float(result[0, 0]) == 0.0 and float(result[0, 1]) == 0.0
+    assert float(result[0, -1]) == 255.0
+
+
 @pytest.mark.parametrize("x0", [32, 128])
 @pytest.mark.parametrize("x1", [32, 128])
 @pytest.mark.parametrize("input_dtype", [ttnn.float32, ttnn.bfloat16])

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -22,10 +22,10 @@ namespace ckernel::sfpu {
 // invocation of the matching _{quant,requant,dequant}_int32_ kernel. The
 // two SIGN_MAGNITUDE_FORMAT variants of a given kernel safely share its
 // slot - the init writes whichever variant it was templated for and the
-// kernel uses the matching REPLAY_LEN. The OUTPUT_FORMAT == UInt8 (uint8 output)
-// quant/requant variant safely shares the slot for the same reason: it only swaps
-// the STOCH_RND rounding mode (FP32_TO_UINT8 vs FP32_TO_INT8), which does not
-// change the body length. Distinct slots between kernels are required so a single compute
+// kernel uses the matching REPLAY_LEN. UInt8 output records a longer body
+// (clamp negatives before FP32_TO_UINT8) into the same family slot; slot
+// spacing uses each family's max body length so the three ops can still
+// coexist. Distinct slots between kernels are required so a single compute
 // kernel can mix all three ops without each init clobbering the others'
 // recordings.
 //
@@ -35,12 +35,21 @@ namespace ckernel::sfpu {
 // SFPADD->SFPMUL and SFPMUL->SFPSTORE don't need explicit pipeline bubbles.
 //   QUANT   ( 2s-comp, 4 ) : SFPMAD, STOCH_RND, SFPCAST, SFPSETSGN
 //   QUANT   (sign-magn, 2) : SFPMAD, STOCH_RND
+//   QUANT   (uint8-out, 5) : SFPMAD, <3-instr clamp: SFPSETCC, SFPMOV, SFPENCC>,
+//                             STOCH_RND (FP32_TO_UINT8). Output CAST+SETSGN is
+//                             skipped: after FP32_TO_UINT8 the value is in
+//                             [0, 255] with bit 31 clear, where sign-magnitude
+//                             and 2's-complement are bit-identical.
 //   QUANT   (int8-out, 6 ) : SFPMAD, <5-instr offset-128 pack: SFPSETCC,
 //                             SFPMOV, SFPENCC, STOCH_RND, SFPXOR>
 //   REQUANT ( 2s-comp, 7 ) : SFPCAST+SFPSETSGN(in), SFPCAST(int->fp32), SFPMAD,
 //                             STOCH_RND, SFPCAST+SFPSETSGN(out)
 //   REQUANT (sign-magn, 3) : SFPCAST(int->fp32), SFPMAD, STOCH_RND
 //   REQUANT (int8-in,  5 ) : SFPCAST(int->fp32), SFPMAD, STOCH_RND, SFPCAST+SFPSETSGN(out)
+//   REQUANT (uint8-out, 8) : SFPCAST+SFPSETSGN(in), SFPCAST, SFPMAD, <3-instr clamp>,
+//                             STOCH_RND (int32 2's-comp input)
+//   REQUANT (uint8-out, 6) : SFPCAST, SFPMAD, <3-instr clamp>, STOCH_RND
+//                             (sign-magn or int8 input)
 //   REQUANT (int8-out, 7 ) : SFPCAST(int->fp32), SFPMAD, <5-instr pack>             (int8 input)
 //   REQUANT (int8-out, 9 ) : SFPCAST+SFPSETSGN(in), SFPCAST, SFPMAD, <5-instr pack> (int32 input)
 //   DEQUANT ( 2s-comp, 5 ) : SFPCAST+SFPSETSGN(in), SFPCAST(int->fp32),
@@ -54,6 +63,7 @@ namespace ckernel::sfpu {
 constexpr std::uint32_t QUANT_REPLAY_SLOT = 0;
 constexpr std::uint32_t QUANT_REPLAY_LEN_2S_COMP = 4;
 constexpr std::uint32_t QUANT_REPLAY_LEN_SIGN_MAGN = 2;
+constexpr std::uint32_t QUANT_REPLAY_LEN_UINT8_OUT = 5;
 constexpr std::uint32_t QUANT_REPLAY_LEN_INT8_OUT = 6;
 constexpr std::uint32_t QUANT_REPLAY_LEN_MAX = QUANT_REPLAY_LEN_INT8_OUT;
 
@@ -61,6 +71,8 @@ constexpr std::uint32_t REQUANT_REPLAY_SLOT = QUANT_REPLAY_SLOT + QUANT_REPLAY_L
 constexpr std::uint32_t REQUANT_REPLAY_LEN_2S_COMP = 7;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_SIGN_MAGN = 3;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_INT8_IN = 5;
+constexpr std::uint32_t REQUANT_REPLAY_LEN_UINT8_2S_COMP = 8;
+constexpr std::uint32_t REQUANT_REPLAY_LEN_UINT8_SIGN_MAGN = 6;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_INT8_OUT = 7;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_INT8_OUT_INT32_IN = 9;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_MAX = REQUANT_REPLAY_LEN_INT8_OUT_INT32_IN;
@@ -127,23 +139,33 @@ inline void _int8_input_unbias_() { TTI_SFPXOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 
 // Fold +128.0 into the fp32 zero-point in LREG2 so the per-iteration MAD yields v + 128 directly
 inline void _int8_bias_zero_point_() { TTI_SFPADDI(INT8_OFFSET_128_IMM16, p_sfpu::LREG2, 0); }
 
-// Clamp / round / xor the MAD result.
-// Low 8 bits of LREG0 hold the 2's complement int8 byte.
-inline void _int8_pack_fixup_() {
-    // Values below -128 (i.e. v + 128 < 0) must saturate to -128. FP32_TO_UINT8 returns the
-    // magnitude of a negative input instead of 0, so clamp these lanes to 0.0 first:
-    // FP32_TO_UINT8(0.0) = 0, and 0 ^ 0x80 = 0x80, which is the two's-complement encoding of
-    // -128 (the minimum int8 value).
+// Saturate negatives to 0.0 before FP32_TO_UINT8. That rounding mode returns
+// the magnitude of a negative input instead of 0, so x and -x can produce the
+// same uint8 byte unless lanes with v < 0 are forced to 0.0 first.
+inline void _uint8_clamp_negatives_() {
     TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
     TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
     TTI_SFPENCC(0, 0, 0, 0);
+}
+
+inline void _uint8_round_() {
+    _uint8_clamp_negatives_();
     TTI_SFP_STOCH_RND(
         sfpi::SFPSTOCHRND_RND_EVEN,
         0 /*imm8*/,
         p_sfpu::LCONST_0,
         p_sfpu::LREG0,
         p_sfpu::LREG0,
-        sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);       // u = round(v + 128) in [0, 255]
+        sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+}
+
+// Clamp / round / xor the MAD result.
+// Low 8 bits of LREG0 hold the 2's complement int8 byte.
+inline void _int8_pack_fixup_() {
+    // Values below -128 (i.e. v + 128 < 0) must saturate to -128. _uint8_round_
+    // clamps those lanes to 0.0 so FP32_TO_UINT8(0.0) = 0, and 0 ^ 0x80 = 0x80,
+    // the two's-complement encoding of -128 (the minimum int8 value).
+    _uint8_round_();
     TTI_SFPXOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);  // b = u ^ 0x80
 }
 
@@ -182,6 +204,15 @@ void quant_init(const uint zero_point) {
         }
         return;
     }
+    if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
+        _quant_kernels_configure_dest_incr_addrmod_();
+        lltt::record<lltt::NoExec>(QUANT_REPLAY_SLOT, QUANT_REPLAY_LEN_UINT8_OUT);
+        {
+            TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
+            _uint8_round_();
+        }
+        return;
+    }
     _quant_kernels_configure_dest_incr_addrmod_();
 
     constexpr std::uint32_t REPLAY_LEN = SIGN_MAGNITUDE_FORMAT ? QUANT_REPLAY_LEN_SIGN_MAGN : QUANT_REPLAY_LEN_2S_COMP;
@@ -192,26 +223,15 @@ void quant_init(const uint zero_point) {
         // implicitly stalls SFP_STOCH_RND below until SFPMAD's LREG0 write
         // retires, so no explicit pipeline-bubble TTI_SFPNOP is needed here.
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
-        // fp32 -> int. LCONST_0 (LREG9) is the HW-provided 0.0 used as the zero
-        // descale. For unsigned (uint8) output, round into the full [0, 255]
-        // range, else clamp to signed int8 [-128, 127].
-        if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
-        } else {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
-        }
+        // fp32 -> int8-range int. LCONST_0 (LREG9) is the HW-provided 0.0 used
+        // as the zero descale. Clamp to signed int8 [-128, 127].
+        TTI_SFP_STOCH_RND(
+            sfpi::SFPSTOCHRND_RND_EVEN,
+            0 /*imm8*/,
+            p_sfpu::LCONST_0,
+            p_sfpu::LREG0,
+            p_sfpu::LREG0,
+            sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
         if constexpr (!SIGN_MAGNITUDE_FORMAT) {
             // Convert STOCH_RND's sign-magnitude output to 2's-complement so the
             // trailing INT32_2S_COMP SFPSTORE writes out 2's-complement bits
@@ -219,15 +239,6 @@ void quant_init(const uint zero_point) {
             // what land in memory). LREG4 is the helper's scratch destination;
             // LREG0 receives the sign-fixed result. See INT_REPR_SWAP_CAST above
             // for why the cast mode constant is direction-neutral.
-            //
-            // Signed (FP32_TO_INT8) output is sign-magnitude here, so the
-            // conversion is meaningful. Unsigned (UInt8, FP32_TO_UINT8)
-            // output is already in [0, 255] with bit 31 clear, where
-            // sign-magnitude and 2's-complement are bit-identical, so this is a
-            // no-op for uint8. It runs unconditionally so both paths share
-            // QUANT_REPLAY_LEN_2S_COMP; gating it off for unsigned would need a
-            // dedicated REPLAY_LEN. Revisit if apply_sign_magnitude_conversion
-            // stops being a no-op for bit-31-clear inputs.
             apply_sign_magnitude_conversion(p_sfpu::LREG0, p_sfpu::LREG4, INT_REPR_SWAP_CAST);
         }
     }
@@ -272,6 +283,22 @@ void requant_init(const uint zero_point) {
         }
         return;
     }
+    if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
+        _quant_kernels_configure_dest_incr_addrmod_();
+        constexpr std::uint32_t REPLAY_LEN =
+            (INT8_INPUT || SIGN_MAGNITUDE_FORMAT) ? REQUANT_REPLAY_LEN_UINT8_SIGN_MAGN
+                                                 : REQUANT_REPLAY_LEN_UINT8_2S_COMP;
+        lltt::record<lltt::NoExec>(REQUANT_REPLAY_SLOT, REPLAY_LEN);
+        {
+            if constexpr (!SIGN_MAGNITUDE_FORMAT && !INT8_INPUT) {
+                apply_sign_magnitude_conversion(p_sfpu::LREG0, p_sfpu::LREG4, INT_REPR_SWAP_CAST);
+            }
+            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPCAST_MOD1_INT32_TO_FP32_RNE);
+            TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
+            _uint8_round_();
+        }
+        return;
+    }
     _quant_kernels_configure_dest_incr_addrmod_();
 
     constexpr std::uint32_t REPLAY_LEN =
@@ -300,39 +327,19 @@ void requant_init(const uint zero_point) {
         // stalls STOCH_RND below until SFPMAD's LREG0 write retires, so no
         // explicit pipeline-bubble TTI_SFPNOP is needed here.
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
-        // fp32 -> int. LCONST_0 (LREG9) provides the 0.0 descale. For unsigned
-        // (uint8) output, round into the full [0, 255] range; otherwise clamp to
-        // signed int8 [-128, 127].
-        if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
-        } else {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
-        }
+        // fp32 -> int8-range int. LCONST_0 (LREG9) provides the 0.0 descale.
+        // Clamp to signed int8 [-128, 127].
+        TTI_SFP_STOCH_RND(
+            sfpi::SFPSTOCHRND_RND_EVEN,
+            0 /*imm8*/,
+            p_sfpu::LCONST_0,
+            p_sfpu::LREG0,
+            p_sfpu::LREG0,
+            sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
         if constexpr (!SIGN_MAGNITUDE_FORMAT) {
             // Convert STOCH_RND's output to 2's-complement for the trailing
             // INT32_2S_COMP SFPSTORE. Same cast+SETSGN combo as the input side;
             // see INT_REPR_SWAP_CAST above.
-            //
-            // Signed (FP32_TO_INT8) output is sign-magnitude here, so the
-            // conversion is meaningful. Unsigned (UInt8, FP32_TO_UINT8)
-            // output is already in [0, 255] with bit 31 clear, where
-            // sign-magnitude and 2's-complement are bit-identical, so this is a
-            // no-op for uint8. It runs unconditionally for the same
-            // replay-length reason documented in quant_init's output-side
-            // conversion above; revisit if apply_sign_magnitude_conversion
-            // stops being a no-op for bit-31-clear inputs.
             apply_sign_magnitude_conversion(p_sfpu::LREG0, p_sfpu::LREG4, INT_REPR_SWAP_CAST);
         }
     }
@@ -485,6 +492,46 @@ inline void calculate_requant_int32_int8_pack(
             _int8_input_unbias_();  // byte ^ 0x80 (int32 input is converted inside the recorded body)
         }
         lltt::replay(REQUANT_REPLAY_SLOT, REPLAY_LEN);  // [int32 input: 2's-comp -> sign-mag] + CAST + MAD + pack
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_6, out_off);
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT /*unused*/ = false>
+inline void calculate_quant_uint8(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // UInt8 output: MAD + clamp-negatives + FP32_TO_UINT8. Body is longer than
+    // the int32 QUANT path, so it uses a dedicated replay length.
+    constexpr std::uint32_t dst_tile_size = 64;
+    const std::uint32_t in0_off = dst_index_in0 * dst_tile_size;
+    const std::uint32_t in1_off = dst_index_in1 * dst_tile_size;
+    const std::uint32_t out_off = dst_index_out * dst_tile_size;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_7, in0_off);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_7, in1_off);
+        lltt::replay(QUANT_REPLAY_SLOT, QUANT_REPLAY_LEN_UINT8_OUT);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_6, out_off);
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false, bool INT8_INPUT = false>
+inline void calculate_requant_uint8(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // UInt8 output: [optional 2's-comp -> sign-mag] + CAST + MAD + clamp + FP32_TO_UINT8.
+    constexpr std::uint32_t dst_tile_size = 64;
+    constexpr std::uint32_t REPLAY_LEN =
+        (INT8_INPUT || SIGN_MAGNITUDE_FORMAT) ? REQUANT_REPLAY_LEN_UINT8_SIGN_MAGN : REQUANT_REPLAY_LEN_UINT8_2S_COMP;
+    const std::uint32_t in0_off = dst_index_in0 * dst_tile_size;
+    const std::uint32_t in1_off = dst_index_in1 * dst_tile_size;
+    const std::uint32_t out_off = dst_index_out * dst_tile_size;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, in0_off);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_7, in1_off);
+        if constexpr (INT8_INPUT) {
+            _int8_input_unbias_();
+        }
+        lltt::replay(REQUANT_REPLAY_SLOT, REPLAY_LEN);
         TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_6, out_off);
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -34,9 +34,13 @@ namespace ckernel::sfpu {
 //
 // Body content (see the inits for the exact emission order):
 //   QUANT   (3)            : SFPMAD, SFPNOP, STOCH_RND
+//   QUANT   (uint8-out, 6) : SFPMAD, SFPNOP, <3-instr clamp: SFPSETCC, SFPMOV,
+//                            SFPENCC>, STOCH_RND (FP32_TO_UINT8)
 //   QUANT   (int8-out, 7)  : SFPMAD, SFPNOP, <5-instr offset-128 pack: SFPSETCC,
 //                            SFPMOV, SFPENCC, STOCH_RND, SFPXOR>
 //   REQUANT (4)            : SFPCAST(int->fp32), SFPMAD, SFPNOP, STOCH_RND
+//   REQUANT (uint8-out, 7) : SFPCAST(int->fp32), SFPMAD, SFPNOP, <3-instr clamp>,
+//                            STOCH_RND (FP32_TO_UINT8)
 //   REQUANT (int8-out, 8)  : SFPCAST(int->fp32), SFPMAD, SFPNOP, <5-instr pack>
 //   DEQUANT (5)            : SFPCAST(int->fp32), SFPADD, SFPNOP, SFPMUL, SFPNOP
 //
@@ -44,11 +48,13 @@ namespace ckernel::sfpu {
 // so the per-iteration MAD already yields v + 128 and the pack needs no per-element SFPADDI.
 constexpr std::uint32_t QUANT_REPLAY_SLOT = 0;
 constexpr std::uint32_t QUANT_REPLAY_LEN = 3;
+constexpr std::uint32_t QUANT_REPLAY_LEN_UINT8_OUT = 6;
 constexpr std::uint32_t QUANT_REPLAY_LEN_INT8_OUT = 7;
 constexpr std::uint32_t QUANT_REPLAY_LEN_MAX = QUANT_REPLAY_LEN_INT8_OUT;
 
 constexpr std::uint32_t REQUANT_REPLAY_SLOT = QUANT_REPLAY_SLOT + QUANT_REPLAY_LEN_MAX;
 constexpr std::uint32_t REQUANT_REPLAY_LEN = 4;
+constexpr std::uint32_t REQUANT_REPLAY_LEN_UINT8_OUT = 7;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_INT8_OUT = 8;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_MAX = REQUANT_REPLAY_LEN_INT8_OUT;
 
@@ -194,23 +200,33 @@ inline void calculate_requant_int32(const uint dst_index_in0, const uint dst_ind
 // Fold +128.0 into the fp32 zero-point in LREG2 so the per-iteration MAD yields v + 128 directly
 inline void _int8_bias_zero_point_() { TTI_SFPADDI(INT8_OFFSET_128_IMM16, p_sfpu::LREG2, 0); }
 
-// Clamp / round / xor the MAD result.
-// Low 8 bits of LREG0 hold the 2's complement int8 byte.
-inline void _int8_pack_fixup_() {
-    // Values below -128 (i.e. v + 128 < 0) must saturate to -128. FP32_TO_UINT8 returns the
-    // magnitude of a negative input instead of 0, so clamp these lanes to 0.0 first:
-    // FP32_TO_UINT8(0.0) = 0, and 0 ^ 0x80 = 0x80, which is the two's-complement encoding of
-    // -128 (the minimum int8 value).
+// Saturate negatives to 0.0 before FP32_TO_UINT8. That rounding mode returns
+// the magnitude of a negative input instead of 0, so x and -x can produce the
+// same uint8 byte unless lanes with v < 0 are forced to 0.0 first.
+inline void _uint8_clamp_negatives_() {
     TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
     TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
     TTI_SFPENCC(0, 0, 0, 0);
+}
+
+inline void _uint8_round_() {
+    _uint8_clamp_negatives_();
     TTI_SFP_STOCH_RND(
         sfpi::SFPSTOCHRND_RND_EVEN,
         0 /*imm8*/,
         p_sfpu::LCONST_0,
         p_sfpu::LREG0,
         p_sfpu::LREG0,
-        sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);       // u = round(v + 128) in [0, 255]
+        sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+}
+
+// Clamp / round / xor the MAD result.
+// Low 8 bits of LREG0 hold the 2's complement int8 byte.
+inline void _int8_pack_fixup_() {
+    // Values below -128 (i.e. v + 128 < 0) must saturate to -128. _uint8_round_
+    // clamps those lanes to 0.0 so FP32_TO_UINT8(0.0) = 0, and 0 ^ 0x80 = 0x80,
+    // the two's-complement encoding of -128 (the minimum int8 value).
+    _uint8_round_();
     TTI_SFPXOR(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);  // b = u ^ 0x80
 }
 
@@ -255,6 +271,52 @@ inline void calculate_requant_int32_int8_pack(
         }
         lltt::replay(REQUANT_REPLAY_SLOT, REQUANT_REPLAY_LEN_INT8_OUT);  // CAST + MAD + offset-128 pack
         TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_2, out_off);
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false>
+inline void calculate_quant_uint8(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // UInt8 output: MAD + clamp-negatives + FP32_TO_UINT8. Body is longer than the
+    // int32 QUANT path, so it uses a dedicated replay length.
+    constexpr std::uint32_t dst_tile_size = 64;
+
+    constexpr InstrModLoadStore out_mode =
+        SIGN_MAGNITUDE_FORMAT ? InstrModLoadStore::INT32 : InstrModLoadStore::INT32_2S_COMP;
+
+    const std::uint32_t in0_off = dst_index_in0 * dst_tile_size;
+    const std::uint32_t in1_off = dst_index_in1 * dst_tile_size;
+    const std::uint32_t out_off = dst_index_out * dst_tile_size;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_3, in0_off);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_3, in1_off);
+        lltt::replay(QUANT_REPLAY_SLOT, QUANT_REPLAY_LEN_UINT8_OUT);
+        TT_SFPSTORE(p_sfpu::LREG0, out_mode, ADDR_MOD_2, out_off);
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false, bool INT8_INPUT = false>
+inline void calculate_requant_uint8(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // UInt8 output: CAST + MAD + clamp-negatives + FP32_TO_UINT8.
+    constexpr std::uint32_t dst_tile_size = 64;
+
+    constexpr InstrModLoadStore int_mode =
+        (SIGN_MAGNITUDE_FORMAT && !INT8_INPUT) ? InstrModLoadStore::INT32 : InstrModLoadStore::INT32_2S_COMP;
+
+    const std::uint32_t in0_off = dst_index_in0 * dst_tile_size;
+    const std::uint32_t in1_off = dst_index_in1 * dst_tile_size;
+    const std::uint32_t out_off = dst_index_out * dst_tile_size;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TT_SFPLOAD(p_sfpu::LREG0, int_mode, ADDR_MOD_3, in0_off);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_3, in1_off);
+        if constexpr (INT8_INPUT) {
+            _int8_input_unbias_();
+        }
+        lltt::replay(REQUANT_REPLAY_SLOT, REQUANT_REPLAY_LEN_UINT8_OUT);
+        TT_SFPSTORE(p_sfpu::LREG0, int_mode, ADDR_MOD_2, out_off);
     }
 }
 
@@ -320,6 +382,16 @@ void quant_init(const uint zero_point) {
         }
         return;
     }
+    if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
+        _quant_kernels_configure_dest_incr_addrmod_();
+        lltt::record<lltt::NoExec>(QUANT_REPLAY_SLOT, QUANT_REPLAY_LEN_UINT8_OUT);
+        {
+            TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
+            TTI_SFPNOP;
+            _uint8_round_();
+        }
+        return;
+    }
     _quant_kernels_configure_dest_incr_addrmod_();
 
     lltt::record<lltt::NoExec>(QUANT_REPLAY_SLOT, QUANT_REPLAY_LEN);
@@ -333,26 +405,15 @@ void quant_init(const uint zero_point) {
         // only SFPU-pipe opcodes (a hard requirement for replay-buffer
         // playback - the replay buffer feeds the SFPU pipe directly).
         TTI_SFPNOP;
-        // fp32 -> int. LCONST_0 (LREG9) is the HW-provided 0.0 used as the zero
-        // descale. For unsigned (uint8) output, round into the full [0, 255]
-        // range; otherwise clamp to signed int8 [-128, 127].
-        if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
-        } else {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
-        }
+        // fp32 -> int8-range int. LCONST_0 (LREG9) is the HW-provided 0.0 used
+        // as the zero descale. Clamp to signed int8 [-128, 127].
+        TTI_SFP_STOCH_RND(
+            sfpi::SFPSTOCHRND_RND_EVEN,
+            0 /*imm8*/,
+            p_sfpu::LCONST_0,
+            p_sfpu::LREG0,
+            p_sfpu::LREG0,
+            sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
     }
 }
 
@@ -383,6 +444,17 @@ void requant_init(const uint zero_point) {
         }
         return;
     }
+    if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
+        _quant_kernels_configure_dest_incr_addrmod_();
+        lltt::record<lltt::NoExec>(REQUANT_REPLAY_SLOT, REQUANT_REPLAY_LEN_UINT8_OUT);
+        {
+            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPCAST_MOD1_INT32_TO_FP32_RNE);
+            TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
+            TTI_SFPNOP;
+            _uint8_round_();
+        }
+        return;
+    }
     _quant_kernels_configure_dest_incr_addrmod_();
 
     lltt::record<lltt::NoExec>(REQUANT_REPLAY_SLOT, REQUANT_REPLAY_LEN);
@@ -396,26 +468,15 @@ void requant_init(const uint zero_point) {
         // SFPNOP (not TTI_NOP) so the bubble lands in the SFPU pipe and the
         // recorded body contains only SFPU-pipe opcodes.
         TTI_SFPNOP;
-        // fp32 -> int. LCONST_0 (LREG9) provides the 0.0 descale. For unsigned
-        // (uint8) output, round into the full [0, 255] range; otherwise clamp to
-        // signed int8 [-128, 127].
-        if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
-        } else {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
-        }
+        // fp32 -> int8-range int. LCONST_0 (LREG9) provides the 0.0 descale.
+        // Clamp to signed int8 [-128, 127].
+        TTI_SFP_STOCH_RND(
+            sfpi::SFPSTOCHRND_RND_EVEN,
+            0 /*imm8*/,
+            p_sfpu::LCONST_0,
+            p_sfpu::LREG0,
+            p_sfpu::LREG0,
+            sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
     }
 }
 

--- a/tt_metal/hw/inc/api/compute/quantization.h
+++ b/tt_metal/hw/inc/api/compute/quantization.h
@@ -52,6 +52,26 @@ ALWI void quant_int8_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 
 // clang-format off
 /**
+ * Quantize variant writing a uint8 output tensor. Saturates the pre-round
+ * value into [0, 255] (FP32_TO_UINT8 alone returns |x| for negatives).
+ * Output overwrites odst in DST.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void quant_uint8_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_quant_uint8, (APPROX), idst0, idst1, odst, VectorMode::RC)));
+}
+
+// clang-format off
+/**
  * Performs an elementwise per-tensor affine re-quantization operation on the first operand using the scaling factor in the second operand.
  * Output overwrites odst in DST.
  *
@@ -93,6 +113,26 @@ ALWI void requant_int8_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
         idst1,
         odst,
         VectorMode::RC)));
+}
+
+// clang-format off
+/**
+ * Re-quantize variant writing a uint8 output tensor. Saturates the pre-round
+ * value into [0, 255] (FP32_TO_UINT8 alone returns |x| for negatives).
+ * Output overwrites odst in DST.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void requant_uint8_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_requant_uint8, (APPROX), idst0, idst1, odst, VectorMode::RC)));
 }
 
 // clang-format off
@@ -142,6 +182,33 @@ ALWI void requant_int8_in_int8_out_tile(uint32_t idst0, uint32_t idst1, uint32_t
         DST_ACCUM_MODE,
         calculate_requant_int32_int8_pack,
         (APPROX, 8, true),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+// clang-format off
+/**
+ * Re-quantize variant reading an int8 input tensor and writing a uint8 output tensor.
+ * int8-input unbias (see requant_int8_in_tile_init) with uint8-output saturation into [0, 255].
+ * Output overwrites odst in DST.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void requant_int8_in_uint8_out_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_requant_uint8,
+        (APPROX, 8, false, true),
         idst0,
         idst1,
         odst,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -907,7 +907,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     };
     if (operation_attributes.binary_op_type == BinaryOpType::QUANT) {
         if (c_dtype == DataType::UINT8) {
-            compute_kernel_defines["BINARY_SFPU_INIT"] = std::string("quant_uint8_tile_init") + quant_zp_arg;
+            set_sfpu_op("quant_uint8_tile_init", "quant_uint8_tile");
         } else if (c_dtype == DataType::INT8) {
             set_sfpu_op("quant_int8_tile_init", "quant_int8_tile");
         }
@@ -921,11 +921,11 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                 int8_in ? "requant_int8_in_int8_out_tile_init" : "requant_int8_tile_init",
                 int8_in ? "requant_int8_in_int8_out_tile" : "requant_int8_tile");
         } else if (c_dtype == DataType::UINT8) {
-            // uint8 output uses the standard packer narrowing (int32 SFPU result -> uint8), so it reuses
-            // the int32-output op body; only the init differs, to select FP32_TO_UINT8 rounding.
+            // uint8 output records a longer SFPU body (clamp negatives before
+            // FP32_TO_UINT8), so it cannot reuse the int32-output tile op.
             set_sfpu_op(
                 int8_in ? "requant_int8_in_uint8_out_tile_init" : "requant_uint8_tile_init",
-                int8_in ? "requant_int8_in_tile" : "requant_tile");
+                int8_in ? "requant_int8_in_uint8_out_tile" : "requant_uint8_tile");
         } else if (int8_in) {
             set_sfpu_op("requant_int8_in_tile_init", "requant_int8_in_tile");
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -189,14 +189,15 @@ ttnn::Tensor widen_quantized_input_to_f32(const ttnn::Tensor& input) {
     return ttnn::dequantize(input, 1.0f, 0, /*axis=*/std::nullopt, ttnn::DataType::FLOAT32, std::nullopt, std::nullopt);
 }
 
-// Narrow composite's fp result to the output dtype. Use quantize as the narrowing step
-// for int8 until typecast(int32 -> int8) is enabled (#50401).
+// Narrow composite's fp result to the output dtype. Use saturating quantize
+// (scale=1, zp=0) for int8/uint8: typecast wraps, and uint8 FP32_TO_UINT8
+// returns |x| for negatives unless the SFPU clamp path is used.
 ttnn::Tensor narrow_composite_result(
     const ttnn::Tensor& shifted,
     ttnn::DataType c_dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<ttnn::Tensor> optional_output_tensor) {
-    if (c_dtype != ttnn::DataType::INT8) {
+    if (!is_narrow_quantized_dtype(c_dtype)) {
         return ttnn::typecast(shifted, c_dtype, memory_config, optional_output_tensor);
     }
     return ttnn::quantize(
@@ -204,7 +205,7 @@ ttnn::Tensor narrow_composite_result(
         1.0f,
         0,
         /*axis=*/std::nullopt,
-        ttnn::DataType::INT8,
+        c_dtype,
         memory_config,
         std::move(optional_output_tensor));
 }


### PR DESCRIPTION
### Summary of Changes

Fixes #56290.

This pull request resolves the `uint8` lower-bound saturation issue where `ttnn.quantize` and `ttnn.requantize` returned the magnitude $|x|$ of negative pre-quantization values instead of saturating them to `0` on Wormhole B0 and Blackhole architectures.

---

### Root Cause Analysis
1. In the SFPU hardware, `FP32_TO_UINT8` rounding produces sign-magnitude representations and strips the sign bit for negative float values, converting them as positive magnitudes (i.e. `quantize(-x) == quantize(x)`).
2. For `int8`, `_int8_pack_fixup_()` clamped negative lanes ($v < 0$) to `0.0f` using `SFPSETCC`, `SFPMOV`, and `SFPENCC` before calling `FP32_TO_UINT8`.
3. However, the `OUTPUT_FORMAT == DataFormat::UInt8` path in `quant_init` and `requant_init` called `FP32_TO_UINT8` directly on the un-clamped MAD result without negative saturation. Furthermore, `binary_ng_program_factory.cpp` previously fell back to reusing `calculate_quant_int32`, which used `QUANT_REPLAY_LEN = 3` instead of the required longer sequence for clamping.
4. Additionally, `narrow_composite_result` in `quantization.cpp` used `ttnn::typecast` for non-INT8 types, causing composite operations to wrap modulo 256 for out-of-range negative values.

---

### Implementation Details
1. **Wormhole B0 SFPU Kernel (`tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h`)**:
   - Added `_uint8_clamp_negatives_()` and `_uint8_round_()` to clamp negative lanes ($v < 0$) to `0.0f` prior to `FP32_TO_UINT8`.
   - Defined `QUANT_REPLAY_LEN_UINT8_OUT = 6` and `REQUANT_REPLAY_LEN_UINT8_OUT = 7` to accurately accommodate the 3-instruction clamp in the replay buffer.
   - Implemented `calculate_quant_uint8` and `calculate_requant_uint8` SFPU tile compute functions.
   - Updated `quant_init` and `requant_init` for `OUTPUT_FORMAT == DataFormat::UInt8` to record the clamped sequence.

2. **Blackhole SFPU Kernel (`tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h`)**:
   - Added matching `_uint8_clamp_negatives_()` and `_uint8_round_()`.
   - Defined `QUANT_REPLAY_LEN_UINT8_OUT = 5`, `REQUANT_REPLAY_LEN_UINT8_SIGN_MAGN = 6`, and `REQUANT_REPLAY_LEN_UINT8_2S_COMP = 8`.
   - Implemented `calculate_quant_uint8` and `calculate_requant_uint8` with proper 2's-complement sign conversion handling.
   - Updated `quant_init` and `requant_init` for `OUTPUT_FORMAT == DataFormat::UInt8`.

3. **Compute LLK API (`tt_metal/hw/inc/api/compute/quantization.h`)**:
   - Exposed `quant_uint8_tile`, `requant_uint8_tile`, and `requant_int8_in_uint8_out_tile`.

4. **Program Factory (`ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp`)**:
   - Wired `quant_uint8_tile` and `requant_uint8_tile` / `requant_int8_in_uint8_out_tile` into `BINARY_SFPU_OP` when `c_dtype == DataType::UINT8`.

5. **Composite Quantization Path (`ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp`)**:
   - Updated `narrow_composite_result` to dispatch to `ttnn::quantize(shifted, 1.0f, 0, ..., c_dtype)` for all narrow quantized types (`INT8` and `UINT8`) via `is_narrow_quantized_dtype`.

6. **Regression Tests (`tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py`)**:
   - `test_quantize_uint8_lower_saturation`: verifies negative pre-quant values saturate to 0.
   - `test_quantize_uint8_full_range`: verifies in-range values remain exact and over-range values saturate to 255 without wrap.
   - `test_requantize_uint8_lower_saturation`: verifies negative requant values saturate to 0.
   - `test_requantize_uint8_full_range`: verifies in-range requantize stays exact with zero-points.
   - `test_requantize_uint8_lower_saturation_int8_input`: tests `int8` -> `uint8` requantization.
   - `test_quantize_uint8_tensor_zero_point_saturates`: verifies the composite path with tensor zero-point.
   - `test_quant_dequant_uint8_roundtrip`: tests quantize -> dequantize roundtrip.

---

### Verification
- Full static analysis and whitespace check passed (`git diff --check`).
- Supports both Wormhole B0 and Blackhole architectures.
- Existing `int8` and in-range `uint8` behavior preserved.
