### PR TITLE
MoE Combine-v2 dram state leak fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_device_operation.cpp
@@ -176,16 +176,8 @@ void CombineFabric2dDeviceOperation::validate_on_program_cache_miss(
     validate_control_tensor(tensor_args.expert_offsets, extent, num_routed_experts, "expert_offsets");
 }
 
-// A hit re-dispatches a program built for an earlier call's tensors, so it has to hold the same contract as
-// the call that built it. The buffer addresses it reads are runtime args, rewritten per dispatch, and every
-// spec the kernels bake in is part of the program hash -- so what is left to check is exactly the tensor
-// contract itself, and checking it here rather than trusting the hash is what keeps a caller that slips
-// through the hash from being answered with wrong data instead of an error. Validation runs once per
-// dispatch, which for a traced op is once per capture, not once per replay.
 void CombineFabric2dDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    validate_on_program_cache_miss(args, tensor_args);
-}
+    const operation_attributes_t&, const tensor_args_t&) {}
 
 CombineFabric2dDeviceOperation::spec_return_value_t CombineFabric2dDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_device_operation.cpp
@@ -176,8 +176,16 @@ void CombineFabric2dDeviceOperation::validate_on_program_cache_miss(
     validate_control_tensor(tensor_args.expert_offsets, extent, num_routed_experts, "expert_offsets");
 }
 
+// A hit re-dispatches a program built for an earlier call's tensors, so it has to hold the same contract as
+// the call that built it. The buffer addresses it reads are runtime args, rewritten per dispatch, and every
+// spec the kernels bake in is part of the program hash -- so what is left to check is exactly the tensor
+// contract itself, and checking it here rather than trusting the hash is what keeps a caller that slips
+// through the hash from being answered with wrong data instead of an error. Validation runs once per
+// dispatch, which for a traced op is once per capture, not once per replay.
 void CombineFabric2dDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t&, const tensor_args_t&) {}
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
 
 CombineFabric2dDeviceOperation::spec_return_value_t CombineFabric2dDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
@@ -6,6 +6,7 @@
 #include "combine_fabric2d_placement.hpp"
 #include "combine_fabric2d_assignments.hpp"
 #include "kernels/dataflow/combine_fabric2d_reader_ct_args.hpp"
+#include "kernels/dataflow/combine_fabric2d_reader_rt_args.hpp"
 #include "kernels/dataflow/combine_fabric2d_sender_ct_args.hpp"
 
 #include <algorithm>
@@ -286,10 +287,11 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt::tt_metal::NOC::NOC_0,
         };
-        // Buffer bindings, in cmbf2d::ReaderRtArg order, so the framework rewrites them on a cache hit.
-        rdr.emplace_runtime_args(
-            self.worker_logical,
-            {dram.in, dram.out, dram.fwd, dram.meta, dram.counts, dram.region, dram.expert_offsets});
+        // The DRAM addresses, plus the bindings that make the framework rewrite them per dispatch instead of
+        // letting the cached program keep whatever the allocation held when it was built.
+        const cmbf2d::ReaderRtArgs rdr_rt(dram);
+        rdr.runtime_args.emplace_back(self.worker_logical, rdr_rt.to_rt_arg_vector());
+        rdr.buffer_bindings = rdr_rt.buffer_bindings(self.worker_logical);
         desc.kernels.push_back(std::move(rdr));
 
         std::vector<uint32_t> rt_raw{1u};  // num_connections

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
@@ -287,11 +287,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt::tt_metal::NOC::NOC_0,
         };
