### PR TITLE
[Bug fix] Protect Copilot runtime output from Actions log backpressure

### DIFF
--- a/.github/instructions/copilot-cloud.instructions.md
+++ b/.github/instructions/copilot-cloud.instructions.md
@@ -46,6 +46,15 @@ treat their absence in your environment as a reason to skip the table above.
 
 **If you are unsure whether your change affects the build, build it.**
 
+For agentic workflow sources (`.github/workflows/*.md`), regenerate the
+corresponding `.lock.yml` with the installed, pinned `gh aw compile` command.
+Do not substitute a manual edit of the generated command line for compilation.
+
+An unavailable, skipped, or timed-out validation is **unverified**, even if its
+wrapper reports success. For example, a code-review result that says the
+`autofind` binary is unavailable does not establish that a review ran. Report
+which checks actually completed and which remain outstanding in the PR.
+
 ## Building
 
 If you changed C++ or CMake, compile before opening the PR.

--- a/.github/scripts/copilot-runtime-stdio.py
+++ b/.github/scripts/copilot-runtime-stdio.py
@@ -31,17 +31,25 @@ def install():
     if previous != str(startup):
         # Only the generated Processing Request step has this runtime marker
         # after user setup. Ordinary Actions steps and nested shells keep their
-        # normal behavior. Re-execute the same script with its generated flags.
+        # normal behavior. Before Bash 5.2, $0 is still the shell name while
+        # reading BASH_ENV. Defer re-exec until the first script command, when
+        # the script name and arguments are available on Ubuntu 22.04's Bash.
+        relaunch = f"""trap - DEBUG
+export TT_COPILOT_STDIO_SPOOLED=1
+exec {shlex.quote(sys.executable)} {shlex.quote(str(relay))} -- \\
+  "$BASH" --noprofile --norc -e -o pipefail "$0" "$@"
+"""
         content = f"""# Installed by copilot-runtime-stdio.py
 if [ -n "${{COPILOT_AGENT_RUNTIME_VERSION:-}}" ] &&
-   [ "${{TT_COPILOT_STDIO_SPOOLED:-}}" != 1 ] && [ -f "$0" ]; then
-  export TT_COPILOT_STDIO_SPOOLED=1
-  exec {shlex.quote(sys.executable)} {shlex.quote(str(relay))} -- \\
-    "$BASH" --noprofile --norc -e -o pipefail "$0" "$@"
-fi
+   [ "${{TT_COPILOT_STDIO_SPOOLED:-}}" != 1 ]; then
+  trap {shlex.quote(relaunch)} DEBUG
+else
 """
         if previous:
             content += f"if [ -f {shlex.quote(previous)} ]; then . {shlex.quote(previous)}; fi\n"
+        else:
+            content += ":\n"
+        content += "fi\n"
         startup.write_text(content)
     with open(os.environ["GITHUB_ENV"], "a") as env_file:
         env_file.write(f"BASH_ENV={startup}\n")

