### PR TITLE
[Bug fix] Fold polygamma's n! scale into each term so large x stops returning zero

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -78,8 +78,10 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
             if (!pwr) {
                 break;
             }
-            // The last squaring goes into val as two multiplies, so no power of x is formed on its
-            // own: x^(2^k) alone can flush while val * x^(2^k) is still a normal float.
+            // The last squaring goes into val as two multiplies, so the top power of x is never
+            // formed on its own: x^(2^k) alone can flush while val * x^(2^k) is still a normal
+            // float. The lower squares stay normal well past the x where the result itself leaves
+            // fp32 range, so they are still formed directly.
             if (pwr == 1) {
                 val *= x;
                 val *= x;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -59,10 +59,13 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
     float n4 = n + 4;
     float n5 = n + 5;
     float nf = n;
-    float inv_nf = 1.0f / nf;
-    float c_b2 = n1 / 12.0f;                           // B_2 term coefficient
-    float c_b4 = -(n1 * n2 * n3) / 720.0f;             // B_4 term coefficient
-    float c_b6 = (n1 * n2 * n3 * n4 * n5) / 30240.0f;  // B_6 term coefficient
+    // The scale (-1)^(n+1) * n! goes into every term rather than onto the final sum: the unscaled
+    // sum sits n! below the result and flushes to zero while the result is still a normal float.
+    float inv_nf = scale / nf;
+    float c_b2 = scale * n1 / 12.0f;                           // B_2 term coefficient
+    float c_b4 = -scale * (n1 * n2 * n3) / 720.0f;             // B_4 term coefficient
+    float c_b6 = scale * (n1 * n2 * n3 * n4 * n5) / 30240.0f;  // B_6 term coefficient
+    float half_scale = 0.5f * scale;
 
     constexpr auto RECIP = APPROXIMATION_MODE ? 0 : is_fp32_dest_acc_en ? 2 : 1;
 
@@ -75,6 +78,13 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
             if (!pwr) {
                 break;
             }
+            // The last squaring goes into val as two multiplies, so no power of x is formed on its
+            // own: x^(2^k) alone can flush while val * x^(2^k) is still a normal float.
+            if (pwr == 1) {
+                val *= x;
+                val *= x;
+                break;
+            }
             x *= x;
         }
         return val;
@@ -84,15 +94,16 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
         sfpi::vFloat sum = 0.0f;
+        sfpi::vFloat vscale = scale;
 
         // Part 1: Exact summation of first NUM_TERMS terms
-        // Σ_{k=0}^{NUM_TERMS-1} 1/(x+k)^(n+1)
+        // Σ_{k=0}^{NUM_TERMS-1} scale/(x+k)^(n+1)
         for (int k = 0; k < NUM_TERMS; k++) {
             sfpi::vFloat xi = x + float(k);
 
             // Compute reciprocal first, then raise to power (avoids overflow of large intermediates)
             sfpi::vFloat inv_xi = sfpu_reciprocal_iter<RECIP>(xi);
-            sfpi::vFloat inv_power = power(inv_xi, n, inv_xi);
+            sfpi::vFloat inv_power = power(inv_xi, n + 1, vscale);
 
             sum += inv_power;
         }
@@ -107,7 +118,7 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
         // Use PolynomialEvaluator for the Bernoulli polynomial in the tail:
         // E = inv_nf + c_b2*inv_z2 + c_b4*inv_z2^2 + c_b6*inv_z2^3
         sfpi::vFloat E = PolynomialEvaluator::eval(inv_z2, inv_nf, c_b2, c_b4, c_b6);
-        sfpi::vFloat tail = E + 0.5f * inv_z;
+        sfpi::vFloat tail = E + half_scale * inv_z;
 
         // Scale by inv_z^n, taking advantage of inv_z^2's
         // computation above
@@ -123,8 +134,7 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
 
         sum += tail;
 
-        // Apply scale: (-1)^(n+1) * n!
-        sfpi::vFloat result = sum * scale;
+        sfpi::vFloat result = sum;
 
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -61,10 +61,13 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
     float n4 = static_cast<float>(n + 4);
     float n5 = static_cast<float>(n + 5);
     float nf = static_cast<float>(n);
