### PR TITLE
Refactoring failure/warning reporting data in tt-triage

### DIFF
--- a/tools/tests/triage/test_sqlite_serializer.py
+++ b/tools/tests/triage/test_sqlite_serializer.py
@@ -12,7 +12,6 @@ import sys
 
 import pytest
 
-
 metal_home = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 triage_home = os.path.join(metal_home, "tools", "triage")
 sys.path.insert(0, triage_home)
@@ -27,7 +26,37 @@ from sqlite_serializer import (
     _sql_value,
     quote_identifier,
 )
-from triage import hex_serializer, recurse_field, triage_field
+from triage import CheckEntry, CheckType, hex_serializer, recurse_field, triage_field
+
+
+class FakeNocBlock:
+    def __init__(self, block_type: str):
+        self.block_type = block_type
+
+
+class FakeDevice:
+    def __init__(self, id: int):
+        self.id = id
+
+
+class FakeLocation:
+    """Stand-in for an `OnChipCoordinate`, which needs a real device to build."""
+
+    def __init__(self, device: FakeDevice, block_type: str, user_str: str):
+        self.device = device
+        self.noc_block = FakeNocBlock(block_type)
+        self._user_str = user_str
+
+    def to_user_str(self) -> str:
+        return self._user_str
+
+
+def error(message, device=None, location=None, risc_name=None):
+    return CheckEntry(message, CheckType.ERROR, device=device, location=location, risc_name=risc_name)
+
+
+def warning(message, device=None, location=None, risc_name=None):
+    return CheckEntry(message, CheckType.WARNING, device=device, location=location, risc_name=risc_name)
 
 
 @dataclass
@@ -67,8 +96,7 @@ def write(path, script_name, result, **kwargs):
         script_name=script_name,
         execution_time="",
         result=result,
-        failures=kwargs.get("failures", []),
-        warnings=kwargs.get("warnings", []),
+        checks=kwargs.get("checks", []),
         script_failed=kwargs.get("script_failed", False),
         failure_message=kwargs.get("failure_message"),
         documentation=None,
@@ -165,20 +193,57 @@ def test_diagnostics_table_exists_even_when_empty(tmp_path):
 
 
 def test_check_only_script_records_diagnostics_but_no_table(tmp_path):
+    device0 = FakeDevice(0)
     con = write(
         tmp_path / "t.db",
         "check_noc_status.py",
         None,
-        failures=["Device 0: tensix [1-1 (0,0)]: brisc: [error]NOC0 mismatch[/]"],
-        warnings=["Device 1: skipping"],
+        checks=[
+            error(
+                "[error]NOC0 mismatch[/]",
+                device=device0,
+                location=FakeLocation(device0, "tensix", "1-1 (0,0)"),
+                risc_name="brisc",
+            ),
+            warning("skipping", device=FakeDevice(1)),
+        ],
     )
     tables = [row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")]
     assert tables == [DIAGNOSTICS_TABLE]
-    rows = con.execute(f'SELECT "Script", "Severity", "Message" FROM {quote_identifier(DIAGNOSTICS_TABLE)}').fetchall()
+    rows = con.execute(f"SELECT * FROM {quote_identifier(DIAGNOSTICS_TABLE)}").fetchall()
     assert rows == [
-        ("check_noc_status.py", "failure", "Device 0: tensix [1-1 (0,0)]: brisc: NOC0 mismatch"),
-        ("check_noc_status.py", "warning", "Device 1: skipping"),
+        ("check_noc_status.py", "error", 0, "1-1 (0,0)", "brisc", "NOC0 mismatch"),
+        ("check_noc_status.py", "warning", 1, None, None, "skipping"),
     ]
+
+
+def test_diagnostics_columns_are_the_reported_context(tmp_path):
+    con = write(tmp_path / "t.db", "check_l1_status.py", None, checks=[error("no context here")])
+    names = [row[1] for row in con.execute(f"PRAGMA table_info({quote_identifier(DIAGNOSTICS_TABLE)})")]
+    assert names == ["Script", "Type", "Device", "Location", "RISC", "Message"]
+    # Only `message` is required, so the context columns are NULL when unreported.
+    assert con.execute(f"SELECT * FROM {quote_identifier(DIAGNOSTICS_TABLE)}").fetchall() == [
+        ("check_l1_status.py", "error", None, None, None, "no context here")
+    ]
+
+
+def test_same_message_from_many_cores_groups_into_one_row(tmp_path):
+    # The point of splitting the context out of the message: a report repeated
+    # across cores collapses to a single row.
+    device = FakeDevice(0)
+    con = write(
+        tmp_path / "t.db",
+        "check_core_magic.py",
+        None,
+        checks=[
+            error("Magic value mismatch", device=device, location=FakeLocation(device, "tensix", f"1-{x} (0,{x})"))
+            for x in range(5)
+        ],
+    )
+    grouped = con.execute(
+        f'SELECT "Message", count(*) FROM {quote_identifier(DIAGNOSTICS_TABLE)} GROUP BY "Message"'
+    ).fetchall()
+    assert grouped == [("Magic value mismatch", 5)]
 
 
 def test_failed_script_is_recorded_as_error(tmp_path):
@@ -189,7 +254,7 @@ def test_failed_script_is_recorded_as_error(tmp_path):
         script_failed=True,
         failure_message="Skipped: dependency inspector_data.py failed.",
     )
