### PR TITLE
c4ai-command-r7b bring-up using TTNN APIs

### DIFF
--- a/models/common/rmsnorm.py
+++ b/models/common/rmsnorm.py
@@ -58,7 +58,7 @@ class RMSNorm(LightweightModule):
     ):
         super().__init__()
         self.device = device
-        self.eps = eps
+        self.eps: float  = 1e-05 if eps is None else eps
         self.is_distributed = is_distributed
         self.ccl_topology = ccl_topology
         self.tt_ccl = tt_ccl

--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -147,6 +147,9 @@ class TransformerBlock(LightweightModule):
             TG=args.is_galaxy,
             ag_config_key="ATTN_LN_AG_CONFIG",
         )
+        weight_key = "attention_norm" if args.base_model_name in (
+            "c4ai-command-r7b",
+        ) else "ffn_norm"
         self.ff_norm = DistributedNorm(
             RMSNorm(
                 device=mesh_device,
@@ -156,7 +159,7 @@ class TransformerBlock(LightweightModule):
                 state_dict_prefix=args.get_state_dict_prefix("", layer_num),
                 weight_cache_path=None if args.dummy_weights else weight_cache_path,
                 weight_dtype=ttnn.bfloat16,
-                weight_key="ffn_norm",
+                weight_key=weight_key,
                 is_distributed=self.args.is_distributed_norm,
                 add_unit_offset=self.args.rms_norm_add_unit_offset,
                 ccl_topology=self.args.ccl_topology(),


### PR DESCRIPTION
This PR aims to solve [#49307](https://github.com/tenstorrent/tt-metal/issues/49307).
But due to availability of the hardware the scope was changed to [Command-r7b](https://huggingface.co/CohereLabs/c4ai-command-r7b-12-2024).
**Hardware Validation**: Tests were run on blackhole P150b
**Changes**: Integrated command-r7b into tt_transformers.
**Demo**: Demo is done using standard tt_transformers demo with batch-1 and batch-32

The numbers achieved are around 35/t/s/u and 28 ms of TTFT.If given access to T3k I can validate the working of Command-r-v01. Command-r7b and Command-r-v01 have no architectural difference, so Command-r-v01 should work give the working of Command-r7b but command-r-v01 is yet to test, give the unavailability of the hardware.

Stage 1 of bringup is complete but some optimizations might be done to increase the t/s/u.
Give the target t/s/u of llama-8.1 8B and mistral-7b, this might be limit.

The RAG capability of the model is yet to test.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217162603527284