-    float inv_nf = 1.0f / nf;
-    float c_b2 = n1 / 12.0f;                           // B_2 term coefficient
-    float c_b4 = -(n1 * n2 * n3) / 720.0f;             // B_4 term coefficient
-    float c_b6 = (n1 * n2 * n3 * n4 * n5) / 30240.0f;  // B_6 term coefficient
+    // The scale (-1)^(n+1) * n! goes into every term rather than onto the final sum: the unscaled
+    // sum sits n! below the result and flushes to zero while the result is still a normal float.
+    float inv_nf = scale / nf;
+    float c_b2 = scale * n1 / 12.0f;                           // B_2 term coefficient
+    float c_b4 = -scale * (n1 * n2 * n3) / 720.0f;             // B_4 term coefficient
+    float c_b6 = scale * (n1 * n2 * n3 * n4 * n5) / 30240.0f;  // B_6 term coefficient
+    float half_scale = 0.5f * scale;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -72,7 +75,7 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
         sfpi::vFloat sum = sfpi::vFloat(0.0f);
 
         // Part 1: Exact summation of first NUM_TERMS terms
-        // Σ_{k=0}^{NUM_TERMS-1} 1/(x+k)^(n+1)
+        // Σ_{k=0}^{NUM_TERMS-1} scale/(x+k)^(n+1)
         for (int k = 0; k < NUM_TERMS; k++) {
             sfpi::vFloat xi = x + static_cast<float>(k);
 
@@ -86,7 +89,7 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
                 inv_xi = sfpu_reciprocal_iter<1>(xi);
             }
 
-            sfpi::vFloat inv_power = inv_xi;
+            sfpi::vFloat inv_power = inv_xi * scale;
             for (int j = 1; j < n_plus_1; j++) {
                 inv_power = inv_power * inv_xi;
             }
@@ -110,21 +113,19 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
 
         sfpi::vFloat inv_z2 = inv_z * inv_z;
 
-        // Compute inv_z^n by repeated multiplication
-        sfpi::vFloat inv_z_n = inv_z;  // inv_z^1
-        for (int j = 1; j < n; j++) {
-            inv_z_n = inv_z_n * inv_z;  // inv_z^n
-        }
-
         // Use PolynomialEvaluator for the Bernoulli polynomial in the tail:
         // E = inv_nf + c_b2*inv_z2 + c_b4*inv_z2^2 + c_b6*inv_z2^3
         sfpi::vFloat E = PolynomialEvaluator::eval(inv_z2, inv_nf, c_b2, c_b4, c_b6);
-        sfpi::vFloat tail = inv_z_n * (E + 0.5f * inv_z);
+        // Multiply inv_z^n into the scaled tail one factor at a time, so that no intermediate
+        // falls below the result.
+        sfpi::vFloat tail = E + half_scale * inv_z;
+        for (int j = 0; j < n; j++) {
+            tail = tail * inv_z;
+        }
 
         sum = sum + tail;
 
-        // Apply scale: (-1)^(n+1) * n!
-        sfpi::vFloat result = sum * scale;
+        sfpi::vFloat result = sum;
 
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -734,6 +734,17 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
 #else
     constexpr std::uint32_t SHIFT_AMOUNT = 3u;
 #endif
+    // Polygamma order n and its scale (-1)^(n+1) * n!, as the fp32 bit patterns ttnn passes to
+    // polygamma_tile. Overridable via the SFPU_POLYGAMMA_ORDER template parameter so the Python
+    // side can sweep n = 1..11; a test that does not set it keeps trigamma (n = 1, scale = 1).
+    // The golden reads the same order through UnarySFPUGolden's polygamma_order argument.
+#ifdef SFPU_POLYGAMMA_N_BITS
+    constexpr std::uint32_t POLYGAMMA_N_BITS     = SFPU_POLYGAMMA_N_BITS;
+    constexpr std::uint32_t POLYGAMMA_SCALE_BITS = SFPU_POLYGAMMA_SCALE_BITS;
+#else
+    constexpr std::uint32_t POLYGAMMA_N_BITS     = 0x3f800000u; // n = 1.0f
+    constexpr std::uint32_t POLYGAMMA_SCALE_BITS = 0x3f800000u; // scale = 1.0f
+#endif
     // Integer threshold for relu_min's vInt branch, as a two's-complement uint32 (_relu_min_
     // declares the parameter std::uint32_t and immediately static_casts it to int). Overridable
     // via the SFPU_RELU_MIN_INT_THRESHOLD template parameter, on the same #ifdef arrangement as