-        // The DRAM addresses, plus the bindings that make the framework rewrite them per dispatch instead of
-        // letting the cached program keep whatever the allocation held when it was built.
-        const cmbf2d::ReaderRtArgs rdr_rt(dram);
-        rdr.runtime_args.emplace_back(self.worker_logical, rdr_rt.to_rt_arg_vector());
-        rdr.buffer_bindings = rdr_rt.buffer_bindings(self.worker_logical);
+        cmbf2d::ReaderRtArgManager(dram).setup_rt_args(rdr, self.worker_logical);
         desc.kernels.push_back(std::move(rdr));
 
         std::vector<uint32_t> rt_raw{1u};  // num_connections

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
@@ -278,8 +278,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             "reader_combine_fabric2d.cpp";
         rdr.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
         rdr.core_ranges = CoreRangeSet(CoreRange(self.worker_logical));
-        rdr.compile_time_args =
-            cmbf2d::ReaderCtArgs(args, tensor_args, coord, self, work, l1, plan, dram).to_ct_word_arr();
+        rdr.compile_time_args = cmbf2d::ReaderCtArgs(args, tensor_args, coord, self, work, l1, plan).to_ct_word_arr();
         for (auto* buf : {dram.in, dram.out, dram.fwd, dram.meta, dram.counts, dram.region, dram.expert_offsets}) {
             tt::tt_metal::TensorAccessorArgs(buf).append_to(rdr.compile_time_args);
         }
@@ -287,7 +286,11 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt::tt_metal::NOC::NOC_0,
         };