-    rows = con.execute(f'SELECT "Severity", "Message" FROM {quote_identifier(DIAGNOSTICS_TABLE)}').fetchall()
+    rows = con.execute(f'SELECT "Type", "Message" FROM {quote_identifier(DIAGNOSTICS_TABLE)}').fetchall()
     assert rows == [("error", "Skipped: dependency inspector_data.py failed.")]
 
 
@@ -218,17 +283,19 @@ def test_record_diagnostics_without_a_result(tmp_path):
     # through record_diagnostics rather than emit.
     path = tmp_path / "t.db"
     serializer = SqliteSerializer(str(path), lambda: 0)
-    serializer.record_diagnostics("inspector_data.py", [], [], True, "Inspector unavailable")
-    serializer.record_diagnostics("dump_configuration.py", [], [], True, "Skipped: dependency failed.")
-    serializer.record_diagnostics("dispatcher_data.py", [], ["Device 0: no rank"], False, None)
+    serializer.record_diagnostics("inspector_data.py", [], True, "Inspector unavailable")
+    serializer.record_diagnostics("dump_configuration.py", [], True, "Skipped: dependency failed.")
+    serializer.record_diagnostics("dispatcher_data.py", [warning("no rank", device=FakeDevice(0))], False, None)
     serializer.close()
 
     con = sqlite3.connect(str(path))