@@ -1506,16 +1517,8 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::polygamma)
     {
-        // order n = 1 (trigamma); scale = (-1)^(n+1) * n! = 1.0f.
         SFPU_UNARY_CALL(
-            DST_SYNC_MODE,
-            DST_ACCUM_MODE,
-            calculate_polygamma,
-            (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS),
-            dst_index,
-            vector_mode,
-            0x3f800000u /* n = 1.0f */,
-            0x3f800000u /* scale = 1.0f */);
+            DST_SYNC_MODE, DST_ACCUM_MODE, calculate_polygamma, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode, POLYGAMMA_N_BITS, POLYGAMMA_SCALE_BITS);
     }
     else if constexpr (OPERATION == SfpuType::xielu)
     {

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -1518,7 +1518,14 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     else if constexpr (OPERATION == SfpuType::polygamma)
     {
         SFPU_UNARY_CALL(
-            DST_SYNC_MODE, DST_ACCUM_MODE, calculate_polygamma, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode, POLYGAMMA_N_BITS, POLYGAMMA_SCALE_BITS);
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            calculate_polygamma,
+            (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS),
+            dst_index,
+            vector_mode,
+            POLYGAMMA_N_BITS,
+            POLYGAMMA_SCALE_BITS);
     }
     else if constexpr (OPERATION == SfpuType::xielu)
     {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2401,6 +2401,8 @@ class UnarySFPUGolden:
         # relu_min's integer threshold, matching the kernel's RELU_MIN_INT_THRESHOLD default.
         # Signed: the kernel carries it as a two's-complement uint32 and static_casts to int.
         self._relu_min_int_threshold = int(RELU_MIN_THRESHOLD)
+        # polygamma's order, matching the kernel's default when SFPU_POLYGAMMA_ORDER is unset.
+        self._polygamma_order = 1
         self.data_format = None
         # Precision the SFPU actually evaluates at, which is Dest's and not the output
         # format's. The per-element ops below read this rather than data_format: no
@@ -2425,12 +2427,15 @@ class UnarySFPUGolden:
         unpack_to_srcs: bool = False,
         shift_amount: int = 3,
         relu_min_int_threshold: int = int(RELU_MIN_THRESHOLD),
+        polygamma_order: int = 1,
     ):
         self.data_format = data_format
         self.dst_format = data_format
         self.dest_acc = dest_acc
         # Mirrors the SFPU_SHIFT_AMOUNT template parameter; only the unary shift ops read it.
         self._int_shift_amount = shift_amount
+        # Mirrors the SFPU_POLYGAMMA_ORDER template parameter; only polygamma reads it.
+        self._polygamma_order = polygamma_order
         # Mirrors the SFPU_RELU_MIN_INT_THRESHOLD template parameter; only relu_min on an
         # integer format reads it. Signed here, two's-complement uint32 on the kernel side.
         self._relu_min_int_threshold = relu_min_int_threshold
@@ -3181,7 +3186,6 @@ class UnarySFPUGolden:
     _REMAINDER_DIVISOR = 2.0
     _UNARY_COMP_THRESHOLD = UNARY_COMP_THRESHOLD
     _UNARY_MAX_MIN_VALUE = UNARY_MAX_MIN_VALUE
-    _POLYGAMMA_ORDER = 1
     _XIELU_ALPHA_P = 1.0
     _XIELU_ALPHA_N = 1.0
     _XIELU_BETA = 0.5
@@ -3244,7 +3248,11 @@ class UnarySFPUGolden:
         return sfpu_min(x, self._UNARY_MAX_MIN_VALUE)
 
     def _polygamma(self, x):
