### PR TITLE
[Bug fix] quantize/requantize: clamp negatives before the uint8 rounding

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
@@ -657,6 +657,23 @@ def test_quantize_uint8_lower_saturation(device):
     assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
 
 
+def test_quantize_uint8_lower_saturation_composite(device):
+    """Test quantize uint8 lower saturation to 0 on the composite path, reached with a tensor zero point"""
+    row = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 2.0, 5.0]
+    input_tr = torch.tensor([row, [-v for v in row]], dtype=torch.float32)
+    scale, zero_point = 1.0 / 255.0, 0
+    expected = torch.clamp(torch.round(input_tr / scale + zero_point), 0, 255).to(torch.uint8)
+
+    input_tt = ttnn.from_torch(input_tr, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    zero_point_tt = ttnn.from_torch(
+        torch.zeros(1, 1, dtype=torch.int32), dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    out_tt = ttnn.quantize(input_tt, scale, zero_point_tt, dtype=ttnn.uint8)
+    assert out_tt.dtype == ttnn.uint8
+    result = ttnn.to_torch(out_tt)
+    assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
+
+
 def test_requantize_uint8_upper_saturation(device):
     """Test requantize uint8 upper saturation to 255 on the output side"""
     q_in = torch.tensor([[0, 50, 100, 200, 255, 300, 1000]], dtype=torch.int32)

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
@@ -638,6 +638,25 @@ def test_quantize_uint8_upper_saturation(device):
     assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
 
 
+def test_quantize_uint8_lower_saturation(device):
+    """Test quantize uint8 lower saturation to 0, against the matching positive row"""
+    input_tr = torch.tensor(
+        [
+            [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 2.0, 5.0],
+            [0.0, -0.2, -0.4, -0.6, -0.8, -1.0, -2.0, -5.0],
+        ],
+        dtype=torch.float32,
+    )
+    scale, zero_point = 1.0 / 255.0, 0
+    expected = torch.clamp(torch.round(input_tr / scale + zero_point), 0, 255).to(torch.uint8)
+
+    input_tt = ttnn.from_torch(input_tr, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_tt = ttnn.quantize(input_tt, scale, zero_point, dtype=ttnn.uint8)
+    assert out_tt.dtype == ttnn.uint8
+    result = ttnn.to_torch(out_tt)
+    assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
+
+
 def test_requantize_uint8_upper_saturation(device):
     """Test requantize uint8 upper saturation to 255 on the output side"""
     q_in = torch.tensor([[0, 50, 100, 200, 255, 300, 1000]], dtype=torch.int32)
@@ -645,6 +664,29 @@ def test_requantize_uint8_upper_saturation(device):
     expected = torch.clamp(torch.round((q_in - in_zp) * in_scale / out_scale + out_zp), 0, 255).to(torch.uint8)
 
     q_in_tt = ttnn.from_torch(q_in, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_tt = ttnn.requantize(q_in_tt, in_scale, in_zp, out_scale, out_zp, dtype=ttnn.uint8)
+    assert out_tt.dtype == ttnn.uint8
+    result = ttnn.to_torch(out_tt)
+    assert torch.equal(result, expected), f"got {result.tolist()} expected {expected.tolist()}"
+
+
+@pytest.mark.parametrize(
+    "in_dtype,q_values,in_scale,in_zp",
+    [
+        (ttnn.int32, [0, 10, 64, 127, 200, 255, -1, -50, -300, -1000], 1.0, 0),
+        (ttnn.int32, [0, 10, 64, 127, 200, 255], 2.0, 10),
+        (ttnn.int8, [-128, -100, -32, -1, 0, 1, 32, 100, 127], 1.0, 0),
+    ],
+)
+def test_requantize_uint8_lower_saturation(device, in_dtype, q_values, in_scale, in_zp):
+    """Test requantize saturating the lower end of a uint8 output to 0"""
+    q_in = torch.tensor([q_values], dtype=torch.int32 if in_dtype == ttnn.int32 else torch.int8)
+    out_scale, out_zp = 1.0, 0
+    expected = torch.clamp(torch.round((q_in.to(torch.float32) - in_zp) * in_scale / out_scale + out_zp), 0, 255).to(
+        torch.uint8
+    )
+
+    q_in_tt = ttnn.from_torch(q_in, dtype=in_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     out_tt = ttnn.requantize(q_in_tt, in_scale, in_zp, out_scale, out_zp, dtype=ttnn.uint8)
     assert out_tt.dtype == ttnn.uint8
     result = ttnn.to_torch(out_tt)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -90,6 +90,8 @@ constexpr std::uint32_t DEQUANT_REPLAY_LEN_SIGN_MAGN = 3;
 // helper is what keeps them from drifting apart.
 template <bool SIGN_MAGNITUDE_FORMAT, DataFormat OUTPUT_FORMAT>
 inline constexpr std::uint32_t quant_replay_len() {
+    static_assert(
+        OUTPUT_FORMAT != DataFormat::Int8, "int8 output records its own body; replay it with the _int8_pack kernels");
     if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
         return QUANT_REPLAY_LEN_UINT8_OUT;
     } else {
@@ -99,6 +101,8 @@ inline constexpr std::uint32_t quant_replay_len() {
 
 template <bool SIGN_MAGNITUDE_FORMAT, DataFormat OUTPUT_FORMAT, bool INT8_INPUT>
 inline constexpr std::uint32_t requant_replay_len() {
+    static_assert(
+        OUTPUT_FORMAT != DataFormat::Int8, "int8 output records its own body; replay it with the _int8_pack kernels");
     if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
         return (SIGN_MAGNITUDE_FORMAT || INT8_INPUT) ? REQUANT_REPLAY_LEN_UINT8_OUT
                                                      : REQUANT_REPLAY_LEN_UINT8_OUT_INT32_IN;
@@ -235,8 +239,9 @@ void quant_init(const uint zero_point) {
     lltt::record<lltt::NoExec>(QUANT_REPLAY_SLOT, REPLAY_LEN);
     {
         // D(LREG0) = LREG0 * LREG1 + LREG2 (zero point). The Blackhole SFPU
-        // implicitly stalls SFP_STOCH_RND below until SFPMAD's LREG0 write
-        // retires, so no explicit pipeline-bubble TTI_SFPNOP is needed here.
+        // implicitly stalls the next instruction (SFP_STOCH_RND, or SFPSETCC on
+        // the uint8 path) until SFPMAD's LREG0 write retires, so no explicit
+        // pipeline-bubble TTI_SFPNOP is needed here.
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
         // fp32 -> int. LCONST_0 (LREG9) is the HW-provided 0.0 used as the zero
         // descale. For unsigned (uint8) output, round into the full [0, 255]
@@ -332,8 +337,9 @@ void requant_init(const uint zero_point) {
         // int32 sign-magnitude -> fp32.
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPCAST_MOD1_INT32_TO_FP32_RNE);
         // D(LREG0) = LREG0 * LREG1 + LREG2 (zero point). BH SFPU implicitly
-        // stalls STOCH_RND below until SFPMAD's LREG0 write retires, so no
-        // explicit pipeline-bubble TTI_SFPNOP is needed here.
+        // stalls the next instruction (STOCH_RND, or SFPSETCC on the uint8 path)
+        // until SFPMAD's LREG0 write retires, so no explicit pipeline-bubble
+        // TTI_SFPNOP is needed here.
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
         // fp32 -> int. LCONST_0 (LREG9) provides the 0.0 descale. For unsigned
         // (uint8) output, round into the full [0, 255] range; otherwise clamp to
@@ -410,7 +416,8 @@ inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index
     // Operand A is input (fp32).
     // Operand B is scaling factor (fp32).
     // LREG2 holds the zero-point constant (fp32) loaded by _init_quant_int32_.
-    // Output is int32 scaled to int8 range (sign-magnitude or 2's-complement).
+    // Output is int32 holding the quantized value in the output dtype's range:
+    // int8 (sign-magnitude or 2's-complement), or [0, 255] for uint8.
     //
     // Tile layout in Dest: each tile occupies 64 dest-address units (4 faces
     // x 16 addr/face). Each SFPLOAD/SFPSTORE moves 4 dest rows x 8 SFPU lanes,
@@ -419,7 +426,8 @@ inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index
     //
     // The replay-buffer body at QUANT_REPLAY_SLOT and ADDR_MOD_6's dest+=2
     // slot are programmed by _init_quant_int32_<APPROXIMATION_MODE,
-    // SIGN_MAGNITUDE_FORMAT>, which must run before the first call here.
+    // SIGN_MAGNITUDE_FORMAT, OUTPUT_FORMAT>, which must run before the first
+    // call here.
     constexpr std::uint32_t dst_tile_size = 64;
 
     constexpr std::uint32_t REPLAY_LEN = quant_replay_len<SIGN_MAGNITUDE_FORMAT, OUTPUT_FORMAT>();
@@ -436,7 +444,7 @@ inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index
     for (int d = 0; d < ITERATIONS; d++) {
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_7, in0_off);  // operand A (fp32)
         TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_7, in1_off);  // operand B (fp32 scaler)
-        lltt::replay(QUANT_REPLAY_SLOT, REPLAY_LEN);                              // MAD + STOCH_RND + (CAST + SETSGN)
+        lltt::replay(QUANT_REPLAY_SLOT, REPLAY_LEN);  // MAD + [clamp] + STOCH_RND + (CAST + SETSGN)
         TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_6, out_off);  // store + dst_reg += 2
     }
 }
@@ -450,7 +458,8 @@ template <
 inline void calculate_requant_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Operand A is input to requant (int32, sign-magnitude or 2's complement bits or UInt8-unpacked int8 byte in [0,
     // 255]). Operand B is scaling factor (fp32). LREG2 holds the zero-point constant (fp32) loaded by
-    // _init_requant_int32_. Output is int32 scaled to int8 range (sign-magnitude or 2's-complement).
+    // _init_requant_int32_. Output is int32 holding the quantized value in the output dtype's range: int8
+    // (sign-magnitude or 2's-complement), or [0, 255] for uint8.
     //
     // The replay-buffer body at REQUANT_REPLAY_SLOT and ADDR_MOD_6's dest+=2
     // slot are programmed by _init_requant_int32_<APPROXIMATION_MODE,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -23,9 +23,11 @@ namespace ckernel::sfpu {
 // two SIGN_MAGNITUDE_FORMAT variants of a given kernel safely share its
 // slot - the init writes whichever variant it was templated for and the
 // kernel uses the matching REPLAY_LEN. The OUTPUT_FORMAT == UInt8 (uint8 output)
-// quant/requant variant safely shares the slot for the same reason: it only swaps
-// the STOCH_RND rounding mode (FP32_TO_UINT8 vs FP32_TO_INT8), which does not
-// change the body length. Distinct slots between kernels are required so a single compute
+// quant/requant variant records a body of its own length into the same slot:
+// it clamps negatives to zero before the STOCH_RND and skips the output
+// int-repr conversion, so its length comes from the UINT8_OUT constants below.
+// Slot spacing uses each family's max body length, so every variant fits.
+// Distinct slots between kernels are required so a single compute
 // kernel can mix all three ops without each init clobbering the others'
 // recordings.
 //
@@ -35,12 +37,15 @@ namespace ckernel::sfpu {
 // SFPADD->SFPMUL and SFPMUL->SFPSTORE don't need explicit pipeline bubbles.
 //   QUANT   ( 2s-comp, 4 ) : SFPMAD, STOCH_RND, SFPCAST, SFPSETSGN
 //   QUANT   (sign-magn, 2) : SFPMAD, STOCH_RND
+//   QUANT   (uint8-out, 5) : SFPMAD, <3-instr clamp: SFPSETCC, SFPMOV, SFPENCC>, STOCH_RND
 //   QUANT   (int8-out, 6 ) : SFPMAD, <5-instr offset-128 pack: SFPSETCC,
 //                             SFPMOV, SFPENCC, STOCH_RND, SFPXOR>
 //   REQUANT ( 2s-comp, 7 ) : SFPCAST+SFPSETSGN(in), SFPCAST(int->fp32), SFPMAD,
 //                             STOCH_RND, SFPCAST+SFPSETSGN(out)
 //   REQUANT (sign-magn, 3) : SFPCAST(int->fp32), SFPMAD, STOCH_RND
 //   REQUANT (int8-in,  5 ) : SFPCAST(int->fp32), SFPMAD, STOCH_RND, SFPCAST+SFPSETSGN(out)
+//   REQUANT (uint8-out, 6) : SFPCAST(int->fp32), SFPMAD, <3-instr clamp>, STOCH_RND (no input conv)
+//   REQUANT (uint8-out, 8) : SFPCAST+SFPSETSGN(in), SFPCAST, SFPMAD, <3-instr clamp>, STOCH_RND
 //   REQUANT (int8-out, 7 ) : SFPCAST(int->fp32), SFPMAD, <5-instr pack>             (int8 input)
 //   REQUANT (int8-out, 9 ) : SFPCAST+SFPSETSGN(in), SFPCAST, SFPMAD, <5-instr pack> (int32 input)
 //   DEQUANT ( 2s-comp, 5 ) : SFPCAST+SFPSETSGN(in), SFPCAST(int->fp32),
@@ -54,6 +59,10 @@ namespace ckernel::sfpu {
 constexpr std::uint32_t QUANT_REPLAY_SLOT = 0;
 constexpr std::uint32_t QUANT_REPLAY_LEN_2S_COMP = 4;
 constexpr std::uint32_t QUANT_REPLAY_LEN_SIGN_MAGN = 2;
+// The uint8 body clamps negatives before rounding and skips the output int-repr
+// conversion, so it is the int8 body without the trailing SFPXOR, and is the same
+// length for both SIGN_MAGNITUDE_FORMAT variants.
+constexpr std::uint32_t QUANT_REPLAY_LEN_UINT8_OUT = 5;
 constexpr std::uint32_t QUANT_REPLAY_LEN_INT8_OUT = 6;
 constexpr std::uint32_t QUANT_REPLAY_LEN_MAX = QUANT_REPLAY_LEN_INT8_OUT;
 
@@ -61,6 +70,11 @@ constexpr std::uint32_t REQUANT_REPLAY_SLOT = QUANT_REPLAY_SLOT + QUANT_REPLAY_L
 constexpr std::uint32_t REQUANT_REPLAY_LEN_2S_COMP = 7;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_SIGN_MAGN = 3;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_INT8_IN = 5;
+// uint8 output drops the trailing int-repr conversion, so the only body-length
+// variable left is whether the input side converts: sign-magnitude and int8 input
+// both skip it, 2's-complement int32 input does not.
+constexpr std::uint32_t REQUANT_REPLAY_LEN_UINT8_OUT = 6;
+constexpr std::uint32_t REQUANT_REPLAY_LEN_UINT8_OUT_INT32_IN = 8;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_INT8_OUT = 7;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_INT8_OUT_INT32_IN = 9;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_MAX = REQUANT_REPLAY_LEN_INT8_OUT_INT32_IN;
@@ -68,6 +82,31 @@ constexpr std::uint32_t REQUANT_REPLAY_LEN_MAX = REQUANT_REPLAY_LEN_INT8_OUT_INT
 constexpr std::uint32_t DEQUANT_REPLAY_SLOT = REQUANT_REPLAY_SLOT + REQUANT_REPLAY_LEN_MAX;
 constexpr std::uint32_t DEQUANT_REPLAY_LEN_2S_COMP = 5;
 constexpr std::uint32_t DEQUANT_REPLAY_LEN_SIGN_MAGN = 3;
+
+// Recorded body length, selected from the same template arguments by the init that
+// records the body and by the kernel that replays it. The replay buffer carries no
+// length with the recording and the hardware does not check one, so a recorded and a
+// replayed length that disagree misalign the buffer silently; deriving both from one
+// helper is what keeps them from drifting apart.
+template <bool SIGN_MAGNITUDE_FORMAT, DataFormat OUTPUT_FORMAT>
+inline constexpr std::uint32_t quant_replay_len() {
+    if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
+        return QUANT_REPLAY_LEN_UINT8_OUT;
+    } else {
+        return SIGN_MAGNITUDE_FORMAT ? QUANT_REPLAY_LEN_SIGN_MAGN : QUANT_REPLAY_LEN_2S_COMP;
+    }
+}
+
+template <bool SIGN_MAGNITUDE_FORMAT, DataFormat OUTPUT_FORMAT, bool INT8_INPUT>
+inline constexpr std::uint32_t requant_replay_len() {
+    if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
+        return (SIGN_MAGNITUDE_FORMAT || INT8_INPUT) ? REQUANT_REPLAY_LEN_UINT8_OUT
+                                                     : REQUANT_REPLAY_LEN_UINT8_OUT_INT32_IN;
+    } else {
+        return INT8_INPUT ? REQUANT_REPLAY_LEN_INT8_IN
+                          : (SIGN_MAGNITUDE_FORMAT ? REQUANT_REPLAY_LEN_SIGN_MAGN : REQUANT_REPLAY_LEN_2S_COMP);
+    }
+}
 
 // Direction-neutral alias for the SFPCAST+SFPSETSGN combo emitted by
 // apply_sign_magnitude_conversion. The combo is the Blackhole workaround
@@ -127,13 +166,11 @@ inline void _int8_input_unbias_() { TTI_SFPXOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 
 // Fold +128.0 into the fp32 zero-point in LREG2 so the per-iteration MAD yields v + 128 directly
 inline void _int8_bias_zero_point_() { TTI_SFPADDI(INT8_OFFSET_128_IMM16, p_sfpu::LREG2, 0); }
 
-// Clamp / round / xor the MAD result.
-// Low 8 bits of LREG0 hold the 2's complement int8 byte.
-inline void _int8_pack_fixup_() {
-    // Values below -128 (i.e. v + 128 < 0) must saturate to -128. FP32_TO_UINT8 returns the
-    // magnitude of a negative input instead of 0, so clamp these lanes to 0.0 first:
-    // FP32_TO_UINT8(0.0) = 0, and 0 ^ 0x80 = 0x80, which is the two's-complement encoding of
-    // -128 (the minimum int8 value).
+// Round the fp32 value in LREG0 into [0, 255].
+// FP32_TO_UINT8 returns the magnitude of a negative input instead of 0, so lanes below
+// zero are clamped to 0.0 first and FP32_TO_UINT8(0.0) = 0. Both the unsigned output
+// path and the int8 offset-128 pack below round through here, so they share one clamp.
+inline void _round_fp32_to_uint8_() {
     TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
     TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
     TTI_SFPENCC(0, 0, 0, 0);
@@ -143,7 +180,16 @@ inline void _int8_pack_fixup_() {
         p_sfpu::LCONST_0,
         p_sfpu::LREG0,
         p_sfpu::LREG0,
-        sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);       // u = round(v + 128) in [0, 255]
+        sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+}
+
+// Clamp / round / xor the MAD result.
+// Low 8 bits of LREG0 hold the 2's complement int8 byte.
+inline void _int8_pack_fixup_() {
+    // Values below -128 (i.e. v + 128 < 0) must saturate to -128: the clamp inside
+    // _round_fp32_to_uint8_ yields 0, and 0 ^ 0x80 = 0x80, which is the two's-complement
+    // encoding of -128 (the minimum int8 value).
+    _round_fp32_to_uint8_();                         // u = round(v + 128) in [0, 255]
     TTI_SFPXOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);  // b = u ^ 0x80
 }
 
@@ -184,7 +230,7 @@ void quant_init(const uint zero_point) {
     }
     _quant_kernels_configure_dest_incr_addrmod_();
 
-    constexpr std::uint32_t REPLAY_LEN = SIGN_MAGNITUDE_FORMAT ? QUANT_REPLAY_LEN_SIGN_MAGN : QUANT_REPLAY_LEN_2S_COMP;
+    constexpr std::uint32_t REPLAY_LEN = quant_replay_len<SIGN_MAGNITUDE_FORMAT, OUTPUT_FORMAT>();
 
     lltt::record<lltt::NoExec>(QUANT_REPLAY_SLOT, REPLAY_LEN);
     {
@@ -196,13 +242,7 @@ void quant_init(const uint zero_point) {
         // descale. For unsigned (uint8) output, round into the full [0, 255]
         // range, else clamp to signed int8 [-128, 127].
         if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+            _round_fp32_to_uint8_();
         } else {
             TTI_SFP_STOCH_RND(
                 sfpi::SFPSTOCHRND_RND_EVEN,
@@ -212,7 +252,7 @@ void quant_init(const uint zero_point) {
                 p_sfpu::LREG0,
                 sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
         }
-        if constexpr (!SIGN_MAGNITUDE_FORMAT) {
+        if constexpr (!SIGN_MAGNITUDE_FORMAT && OUTPUT_FORMAT != DataFormat::UInt8) {
             // Convert STOCH_RND's sign-magnitude output to 2's-complement so the
             // trailing INT32_2S_COMP SFPSTORE writes out 2's-complement bits
             // (on BH the store mode itself is a no-op, so the bits in LREG0 are
@@ -220,14 +260,11 @@ void quant_init(const uint zero_point) {
             // LREG0 receives the sign-fixed result. See INT_REPR_SWAP_CAST above
             // for why the cast mode constant is direction-neutral.
             //
-            // Signed (FP32_TO_INT8) output is sign-magnitude here, so the
-            // conversion is meaningful. Unsigned (UInt8, FP32_TO_UINT8)
-            // output is already in [0, 255] with bit 31 clear, where
-            // sign-magnitude and 2's-complement are bit-identical, so this is a
-            // no-op for uint8. It runs unconditionally so both paths share
-            // QUANT_REPLAY_LEN_2S_COMP; gating it off for unsigned would need a
-            // dedicated REPLAY_LEN. Revisit if apply_sign_magnitude_conversion
-            // stops being a no-op for bit-31-clear inputs.
+            // Skipped for unsigned (UInt8) output: the clamp above leaves the
+            // FP32_TO_UINT8 result in [0, 255] with bit 31 clear, where
+            // sign-magnitude and 2's-complement are bit-identical, so the
+            // conversion would be a no-op. The uint8 body records its own
+            // QUANT_REPLAY_LEN_UINT8_OUT, so skipping it costs no slot sharing.
             apply_sign_magnitude_conversion(p_sfpu::LREG0, p_sfpu::LREG4, INT_REPR_SWAP_CAST);
         }
     }
@@ -274,9 +311,7 @@ void requant_init(const uint zero_point) {
     }
     _quant_kernels_configure_dest_incr_addrmod_();
 
-    constexpr std::uint32_t REPLAY_LEN =
-        INT8_INPUT ? REQUANT_REPLAY_LEN_INT8_IN
-                   : (SIGN_MAGNITUDE_FORMAT ? REQUANT_REPLAY_LEN_SIGN_MAGN : REQUANT_REPLAY_LEN_2S_COMP);
+    constexpr std::uint32_t REPLAY_LEN = requant_replay_len<SIGN_MAGNITUDE_FORMAT, OUTPUT_FORMAT, INT8_INPUT>();
 
     lltt::record<lltt::NoExec>(REQUANT_REPLAY_SLOT, REPLAY_LEN);
     {
@@ -304,13 +339,7 @@ void requant_init(const uint zero_point) {
         // (uint8) output, round into the full [0, 255] range; otherwise clamp to
         // signed int8 [-128, 127].
         if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+            _round_fp32_to_uint8_();
         } else {
             TTI_SFP_STOCH_RND(
                 sfpi::SFPSTOCHRND_RND_EVEN,
@@ -320,19 +349,15 @@ void requant_init(const uint zero_point) {
                 p_sfpu::LREG0,
                 sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT8);
         }
-        if constexpr (!SIGN_MAGNITUDE_FORMAT) {
+        if constexpr (!SIGN_MAGNITUDE_FORMAT && OUTPUT_FORMAT != DataFormat::UInt8) {
             // Convert STOCH_RND's output to 2's-complement for the trailing
             // INT32_2S_COMP SFPSTORE. Same cast+SETSGN combo as the input side;
             // see INT_REPR_SWAP_CAST above.
             //
-            // Signed (FP32_TO_INT8) output is sign-magnitude here, so the
-            // conversion is meaningful. Unsigned (UInt8, FP32_TO_UINT8)
-            // output is already in [0, 255] with bit 31 clear, where
-            // sign-magnitude and 2's-complement are bit-identical, so this is a
-            // no-op for uint8. It runs unconditionally for the same
-            // replay-length reason documented in quant_init's output-side
-            // conversion above; revisit if apply_sign_magnitude_conversion
-            // stops being a no-op for bit-31-clear inputs.
+            // Skipped for unsigned (UInt8) output for the same reason documented
+            // in quant_init's output-side conversion above: after the clamp the
+            // result is in [0, 255] with bit 31 clear, where the two int32
+            // representations coincide.
             apply_sign_magnitude_conversion(p_sfpu::LREG0, p_sfpu::LREG4, INT_REPR_SWAP_CAST);
         }
     }
@@ -376,7 +401,11 @@ void dequant_init(const uint zero_point) {
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false>
+template <
+    bool APPROXIMATION_MODE,
+    int ITERATIONS = 8,
+    bool SIGN_MAGNITUDE_FORMAT = false,
+    DataFormat OUTPUT_FORMAT = DataFormat::Int32>
 inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Operand A is input (fp32).
     // Operand B is scaling factor (fp32).
@@ -393,7 +422,7 @@ inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index
     // SIGN_MAGNITUDE_FORMAT>, which must run before the first call here.
     constexpr std::uint32_t dst_tile_size = 64;
 
-    constexpr std::uint32_t REPLAY_LEN = SIGN_MAGNITUDE_FORMAT ? QUANT_REPLAY_LEN_SIGN_MAGN : QUANT_REPLAY_LEN_2S_COMP;
+    constexpr std::uint32_t REPLAY_LEN = quant_replay_len<SIGN_MAGNITUDE_FORMAT, OUTPUT_FORMAT>();
 
     const std::uint32_t in0_off = dst_index_in0 * dst_tile_size;
     const std::uint32_t in1_off = dst_index_in1 * dst_tile_size;
@@ -412,7 +441,12 @@ inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false, bool INT8_INPUT = false>
+template <
+    bool APPROXIMATION_MODE,
+    int ITERATIONS = 8,
+    bool SIGN_MAGNITUDE_FORMAT = false,
+    bool INT8_INPUT = false,
+    DataFormat OUTPUT_FORMAT = DataFormat::Int32>
 inline void calculate_requant_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Operand A is input to requant (int32, sign-magnitude or 2's complement bits or UInt8-unpacked int8 byte in [0,
     // 255]). Operand B is scaling factor (fp32). LREG2 holds the zero-point constant (fp32) loaded by
@@ -424,9 +458,7 @@ inline void calculate_requant_int32(const uint dst_index_in0, const uint dst_ind
     // the first call here.
     constexpr std::uint32_t dst_tile_size = 64;
 
-    constexpr std::uint32_t REPLAY_LEN =
-        INT8_INPUT ? REQUANT_REPLAY_LEN_INT8_IN
-                   : (SIGN_MAGNITUDE_FORMAT ? REQUANT_REPLAY_LEN_SIGN_MAGN : REQUANT_REPLAY_LEN_2S_COMP);
+    constexpr std::uint32_t REPLAY_LEN = requant_replay_len<SIGN_MAGNITUDE_FORMAT, OUTPUT_FORMAT, INT8_INPUT>();
 
     const std::uint32_t in0_off = dst_index_in0 * dst_tile_size;
     const std::uint32_t in1_off = dst_index_in1 * dst_tile_size;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -90,9 +90,9 @@ constexpr std::uint32_t DEQUANT_REPLAY_LEN_SIGN_MAGN = 3;
 // helper is what keeps them from drifting apart.
 template <bool SIGN_MAGNITUDE_FORMAT, DataFormat OUTPUT_FORMAT>
 inline constexpr std::uint32_t quant_replay_len() {
-    static_assert(
-        OUTPUT_FORMAT != DataFormat::Int8, "int8 output records its own body; replay it with the _int8_pack kernels");
-    if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
+    if constexpr (OUTPUT_FORMAT == DataFormat::Int8) {
+        return QUANT_REPLAY_LEN_INT8_OUT;
+    } else if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
         return QUANT_REPLAY_LEN_UINT8_OUT;
     } else {
         return SIGN_MAGNITUDE_FORMAT ? QUANT_REPLAY_LEN_SIGN_MAGN : QUANT_REPLAY_LEN_2S_COMP;
@@ -101,9 +101,9 @@ inline constexpr std::uint32_t quant_replay_len() {
 
 template <bool SIGN_MAGNITUDE_FORMAT, DataFormat OUTPUT_FORMAT, bool INT8_INPUT>
 inline constexpr std::uint32_t requant_replay_len() {
-    static_assert(
-        OUTPUT_FORMAT != DataFormat::Int8, "int8 output records its own body; replay it with the _int8_pack kernels");
-    if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
+    if constexpr (OUTPUT_FORMAT == DataFormat::Int8) {
+        return INT8_INPUT ? REQUANT_REPLAY_LEN_INT8_OUT : REQUANT_REPLAY_LEN_INT8_OUT_INT32_IN;
+    } else if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
         return (SIGN_MAGNITUDE_FORMAT || INT8_INPUT) ? REQUANT_REPLAY_LEN_UINT8_OUT
                                                      : REQUANT_REPLAY_LEN_UINT8_OUT_INT32_IN;
     } else {
@@ -224,7 +224,7 @@ void quant_init(const uint zero_point) {
         _int8_bias_zero_point_();  // fold +128 into the fp32 zero-point in LREG2
         _quant_kernels_configure_dest_incr_addrmod_();
         // Record the int8 body (MAD + offset-128 pack)
-        lltt::record<lltt::NoExec>(QUANT_REPLAY_SLOT, QUANT_REPLAY_LEN_INT8_OUT);
+        lltt::record<lltt::NoExec>(QUANT_REPLAY_SLOT, quant_replay_len<SIGN_MAGNITUDE_FORMAT, OUTPUT_FORMAT>());
         {
             TTI_SFPMAD(
                 p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);  // v = A * B + (zp + 128)
@@ -298,8 +298,7 @@ void requant_init(const uint zero_point) {
         // Record the int8 body. Int8 input is unbiased (byte ^ 0x80) inline by the kernel
         // before the replay, so its body is just CAST + MAD + offset-128 pack (7). Int32
         // input runs the 2's-complement -> sign-magnitude fixup inside the recorded body (9).
-        constexpr std::uint32_t REPLAY_LEN =
-            INT8_INPUT ? REQUANT_REPLAY_LEN_INT8_OUT : REQUANT_REPLAY_LEN_INT8_OUT_INT32_IN;
+        constexpr std::uint32_t REPLAY_LEN = requant_replay_len<SIGN_MAGNITUDE_FORMAT, OUTPUT_FORMAT, INT8_INPUT>();
         lltt::record<lltt::NoExec>(REQUANT_REPLAY_SLOT, REPLAY_LEN);
         {
             if constexpr (!INT8_INPUT) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -183,7 +183,7 @@ inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index
     for (int d = 0; d < ITERATIONS; d++) {
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_3, in0_off);  // operand A (fp32)
         TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_3, in1_off);  // operand B (fp32 scaler)
-        lltt::replay(QUANT_REPLAY_SLOT, quant_replay_len<OUTPUT_FORMAT>());  // MAD + SFPNOP + [clamp] + STOCH_RND
+        lltt::replay(QUANT_REPLAY_SLOT, quant_replay_len<OUTPUT_FORMAT>());       // MAD + SFPNOP + [clamp] + STOCH_RND
         TT_SFPSTORE(p_sfpu::LREG0, out_mode, ADDR_MOD_2, out_off);                // store + dst_reg += 2
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -72,15 +72,17 @@ constexpr std::uint32_t DEQUANT_REPLAY_LEN = 5;
 // helper is what keeps them from drifting apart.
 template <DataFormat OUTPUT_FORMAT>
 inline constexpr std::uint32_t quant_replay_len() {
-    static_assert(
-        OUTPUT_FORMAT != DataFormat::Int8, "int8 output records its own body; replay it with the _int8_pack kernels");
+    if constexpr (OUTPUT_FORMAT == DataFormat::Int8) {
+        return QUANT_REPLAY_LEN_INT8_OUT;
+    }
     return OUTPUT_FORMAT == DataFormat::UInt8 ? QUANT_REPLAY_LEN_UINT8_OUT : QUANT_REPLAY_LEN;
 }
 
 template <DataFormat OUTPUT_FORMAT>
 inline constexpr std::uint32_t requant_replay_len() {
-    static_assert(
-        OUTPUT_FORMAT != DataFormat::Int8, "int8 output records its own body; replay it with the _int8_pack kernels");
+    if constexpr (OUTPUT_FORMAT == DataFormat::Int8) {
+        return REQUANT_REPLAY_LEN_INT8_OUT;
+    }
     return OUTPUT_FORMAT == DataFormat::UInt8 ? REQUANT_REPLAY_LEN_UINT8_OUT : REQUANT_REPLAY_LEN;
 }
 
@@ -361,7 +363,7 @@ void quant_init(const uint zero_point) {
         _int8_bias_zero_point_();  // fold +128 into the fp32 zero-point in LREG2
         _quant_kernels_configure_dest_incr_addrmod_();
         // Record the int8 body (MAD + offset-128 pack)
-        lltt::record<lltt::NoExec>(QUANT_REPLAY_SLOT, QUANT_REPLAY_LEN_INT8_OUT);
+        lltt::record<lltt::NoExec>(QUANT_REPLAY_SLOT, quant_replay_len<OUTPUT_FORMAT>());
         {
             TTI_SFPMAD(
                 p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);  // v = A * B + (zp + 128)
@@ -417,7 +419,7 @@ void requant_init(const uint zero_point) {
         _int8_bias_zero_point_();  // fold +128 into the fp32 zero-point in LREG2
         _quant_kernels_configure_dest_incr_addrmod_();
         // Record the int8 body (CAST + MAD + offset-128 pack)
-        lltt::record<lltt::NoExec>(REQUANT_REPLAY_SLOT, REQUANT_REPLAY_LEN_INT8_OUT);
+        lltt::record<lltt::NoExec>(REQUANT_REPLAY_SLOT, requant_replay_len<OUTPUT_FORMAT>());
         {
             TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPCAST_MOD1_INT32_TO_FP32_RNE);  // int32 -> fp32
             TTI_SFPMAD(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -29,14 +29,18 @@ namespace ckernel::sfpu {
 // Distinct slots between kernels are required so a single compute kernel
 // can mix all three ops without each init clobbering the others' recordings.
 // Int8 output records a longer body (the offset-128 pack) into the same family
-// slot; slot spacing uses each family's max body length so the three ops can
-// still coexist.
+// slot, and uint8 output records a longer body too (the same clamp without the
+// closing SFPXOR); slot spacing uses each family's max body length so the three
+// ops can still coexist.
 //
 // Body content (see the inits for the exact emission order):
 //   QUANT   (3)            : SFPMAD, SFPNOP, STOCH_RND
+//   QUANT   (uint8-out, 6) : SFPMAD, SFPNOP, <3-instr clamp: SFPSETCC, SFPMOV,
+//                            SFPENCC>, STOCH_RND
 //   QUANT   (int8-out, 7)  : SFPMAD, SFPNOP, <5-instr offset-128 pack: SFPSETCC,
 //                            SFPMOV, SFPENCC, STOCH_RND, SFPXOR>
 //   REQUANT (4)            : SFPCAST(int->fp32), SFPMAD, SFPNOP, STOCH_RND
+//   REQUANT (uint8-out, 7) : SFPCAST(int->fp32), SFPMAD, SFPNOP, <3-instr clamp>, STOCH_RND
 //   REQUANT (int8-out, 8)  : SFPCAST(int->fp32), SFPMAD, SFPNOP, <5-instr pack>
 //   DEQUANT (5)            : SFPCAST(int->fp32), SFPADD, SFPNOP, SFPMUL, SFPNOP
 //
@@ -44,16 +48,37 @@ namespace ckernel::sfpu {
 // so the per-iteration MAD already yields v + 128 and the pack needs no per-element SFPADDI.
 constexpr std::uint32_t QUANT_REPLAY_SLOT = 0;
 constexpr std::uint32_t QUANT_REPLAY_LEN = 3;
+// The uint8 bodies clamp negatives before rounding, which is the int8 offset-128
+// pack without its closing SFPXOR. As with the other lengths here, the int32
+// representation conversion happens in SFPLOAD/SFPSTORE instr_mod0, outside the
+// recorded window, so one length per kernel still suffices.
+constexpr std::uint32_t QUANT_REPLAY_LEN_UINT8_OUT = 6;
 constexpr std::uint32_t QUANT_REPLAY_LEN_INT8_OUT = 7;
 constexpr std::uint32_t QUANT_REPLAY_LEN_MAX = QUANT_REPLAY_LEN_INT8_OUT;
 
 constexpr std::uint32_t REQUANT_REPLAY_SLOT = QUANT_REPLAY_SLOT + QUANT_REPLAY_LEN_MAX;
 constexpr std::uint32_t REQUANT_REPLAY_LEN = 4;
+constexpr std::uint32_t REQUANT_REPLAY_LEN_UINT8_OUT = 7;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_INT8_OUT = 8;
 constexpr std::uint32_t REQUANT_REPLAY_LEN_MAX = REQUANT_REPLAY_LEN_INT8_OUT;
 
 constexpr std::uint32_t DEQUANT_REPLAY_SLOT = REQUANT_REPLAY_SLOT + REQUANT_REPLAY_LEN_MAX;
 constexpr std::uint32_t DEQUANT_REPLAY_LEN = 5;
+
+// Recorded body length, selected from the same template argument by the init that
+// records the body and by the kernel that replays it. The replay buffer carries no
+// length with the recording and the hardware does not check one, so a recorded and a
+// replayed length that disagree misalign the buffer silently; deriving both from one
+// helper is what keeps them from drifting apart.
+template <DataFormat OUTPUT_FORMAT>
+inline constexpr std::uint32_t quant_replay_len() {
+    return OUTPUT_FORMAT == DataFormat::UInt8 ? QUANT_REPLAY_LEN_UINT8_OUT : QUANT_REPLAY_LEN;
+}
+
+template <DataFormat OUTPUT_FORMAT>
+inline constexpr std::uint32_t requant_replay_len() {
+    return OUTPUT_FORMAT == DataFormat::UInt8 ? REQUANT_REPLAY_LEN_UINT8_OUT : REQUANT_REPLAY_LEN;
+}
 
 // Int8 L1 pack path:
 // FP32_TO_INT8 rounding cannot be used here since it produces a sign-magnitude result
@@ -114,7 +139,11 @@ inline void _quant_kernels_configure_dest_incr_addrmod_() {
         .set(ADDR_MOD_6);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false>
+template <
+    bool APPROXIMATION_MODE,
+    int ITERATIONS = 8,
+    bool SIGN_MAGNITUDE_FORMAT = false,
+    DataFormat OUTPUT_FORMAT = DataFormat::Int32>
 inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Operand A is input (fp32).
     // Operand B is scaling factor (fp32).
@@ -147,12 +176,17 @@ inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index
     for (int d = 0; d < ITERATIONS; d++) {
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_3, in0_off);  // operand A (fp32)
         TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_3, in1_off);  // operand B (fp32 scaler)
-        lltt::replay(QUANT_REPLAY_SLOT, QUANT_REPLAY_LEN);                        // MAD + SFPNOP + STOCH_RND
+        lltt::replay(QUANT_REPLAY_SLOT, quant_replay_len<OUTPUT_FORMAT>());  // MAD + SFPNOP + [clamp] + STOCH_RND
         TT_SFPSTORE(p_sfpu::LREG0, out_mode, ADDR_MOD_2, out_off);                // store + dst_reg += 2
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false, bool INT8_INPUT = false>
+template <
+    bool APPROXIMATION_MODE,
+    int ITERATIONS = 8,
+    bool SIGN_MAGNITUDE_FORMAT = false,
+    bool INT8_INPUT = false,
+    DataFormat OUTPUT_FORMAT = DataFormat::Int32>
 inline void calculate_requant_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Operand A is input to requant (int32, sign-magnitude or 2's complement bits or UInt8-unpacked int8 byte).
     // Operand B is scaling factor (fp32).
@@ -186,7 +220,7 @@ inline void calculate_requant_int32(const uint dst_index_in0, const uint dst_ind
         if constexpr (INT8_INPUT) {
             _int8_input_unbias_();  // byte ^ 0x80 (excess-128)
         }
-        lltt::replay(REQUANT_REPLAY_SLOT, REQUANT_REPLAY_LEN);      // CAST + MAD + SFPNOP + STOCH_RND
+        lltt::replay(REQUANT_REPLAY_SLOT, requant_replay_len<OUTPUT_FORMAT>());  // CAST + MAD + NOP + [clamp] + RND
         TT_SFPSTORE(p_sfpu::LREG0, int_mode, ADDR_MOD_2, out_off);  // store (sign-magn -> int_mode bits) + dst_reg += 2
     }
 }
@@ -194,13 +228,14 @@ inline void calculate_requant_int32(const uint dst_index_in0, const uint dst_ind
 // Fold +128.0 into the fp32 zero-point in LREG2 so the per-iteration MAD yields v + 128 directly
 inline void _int8_bias_zero_point_() { TTI_SFPADDI(INT8_OFFSET_128_IMM16, p_sfpu::LREG2, 0); }
 
-// Clamp / round / xor the MAD result.
-// Low 8 bits of LREG0 hold the 2's complement int8 byte.
-inline void _int8_pack_fixup_() {
-    // Values below -128 (i.e. v + 128 < 0) must saturate to -128. FP32_TO_UINT8 returns the
-    // magnitude of a negative input instead of 0, so clamp these lanes to 0.0 first:
-    // FP32_TO_UINT8(0.0) = 0, and 0 ^ 0x80 = 0x80, which is the two's-complement encoding of
-    // -128 (the minimum int8 value).
+// Round the fp32 value in LREG0 into [0, 255].
+// FP32_TO_UINT8 returns the magnitude of a negative input instead of 0, so lanes below
+// zero are clamped to 0.0 first and FP32_TO_UINT8(0.0) = 0. Both the unsigned output
+// path and the int8 offset-128 pack below round through here, so they share one clamp.
+// The SFPMAD -> SFPNOP bubble emitted by each init already covers the read-after-write
+// hazard on LREG0 for the SFPSETCC that opens this sequence, exactly as it does today
+// for the STOCH_RND that used to read LREG0 first.
+inline void _round_fp32_to_uint8_() {
     TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
     TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
     TTI_SFPENCC(0, 0, 0, 0);
@@ -210,7 +245,16 @@ inline void _int8_pack_fixup_() {
         p_sfpu::LCONST_0,
         p_sfpu::LREG0,
         p_sfpu::LREG0,
-        sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);       // u = round(v + 128) in [0, 255]
+        sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+}
+
+// Clamp / round / xor the MAD result.
+// Low 8 bits of LREG0 hold the 2's complement int8 byte.
+inline void _int8_pack_fixup_() {
+    // Values below -128 (i.e. v + 128 < 0) must saturate to -128: the clamp inside
+    // _round_fp32_to_uint8_ yields 0, and 0 ^ 0x80 = 0x80, which is the two's-complement
+    // encoding of -128 (the minimum int8 value).
+    _round_fp32_to_uint8_();                         // u = round(v + 128) in [0, 255]
     TTI_SFPXOR(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);  // b = u ^ 0x80
 }
 
@@ -322,7 +366,7 @@ void quant_init(const uint zero_point) {
     }
     _quant_kernels_configure_dest_incr_addrmod_();
 
-    lltt::record<lltt::NoExec>(QUANT_REPLAY_SLOT, QUANT_REPLAY_LEN);
+    lltt::record<lltt::NoExec>(QUANT_REPLAY_SLOT, quant_replay_len<OUTPUT_FORMAT>());
     {
         // D(LREG0) = LREG0 * LREG1 + LREG2 (zero point)
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0 /*mod1*/);
@@ -337,13 +381,7 @@ void quant_init(const uint zero_point) {
         // descale. For unsigned (uint8) output, round into the full [0, 255]
         // range; otherwise clamp to signed int8 [-128, 127].
         if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+            _round_fp32_to_uint8_();
         } else {
             TTI_SFP_STOCH_RND(
                 sfpi::SFPSTOCHRND_RND_EVEN,
@@ -385,7 +423,7 @@ void requant_init(const uint zero_point) {
     }
     _quant_kernels_configure_dest_incr_addrmod_();
 
-    lltt::record<lltt::NoExec>(REQUANT_REPLAY_SLOT, REQUANT_REPLAY_LEN);
+    lltt::record<lltt::NoExec>(REQUANT_REPLAY_SLOT, requant_replay_len<OUTPUT_FORMAT>());
     {
         // int32 sign-magnitude (loaded that way regardless of input bit
         // representation, via SFPLOAD instr_mod0) -> fp32.
@@ -400,13 +438,7 @@ void requant_init(const uint zero_point) {
         // (uint8) output, round into the full [0, 255] range; otherwise clamp to
         // signed int8 [-128, 127].
         if constexpr (OUTPUT_FORMAT == DataFormat::UInt8) {
-            TTI_SFP_STOCH_RND(
-                sfpi::SFPSTOCHRND_RND_EVEN,
-                0 /*imm8*/,
-                p_sfpu::LCONST_0,
-                p_sfpu::LREG0,
-                p_sfpu::LREG0,
-                sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);
+            _round_fp32_to_uint8_();
         } else {
             TTI_SFP_STOCH_RND(
                 sfpi::SFPSTOCHRND_RND_EVEN,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -72,11 +72,15 @@ constexpr std::uint32_t DEQUANT_REPLAY_LEN = 5;
 // helper is what keeps them from drifting apart.
 template <DataFormat OUTPUT_FORMAT>
 inline constexpr std::uint32_t quant_replay_len() {
+    static_assert(
+        OUTPUT_FORMAT != DataFormat::Int8, "int8 output records its own body; replay it with the _int8_pack kernels");
     return OUTPUT_FORMAT == DataFormat::UInt8 ? QUANT_REPLAY_LEN_UINT8_OUT : QUANT_REPLAY_LEN;
 }
 
 template <DataFormat OUTPUT_FORMAT>
 inline constexpr std::uint32_t requant_replay_len() {
+    static_assert(
+        OUTPUT_FORMAT != DataFormat::Int8, "int8 output records its own body; replay it with the _int8_pack kernels");
     return OUTPUT_FORMAT == DataFormat::UInt8 ? REQUANT_REPLAY_LEN_UINT8_OUT : REQUANT_REPLAY_LEN;
 }
 
@@ -148,8 +152,9 @@ inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index
     // Operand A is input (fp32).
     // Operand B is scaling factor (fp32).
     // LREG2 holds the zero-point constant (fp32) loaded by _init_quant_int32_.
-    // Output is int32 scaled to int8 range (sign-magnitude or 2's-complement
-    // depending on SIGN_MAGNITUDE_FORMAT - the conversion is done by SFPSTORE).
+    // Output is int32 holding the quantized value in the output dtype's range:
+    // int8 (sign-magnitude or 2's-complement depending on SIGN_MAGNITUDE_FORMAT
+    // - the conversion is done by SFPSTORE), or [0, 255] for uint8.
     //
     // Tile layout in Dest: each tile occupies 64 dest-address units. Each
     // SFPLOAD/SFPSTORE moves 4 dest rows x 8 SFPU lanes, so advancing dst_reg
@@ -191,7 +196,8 @@ inline void calculate_requant_int32(const uint dst_index_in0, const uint dst_ind
     // Operand A is input to requant (int32, sign-magnitude or 2's complement bits or UInt8-unpacked int8 byte).
     // Operand B is scaling factor (fp32).
     // LREG2 holds the zero-point constant (fp32) loaded by _init_requant_int32_.
-    // Output is int32 scaled to int8 range.
+    // Output is int32 holding the quantized value in the output dtype's range:
+    // int8 (sign-magnitude or 2's-complement), or [0, 255] for uint8.
     //
     // The int32 in/out format conversion is done by the SFPLOAD/SFPSTORE
     // instr_mod0 field (INT32 vs INT32_2S_COMP); the recorded compute body

--- a/tt_metal/hw/inc/api/compute/quantization.h
+++ b/tt_metal/hw/inc/api/compute/quantization.h
@@ -52,6 +52,32 @@ ALWI void quant_int8_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 
 // clang-format off
 /**
+ * Quantize variant writing a uint8 output tensor.
+ * Output overwrites odst in DST.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void quant_uint8_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_quant_int32,
+        (APPROX, 8, false, DataFormat::UInt8),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+// clang-format off
+/**
  * Performs an elementwise per-tensor affine re-quantization operation on the first operand using the scaling factor in the second operand.
  * Output overwrites odst in DST.
  *
@@ -115,6 +141,59 @@ ALWI void requant_int8_in_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
         DST_ACCUM_MODE,
         calculate_requant_int32,
         (APPROX, 8, false, true),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+// clang-format off
+/**
+ * Re-quantize variant writing a uint8 output tensor.
+ * Output overwrites odst in DST.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void requant_uint8_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_requant_int32,
+        (APPROX, 8, false, false, DataFormat::UInt8),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+// clang-format off
+/**
+ * Re-quantize variant reading an int8 input tensor and writing a uint8 output tensor.
+ * int8-input unbias (see requant_int8_in_tile_init) with the result rounded into [0, 255].
+ * Output overwrites odst in DST.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void requant_int8_in_uint8_out_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_requant_int32,
+        (APPROX, 8, false, true, DataFormat::UInt8),
         idst0,
         idst1,
         odst,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -907,7 +907,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     };
     if (operation_attributes.binary_op_type == BinaryOpType::QUANT) {
         if (c_dtype == DataType::UINT8) {
-            compute_kernel_defines["BINARY_SFPU_INIT"] = std::string("quant_uint8_tile_init") + quant_zp_arg;
+            set_sfpu_op("quant_uint8_tile_init", "quant_uint8_tile");
         } else if (c_dtype == DataType::INT8) {
             set_sfpu_op("quant_int8_tile_init", "quant_int8_tile");
         }
@@ -921,11 +921,12 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                 int8_in ? "requant_int8_in_int8_out_tile_init" : "requant_int8_tile_init",
                 int8_in ? "requant_int8_in_int8_out_tile" : "requant_int8_tile");
         } else if (c_dtype == DataType::UINT8) {
-            // uint8 output uses the standard packer narrowing (int32 SFPU result -> uint8), so it reuses
-            // the int32-output op body; only the init differs, to select FP32_TO_UINT8 rounding.
+            // uint8 output uses the standard packer narrowing (int32 SFPU result -> uint8), but the SFPU
+            // body clamps negatives before the FP32_TO_UINT8 rounding, so it records and replays a length
+            // of its own and needs the matching uint8 op, not the int32-output one.
             set_sfpu_op(
                 int8_in ? "requant_int8_in_uint8_out_tile_init" : "requant_uint8_tile_init",
-                int8_in ? "requant_int8_in_tile" : "requant_tile");
+                int8_in ? "requant_int8_in_uint8_out_tile" : "requant_uint8_tile");
         } else if (int8_in) {
             set_sfpu_op("requant_int8_in_tile_init", "requant_int8_in_tile");
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -189,14 +189,16 @@ ttnn::Tensor widen_quantized_input_to_f32(const ttnn::Tensor& input) {
     return ttnn::dequantize(input, 1.0f, 0, /*axis=*/std::nullopt, ttnn::DataType::FLOAT32, std::nullopt, std::nullopt);
 }
 
-// Narrow composite's fp result to the output dtype. Use quantize as the narrowing step
-// for int8 until typecast(int32 -> int8) is enabled (#50401).
+// Narrow composite's fp result to the output dtype. typecast wraps modulo 256, so the narrow
+// quantized dtypes go through quantize instead, which saturates: int8 until
+// typecast(int32 -> int8) is enabled (#50401), and uint8 because the composite path would
+// otherwise miss the lower clamp the fused path applies.
 ttnn::Tensor narrow_composite_result(
     const ttnn::Tensor& shifted,
     ttnn::DataType c_dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<ttnn::Tensor> optional_output_tensor) {
-    if (c_dtype != ttnn::DataType::INT8) {
+    if (!is_narrow_quantized_dtype(c_dtype)) {
         return ttnn::typecast(shifted, c_dtype, memory_config, optional_output_tensor);
     }
     return ttnn::quantize(
@@ -204,7 +206,7 @@ ttnn::Tensor narrow_composite_result(
         1.0f,
         0,
         /*axis=*/std::nullopt,
-        ttnn::DataType::INT8,
+        c_dtype,
         memory_config,
         std::move(optional_output_tensor));
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -189,10 +189,11 @@ ttnn::Tensor widen_quantized_input_to_f32(const ttnn::Tensor& input) {
     return ttnn::dequantize(input, 1.0f, 0, /*axis=*/std::nullopt, ttnn::DataType::FLOAT32, std::nullopt, std::nullopt);
 }
 
-// Narrow composite's fp result to the output dtype. typecast wraps modulo 256, so the narrow
-// quantized dtypes go through quantize instead, which saturates: int8 until
-// typecast(int32 -> int8) is enabled (#50401), and uint8 because the composite path would
-// otherwise miss the lower clamp the fused path applies.
+// Narrow composite's fp result to the output dtype. typecast truncates toward zero and wraps
+// modulo 256, so the narrow quantized dtypes go through quantize instead, which saturates and
+// rounds to nearest even: int8 until typecast(int32 -> int8) is enabled (#50401), and uint8
+// because the composite path would otherwise miss the lower clamp the fused path applies, and
+// would keep truncating where the fused path rounds (#51304).
 ttnn::Tensor narrow_composite_result(
     const ttnn::Tensor& shifted,
     ttnn::DataType c_dtype,


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #56290.

`ttnn.quantize` and `ttnn.requantize` with a uint8 output returned the magnitude of negative values (quantize(-5.0) at scale 0.1 gave 50), because `SFPSTOCHRND_MOD1_FP32_TO_UINT8` rounds |x| and only the int8 path clamped to 0 first. That clamp is now `_round_fp32_to_uint8_`, shared by the int8 path and the uint8 arms of `quant_init` and `requant_init` on Wormhole and Blackhole.

The composite path in `quantization.cpp` narrowed to uint8 with `ttnn::typecast`, which wraps modulo 256 (-25.5 gave 1 and 30.0 gave 44 at scale 0.1). It now goes through `ttnn::quantize` as int8 already did, which also fixes the uint8 half of #51304 (truncation instead of rounding).

On Blackhole under ttsim, quantize was wrong on 5 of 13 values with float32 and with bfloat16 input, requantize on 4 of 10 int32 inputs and on 10 of 18 int8 inputs, and all are exact after the fix. uint8 upper saturation, int8 quantize and requantize, and dequantize are bit identical before and after. The new tests are in the nightly `test_quantization.py` (`-k lower_saturation`).

On a Wormhole n150 (TT-Console), this branch built on the card passes all 5 new tests. On stable `9f9cd4fd590` 4 of them fail on values (quantize returns the magnitudes of negatives, requantize turns -1, -50, -300, -1000 into 1, 50, 255, 255); the INT8 requantize case cannot run there because that build predates INT8 input support. With the single-SFPSWAP clamp from review, the card gives the same outputs as the earlier three-instruction clamp for NaN of both signs, infinities, -0, rounding ties and both saturation ends (float32 and bfloat16 input, uint8 and int8 output, int32 requantize), and the 40 saturation, int8 and uint8 tests in `test_quantization.py` pass before and after.

### Notes for reviewers

The clamp makes the recorded uint8 body longer, so the init and the kernel that replays it have to agree on its length. Both now take it from one constexpr helper keyed on the output format, and the PR adds matching uint8 quant and requant tile ops and points binary_ng at them. The helper static_asserts on any format other than Int32, UInt8 and Int8. The clamp is one SFPSWAP against LCONST_0, so a uint8 body is one instruction longer than the Wormhole int32 body and the Blackhole sign-magnitude one; the int8 offset-128 pack shares it and is two instructions shorter than on main, so the replay maxima and slot bases shrink by two. Quasar has no uint8 output path.