-    rows = con.execute(f'SELECT "Script", "Severity", "Message" FROM {quote_identifier(DIAGNOSTICS_TABLE)}').fetchall()
+    rows = con.execute(
+        f'SELECT "Script", "Type", "Device", "Message" FROM {quote_identifier(DIAGNOSTICS_TABLE)}'
+    ).fetchall()
     assert rows == [
-        ("inspector_data.py", "error", "Inspector unavailable"),
-        ("dump_configuration.py", "error", "Skipped: dependency failed."),
-        ("dispatcher_data.py", "warning", "Device 0: no rank"),
+        ("inspector_data.py", "error", None, "Inspector unavailable"),
+        ("dump_configuration.py", "error", None, "Skipped: dependency failed."),
+        ("dispatcher_data.py", "warning", 0, "no rank"),
     ]
     # no script produced rows, so the only table is diagnostics
     tables = [row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")]
@@ -238,7 +305,7 @@ def test_record_diagnostics_without_a_result(tmp_path):
 def test_record_diagnostics_with_nothing_to_record(tmp_path):
     path = tmp_path / "t.db"
     serializer = SqliteSerializer(str(path), lambda: 0)
-    serializer.record_diagnostics("elfs_cache.py", [], [], False, None)
+    serializer.record_diagnostics("elfs_cache.py", [], False, None)
     serializer.close()
     con = sqlite3.connect(str(path))
     assert con.execute(f"SELECT count(*) FROM {quote_identifier(DIAGNOSTICS_TABLE)}").fetchone()[0] == 0
@@ -248,7 +315,7 @@ def test_multiple_scripts_share_one_database(tmp_path):
     path = tmp_path / "t.db"
     serializer = SqliteSerializer(str(path), lambda: 0)
     for script in ("check_arc.py", "device_info.py"):
-        serializer.emit(script, "", [Row("matmul", 1, 1.0, True)], [], [], False, None, None)
+        serializer.emit(script, "", [Row("matmul", 1, 1.0, True)], [], False, None, None)
     serializer.close()
     con = sqlite3.connect(str(path))
     tables = sorted(row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'"))

--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -25,13 +25,19 @@ sys.path.insert(0, triage_home)
 
 
 import triage
-from triage import run_script, FAILURE_CHECKS, ScriptArguments
+from triage import CheckType, run_script, ScriptArguments
 from ttexalens.context import Context
 from ttexalens.tt_exalens_init import init_ttexalens
 from ttexalens.coordinate import OnChipCoordinate
 
 
 triage.progress_disabled = True  # Disable progress bars for tests
+
+
+def logged_errors() -> list[str]:
+    """The failed checks reported so far, formatted the way triage prints them."""
+    return [check.formatted_message for check in triage.CHECKS if check.type is CheckType.ERROR]
+
 
 # Mapping of hang application paths to their expected test results
 HANG_APP_ADD_2_INTEGERS = "tools/tests/triage/hang_apps/add_2_integers_hang/triage_hang_app_add_2_integers_hang"
@@ -390,10 +396,8 @@ class TestTriage:
     def test_check_noc_status(self):
         self.run_triage_script("check_noc_status.py", assert_failure_checks=False)
 
-        global FAILURE_CHECKS
-
         # Some mismatches may occur on unused cores.
-        non_state_failures = [failure for failure in FAILURE_CHECKS if "Mismatched state" not in failure]
+        non_state_failures = [failure for failure in logged_errors() if "Mismatched state" not in failure]
         assert (
             len(non_state_failures) == 0
         ), f"Check NOC status check failed with {len(non_state_failures)} failures: {non_state_failures}"
@@ -632,9 +636,8 @@ class TestTriage:
         assert_failure_checks: bool = True,
     ):
         global triage_home
-        global FAILURE_CHECKS
 
-        FAILURE_CHECKS.clear()
+        triage.CHECKS.clear()
         result = run_script(
             script_path=os.path.join(triage_home, script_name),
             args=args,
@@ -644,9 +647,8 @@ class TestTriage:
         )
 
         if assert_failure_checks:
-            assert (
-                len(FAILURE_CHECKS) == 0
-            ), f"{script_name} failed with {len(FAILURE_CHECKS)} failures: {FAILURE_CHECKS}"
+            failures = logged_errors()
+            assert len(failures) == 0, f"{script_name} failed with {len(failures)} failures: {failures}"
 
         return result
 
@@ -669,16 +671,16 @@ class TestMeshSocketTriage:
 
     def test_dump_mesh_sockets(self):
         global triage_home
-        global FAILURE_CHECKS
 
-        FAILURE_CHECKS.clear()
+        triage.CHECKS.clear()
         result = run_script(
             script_path=os.path.join(triage_home, "dump_mesh_sockets.py"),
             context=self.exalens_context,
             argv=[],
             return_result=True,
         )
-        assert not FAILURE_CHECKS, f"dump_mesh_sockets.py failed with: {FAILURE_CHECKS}"
+        failures = logged_errors()
+        assert not failures, f"dump_mesh_sockets.py failed with: {failures}"
         assert result is not None, "Expected socket rows while MeshSockets are wedged"
 
         rows = [check.result for check in result]

--- a/tools/triage/serializers.py
+++ b/tools/triage/serializers.py
@@ -22,6 +22,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Any, Callable, Iterable
 
+from triage import CheckEntry, CheckType
+
 
 @dataclass
 class TableData:
@@ -98,6 +100,11 @@ def extract_table_data(result: Any, verbose_level: int = 0) -> TableData | None:
     return TableData(columns=columns, rows=rows, unserialized_values=unserialized_values)
 
 
+def formatted_messages(checks: Iterable[CheckEntry], check_type: CheckType) -> list[str]:
+    """The formatted messages of every entry of one type, in report order."""
+    return [check.formatted_message for check in checks if check.type is check_type]
+
+
 class OutputSerializer(ABC):
     """Turns one script's result into output. Subclasses pick the format
     (Rich tables, CSV, future JSON, …). The *destination* is handled by a
@@ -109,8 +116,7 @@ class OutputSerializer(ABC):
         script_name: str | None,
         execution_time: str,
         result: Any,
-        failures: list[str],
-        warnings: list[str],
+        checks: list[CheckEntry],
         script_failed: bool,
         failure_message: str | None,
         documentation: str | None,
@@ -120,8 +126,7 @@ class OutputSerializer(ABC):
     def record_diagnostics(
         self,
         script_name: str,
-        failures: list[str],
-        warnings: list[str],
+        checks: list[CheckEntry],
         script_failed: bool,
         failure_message: str | None,
     ) -> None:
@@ -192,8 +197,7 @@ class RichSerializer(OutputSerializer):
         script_name: str | None,
         execution_time: str,
         result: Any,
-        failures: list[str],
-        warnings: list[str],
+        checks: list[CheckEntry],
         script_failed: bool,
         failure_message: str | None,
         documentation: str | None,
@@ -201,6 +205,9 @@ class RichSerializer(OutputSerializer):
         from rich.table import Table
 
         utils = self._utils
+        failures = formatted_messages(checks, CheckType.ERROR)
+        warnings = formatted_messages(checks, CheckType.WARNING)
+
         if script_name is not None:
             print()
             utils.INFO(f"{script_name}{execution_time}:")
@@ -297,12 +304,14 @@ class CsvSerializer(OutputSerializer):
         script_name: str | None,
         execution_time: str,
         result: Any,
-        failures: list[str],
-        warnings: list[str],
+        checks: list[CheckEntry],
         script_failed: bool,
         failure_message: str | None,
         documentation: str | None,
     ) -> None:
+        failures = formatted_messages(checks, CheckType.ERROR)
+        warnings = formatted_messages(checks, CheckType.WARNING)
+
         if script_name is not None:
             self._print()
             self._print(f"{script_name}{execution_time}:")
@@ -353,8 +362,7 @@ class MultiSerializer(OutputSerializer):
         script_name: str | None,
         execution_time: str,
         result: Any,
-        failures: list[str],
-        warnings: list[str],
+        checks: list[CheckEntry],
         script_failed: bool,
         failure_message: str | None,
         documentation: str | None,
@@ -364,8 +372,7 @@ class MultiSerializer(OutputSerializer):
                 script_name=script_name,
                 execution_time=execution_time,
                 result=result,
-                failures=failures,
-                warnings=warnings,
+                checks=checks,
                 script_failed=script_failed,
                 failure_message=failure_message,
                 documentation=documentation,
@@ -374,13 +381,12 @@ class MultiSerializer(OutputSerializer):
     def record_diagnostics(
         self,
         script_name: str,
-        failures: list[str],
-        warnings: list[str],
+        checks: list[CheckEntry],
         script_failed: bool,
         failure_message: str | None,
     ) -> None:
         for s in self._serializers:
-            s.record_diagnostics(script_name, failures, warnings, script_failed, failure_message)
+            s.record_diagnostics(script_name, checks, script_failed, failure_message)
 
     def close(self) -> None:
         for s in self._serializers:

--- a/tools/triage/sqlite_serializer.py
+++ b/tools/triage/sqlite_serializer.py
@@ -10,8 +10,10 @@ Each script's output becomes one table, named after the script, with a row per
 result and a column per displayed field. Columns are INTEGER, REAL or TEXT,
 chosen from the values the script produced.
 
-A shared `diagnostics` table collects the check failures, warnings and script
-errors reported alongside those results.
+A shared `diagnostics` table collects the errors and warnings reported alongside
+those results. The reporting context is kept in its own columns (`Device`,
+`Location`, `RISC`) instead of being prefixed onto `Message`, so the same report
+from many cores groups into one row with `GROUP BY "Message"`.
 """
 
 from __future__ import annotations
@@ -20,6 +22,7 @@ import os
 import sqlite3
 from typing import Any, Callable, Iterable
 
+from triage import CheckEntry, CheckType
 from serializers import OutputSerializer, strip_rich_markup, extract_table_data
 
 
@@ -100,6 +103,14 @@ def _column_type(values: Iterable[Any]) -> str:
 
 
 DIAGNOSTICS_TABLE = "diagnostics"
+DIAGNOSTICS_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("Script", "TEXT NOT NULL"),
+    ("Type", "TEXT NOT NULL"),
+    ("Device", "INTEGER"),
+    ("Location", "TEXT"),
+    ("RISC", "TEXT"),
+    ("Message", "TEXT NOT NULL"),
+)
 
 
 class SqliteSerializer(OutputSerializer):