-        return self._torch_unary(x, lambda t: torch.polygamma(self._POLYGAMMA_ORDER, t))
+        # float64: torch's float32 polygamma loses precision as the result nears the bottom of
+        # the normal range and returns 0 there (n = 11, x = 1.1e4), where the kernel must not.
+        return torch.polygamma(
+            self._polygamma_order, torch.tensor(x, dtype=torch.float64)
+        ).item()
 
     def _xielu(self, x):
         # Mirrors calculate_xielu: beta = 0.5, alpha_p/alpha_n learnable params.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -342,6 +342,29 @@ class SFPU_SHIFT_AMOUNT(TemplateParameter):
 
 
 @dataclass
+class SFPU_POLYGAMMA_ORDER(TemplateParameter):
+    """Order n for polygamma, emitted as the (n, scale) fp32 bit patterns ttnn passes.
+
+    ``scale`` is (-1)^(n+1) * n!, exact in fp32 for every supported order (1..11). Macros
+    rather than constexprs for the same reason as :class:`SFPU_SHIFT_AMOUNT`: sfpu_operations.h
+    selects on ``#ifdef``, and a test that does not set this keeps trigamma (n = 1).
+    """
+
+    polygamma_order: int = 1
+
+    def convert_to_cpp(self) -> str:
+        n = self.polygamma_order
+        scale = (-1) ** (n + 1) * math.factorial(n)
+        n_bits, scale_bits = (
+            struct.unpack("<I", struct.pack("<f", v))[0] for v in (n, scale)
+        )
+        return (
+            f"#define SFPU_POLYGAMMA_N_BITS {n_bits:#x}u\n"
+            f"#define SFPU_POLYGAMMA_SCALE_BITS {scale_bits:#x}u"
+        )
+
+
+@dataclass
 class DISABLE_SRC_ZERO_FLAG(TemplateParameter):
     disable_src_zero_flag: bool
 

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import math
 from itertools import chain, product
 
 import pytest
