### PR TITLE
fix(eltwise): overflow-safe logaddexp/logaddexp2 via composite reformulation

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -287,6 +287,41 @@ def test_logaddexp2_fp32(device, ttnn_function):
     assert status
 
 
+@pytest.mark.parametrize("ttnn_function", [ttnn.logaddexp, ttnn.logaddexp2])
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_logaddexp_overflow_safe(device, ttnn_function, dtype):
+    # Regression for #52037: log(exp(a) + exp(b)) saturates for |a| or |b| > ~88.7
+    # and returns inf/-inf although the exact result is always finite.
+    # The sweep must sample past the saturation point on both sides.
+    pairs = [
+        (100.0, 0.0),      # exact: 100
+        (89.0, 0.0),       # exact: 89
+        (90.0, 89.0),      # exact: ~90.313
+        (100.0, 100.0),    # exact: 100 + ln2 (base e) / 101 (base 2)
+        (200.0, 199.0),    # exact: ~200.313
+        (-100.0, -100.0),  # exact: ~-99.307 (base e) / -99 (base 2)
+        (1000.0, 999.0),   # exact: ~1000.313
+        (1e4, -1e4),       # exact: 1e4
+        (-1e4, 1e4),       # exact: 1e4
+        (88.0, 0.0),       # in-range regression check
+        (0.0, 0.0),        # exact: ln2 (base e) / 1 (base 2)
+    ]
+    x_torch = torch.tensor([p[0] for p in pairs], dtype=torch.float32)
+    y_torch = torch.tensor([p[1] for p in pairs], dtype=torch.float32)
+    golden_fn = ttnn.get_golden_function(ttnn_function)
+    z_torch = golden_fn(x_torch, y_torch)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    z_tt_out = ttnn_function(x_tt, y_tt)
+    tt_out = ttnn.to_torch(z_tt_out)
+
+    # Finite inputs must produce finite outputs; inf/-inf here is always wrong.
+    assert torch.isfinite(tt_out).all(), f"{ttnn_function} produced non-finite output: {tt_out}"
+    status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
+    assert status
+
+
 @pytest.mark.parametrize(
     "ttnn_function",
     [

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -9,10 +9,16 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/repeat/repeat.hpp"
+#include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp"
+#include "ttnn/operations/eltwise/ternary/ternary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/operations/core/core.hpp"
+
+#include <variant>
+#include <vector>
 
 // Implementation macros for binary operations (must match declarations in binary.hpp)
 #define TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(NAME, OP_TYPE)                             \
@@ -1137,12 +1143,247 @@ TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(logical_xor, LOGICAL_XOR)
 TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(ldexp, LDEXP)
 TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(ldexp, LDEXP)
 TTNN_BINARY_OP_INPLACE_IMPL(ldexp_, LDEXP)
-TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(logaddexp, LOGADDEXP)
-TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(logaddexp, LOGADDEXP)
-TTNN_BINARY_OP_INPLACE_IMPL(logaddexp_, LOGADDEXP)
-TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(logaddexp2, LOGADDEXP2)
-TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(logaddexp2, LOGADDEXP2)
-TTNN_BINARY_OP_INPLACE_IMPL(logaddexp2_, LOGADDEXP2)
+// Overflow-safe logaddexp/logaddexp2 (see #52037).
+//
+// The fused pipeline composes these as log(exp(a) + exp(b)), so exp() saturates
+// for |a| or |b| above ~88.7 and the op returns inf even though the exact result
+// is bounded by max(a, b) + ln 2. The reformulation keeps every intermediate in
+// range:
+//
+//   logaddexp(a, b)  = max(a, b) + log1p(exp(-|a - b|))
+//   logaddexp2(a, b) = max(a, b) + log1p(exp2(-|a - b|)) * (1 / ln 2)
+//
+// -|a - b| <= 0, so the exp term stays in (0, 1] and cannot overflow; the result
+// inherits its magnitude from max(a, b). log1p (rather than log(1 + x)) preserves
+// the correction term when |a - b| is large and exp(-|a - b|) underflows toward 0.
+// When a == b == +-inf the difference is NaN, so the |a - b| path is bypassed and
+// max(a, b) is returned, matching torch.
+namespace {
+
+Tensor logaddexp_apply_activations(
+    const Tensor& input,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> activations,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    if (activations.empty()) {
+        return input;
+    }
+    return operations::unary::detail::unary_impl(
+        input,
+        std::vector<operations::unary::EltwiseUnaryWithParam>(activations.begin(), activations.end()),
+        std::nullopt,
+        std::nullopt,
+        sub_core_grids);
+}
+
+Tensor logaddexp_composite(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    bool base2) {
+    Tensor a = logaddexp_apply_activations(lhs, lhs_activations, sub_core_grids);
+    Tensor b = logaddexp_apply_activations(rhs, rhs_activations, sub_core_grids);
+
+    Tensor max_ab = ttnn::maximum(a, b);
+    Tensor neg_abs_diff = ttnn::neg(ttnn::abs(ttnn::subtract(a, b)));
+    Tensor correction =
+        base2 ? ttnn::multiply(
+                    ttnn::log1p(ttnn::exp2(neg_abs_diff)), operations::unary::ScalarVariant{1.4426950408889634f})
+                : ttnn::log1p(ttnn::exp(neg_abs_diff));
+    Tensor composite = ttnn::add(max_ab, correction, output_dtype);
+
+    // |a - b| is NaN when a == b == +-inf; return max(a, b) there, matching torch.
+    Tensor same_inf = ttnn::logical_and(ttnn::eq(a, b), ttnn::isinf(a));
+    Tensor result = ttnn::where(
+        same_inf,
+        max_ab,
+        composite,
+        memory_config,
+        post_activations.empty() ? output : std::optional<Tensor>{},
+        sub_core_grids);
+    if (!post_activations.empty()) {
+        result = operations::unary::detail::unary_impl(
+            result,
+            std::vector<operations::unary::EltwiseUnaryWithParam>(post_activations.begin(), post_activations.end()),
+            memory_config,
+            output,
+            sub_core_grids);
+    }
+    return result;
+}
+
+}  // namespace
+
+Tensor logaddexp(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return logaddexp_composite(
+        lhs,
+        rhs,
+        output_dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        sub_core_grids,
+        /*base2=*/false);
+}
+
+Tensor logaddexp(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    Tensor rhs_tensor = std::visit(
+        [&](auto value) { return ttnn::full_like(lhs, static_cast<float>(value)); }, rhs);
+    return logaddexp_composite(
+        lhs,
+        rhs_tensor,
+        output_dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        sub_core_grids,
+        /*base2=*/false);
+}
+
+Tensor logaddexp_(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return logaddexp_composite(
+        lhs,
+        rhs,
+        std::nullopt,
+        std::nullopt,
+        lhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        sub_core_grids,
+        /*base2=*/false);
+}
+
+Tensor logaddexp_(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return logaddexp(
+        lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, sub_core_grids, sub_device_id);
+}
+
+Tensor logaddexp2(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return logaddexp_composite(
+        lhs,
+        rhs,
+        output_dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        sub_core_grids,
+        /*base2=*/true);
+}
+
+Tensor logaddexp2(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    Tensor rhs_tensor = std::visit(
+        [&](auto value) { return ttnn::full_like(lhs, static_cast<float>(value)); }, rhs);
+    return logaddexp_composite(
+        lhs,
+        rhs_tensor,
+        output_dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        sub_core_grids,
+        /*base2=*/true);
+}
+
+Tensor logaddexp2_(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return logaddexp_composite(
+        lhs,
+        rhs,
+        std::nullopt,
+        std::nullopt,
+        lhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        sub_core_grids,
+        /*base2=*/true);
+}
+
+Tensor logaddexp2_(
+    const Tensor& lhs,
+    operations::unary::ScalarVariant rhs,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    return logaddexp2(
+        lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, sub_core_grids, sub_device_id);
+}
 TTNN_BINARY_OP_TENSOR_TENSOR_IMPL(squared_difference, SQUARED_DIFFERENCE)
 TTNN_BINARY_OP_TENSOR_SCALAR_IMPL(squared_difference, SQUARED_DIFFERENCE)
 TTNN_BINARY_OP_INPLACE_IMPL(squared_difference_, SQUARED_DIFFERENCE)


### PR DESCRIPTION
## Summary

`ttnn.logaddexp` / `ttnn.logaddexp2` are composed as `log(exp(a) + exp(b))`, so `exp()` saturates once `|a|` or `|b|` exceeds ~88.7 and the ops return `inf` even though the exact result is always finite and bounded by `max(a, b) + ln 2` (see #52037 for the full write-up).

This PR replaces the public ops with the standard overflow-safe identity, composed from existing primitives:

    logaddexp(a, b)  = max(a, b) + log1p(exp(-|a - b|))
    logaddexp2(a, b) = max(a, b) + log1p(exp2(-|a - b|)) * (1 / ln 2)

`-|a - b| <= 0`, so the exp term stays in `(0, 1]` and cannot overflow; the result inherits its magnitude from `max(a, b)`. `log1p` (rather than `log(1 + x)`) preserves the correction term when `|a - b|` is large and the exp term underflows toward zero. When `a == b == ±inf` the difference is NaN, so the `|a - b|` path is bypassed via `where` and `max(a, b)` is returned, matching torch.

`lhs_activations` / `rhs_activations` / `post_activations` are applied through the existing unary chain helper, and the tensor-scalar overloads materialize the scalar via `full_like` so both paths share one implementation. The `BinaryOpType::LOGADDEXP`/`LOGADDEXP2` fused mappings remain for any direct `invoke_binary_ng` use, but the public ops no longer route through them.

Trade-off deliberately taken (the issue leaves this open): this is a composite of ~7 primitive ops instead of one fused kernel — more launches, but correct across the whole range. A dedicated fused SFPU tile op can be layered in later if the perf matters.

#### Test plan

- [x] New regression test `test_logaddexp_overflow_safe` sweeps both ops in fp32 + bf16 across `(±100, ±200, ±1000, ±1e4)` pairs that previously returned `inf`, plus in-range and equal-input cases — asserts `isfinite` on all outputs and PCC >= 0.999 vs the golden
- [ ] CI on Wormhole/Blackhole (no local hardware — relying on CI for device verification)

Fixes #52037

Generated with [Devin](https://devin.ai)