@@ -116,24 +127,21 @@ class SqliteSerializer(OutputSerializer):
         self._verbose_getter = verbose_level_getter
         self._con = sqlite3.connect(path)
         # Created up front so it can always be queried, even on a clean run.
-        self._con.execute(
-            f"CREATE TABLE {quote_identifier(DIAGNOSTICS_TABLE)} "
-            f'("Script" TEXT NOT NULL, "Severity" TEXT NOT NULL, "Message" TEXT NOT NULL)'
-        )
+        spec = ", ".join(f"{quote_identifier(name)} {declared_type}" for name, declared_type in DIAGNOSTICS_COLUMNS)
+        self._con.execute(f"CREATE TABLE {quote_identifier(DIAGNOSTICS_TABLE)} ({spec})")
 
     def emit(
         self,
         script_name: str | None,
         execution_time: str,
         result: Any,
-        failures: list[str],
-        warnings: list[str],
+        checks: list[CheckEntry],
         script_failed: bool,
         failure_message: str | None,
         documentation: str | None,
     ) -> None:
         assert script_name is not None, "cannot serialize a result without a script name"
-        self._insert_diagnostics(script_name, failures, warnings, script_failed, failure_message)
+        self._insert_diagnostics(script_name, checks, script_failed, failure_message)
 
         table_data = extract_table_data(result, self._verbose_getter())
         if table_data is None or not table_data.rows:
