### PR TITLE
[LLK][Quasar] Emit the semaphore pre-stall for every wait-resource slot

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_quasar_stall_wrapper_codegen.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_quasar_stall_wrapper_codegen.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+``t6_semaphore_post``/``t6_semaphore_get`` (Quasar) take three independently
+optional pre-stall resources. This test asserts each slot on its own produces a
+stall, that naming none produces no stall, and that the emitted word is exactly
+what a hand-written ``TTI_STALLWAIT`` with the same slots produces.
+
+Compile-only. It builds a probe translation unit against the Quasar headers with
+the sfpi compiler and reads the ``.ttinsn`` words back out of the assembly, so it
+needs no Quasar device and runs in a session of any arch. Every probe is paired
+with a reference function that hand-writes the expected stall, which keeps the
+expected encoding in the C++ where the constants live rather than duplicating
+opcode and field values here.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_TESTS_ROOT = Path(__file__).resolve().parents[1]
+_TT_METAL = Path(__file__).resolve().parents[3]
+_COMPILER = _TESTS_ROOT / "sfpi/compiler/bin/riscv-tt-elf-g++"
+_QUASAR_LLK = _TT_METAL / "tt-llk/tt_llk_quasar"
+
+# Each probe_* calls the wrapper; the ref_* beside it hand-writes the stall that
+# wrapper must emit. TTI_STALLWAIT takes (stall_res, idx_2, idx_1, idx_0), which
+# is why the reference argument order mirrors the template arguments reversed.
+_PROBE_SOURCE = """
+#include "ckernel_trisc_common.h"
+
+using namespace ckernel;
+using namespace ckernel::trisc;
+
+extern "C" void probe_none() { t6_semaphore_post<>(3); }
+extern "C" void ref_none() {}
+
+extern "C" void probe_w0() { t6_semaphore_post<p_stall::MATH>(3); }
+extern "C" void ref_w0() { TTI_STALLWAIT(p_stall::STALL_SYNC, p_stall::NOTHING, p_stall::NOTHING, p_stall::MATH); }
+
+extern "C" void probe_w1() { t6_semaphore_post<p_stall::NOTHING, p_stall::MATH>(3); }
+extern "C" void ref_w1() { TTI_STALLWAIT(p_stall::STALL_SYNC, p_stall::NOTHING, p_stall::MATH, p_stall::NOTHING); }
+
+extern "C" void probe_w2() { t6_semaphore_post<p_stall::NOTHING, p_stall::NOTHING, p_stall::MATH>(3); }
+extern "C" void ref_w2() { TTI_STALLWAIT(p_stall::STALL_SYNC, p_stall::MATH, p_stall::NOTHING, p_stall::NOTHING); }
+
+extern "C" void probe_all() { t6_semaphore_post<p_stall::THCON, p_stall::MATH, p_stall::PACK0>(3); }
+extern "C" void ref_all() { TTI_STALLWAIT(p_stall::STALL_SYNC, p_stall::PACK0, p_stall::MATH, p_stall::THCON); }
+
+extern "C" void probe_get_w1() { t6_semaphore_get<p_stall::NOTHING, p_stall::MATH>(3); }
+extern "C" void ref_get_w1() { TTI_STALLWAIT(p_stall::STALL_SYNC, p_stall::NOTHING, p_stall::MATH, p_stall::NOTHING); }
+
+extern "C" void probe_get_w2() { t6_semaphore_get<p_stall::NOTHING, p_stall::NOTHING, p_stall::MATH>(3); }
+extern "C" void ref_get_w2() { TTI_STALLWAIT(p_stall::STALL_SYNC, p_stall::MATH, p_stall::NOTHING, p_stall::NOTHING); }
+"""
+
+_LABEL = re.compile(r"^(probe_\w+|ref_\w+):")
+_TTINSN = re.compile(r"\.ttinsn\s+(-?\d+|0x[0-9a-fA-F]+)")
+
+
+def _emitted_words(assembly: str) -> dict:
+    """Map each ``extern "C"`` function to the instruction words it emits."""
+    words, current = {}, None
+    for line in assembly.splitlines():
+        stripped = line.strip()
+        label = _LABEL.match(stripped)
+        if label:
+            current = label.group(1)
+            words[current] = []
+        insn = _TTINSN.search(stripped)
+        if insn and current is not None:
+            words[current].append(int(insn.group(1), 0) & 0xFFFFFFFF)
+    return words
+
+
+@pytest.fixture(scope="module")
+def emitted(tmp_path_factory):
+    if not _COMPILER.exists():
+        pytest.skip(f"sfpi compiler not present at {_COMPILER}")
+
+    tmp = tmp_path_factory.mktemp("quasar_stall_probe")
+    source = tmp / "probe.cpp"
+    source.write_text(_PROBE_SOURCE)
+    assembly = tmp / "probe.s"
+
+    subprocess.run(
+        [
+            str(_COMPILER),
+            "-std=c++17",
+            "-S",
+            "-O2",
+            # TRISC id and the firmware guard that keeps host-only headers out.
+            "-DCOMPILE_FOR_TRISC=0",
+            "-DTENSIX_FIRMWARE",
+            f"-I{_QUASAR_LLK / 'common/inc'}",
+            f"-I{_QUASAR_LLK / 'common/inc/sfpu'}",
+            f"-I{_QUASAR_LLK / 'llk_lib'}",
+            f"-I{_TT_METAL / 'tt-llk/common'}",
+            f"-I{_TT_METAL / 'hw/inc'}",
+            f"-I{_TT_METAL / 'hw/inc/internal/tt-2xx/quasar'}",
+            "-o",
+            str(assembly),
+            str(source),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    return _emitted_words(assembly.read_text())
+
+
+@pytest.mark.parametrize(
+    "probe",
+    ["w0", "w1", "w2", "all", "get_w1", "get_w2"],
+)
+def test_named_resource_emits_its_stall(emitted, probe):
+    got, expected = emitted[f"probe_{probe}"], emitted[f"ref_{probe}"]
+    assert expected, f"ref_{probe} emitted no stall -- the reference itself is wrong"
+    assert got == expected, (
+        f"t6_semaphore_{'get' if probe.startswith('get') else 'post'} with slots "
+        f"'{probe}' emitted {[hex(w) for w in got]}, expected "
+        f"{[hex(w) for w in expected]}. A named wait resource in any slot must "
+        f"produce the same STALLWAIT as writing it by hand."
+    )
+
+
+def test_no_named_resource_emits_no_stall(emitted):
+    assert emitted["probe_none"] == [], (
+        "t6_semaphore_post<> named no wait resource but still emitted "
+        f"{[hex(w) for w in emitted['probe_none']]}"
+    )

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -347,7 +347,8 @@ struct semaphore
 template <std::uint32_t WaitRes0 = p_stall::NOTHING, std::uint32_t WaitRes1 = p_stall::NOTHING, std::uint32_t WaitRes2 = p_stall::NOTHING>
 inline void t6_semaphore_post(const std::uint8_t index)
 {
-    if constexpr (WaitRes0 != p_stall::NOTHING)
+    // Each slot is independently optional: emit the stall whenever any resource is named.
+    if constexpr (WaitRes0 != p_stall::NOTHING || WaitRes1 != p_stall::NOTHING || WaitRes2 != p_stall::NOTHING)
     {
         TTI_STALLWAIT(p_stall::STALL_SYNC, WaitRes2, WaitRes1, WaitRes0);
     }
@@ -360,7 +361,8 @@ inline void t6_semaphore_post(const std::uint8_t index)
 template <std::uint32_t WaitRes0 = p_stall::NOTHING, std::uint32_t WaitRes1 = p_stall::NOTHING, std::uint32_t WaitRes2 = p_stall::NOTHING>
 inline void t6_semaphore_get(const std::uint8_t index)
 {
-    if constexpr (WaitRes0 != p_stall::NOTHING)
+    // Each slot is independently optional: emit the stall whenever any resource is named.
+    if constexpr (WaitRes0 != p_stall::NOTHING || WaitRes1 != p_stall::NOTHING || WaitRes2 != p_stall::NOTHING)
     {
         TTI_STALLWAIT(p_stall::STALL_SYNC, WaitRes2, WaitRes1, WaitRes0);
     }


### PR DESCRIPTION
Fixes tenstorrent/tt-llk#1697

### What

`t6_semaphore_post` / `t6_semaphore_get` (Quasar) take three independently optional pre-stall resources, but gate the `TTI_STALLWAIT` on `WaitRes0` alone. Setting only the second or third slot compiles and emits no guard at all, while `llk_sync.h` re-exports both and documents each parameter as independently optional.

The fix tests all three slots. `p_stall::NOTHING` is `0` and the `STALLWAIT` encoding carries three 5-bit resource fields, so a zero in an unused slot is well-formed — the stall is correct with only slot 1 or slot 2 named.

### Test

`tests/python_tests/test_quasar_stall_wrapper_codegen.py` is compile-only and needs no device: it builds a probe translation unit against the Quasar headers with the sfpi compiler and compares each wrapper's emitted `.ttinsn` word against a hand-written `TTI_STALLWAIT` with the same slots, so the expected encoding stays in the C++ where the constants live rather than being duplicated in Python.

| | without the fix | with the fix |
|---|---|---|
| `test_quasar_stall_wrapper_codegen.py` | **4 failed**, 3 passed | **7 passed** |

The four failures are exactly the slot-1 and slot-2 cases for both `post` and `get`; the slot-0 case, the all-three-slots case, and the no-resource case pass either way, which is what shows the change neither regresses the working path nor over-emits.

Also compiled a translation unit pulling in `llk_sync.h`, `llk_math_common.h` and `llk_pack_common.h` and exercising `_llk_sync_post_` / `_llk_sync_get_` in every slot combination — clean.

### Scope

Quasar only. Blackhole and Wormhole have a single-parameter `WaitRes` form of the same wrapper with no equivalent gap, so there is nothing to port. No in-tree caller sets only slot 1 or 2 today, so the defect is latent; the forwarding wrappers in `llk_sync.h` are what expose it to future callers.

No Quasar hardware was used — the defect and the fix are both compile-level, and the test verifies them that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/qsr-stall-wrapper-waitres)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/qsr-stall-wrapper-waitres)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/qsr-stall-wrapper-waitres)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/qsr-stall-wrapper-waitres)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/qsr-stall-wrapper-waitres)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/qsr-stall-wrapper-waitres)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/qsr-stall-wrapper-waitres)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/qsr-stall-wrapper-waitres)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/qsr-stall-wrapper-waitres)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/qsr-stall-wrapper-waitres)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/qsr-stall-wrapper-waitres)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/qsr-stall-wrapper-waitres)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/qsr-stall-wrapper-waitres)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/qsr-stall-wrapper-waitres)