### PR TITLE
[Bug fix] Fix ttnn.silu tail preservation for x <= -87.0f (#55711)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -17,7 +17,20 @@ inline void calculate_silu() {
         sfpi::vFloat x = sfpi::dst_reg[0];
 
         // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        // For x <= -87.0f, sigmoid(x) ~ exp(x) and x*exp(x) stays normal down to x = -91.83f
+        sfpi::vFloat result;
+        v_if (x <= -87.0f) {
+            sfpi::vFloat exp_x;
+            if constexpr (is_fp32_dest_acc_en) {
+                exp_x = _sfpu_exp_accurate_<true>(x);
+            } else {
+                exp_x = _sfpu_exp_21f_bf16_<true>(x);
+            }
+            result = x * exp_x;
+        } v_else {
+            result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        }
+        v_endif;
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -17,7 +17,20 @@ inline void calculate_silu() {
         sfpi::vFloat x = sfpi::dst_reg[0];
 
         // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        // For x <= -87.0f, sigmoid(x) ~ exp(x) and x*exp(x) stays normal down to x = -91.83f
+        sfpi::vFloat result;
+        v_if (x <= -87.0f) {
+            sfpi::vFloat exp_x;
+            if constexpr (is_fp32_dest_acc_en) {
+                exp_x = _sfpu_exp_accurate_<true>(x);
+            } else {
+                exp_x = _sfpu_exp_21f_bf16_<true>(x);
+            }
+            result = x * exp_x;
+        } v_else {
+            result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        }
+        v_endif;
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #55711.

In `ckernel_sfpu_silu.h` (Wormhole B0 and Blackhole), `ttnn.silu(x)` evaluates $x / (1 + e^{-x})$. For $x \le -87.34$, $e^{-x} \ge 2^{126}$, which causes reciprocal to flush to zero, yielding $0.0f$.
However, asymptotically $\text{silu}(x) \sim x \cdot e^x$, which remains a normal float32 number down to $x = -91.83$ ($-1.02 \times 10^{-36}$ at $x = -87.34$).

#### Fix:
Directly evaluates $x \cdot e^x$ in the deep negative tail ($x \le -87.0f$):
- Recovers ~590,000 representable float32 values in $[-91.83, -87.34]$ that previously collapsed to zero.
- Preserves exact parity with `torch.nn.functional.silu`.

### Notes for reviewers
- Applied symmetrically to both Blackhole and Wormhole B0 kernels.