@@ -166,32 +174,40 @@ class SqliteSerializer(OutputSerializer):
     def record_diagnostics(
         self,
         script_name: str,
-        failures: list[str],
-        warnings: list[str],
+        checks: list[CheckEntry],
         script_failed: bool,
         failure_message: str | None,
     ) -> None:
-        self._insert_diagnostics(script_name, failures, warnings, script_failed, failure_message)
+        self._insert_diagnostics(script_name, checks, script_failed, failure_message)
         self._con.commit()
 
     def _insert_diagnostics(
         self,
         script_name: str,
-        failures: list[str],
-        warnings: list[str],
+        checks: list[CheckEntry],
         script_failed: bool,
         failure_message: str | None,
     ) -> None:
-        rows = [(script_name, "failure", message) for message in failures]
-        rows += [(script_name, "warning", message) for message in warnings]
+        rows: list[tuple[Any, ...]] = [
+            (
+                script_name,
+                check.type.value,
+                check.device_id,
+                check.location_str,
+                check.risc_name,
+                strip_rich_markup(check.message),
+            )
+            for check in checks
+        ]
         if script_failed:
-            rows.append((script_name, "error", failure_message or "script failed"))
+            # A script that raised (or was skipped) reports no context of its own.
+            message = strip_rich_markup(failure_message or "script failed")
+            rows.append((script_name, CheckType.ERROR.value, None, None, None, message))
         if not rows:
             return
-        self._con.executemany(
-            f"INSERT INTO {quote_identifier(DIAGNOSTICS_TABLE)} VALUES (?, ?, ?)",
-            [(script, severity, strip_rich_markup(message)) for script, severity, message in rows],
-        )
+        names = ", ".join(quote_identifier(name) for name, _ in DIAGNOSTICS_COLUMNS)
+        marks = ", ".join("?" for _ in DIAGNOSTICS_COLUMNS)
+        self._con.executemany(f"INSERT INTO {quote_identifier(DIAGNOSTICS_TABLE)} ({names}) VALUES ({marks})", rows)
 
     def close(self) -> None:
         try:

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -28,7 +28,7 @@ Options:
     --triage-summary-path=<path>          Write a triage summary file to the given path (used by CI for hang reports).
     --llm-output                          Replace Rich tables on the console with a machine-readable report (CSV-formatted tables). Easier and cheaper for LLMs (and grep/CI) to consume. Implies --disable-colors.
     --llm-output-path=<path>              Additionally write the machine-readable report to <path>. Can be combined with --llm-output; without it, Rich output still goes to the console.