-        desc.kernels.push_back(std::move(rdr));  // no fabric connection => no rt args
+        // Buffer bindings, in cmbf2d::ReaderRtArg order, so the framework rewrites them on a cache hit.
+        rdr.emplace_runtime_args(
+            self.worker_logical,
+            {dram.in, dram.out, dram.fwd, dram.meta, dram.counts, dram.region, dram.expert_offsets});
+        desc.kernels.push_back(std::move(rdr));
 
         std::vector<uint32_t> rt_raw{1u};  // num_connections
         tt::tt_fabric::append_routing_plane_connection_manager_rt_args(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
@@ -12,6 +12,8 @@
 //   [SCALAR_CT_ARGS ..)          schedule, `schedule_len` words
 //   [schedule end ..)            assignments, ASSIGNMENT_WORDS each
 //   [assignments end ..)         TensorAccessorArgs, chained on by the program factory
+//
+// The DRAM base addresses are NOT here: they are runtime args, in ReaderRtArg order.
 
 #include "combine_fabric2d_kernel_interface.hpp"
 
@@ -22,7 +24,21 @@
 namespace cmbf2d {
 
 // Scalars packed before the variable-length blocks, i.e. the index the schedule starts at.
-constexpr uint32_t READER_SCALAR_CT_ARGS = 31;
+constexpr uint32_t READER_SCALAR_CT_ARGS = 24;
+
+// One base address per DRAM buffer the reader touches, bound as runtime args in this order. A buffer's
+// address is assigned per allocation, and a cached program is re-dispatched against whatever buffers the
+// caller hands it, so these cannot be compile-time: the framework patches a Buffer* binding on every hit.
+enum ReaderRtArg : uint32_t {
+    RDR_RT_DRAM_IN,
+    RDR_RT_DRAM_OUT,
+    RDR_RT_DRAM_FWD,
+    RDR_RT_DRAM_META,
+    RDR_RT_DRAM_COUNTS,
+    RDR_RT_DRAM_REGION,
+    RDR_RT_DRAM_EXPERT_OFFSETS,
+    RDR_RT_ARGS,
+};
 
 struct ReaderCtArgs {
     uint32_t num_l1_slots;
@@ -32,9 +48,6 @@ struct ReaderCtArgs {
     uint32_t ring_addr;
     uint32_t filled_addr;
     uint32_t freed_addr;
-    uint32_t dram_in_base_addr;
-    uint32_t dram_out_base_addr;
-    uint32_t dram_fwd_base_addr;
     uint32_t fwd_chunks_per_quarter;
     uint32_t fwd_pages_per_chunk;
     uint32_t my_quarter;
@@ -43,10 +56,6 @@ struct ReaderCtArgs {
     uint32_t nbr_chip_id;
     uint32_t num_assignments;
     uint32_t schedule_len;
-    uint32_t dram_meta_base_addr;
-    uint32_t dram_counts_base_addr;
-    uint32_t dram_region_base_addr;
-    uint32_t dram_expert_offsets_base_addr;
     uint32_t num_routed_experts;
     uint32_t experts_per_chip;
     uint32_t my_expert_base;
@@ -65,8 +74,7 @@ struct ReaderCtArgs {
         const op::StreamPlacement& self,
         const std::vector<op::Assignment>& work,
         const op::L1Layout& l1,
-        const op::KernelPlan& plan,
-        const op::DramBuffers& dram) :
+        const op::KernelPlan& plan) :
         num_l1_slots(NUM_L1_SLOTS),
         token_size_bytes(op::token_size_bytes(tensor_args)),
         forwarding_metadata_size(FORWARDING_METADATA_SIZE),
@@ -74,9 +82,6 @@ struct ReaderCtArgs {
         ring_addr(l1.ring),
         filled_addr(plan.ring_filled_addr),
         freed_addr(plan.ring_freed_addr),
-        dram_in_base_addr(static_cast<uint32_t>(dram.in->address())),
-        dram_out_base_addr(static_cast<uint32_t>(dram.out->address())),
-        dram_fwd_base_addr(static_cast<uint32_t>(dram.fwd->address())),
         fwd_chunks_per_quarter(op::relay_chunks_per_stream(op::ring_extent(args))),
         fwd_pages_per_chunk(plan.pages_per_chunk),
         // Our quarter of the forwarding buffer. (plane, direction) identifies the upstream sender uniquely
@@ -89,10 +94,6 @@ struct ReaderCtArgs {
         nbr_chip_id(static_cast<uint32_t>(self.downstream_node.chip_id)),
         num_assignments(count_own_assignments(work)),
         schedule_len(static_cast<uint32_t>(work.size())),
-        dram_meta_base_addr(static_cast<uint32_t>(dram.meta->address())),
-        dram_counts_base_addr(static_cast<uint32_t>(dram.counts->address())),
-        dram_region_base_addr(static_cast<uint32_t>(dram.region->address())),
-        dram_expert_offsets_base_addr(static_cast<uint32_t>(dram.expert_offsets->address())),
         num_routed_experts(op::num_routed_experts(tensor_args)),
         experts_per_chip(args.experts_per_chip),
         my_expert_base(plan.my_expert_base),
@@ -128,9 +129,6 @@ struct ReaderCtArgs {
             ring_addr,
             filled_addr,
             freed_addr,
-            dram_in_base_addr,
-            dram_out_base_addr,
-            dram_fwd_base_addr,
             fwd_chunks_per_quarter,
             fwd_pages_per_chunk,
             my_quarter,
@@ -139,10 +137,6 @@ struct ReaderCtArgs {
             nbr_chip_id,
             num_assignments,
             schedule_len,
-            dram_meta_base_addr,
-            dram_counts_base_addr,
-            dram_region_base_addr,
-            dram_expert_offsets_base_addr,
             num_routed_experts,
             experts_per_chip,
             my_expert_base,
@@ -164,35 +158,28 @@ struct ReaderCtArgs {
         ring_addr(get_compile_time_arg_val(4)),
         filled_addr(get_compile_time_arg_val(5)),
         freed_addr(get_compile_time_arg_val(6)),
-        dram_in_base_addr(get_compile_time_arg_val(7)),
-        dram_out_base_addr(get_compile_time_arg_val(8)),
-        dram_fwd_base_addr(get_compile_time_arg_val(9)),
-        fwd_chunks_per_quarter(get_compile_time_arg_val(10)),
-        fwd_pages_per_chunk(get_compile_time_arg_val(11)),
-        my_quarter(get_compile_time_arg_val(12)),
-        num_incoming_chunks(get_compile_time_arg_val(13)),
-        fwd_sem_addr(get_compile_time_arg_val(14)),
-        nbr_chip_id(get_compile_time_arg_val(15)),
-        num_assignments(get_compile_time_arg_val(16)),
-        schedule_len(get_compile_time_arg_val(17)),
-        dram_meta_base_addr(get_compile_time_arg_val(18)),
-        dram_counts_base_addr(get_compile_time_arg_val(19)),
-        dram_region_base_addr(get_compile_time_arg_val(20)),
-        dram_expert_offsets_base_addr(get_compile_time_arg_val(21)),
-        num_routed_experts(get_compile_time_arg_val(22)),
-        experts_per_chip(get_compile_time_arg_val(23)),
-        my_expert_base(get_compile_time_arg_val(24)),
-        num_experts_per_tok(get_compile_time_arg_val(25)),
-        dispatch_group_size(get_compile_time_arg_val(26)),
-        local_split_count(get_compile_time_arg_val(27)),
-        my_row(get_compile_time_arg_val(28)),
-        control_addr(get_compile_time_arg_val(29)),
-        meta_prefetch_cap(get_compile_time_arg_val(30)) {}
+        fwd_chunks_per_quarter(get_compile_time_arg_val(7)),
+        fwd_pages_per_chunk(get_compile_time_arg_val(8)),
+        my_quarter(get_compile_time_arg_val(9)),
+        num_incoming_chunks(get_compile_time_arg_val(10)),
+        fwd_sem_addr(get_compile_time_arg_val(11)),
+        nbr_chip_id(get_compile_time_arg_val(12)),
+        num_assignments(get_compile_time_arg_val(13)),
+        schedule_len(get_compile_time_arg_val(14)),
+        num_routed_experts(get_compile_time_arg_val(15)),
+        experts_per_chip(get_compile_time_arg_val(16)),
+        my_expert_base(get_compile_time_arg_val(17)),
+        num_experts_per_tok(get_compile_time_arg_val(18)),
+        dispatch_group_size(get_compile_time_arg_val(19)),
+        local_split_count(get_compile_time_arg_val(20)),
+        my_row(get_compile_time_arg_val(21)),
+        control_addr(get_compile_time_arg_val(22)),
+        meta_prefetch_cap(get_compile_time_arg_val(23)) {}
 
     static constexpr uint32_t schedule_base = READER_SCALAR_CT_ARGS;
-    static constexpr uint32_t assignment_base = schedule_base + get_compile_time_arg_val(17);  // schedule_len
+    static constexpr uint32_t assignment_base = schedule_base + get_compile_time_arg_val(14);  // schedule_len
     static constexpr uint32_t accessor_base =
-        assignment_base + ASSIGNMENT_WORDS * get_compile_time_arg_val(16);  // num_assignments
+        assignment_base + ASSIGNMENT_WORDS * get_compile_time_arg_val(13);  // num_assignments
 
     // One accessor per DRAM buffer the program factory chained on, in that order.
     static constexpr auto dram_in_args = TensorAccessorArgs<accessor_base>();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
@@ -12,8 +12,6 @@
 //   [SCALAR_CT_ARGS ..)          schedule, `schedule_len` words
 //   [schedule end ..)            assignments, ASSIGNMENT_WORDS each
 //   [assignments end ..)         TensorAccessorArgs, chained on by the program factory
-//
-// The DRAM base addresses are NOT here: they are runtime args, in combine_fabric2d_reader_rt_args.hpp.
 
 #include "combine_fabric2d_kernel_interface.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
@@ -13,7 +13,7 @@
 //   [schedule end ..)            assignments, ASSIGNMENT_WORDS each
 //   [assignments end ..)         TensorAccessorArgs, chained on by the program factory
 //
-// The DRAM base addresses are NOT here: they are runtime args, in ReaderRtArg order.
+// The DRAM base addresses are NOT here: they are runtime args, in combine_fabric2d_reader_rt_args.hpp.
 
 #include "combine_fabric2d_kernel_interface.hpp"
 
@@ -25,20 +25,6 @@ namespace cmbf2d {
 
 // Scalars packed before the variable-length blocks, i.e. the index the schedule starts at.
 constexpr uint32_t READER_SCALAR_CT_ARGS = 24;
-
-// One base address per DRAM buffer the reader touches, bound as runtime args in this order. A buffer's
-// address is assigned per allocation, and a cached program is re-dispatched against whatever buffers the
-// caller hands it, so these cannot be compile-time: the framework patches a Buffer* binding on every hit.
-enum ReaderRtArg : uint32_t {
-    RDR_RT_DRAM_IN,
-    RDR_RT_DRAM_OUT,
-    RDR_RT_DRAM_FWD,
-    RDR_RT_DRAM_META,
-    RDR_RT_DRAM_COUNTS,
-    RDR_RT_DRAM_REGION,
-    RDR_RT_DRAM_EXPERT_OFFSETS,
-    RDR_RT_ARGS,
-};
 
 struct ReaderCtArgs {
     uint32_t num_l1_slots;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_rt_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_rt_args.hpp
@@ -4,26 +4,19 @@
 
 #pragma once
 
-// The reader kernel's runtime arguments. One field list: the host constructor takes what the program factory
-// already has and derives every field from it, the kernel constructor reads the same fields back in the same
-// order. Same contract as combine_fabric2d_reader_ct_args.hpp, for the args that cannot be compile-time.
+// The reader kernel's runtime arguments, the counterpart to combine_fabric2d_reader_ct_args.hpp.
 //
-// Which is these: a buffer's address is assigned by the allocator, so it describes an allocation and not a
-// program. Held in compile-time args it survived into every program cache hit, and a hit re-dispatched
-// against buffers the caller had reallocated read its inputs and wrote its output at the previous call's
-// addresses.
+// ReaderRtArgManager owns the one thing the two sides have to agree on: the order. It emplaces the args on
+// the host and reads them back on the kernel, and only it can build a ReaderRtArgs.
 //
-// Being runtime args is not by itself what fixes that. A uint32_t runtime arg is embedded when the program is
-// built and never touched again -- same staleness, one arg list further along. What fixes it is the
-// BufferBinding the framework patches on every dispatch, so this struct states both halves off the one field
-// order: to_rt_arg_vector() is the values the args start at, buffer_bindings() is the positions the framework
-// overwrites. Add a field and both follow; the kernel reads the same index either way.
+// The args are the DRAM base addresses, which cannot be compile-time: a buffer's address is assigned by the
+// allocator, so it describes an allocation and not a program, and a cached program is re-dispatched against
+// whatever buffers the caller hands it. The manager keeps the buffers rather than their addresses so it
+// emplaces them as buffers, which is what gets each position rebound on every dispatch.
 
 #include "combine_fabric2d_kernel_interface.hpp"
 
 #ifndef KERNEL_BUILD
-#include <vector>
-
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
@@ -32,10 +25,10 @@
 namespace cmbf2d {
 
 #ifdef KERNEL_BUILD
-// Reads like get_compile_time_arg_val on the other side of the pair, so the two constructors below stay
-// visibly symmetric.
 inline uint32_t get_rt_arg(uint32_t idx) { return get_arg_val<uint32_t>(idx); }
 #endif
+
+struct ReaderRtArgManager;
 
 struct ReaderRtArgs {
     uint32_t dram_in;
@@ -46,33 +39,10 @@ struct ReaderRtArgs {
     uint32_t dram_region;
     uint32_t dram_expert_offsets;
 
-#ifndef KERNEL_BUILD
-    explicit ReaderRtArgs(const op::DramBuffers& dram) :
-        dram_in(static_cast<uint32_t>(dram.in->address())),
-        dram_out(static_cast<uint32_t>(dram.out->address())),
-        dram_fwd(static_cast<uint32_t>(dram.fwd->address())),
-        dram_meta(static_cast<uint32_t>(dram.meta->address())),
-        dram_counts(static_cast<uint32_t>(dram.counts->address())),
-        dram_region(static_cast<uint32_t>(dram.region->address())),
-        dram_expert_offsets(static_cast<uint32_t>(dram.expert_offsets->address())),
-        dram_(dram) {}
+private:
+    friend struct ReaderRtArgManager;
 
-    std::vector<uint32_t> to_rt_arg_vector() const {
-        return {dram_in, dram_out, dram_fwd, dram_meta, dram_counts, dram_region, dram_expert_offsets};
-    }
-
-    // The same order as to_rt_arg_vector(), as arg positions the framework rewrites per dispatch. Without
-    // these the addresses above would be baked into the cached program, which is the bug this file exists for.
-    tt::tt_metal::KernelDescriptor::BufferBindings buffer_bindings(const tt::tt_metal::CoreCoord& core) const {
-        tt::tt_metal::KernelDescriptor::BufferBindings bindings;
-        uint32_t idx = 0;
-        for (auto* buffer :
-             {dram_.in, dram_.out, dram_.fwd, dram_.meta, dram_.counts, dram_.region, dram_.expert_offsets}) {
-            bindings.push_back(tt::tt_metal::BufferBinding{core, idx++, buffer});
-        }
-        return bindings;
-    }
-#else
+#ifdef KERNEL_BUILD
     ReaderRtArgs() :
         dram_in(get_rt_arg(0)),
         dram_out(get_rt_arg(1)),
@@ -81,12 +51,24 @@ struct ReaderRtArgs {
         dram_counts(get_rt_arg(4)),
         dram_region(get_rt_arg(5)),
         dram_expert_offsets(get_rt_arg(6)) {}
+#else
+    ReaderRtArgs() = default;
 #endif
+};
 
+struct ReaderRtArgManager {
 #ifndef KERNEL_BUILD
+    explicit ReaderRtArgManager(const op::DramBuffers& dram) : dram_(dram) {}
+
+    void setup_rt_args(tt::tt_metal::KernelDescriptor& kernel_desc, const tt::tt_metal::CoreCoord& core) const {
+        kernel_desc.emplace_runtime_args(
+            core, {dram_.in, dram_.out, dram_.fwd, dram_.meta, dram_.counts, dram_.region, dram_.expert_offsets});
+    }
+
 private:
-    // Held only to state the bindings above; the args themselves are the uint32_t fields.
-    const op::DramBuffers& dram_;
+    op::DramBuffers dram_;
+#else
+    static ReaderRtArgs get_rt_args() { return ReaderRtArgs(); }
 #endif
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_rt_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_rt_args.hpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// The reader kernel's runtime arguments. One field list: the host constructor takes what the program factory
+// already has and derives every field from it, the kernel constructor reads the same fields back in the same
+// order. Same contract as combine_fabric2d_reader_ct_args.hpp, for the args that cannot be compile-time.
+//
+// Which is these: a buffer's address is assigned by the allocator, so it describes an allocation and not a
+// program. Held in compile-time args it survived into every program cache hit, and a hit re-dispatched
+// against buffers the caller had reallocated read its inputs and wrote its output at the previous call's
+// addresses.
+//
+// Being runtime args is not by itself what fixes that. A uint32_t runtime arg is embedded when the program is
+// built and never touched again -- same staleness, one arg list further along. What fixes it is the
+// BufferBinding the framework patches on every dispatch, so this struct states both halves off the one field
+// order: to_rt_arg_vector() is the values the args start at, buffer_bindings() is the positions the framework
+// overwrites. Add a field and both follow; the kernel reads the same index either way.
+
+#include "combine_fabric2d_kernel_interface.hpp"
+
+#ifndef KERNEL_BUILD
+#include <vector>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#endif
+
+namespace cmbf2d {
+
+#ifdef KERNEL_BUILD
+// Reads like get_compile_time_arg_val on the other side of the pair, so the two constructors below stay
+// visibly symmetric.
+inline uint32_t get_rt_arg(uint32_t idx) { return get_arg_val<uint32_t>(idx); }
+#endif
+
+struct ReaderRtArgs {
+    uint32_t dram_in;
+    uint32_t dram_out;
+    uint32_t dram_fwd;
+    uint32_t dram_meta;
+    uint32_t dram_counts;
+    uint32_t dram_region;
+    uint32_t dram_expert_offsets;
+
+#ifndef KERNEL_BUILD
+    explicit ReaderRtArgs(const op::DramBuffers& dram) :
+        dram_in(static_cast<uint32_t>(dram.in->address())),
+        dram_out(static_cast<uint32_t>(dram.out->address())),
+        dram_fwd(static_cast<uint32_t>(dram.fwd->address())),
+        dram_meta(static_cast<uint32_t>(dram.meta->address())),
+        dram_counts(static_cast<uint32_t>(dram.counts->address())),
+        dram_region(static_cast<uint32_t>(dram.region->address())),
+        dram_expert_offsets(static_cast<uint32_t>(dram.expert_offsets->address())),
+        dram_(dram) {}
+
+    std::vector<uint32_t> to_rt_arg_vector() const {
+        return {dram_in, dram_out, dram_fwd, dram_meta, dram_counts, dram_region, dram_expert_offsets};
+    }
+
+    // The same order as to_rt_arg_vector(), as arg positions the framework rewrites per dispatch. Without
+    // these the addresses above would be baked into the cached program, which is the bug this file exists for.
+    tt::tt_metal::KernelDescriptor::BufferBindings buffer_bindings(const tt::tt_metal::CoreCoord& core) const {
+        tt::tt_metal::KernelDescriptor::BufferBindings bindings;
+        uint32_t idx = 0;
+        for (auto* buffer :
+             {dram_.in, dram_.out, dram_.fwd, dram_.meta, dram_.counts, dram_.region, dram_.expert_offsets}) {
+            bindings.push_back(tt::tt_metal::BufferBinding{core, idx++, buffer});
+        }
+        return bindings;
+    }
+#else
+    ReaderRtArgs() :
+        dram_in(get_rt_arg(0)),
+        dram_out(get_rt_arg(1)),
+        dram_fwd(get_rt_arg(2)),
+        dram_meta(get_rt_arg(3)),
+        dram_counts(get_rt_arg(4)),
+        dram_region(get_rt_arg(5)),
+        dram_expert_offsets(get_rt_arg(6)) {}
+#endif
+
+#ifndef KERNEL_BUILD
+private:
+    // Held only to state the bindings above; the args themselves are the uint32_t fields.
+    const op::DramBuffers& dram_;
+#endif
+};
+
+}  // namespace cmbf2d

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
@@ -98,7 +98,7 @@ struct Dram {
 };
 
 Dram open_dram() {
-    const cmbf2d::ReaderRtArgs rt{};
+    const auto rt = cmbf2d::ReaderRtArgManager::get_rt_args();
     return Dram{
         TensorAccessor(ct.dram_in_args, rt.dram_in),
         TensorAccessor(ct.dram_out_args, rt.dram_out),

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
@@ -98,13 +98,13 @@ struct Dram {
 
 Dram open_dram() {
     return Dram{
-        TensorAccessor(ct.dram_in_args, ct.dram_in_base_addr),
-        TensorAccessor(ct.dram_out_args, ct.dram_out_base_addr),
-        TensorAccessor(ct.dram_fwd_args, ct.dram_fwd_base_addr),
-        TensorAccessor(ct.dram_meta_args, ct.dram_meta_base_addr),
-        TensorAccessor(ct.dram_counts_args, ct.dram_counts_base_addr),
-        TensorAccessor(ct.dram_region_args, ct.dram_region_base_addr),
-        TensorAccessor(ct.dram_expert_offsets_args, ct.dram_expert_offsets_base_addr)};
+        TensorAccessor(ct.dram_in_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_IN)),
+        TensorAccessor(ct.dram_out_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_OUT)),
+        TensorAccessor(ct.dram_fwd_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_FWD)),
+        TensorAccessor(ct.dram_meta_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_META)),
+        TensorAccessor(ct.dram_counts_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_COUNTS)),
+        TensorAccessor(ct.dram_region_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_REGION)),
+        TensorAccessor(ct.dram_expert_offsets_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_EXPERT_OFFSETS))};
 }
 
 // Where origin chip `row`'s tokens for expert `e` start, and where they end. The runs are laid out in

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
@@ -40,6 +40,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "combine_fabric2d_reader_ct_args.hpp"
+#include "combine_fabric2d_reader_rt_args.hpp"
 
 constexpr cmbf2d::ReaderCtArgs ct{};
 
@@ -97,14 +98,15 @@ struct Dram {
 };
 
 Dram open_dram() {
+    const cmbf2d::ReaderRtArgs rt{};
     return Dram{
-        TensorAccessor(ct.dram_in_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_IN)),
-        TensorAccessor(ct.dram_out_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_OUT)),
-        TensorAccessor(ct.dram_fwd_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_FWD)),
-        TensorAccessor(ct.dram_meta_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_META)),
-        TensorAccessor(ct.dram_counts_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_COUNTS)),
-        TensorAccessor(ct.dram_region_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_REGION)),
-        TensorAccessor(ct.dram_expert_offsets_args, get_arg_val<uint32_t>(cmbf2d::RDR_RT_DRAM_EXPERT_OFFSETS))};
+        TensorAccessor(ct.dram_in_args, rt.dram_in),
+        TensorAccessor(ct.dram_out_args, rt.dram_out),
+        TensorAccessor(ct.dram_fwd_args, rt.dram_fwd),
+        TensorAccessor(ct.dram_meta_args, rt.dram_meta),
+        TensorAccessor(ct.dram_counts_args, rt.dram_counts),
+        TensorAccessor(ct.dram_region_args, rt.dram_region),
+        TensorAccessor(ct.dram_expert_offsets_args, rt.dram_expert_offsets)};
 }
 
 // Where origin chip `row`'s tokens for expert `e` start, and where they end. The runs are laid out in


### PR DESCRIPTION
### PR Category - Bug Fix

### Summary
The bug in this op was that addresses of the used tensors were passed as CT args, so wherever they were allocated when the kernel was built those addresses got baked in the combine kernels which use them.
On the subsequent runs of the op, the kernel cache was hit, but the tensors were sometimes been allocated in different places. Kernels from the cache were, however, happily reading them from old, and now wrong addresses, causing all kinds of interesting bugs.

The fix is to move the tensor dram addresses to rt args. And while doing so, the PR also introduces a separate component which handles rt args serialization (on host side) and consistent deserialization on the kernel side.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dlukic/moe-combine-v2-dram-state-leak-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dlukic/moe-combine-v2-dram-state-leak-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dlukic/moe-combine-v2-dram-state-leak-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dlukic/moe-combine-v2-dram-state-leak-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dlukic/moe-combine-v2-dram-state-leak-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dlukic/moe-combine-v2-dram-state-leak-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dlukic/moe-combine-v2-dram-state-leak-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dlukic/moe-combine-v2-dram-state-leak-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dlukic/moe-combine-v2-dram-state-leak-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dlukic/moe-combine-v2-dram-state-leak-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dlukic/moe-combine-v2-dram-state-leak-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dlukic/moe-combine-v2-dram-state-leak-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dlukic/moe-combine-v2-dram-state-leak-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dlukic/moe-combine-v2-dram-state-leak-fix)