@@ -42,7 +43,7 @@ from helpers.sfpu_domains import (
     specials_safe,
 )
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+from helpers.stimuli_generator import DistributionKind, StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     APPROX_MODE,
@@ -51,6 +52,7 @@ from helpers.test_variant_parameters import (
     MATH_OP,
     NUM_BLOCKS,
     NUM_TILES_IN_BLOCK,
+    SFPU_POLYGAMMA_ORDER,
     SFPU_RELU_MIN_INT_THRESHOLD,
     SFPU_SHIFT_AMOUNT,
     TILE_COUNT,
@@ -1021,6 +1023,52 @@ def test_eltwise_unary_sfpu_int_shift(
     )
 
 
+# Every polygamma order ttnn accepts. psi^(n)(x) ~ (n-1)! / x^n for large x, so each order is
+# swept from 0.5 up to where the result is 2^-125, just inside the normal range. The bottom of
+# that range is where the unscaled partial sums sit n! below the result, and atol is 0 because
+# any absolute tolerance would accept a zero there.
+_POLYGAMMA_ORDERS = list(range(1, 12))
+
+
+def _polygamma_stimuli_spec(order):
+    high = (math.factorial(order - 1) * 2.0**125) ** (1.0 / order)
+    return StimuliSpec(distribution=DistributionKind.LOG_UNIFORM, low=0.5, high=high)
+
+
+@pytest.mark.nightly
+@parametrize(
+    formats=input_output_formats([DataFormat.Float16_b, DataFormat.Float32], same=True),
+    polygamma_order=_POLYGAMMA_ORDERS,
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    input_dimensions=[[64, 64]],
+)
+def test_eltwise_unary_sfpu_polygamma_order(
+    formats: InputOutputFormat,
+    polygamma_order: int,
+    dest_acc: DestAccumulation,
+    input_dimensions: list[int],
+):
+    if formats.input_format == DataFormat.Float32 and dest_acc == DestAccumulation.No:
+        pytest.skip(reason="Float32 reaches a 16-bit Dest as Float16_b, which is swept already")
+    eltwise_unary_sfpu(
+        "sources/eltwise_unary_sfpu_test.cpp",
+        formats,
+        dest_acc,
+        ApproximationMode.No,
+        MathOperation.Polygamma,
+        FastMode.No,
+        input_dimensions,
+        spec_A=_polygamma_stimuli_spec(polygamma_order),
+        custom_atol=0.0,
+        # atol is 0 so a flushed lane fails outright at a relative error of 1. The rtol is loose
+        # because the sweep reaches the last binades before underflow, where the Euler-Maclaurin
+        # corrections themselves flush: measured worst case there is 2.0% for float32 at order 11
+        # and 1.1% for bfloat16, against 23.4 float32 ULP and 0.56 bfloat16 ULP above 2^-100.
+        custom_rtol=0.05 if formats.output_format == DataFormat.Float32 else 0.02,
+        polygamma_order=polygamma_order,
+    )
+
+
 @parametrize(
     formats=input_output_formats([DataFormat.Float16_b, DataFormat.Float32]),
     approx_mode=[ApproximationMode.No],
@@ -1219,6 +1267,7 @@ def eltwise_unary_sfpu(
     custom_rtol=None,
     shift_amount=None,
     relu_min_int_threshold=None,
+    polygamma_order=None,
     twos_complement=False,
 ):
     torch.manual_seed(0)
@@ -1262,6 +1311,7 @@ def eltwise_unary_sfpu(
             if relu_min_int_threshold is None
             else {"relu_min_int_threshold": relu_min_int_threshold}
         ),
+        **({} if polygamma_order is None else {"polygamma_order": polygamma_order}),
     )
 
     num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
@@ -1289,6 +1339,11 @@ def eltwise_unary_sfpu(
                 []
                 if relu_min_int_threshold is None
                 else [SFPU_RELU_MIN_INT_THRESHOLD(relu_min_int_threshold)]
+            ),
+            *(
+                []
+                if polygamma_order is None
+                else [SFPU_POLYGAMMA_ORDER(polygamma_order)]
             ),
         ],
         runtimes=[

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1049,7 +1049,9 @@ def test_eltwise_unary_sfpu_polygamma_order(
     input_dimensions: list[int],
 ):
     if formats.input_format == DataFormat.Float32 and dest_acc == DestAccumulation.No:
-        pytest.skip(reason="Float32 reaches a 16-bit Dest as Float16_b, which is swept already")
+        pytest.skip(
+            reason="Float32 reaches a 16-bit Dest as Float16_b, which is swept already"
+        )
     eltwise_unary_sfpu(
         "sources/eltwise_unary_sfpu_test.cpp",
         formats,


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #55105.

`ttnn.polygamma` returned exactly 0 for n >= 3 over a wide band of ordinary x (from x = 2256 at n = 11), because `calculate_polygamma` accumulates the sum unscaled and applies `n!` once at the end, so the accumulator flushes below 2^-126 while the result is still a normal fp32. The scale now folds into every term, and the top power of x is never formed on its own, since a lone `inv_z^n` still flushes at n = 4 and n = 8. Both ideas are @badnikhil's from #55679, which they closed in favour of this report.

On Blackhole under ttsim, over every finite bfloat16 >= 0.5 and 49,280 float32 values, the lanes returning 0 where |psi| >= 2^-125 go from 79 to 278 per order (bfloat16) and 226 to 814 (float32) at n = 3 to 11, down to 0. float32 error at n = 11 drops from 713,564 ULP to 22.7 ULP against a float64 golden, and the bfloat16 worst case is 0.56 ULP.

On a Wormhole n150 (TT-Console), with this change applied to stable `9f9cd4fd590`, 1024 values in [1, 3.2e4] against float64: the zero lanes at n = 9, 10 and 11 go from 90, 142 and 151 (float32; 152 at n = 11 in bfloat16) to 0, and the n = 8 float32 max relative error from 2.9e-3 to 8.4e-7. What is left at n = 9 to 11 (up to 1e-2) sits near |psi| = 2^-116, where the exact terms flush and only the tail survives; above 2^-110 it stays under 1e-6.

`test_eltwise_unary_sfpu_polygamma_order` sweeps n = 1 to 11 in both formats against float64 (torch's float32 polygamma returns 0 in this band too) with atol 0, because the default atol of 0.05 passes a lane that returns 0. On main it fails 27 of 33 Blackhole cases.

### Notes for reviewers

The fix costs 5 extra SFPU multiplies per element on Wormhole at every order. On Blackhole the power chain changes shape: n = 3, 5 and 9 get 1 multiply fewer, n = 7 and 11 get 7 fewer, and the other orders get 5 more.

The new test is marked nightly like the other polygamma cases, so no PR lane runs it.
