### PR TITLE
Update SQLite serializer to ignore verbosity level

### DIFF
--- a/tools/tests/triage/test_sqlite_serializer.py
+++ b/tools/tests/triage/test_sqlite_serializer.py
@@ -36,6 +36,8 @@ class Row:
     pc: "int | None" = triage_field("PC", hex_serializer)
     rate: float = triage_field("Heartbeats/s")
     enabled: bool = triage_field("Preload")
+    offset: "int | None" = triage_field("Kernel Offset", hex_serializer, verbose=1)
+    rd_ptr: int = triage_field("RD PTR", verbose=2)
 
 
 @dataclass
@@ -46,7 +48,7 @@ class Inner:
 @dataclass
 class DuplicateLoc:
     loc: str = triage_field("Loc")
-    inner: Inner = recurse_field()
+    inner: Inner = recurse_field(verbose=2)
 
 
 @dataclass
@@ -62,7 +64,7 @@ class Wide:
 
 def write(path, script_name, result, **kwargs):
     """Serialize one result and return a connection to the finished database."""
-    serializer = SqliteSerializer(str(path), lambda: 0)
+    serializer = SqliteSerializer(str(path))
     serializer.emit(
         script_name=script_name,
         execution_time="",
@@ -136,13 +138,15 @@ def test_round_trip_column_types_and_values(tmp_path):
     con = write(
         tmp_path / "t.db",
         "dump_callstacks.py",
-        [Row("matmul", 0x1000, 9.5, True), Row("add", None, 0.5, False)],
+        [Row("matmul", 0x1000, 9.5, True, 0x20, 3), Row("add", None, 0.5, False, None, 4)],
     )
     schema = con.execute("SELECT sql FROM sqlite_master WHERE name='dump_callstacks'").fetchone()[0]
     assert '"Kernel Name" TEXT' in schema
     assert '"PC" INTEGER' in schema
     assert '"Heartbeats/s" REAL' in schema
     assert '"Preload" INTEGER' in schema
+    assert '"Kernel Offset" INTEGER' in schema
+    assert '"RD PTR" INTEGER' in schema
 
     # A hex-serialized field stays numerically comparable, and NULL is NULL.
     assert con.execute('SELECT count(*) FROM dump_callstacks WHERE "PC" > 4000').fetchone()[0] == 1
@@ -151,16 +155,18 @@ def test_round_trip_column_types_and_values(tmp_path):
     assert con.execute('SELECT printf(\'0x%X\', "PC") FROM dump_callstacks WHERE "PC" IS NOT NULL').fetchone() == (
         "0x1000",
     )
+    # The verbose-gated values are stored, not just their columns.
+    assert con.execute('SELECT "Kernel Offset", "RD PTR" FROM dump_callstacks').fetchall() == [(32, 3), (None, 4)]
 
 
 def test_column_names_are_the_display_headers(tmp_path):
-    con = write(tmp_path / "t.db", "demo.py", [Row("matmul", 1, 1.0, True)])
+    con = write(tmp_path / "t.db", "demo.py", [Row("matmul", 1, 1.0, True, 2, 3)])
     names = [row[1] for row in con.execute("PRAGMA table_info(demo)")]
-    assert names == ["Kernel Name", "PC", "Heartbeats/s", "Preload"]
+    assert names == ["Kernel Name", "PC", "Heartbeats/s", "Preload", "Kernel Offset", "RD PTR"]
 
 
 def test_diagnostics_table_exists_even_when_empty(tmp_path):
-    con = write(tmp_path / "t.db", "demo.py", [Row("matmul", 1, 1.0, True)])
+    con = write(tmp_path / "t.db", "demo.py", [Row("matmul", 1, 1.0, True, 2, 3)])
     assert con.execute(f"SELECT count(*) FROM {quote_identifier(DIAGNOSTICS_TABLE)}").fetchone()[0] == 0
 
 
@@ -205,9 +211,9 @@ def test_ragged_rows_raise_through_emit(tmp_path):
 
 def test_existing_database_is_not_reused(tmp_path):
     path = tmp_path / "t.db"
-    write(path, "demo.py", [Row("matmul", 1, 1.0, True)])
+    write(path, "demo.py", [Row("matmul", 1, 1.0, True, 2, 3)])
     with pytest.raises(FileExistsError):  # allow-pytest.raises: no expect_error fixture
-        SqliteSerializer(str(path), lambda: 0)
+        SqliteSerializer(str(path))
     # the original database is left untouched
     con = sqlite3.connect(str(path))
     assert con.execute("SELECT count(*) FROM demo").fetchone()[0] == 1
@@ -217,7 +223,7 @@ def test_record_diagnostics_without_a_result(tmp_path):
     # main() prints skipped scripts and failed providers itself, so they arrive
     # through record_diagnostics rather than emit.
     path = tmp_path / "t.db"
-    serializer = SqliteSerializer(str(path), lambda: 0)
+    serializer = SqliteSerializer(str(path))
     serializer.record_diagnostics("inspector_data.py", [], [], True, "Inspector unavailable")
     serializer.record_diagnostics("dump_configuration.py", [], [], True, "Skipped: dependency failed.")
     serializer.record_diagnostics("dispatcher_data.py", [], ["Device 0: no rank"], False, None)
@@ -237,7 +243,7 @@ def test_record_diagnostics_without_a_result(tmp_path):
 
 def test_record_diagnostics_with_nothing_to_record(tmp_path):
     path = tmp_path / "t.db"
-    serializer = SqliteSerializer(str(path), lambda: 0)
+    serializer = SqliteSerializer(str(path))
     serializer.record_diagnostics("elfs_cache.py", [], [], False, None)
     serializer.close()
     con = sqlite3.connect(str(path))
@@ -246,9 +252,9 @@ def test_record_diagnostics_with_nothing_to_record(tmp_path):
 
 def test_multiple_scripts_share_one_database(tmp_path):
     path = tmp_path / "t.db"
-    serializer = SqliteSerializer(str(path), lambda: 0)
+    serializer = SqliteSerializer(str(path))
     for script in ("check_arc.py", "device_info.py"):
-        serializer.emit(script, "", [Row("matmul", 1, 1.0, True)], [], [], False, None, None)
+        serializer.emit(script, "", [Row("matmul", 1, 1.0, True, 2, 3)], [], [], False, None, None)
     serializer.close()
     con = sqlite3.connect(str(path))
     tables = sorted(row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'"))

--- a/tools/triage/serializers.py
+++ b/tools/triage/serializers.py
@@ -17,10 +17,13 @@ from __future__ import annotations
 import csv
 import io
 import os
+import sys
 import textwrap
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Any, Callable, Iterable
+
+ALL_VERBOSE_LEVELS = sys.maxsize
 
 
 @dataclass
@@ -33,6 +36,9 @@ class TableData:
 def extract_table_data(result: Any, verbose_level: int = 0) -> TableData | None:
     """
     Convert a dataclass or list-of-dataclasses to a `TableData`.
+
+    Fields declared with a `verbose=` level above `verbose_level` are left out;
+    pass `ALL_VERBOSE_LEVELS` to keep all of them.
 
     Returns `None` for results that aren't a dataclass or non-empty list of
     dataclasses - those are emitted as plain strings by serializers.

--- a/tools/triage/sqlite_serializer.py
+++ b/tools/triage/sqlite_serializer.py
@@ -7,8 +7,14 @@
 SQLite output back end for tt-triage.
 
 Each script's output becomes one table, named after the script, with a row per
-result and a column per displayed field. Columns are INTEGER, REAL or TEXT,
+result and a column per serializable field. Columns are INTEGER, REAL or TEXT,
 chosen from the values the script produced.
+
+Unlike the console and CSV back ends, this one ignores the `-v` verbosity level:
+a database is an archive, not a screen, so every field a script produced is
+stored - including the ones `-v`/`-vv` would have been needed to display. That
+keeps a default run's database queryable for the detail a later question needs,
+without re-running triage at a higher verbosity.
 
 A shared `diagnostics` table collects the check failures, warnings and script
 errors reported alongside those results.
@@ -18,9 +24,9 @@ from __future__ import annotations
 
 import os
 import sqlite3
-from typing import Any, Callable, Iterable
+from typing import Any, Iterable
 
-from serializers import OutputSerializer, strip_rich_markup, extract_table_data
+from serializers import ALL_VERBOSE_LEVELS, OutputSerializer, strip_rich_markup, extract_table_data
 
 
 def quote_identifier(name: str) -> str:
@@ -105,7 +111,7 @@ DIAGNOSTICS_TABLE = "diagnostics"
 class SqliteSerializer(OutputSerializer):
     """Writes each script's rows into a table named after the script."""
 
-    def __init__(self, path: str, verbose_level_getter: Callable[[], int]):
+    def __init__(self, path: str):
         path = os.path.abspath(path)
         parent = os.path.dirname(path)
         if parent:
@@ -113,7 +119,6 @@ class SqliteSerializer(OutputSerializer):
         if os.path.exists(path):
             raise FileExistsError(f"{path} already exists - remove it or pass a different path")
         self.path = path
-        self._verbose_getter = verbose_level_getter
         self._con = sqlite3.connect(path)
         # Created up front so it can always be queried, even on a clean run.
         self._con.execute(
@@ -135,7 +140,7 @@ class SqliteSerializer(OutputSerializer):
         assert script_name is not None, "cannot serialize a result without a script name"
         self._insert_diagnostics(script_name, failures, warnings, script_failed, failure_message)
 
-        table_data = extract_table_data(result, self._verbose_getter())
+        table_data = extract_table_data(result, ALL_VERBOSE_LEVELS)
         if table_data is None or not table_data.rows:
             # Check-only scripts return nothing; their diagnostics are the output.
             self._con.commit()

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -781,7 +781,7 @@ def init_output_serializer(args: ScriptArguments) -> None:
         try:
             from sqlite_serializer import SqliteSerializer
 
-            serializers.append(SqliteSerializer(sqlite_path, get_verbose_level))
+            serializers.append(SqliteSerializer(sqlite_path))
         except Exception as e:
             utils.WARN(f"Failed to open --sqlite-output-path={sqlite_path!r}: {e}. SQLite output will be skipped.")
 

--- a/tools/triage/tt-triage.md
+++ b/tools/triage/tt-triage.md
@@ -87,8 +87,13 @@ You can control the output with two independent flags:
 
 This keeps the default output clean while allowing detailed inspection when needed.
 
+Verbosity is a *display* setting: it governs the console and `--llm-output` reports only.
+A database written with `--sqlite-output-path` always contains every column, whatever `-v`
+the run used, so the detail a `-vv` column would have shown can be queried afterwards
+without re-running triage.
+
 To enable rich visualization, a checker script should return data as a tagged `@dataclass` or a list of tagged `@dataclass` objects of the same type. Visualization in `tt-triage` is achieved by serializing data fields in a way that describes how they should appear in the output. You control this by using tagging methods and their arguments to specify how each field should be serialized and thus visualized:
-- `triage_field(serialized_name, serializer, verbose=0)` – The field will be serialized (and visualized) as `serialized_name` (or the original field name if not provided) using the specified `serializer` (or `default_serializer`). The `verbose` parameter controls at which verbosity level the field is shown (0=always, 1=with `-v`, 2=with `-vv`). This controls how the field appears in the visualization.
+- `triage_field(serialized_name, serializer, verbose=0)` – The field will be serialized (and visualized) as `serialized_name` (or the original field name if not provided) using the specified `serializer` (or `default_serializer`). The `verbose` parameter controls at which verbosity level the field is shown (0=always, 1=with `-v`, 2=with `-vv`). This controls how the field appears in the visualization; SQLite output stores the field regardless.
 - `recurse_field(verbose=0)` – This will cause expansion of a field that is tagged as a `@dataclass`, so its internal fields are visualized as part of the parent. The `verbose` parameter controls the minimum verbosity level for this recursion.
   ```python
   @dataclass


### PR DESCRIPTION
We want all data to end up in SQLite file. Removing verbosity level (`-vv`) from affecting what gets serialized to SQLite.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/triage_sqlite_ignores_verbosity_level)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/triage_sqlite_ignores_verbosity_level)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/triage_sqlite_ignores_verbosity_level)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/triage_sqlite_ignores_verbosity_level)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/triage_sqlite_ignores_verbosity_level)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/triage_sqlite_ignores_verbosity_level)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/triage_sqlite_ignores_verbosity_level)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/triage_sqlite_ignores_verbosity_level)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/triage_sqlite_ignores_verbosity_level)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/triage_sqlite_ignores_verbosity_level)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/triage_sqlite_ignores_verbosity_level)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/triage_sqlite_ignores_verbosity_level)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/triage_sqlite_ignores_verbosity_level)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/triage_sqlite_ignores_verbosity_level)