--- a/.github/scripts/copilot-runtime-stdio.py
+++ b/.github/scripts/copilot-runtime-stdio.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Keep Copilot's native launcher off Actions' potentially nonblocking log pipes.
+
+The runtime writes to a private, unlinked temporary file. This process relays
+its bytes to Actions, retrying temporary pipe backpressure instead of letting
+the runtime panic. It does not inspect/filter output or change validation tools.
+"""
+
+import os
+from pathlib import Path
+import select
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def install():
+    directory = Path(os.environ["RUNNER_TEMP"]) / "tt-copilot-stdio"
+    directory.mkdir(mode=0o700, exist_ok=True)
+    relay = directory / "relay.py"
+    startup = directory / "bash-env.sh"
+    previous = os.environ.get("BASH_ENV", "")
+    shutil.copyfile(__file__, relay)
+    if previous != str(startup):
+        # Only the generated Processing Request step has this runtime marker
+        # after user setup. Ordinary Actions steps and nested shells keep their
+        # normal behavior. Re-execute the same script with its generated flags.
+        content = f"""# Installed by copilot-runtime-stdio.py
+if [ -n "${{COPILOT_AGENT_RUNTIME_VERSION:-}}" ] &&
+   [ "${{TT_COPILOT_STDIO_SPOOLED:-}}" != 1 ] && [ -f "$0" ]; then
+  export TT_COPILOT_STDIO_SPOOLED=1
+  exec {shlex.quote(sys.executable)} {shlex.quote(str(relay))} -- \\
+    "$BASH" --noprofile --norc -e -o pipefail "$0" "$@"
+fi
+"""
+        if previous:
+            content += f"if [ -f {shlex.quote(previous)} ]; then . {shlex.quote(previous)}; fi\n"
+        startup.write_text(content)
+    with open(os.environ["GITHUB_ENV"], "a") as env_file:
+        env_file.write(f"BASH_ENV={startup}\n")
+    print("Installed file-backed output relay for Copilot runtime steps.")
+
+
+def relay_command(command):
+    # Merge streams at the writer, preserving workflow-command suppression
+    # markers relative to stderr diagnostics. Separate relays could emit the
+    # closing marker before queued stderr. pread does not move the write cursor.
+    with tempfile.TemporaryFile(dir=os.environ.get("RUNNER_TEMP")) as spool:
+        child = subprocess.Popen(command, stdout=spool, stderr=subprocess.STDOUT, start_new_session=True)
+        cancelled = []
+
+        def forward_signal(signum, _frame):
+            if not cancelled:
+                cancelled.extend([signum, time.monotonic()])
+            try:
+                os.killpg(child.pid, signum)
+            except ProcessLookupError:
+                pass
+
+        signals = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)
+        previous_handlers = {sig: signal.signal(sig, forward_signal) for sig in signals}
+        blocking = os.get_blocking(1)
+        offset = 0
+        pending = b""
+        try:
+            os.set_blocking(1, False)
+            while True:
+                exited = child.poll() is not None
+                if not pending:
+                    pending = os.pread(spool.fileno(), 65536, offset)
+                if exited and not pending:
+                    break
+                if cancelled and time.monotonic() - cancelled[1] > 5:
+                    try:
+                        os.killpg(child.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    # Cancellation must finish even if Actions stopped reading
+                    # its pipes. Any remaining output is discarded only here.
+                    break
+                _, writable, _ = select.select([], [1] if pending else [], [], 0.05)
+                if writable:
+                    try:
+                        count = os.write(1, pending)
+                    except (BlockingIOError, InterruptedError):
+                        continue
+                    offset += count
+                    pending = pending[count:]
+            result = child.wait()
+            if cancelled:
+                return 128 + cancelled[0]
+            return result if result >= 0 else 128 - result
+        finally:
+            if child.poll() is None:
+                try:
+                    os.killpg(child.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                child.wait()
+            os.set_blocking(1, blocking)
+            for sig, handler in previous_handlers.items():
+                signal.signal(sig, handler)
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--install"]:
+        install()
+    elif len(sys.argv) > 2 and sys.argv[1] == "--":
+        sys.exit(relay_command(sys.argv[2:]))
+    else:
+        sys.exit("usage: copilot-runtime-stdio.py --install | -- COMMAND [ARG ...]")

--- a/.github/scripts/tests/test_copilot_runtime_stdio.py
+++ b/.github/scripts/tests/test_copilot_runtime_stdio.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression checks for Copilot's EAGAIN crash and the Bash startup integration."""
+
+import os
+from pathlib import Path
+import signal
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+
+RELAY = Path(__file__).resolve().parents[1] / "copilot-runtime-stdio.py"
+BURST = """
+import os, sys
+for fd in (1, 2):
+    os.set_blocking(fd, False)
+try:
+    for _ in range(256):
+        os.write(1, b'o' * 4096)
+        os.write(2, b'e' * 4096)
+except BlockingIOError:
+    os._exit(134)
+sys.exit(17)
+"""
+
+
+class RuntimeOutputTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="copilot stdio ")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.env = dict(os.environ, RUNNER_TEMP=str(self.root))
+        for name in ("BASH_ENV", "COPILOT_AGENT_RUNTIME_VERSION", "TT_COPILOT_STDIO_SPOOLED"):
+            self.env.pop(name, None)
+
+    def test_reproduces_eagain_without_relay(self):
+        with subprocess.Popen(
+            [sys.executable, "-c", BURST], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=self.env
+        ) as child:
+            # Deliberately leave both output pipes unread until the writer exits.
+            self.assertEqual(child.wait(timeout=5), 134)
+            child.communicate(timeout=5)
+
+    def test_burst_survives_backpressure_and_preserves_output_and_status(self):
+        with subprocess.Popen(
+            [sys.executable, str(RELAY), "--", sys.executable, "-c", BURST],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self.env,
+        ) as child:
+            time.sleep(0.2)  # A slow Actions log consumer must not kill the runtime.
+            stdout, stderr = child.communicate(timeout=10)
+            self.assertEqual(child.returncode, 17)
+            self.assertEqual(stdout, (b"o" * 4096 + b"e" * 4096) * 256)
+            self.assertEqual(stderr, b"")
+        self.assertEqual(list(self.root.iterdir()), [])  # Spools are private and unlinked.
+
+    def test_workflow_command_markers_stay_ordered_with_stderr(self):
+        command = """
+import os
+os.write(1, b'::stop-commands::fixture-token\\n')
+for _ in range(256):
+    os.write(2, b'diagnostic\\n' * 100)
+os.write(1, b'::fixture-token::\\n')
+"""
+        result = subprocess.run(
+            [sys.executable, str(RELAY), "--", sys.executable, "-c", command],
+            capture_output=True,
+            env=self.env,
+            timeout=5,
+            check=True,
+        )
+        self.assertEqual(
+            result.stdout,
+            b"::stop-commands::fixture-token\n" + b"diagnostic\n" * 25600 + b"::fixture-token::\n",
+        )
+
+    def test_preserves_stdin_arguments_and_signal_exit(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(RELAY),
+                "--",
+                sys.executable,
+                "-c",
+                "import sys; print(sys.argv[1]); print(sys.stdin.read(), end='')",
+                "argument with spaces",
+            ],
+            input=b"stdin fixture\n",
+            capture_output=True,
+            env=self.env,
+            timeout=5,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, b"argument with spaces\nstdin fixture\n")
+        result = subprocess.run(
+            [sys.executable, str(RELAY), "--", "bash", "-c", "kill -TERM $$"],
+            capture_output=True,
+            env=self.env,
+            timeout=5,
+        )
+        self.assertEqual(result.returncode, 128 + signal.SIGTERM)
+
+    def test_cancellation_finishes_when_log_consumer_stops_reading(self):
+        with subprocess.Popen(
+            [sys.executable, str(RELAY), "--", sys.executable, "-c", BURST],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self.env,
+        ) as child:
+            time.sleep(0.2)
+            child.terminate()
+            self.assertEqual(child.wait(timeout=7), 128 + signal.SIGTERM)
+            child.communicate(timeout=5)
+
+    def test_forwards_cancellation(self):
+        ready = self.root / "ready"
+        command = "import pathlib,time; pathlib.Path('ready').touch(); time.sleep(60)"
+        with subprocess.Popen(
+            [sys.executable, str(RELAY), "--", sys.executable, "-c", command],
+            cwd=self.root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self.env,
+        ) as child:
+            deadline = time.monotonic() + 5
+            while not ready.exists() and time.monotonic() < deadline:
+                time.sleep(0.02)
+            self.assertTrue(ready.exists())
+            child.terminate()
+            child.communicate(timeout=7)
+            self.assertEqual(child.returncode, 128 + signal.SIGTERM)
+
+    def install(self):
+        previous = self.root / "previous.sh"
+        previous.write_text('export PREVIOUS_LOADED="${PREVIOUS_LOADED:-}x"\n')
+        env_file = self.root / "github-env"
+        env = dict(self.env, BASH_ENV=str(previous), GITHUB_ENV=str(env_file))
+        subprocess.run([sys.executable, str(RELAY), "--install"], env=env, check=True, capture_output=True)
+        env["BASH_ENV"] = env_file.read_text().strip().split("=", 1)[1]
+        return env
+
+    def test_bash_startup_only_wraps_runtime_and_preserves_previous_startup(self):
+        env = self.install()
+        script = self.root / "step.sh"
+        script.write_text(
+            f"{shlex.quote(sys.executable)} -c 'import os,stat; print(stat.S_ISREG(os.fstat(1).st_mode))'\n"
+            'printf "%s\\n" "$PREVIOUS_LOADED" "$1"\n'
+        )
+        command = ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", str(script), "space argument"]
+        ordinary = subprocess.run(command, env=env, capture_output=True, text=True, check=True, timeout=5)
+        self.assertEqual(ordinary.stdout, "False\nx\nspace argument\n")
+        env["COPILOT_AGENT_RUNTIME_VERSION"] = "test-runtime"
+        wrapped = subprocess.run(command, env=env, capture_output=True, text=True, check=True, timeout=5)
+        self.assertEqual(wrapped.stdout, "True\nx\nspace argument\n")
+        # The generated runtime's errexit/pipefail semantics survive re-exec.
+        script.write_text("false | true\nprintf 'should not execute'\n")
+        failed = subprocess.run(command, env=env, capture_output=True, text=True, timeout=5)
+        self.assertEqual(failed.returncode, 1)
+        self.assertEqual(failed.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_copilot_runtime_stdio.py
+++ b/.github/scripts/tests/test_copilot_runtime_stdio.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import signal
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -143,17 +144,25 @@ os.write(1, b'::fixture-token::\\n')
         env_file = self.root / "github-env"
         env = dict(self.env, BASH_ENV=str(previous), GITHUB_ENV=str(env_file))
         subprocess.run([sys.executable, str(RELAY), "--install"], env=env, check=True, capture_output=True)
-        env["BASH_ENV"] = env_file.read_text().strip().split("=", 1)[1]
+        env["BASH_ENV"] = env_file.read_text().splitlines()[-1].split("=", 1)[1]
         return env
 
     def test_bash_startup_only_wraps_runtime_and_preserves_previous_startup(self):
+        # macOS can have both system Bash 3.2 and Homebrew Bash >=5.2. Ubuntu
+        # 22.04 uses Bash 5.1, before $0 was set to the script during BASH_ENV.
+        shells = {str(Path(path).resolve()) for path in (shutil.which("bash"), "/bin/bash") if path}
+        for shell in sorted(shells):
+            with self.subTest(shell=shell):
+                self.check_bash_startup(shell)
+
+    def check_bash_startup(self, shell):
         env = self.install()
         script = self.root / "step.sh"
         script.write_text(
             f"{shlex.quote(sys.executable)} -c 'import os,stat; print(stat.S_ISREG(os.fstat(1).st_mode))'\n"
             'printf "%s\\n" "$PREVIOUS_LOADED" "$1"\n'
         )
-        command = ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", str(script), "space argument"]
+        command = [shell, "--noprofile", "--norc", "-e", "-o", "pipefail", str(script), "space argument"]
         ordinary = subprocess.run(command, env=env, capture_output=True, text=True, check=True, timeout=5)
         self.assertEqual(ordinary.stdout, "False\nx\nspace argument\n")
         env["COPILOT_AGENT_RUNTIME_VERSION"] = "test-runtime"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,6 +21,8 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
       - .github/scripts/copilot-build.sh
+      - .github/scripts/copilot-runtime-stdio.py
+      - .github/scripts/tests/test_copilot_runtime_stdio.py
 
 jobs:
   # The job MUST be called 'copilot-setup-steps' to be recognized by GitHub Copilot Agent
@@ -113,3 +115,10 @@ jobs:
         uses: github/gh-aw-actions/setup-cli@6aab9e5b5c91c615506061f09bedd81a23babe3c # v0.86.2
         with:
           version: v0.86.2
+
+      - name: Protect Copilot runtime output from log-pipe backpressure
+        # The native runtime can abort on a nonblocking stdout/stderr write.
+        # BASH_ENV wraps only runtime steps, retaining security checks and logs.
+        run: |
+          python3 .github/scripts/tests/test_copilot_runtime_stdio.py
+          python3 .github/scripts/copilot-runtime-stdio.py --install


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Copilot's second run on the dedicated self-hosted runner pushed its changes to #56342, then aborted while printing Dependabot diagnostics: `failed printing to stderr: Resource temporarily unavailable (os error 11)`, followed by exit 134. See [the failing job](https://github.com/tenstorrent/tt-metal/actions/runs/34703102400/job/103578226489) and #56345.

This adds a containment workaround: the generated runtime Bash step writes combined stdout/stderr to a private, unlinked temporary file. A small Python relay forwards the output to Actions, retrying temporary log-pipe backpressure. A `BASH_ENV` hook installed by Copilot setup selects the runtime step using its existing `COPILOT_AGENT_RUNTIME_VERSION` marker. The original script, launcher, validation tools, stdin, arguments, and exit status are retained; cancellation is forwarded to its process group.

The Copilot instructions also require regenerating agentic workflow locks with `gh aw compile` and reporting unavailable or timed-out validation as unverified. This addresses two misleading outcomes in the same session: a manually edited workflow lock and a missing review binary reported as a successful review.

Relates to #56345.

### Notes for reviewers
- **Draft pending a fresh cloud-agent run.** Local tests establish the pipe-backpressure mechanism and Bash integration, not a reproduction using GitHub's proprietary runtime. The observed crash is consistent with this mechanism, but its underlying nonblocking-descriptor setup is not established. The hook depends on the current generated Bash step and runtime marker; setup-only CI cannot prove that integration.
- stdout/stderr share one spool so GitHub's workflow-command suppression markers retain their order relative to diagnostics. The relay does not parse or filter output. The file is private and unlinked, uses temporary disk space for the session's output, and is removed when the process closes it.
- Cancellation has a five-second drain limit when Actions stops reading logs, then kills the process group. Queued output may be discarded only on cancellation.
- This leaves security checks enabled. It does not repair the separately observed PR-description `fetch failed`, unavailable Autofind, CodeQL's 180-second timeout, or Dependabot's generated `org/repo` metadata. Those findings are recorded in #56345 for upstream investigation.
- The startup hook uses a one-shot DEBUG trap to re-execute before the first script command. Ubuntu 22.04's Bash predates the Bash 5.2 change that makes the script name available as `$0` during `BASH_ENV`. The original startup file runs once inside the re-executed shell; ordinary steps retain their startup behavior.
- Validation on head `3ffbbfd`: [Copilot Setup Steps passed](https://github.com/tenstorrent/tt-metal/actions/runs/34707094954/job/103589004934) in 37 seconds on `tt-ubuntu-2204-copilot-stable-tx7nr-runner-gc4rv`. All seven regression tests passed in 6.238 seconds, and relay installation succeeded. [Repository static checks, including pre-commit, passed](https://github.com/tenstorrent/tt-metal/actions/runs/34707096775). Local tests also pass with Bash 3.2 and 5.3; Black 23.10.1, repository-configured yamllint 1.35.1, and `git diff --check` pass.
- Regression coverage includes an EAGAIN fixture without the relay, a 2 MiB burst with a slow reader, byte ordering and command-suppression markers, stdin/arguments/status, cancellation with an unread pipe, and Bash startup scoping/flags/previous startup.
- Separate CI limitation: [Verify changed tests](https://github.com/tenstorrent/tt-metal/actions/runs/34707097321) fails workflow evaluation at its existing line 224 (`fromJson`: empty input) when its scope job is skipped for this draft PR. Its `Changed tests verified` check succeeds. That workflow is unchanged here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/harden-copilot-runtime-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/harden-copilot-runtime-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/harden-copilot-runtime-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/harden-copilot-runtime-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/harden-copilot-runtime-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/harden-copilot-runtime-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/harden-copilot-runtime-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/harden-copilot-runtime-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/harden-copilot-runtime-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/harden-copilot-runtime-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/harden-copilot-runtime-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/harden-copilot-runtime-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/harden-copilot-runtime-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/harden-copilot-runtime-output)