-    --sqlite-output-path=<path>           Additionally write a SQLite database to <path>, with one table per script that returns non-empty tabular data; check-only output is stored in the diagnostics table.
+    --sqlite-output-path=<path>           Additionally write a SQLite database to <path>, with one table per script that returns non-empty tabular data; reported errors and warnings go to the diagnostics table.
     --additional-scripts-directory=<dir>  Discover triage scripts in <dir> too. Repeat for several directories. Scripts are imported by module name, so file names there must not repeat a file name used in tools/triage.
 
 Description:
@@ -666,58 +666,102 @@ def parse_arguments(
     raise DocoptExit()
 
 
-FAILURE_CHECKS_LOCK = threading.Lock()
-FAILURE_CHECKS: list[str] = []
+class CheckType(Enum):
+    ERROR = "error"
+    WARNING = "warning"
+
+
+@dataclass
+class CheckEntry:
+    message: str
+    type: CheckType
+    device: Device | None = None
+    location: OnChipCoordinate | None = None
+    risc_name: str | None = None
+
+    @property
+    def device_id(self) -> int | None:
+        return self.device.id if self.device is not None else None
+
+    @property
+    def location_str(self) -> str | None:
+        return self.location.to_user_str() if self.location is not None else None
+
+    @property
+    def block_type(self) -> str | None:
+        return self.location.noc_block.block_type if self.location is not None else None
+
+    @property
+    def formatted_message(self) -> str:
+        prefix = ""
+        if self.device is not None:
+            prefix += f"Device {self.device.id}: "
+        if self.location is not None:
+            prefix += f"{self.block_type} [{self.location_str}]: "
+        if self.risc_name is not None:
+            prefix += f"{self.risc_name}: "
+        return f"{prefix}{self.message}"
+
+
+CHECKS_LOCK = threading.Lock()
+CHECKS: list[CheckEntry] = []
+
+
+def log_entry(entry: CheckEntry) -> None:
+    with CHECKS_LOCK:
+        CHECKS.append(entry)
 
 
 def log_check(success: bool, message: str) -> None:
-    global FAILURE_CHECKS, FAILURE_CHECKS_LOCK
     if not success:
-        with FAILURE_CHECKS_LOCK:
-            FAILURE_CHECKS.append(message)
+        log_entry(CheckEntry(message=message, type=CheckType.ERROR))
 
 
 def log_check_device(device: Device, success: bool, message: str) -> None:
-    formatted_message = f"Device {device.id}: {message}"
-    log_check(success, formatted_message)
+    if not success:
+        log_entry(CheckEntry(message=message, type=CheckType.ERROR, device=device))
 
 
 def log_check_location(location: OnChipCoordinate, success: bool, message: str) -> None:
-    device = location.device
-    block_type = location.noc_block.block_type
-    location_str = location.to_user_str()
-    formatted_message = f"{block_type} [{location_str}]: {message}"
-    log_check_device(device, success, formatted_message)
+    if not success:
+        log_entry(CheckEntry(message=message, type=CheckType.ERROR, device=location.device, location=location))
 
 
 def log_check_risc(risc_name: str, location: OnChipCoordinate, success: bool, message: str) -> None:
-    formatted_message = f"{risc_name}: {message}"
-    log_check_location(location, success, formatted_message)
-
-
-WARNING_CHECKS_LOCK = threading.Lock()
-WARNING_CHECKS: list[str] = []
+    if not success:
+        log_entry(
+            CheckEntry(
+                message=message,
+                type=CheckType.ERROR,
+                device=location.device,
+                location=location,
+                risc_name=risc_name,
+            )
+        )
 
 
 def log_warning(message: str) -> None:
-    global WARNING_CHECKS, WARNING_CHECKS_LOCK
-    with WARNING_CHECKS_LOCK:
-        WARNING_CHECKS.append(message)
+    log_entry(CheckEntry(message=message, type=CheckType.WARNING))
 
 
 def log_warning_device(device: Device, message: str) -> None:
-    log_warning(f"Device {device.id}: {message}")
+    log_entry(CheckEntry(message=message, type=CheckType.WARNING, device=device))
 
 
 def log_warning_location(location: OnChipCoordinate, message: str) -> None:
-    device = location.device
-    block_type = location.noc_block.block_type
-    location_str = location.to_user_str()
-    log_warning_device(device, f"{block_type} [{location_str}]: {message}")
+    log_entry(CheckEntry(message=message, type=CheckType.WARNING, device=location.device, location=location))
 
 
 def log_warning_risc(risc_name: str, location: OnChipCoordinate, message: str) -> None:
-    log_warning_location(location, f"{risc_name}: {message}")
+    log_entry(
+        CheckEntry(
+            message=message,
+            type=CheckType.WARNING,
+            device=location.device,
+            location=location,
+            risc_name=risc_name,
+        )
+    )
 
 
 _output_serializer: Any = None
@@ -789,20 +833,15 @@ def init_output_serializer(args: ScriptArguments) -> None:
 
 
 def serialize_result(script: TriageScript | None, result, execution_time: str = ""):
-    global FAILURE_CHECKS, FAILURE_CHECKS_LOCK, WARNING_CHECKS, WARNING_CHECKS_LOCK
-    with FAILURE_CHECKS_LOCK:
-        failures = FAILURE_CHECKS
-        FAILURE_CHECKS = []
-    with WARNING_CHECKS_LOCK:
-        warnings = WARNING_CHECKS
-        WARNING_CHECKS = []
-
+    global CHECKS
+    with CHECKS_LOCK:
+        checks = CHECKS
+        CHECKS = []
     get_output_serializer().emit(
         script_name=script.name if script is not None else None,
         execution_time=execution_time,
         result=result,
-        failures=failures,
-        warnings=warnings,
+        checks=checks,
         script_failed=script.failed if script is not None else False,
         failure_message=script.failure_message if script is not None else None,
         documentation=script.documentation if script is not None else None,
@@ -810,18 +849,13 @@ def serialize_result(script: TriageScript | None, result, execution_time: str = 
 
 
 def record_diagnostics(script: TriageScript) -> None:
-    global FAILURE_CHECKS, WARNING_CHECKS
-    with FAILURE_CHECKS_LOCK:
-        failures = FAILURE_CHECKS
-        FAILURE_CHECKS = []
-    with WARNING_CHECKS_LOCK:
-        warnings = WARNING_CHECKS
-        WARNING_CHECKS = []
-
+    global CHECKS
+    with CHECKS_LOCK:
+        checks = CHECKS
+        CHECKS = []
     get_output_serializer().record_diagnostics(
         script_name=script.name,
-        failures=failures,
-        warnings=warnings,
+        checks=checks,
         script_failed=script.failed,
         failure_message=script.failure_message,
     )

--- a/tools/triage/tt-triage.md
+++ b/tools/triage/tt-triage.md
@@ -50,7 +50,9 @@ If a data provider script fails, all scripts that depend on it will also fail.
 
 A state checker script can only check state (see `check_noc_locations` for an example), or it can perform checks and return data as well (see `check_arc` for an example).
 
-To log a check failure but continue execution, use the `log_check` method. It will log failures after the script has finished executing.
+To log a check failure but continue execution, use the `log_check` method. It will log failures after the script has finished executing. `log_warning` does the same for something worth noting that is not a failure.
+
+Both come in variants that take the context the check ran against - `log_check_device` / `log_check_location` / `log_check_risc` and the matching `log_warning_*`. Pass the context as those arguments rather than formatting it into the message.
 
 If a check is critical (such as a missing ELF file), the script should raise a `TTTriageError` exception. Critical error means that script cannot advance without that check and that all dependent scripts shouldn't be executed.
 


### PR DESCRIPTION
We have stored failures and warnings in tt-triage as messages and now this PR is changing it to be structured (message, type, device, location, risc_name). This PR is not changing how we display CSV and Rich output, it just enhances SQLite output. This will allow simpler query to find problems within diagnostic messages.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/triage_structured_errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/triage_structured_errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/triage_structured_errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/triage_structured_errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/triage_structured_errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/triage_structured_errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/triage_structured_errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/triage_structured_errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/triage_structured_errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/triage_structured_errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/triage_structured_errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/triage_structured_errors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/triage_structured_errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/triage_structured_errors)