### PR TITLE
[Performance] Deduplicate redundant eqz(input) guard in polygamma_bw (#54825)

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1482,15 +1482,16 @@ std::vector<Tensor> polygamma_bw(
         t_nan,
         grad_a,
         output_mem_config);
+    Tensor input_is_zero = ttnn::eqz(input, output_mem_config);
     grad_a = where(
         ttnn::logical_and(
-            ttnn::eqz(input, output_mem_config), ttnn::gtz(grad, output_mem_config), std::nullopt, output_mem_config),
+            input_is_zero, ttnn::gtz(grad, output_mem_config), std::nullopt, output_mem_config),
         (-std::numeric_limits<float>::infinity() * pos_neg),
         grad_a,
         output_mem_config);
     grad_a = where(
         ttnn::logical_and(
-            ttnn::eqz(input, output_mem_config), ttnn::ltz(grad, output_mem_config), std::nullopt, output_mem_config),
+            input_is_zero, ttnn::ltz(grad, output_mem_config), std::nullopt, output_mem_config),
         (std::numeric_limits<float>::infinity() * pos_neg),
         grad_a,
         output_mem_config);


### PR DESCRIPTION
### PR Category
Performance

### Summary
Fixes #54825.

In `ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp`, `polygamma_bw` evaluates the `eqz(input)` singularity guard twice sequentially, unnecessarily doubling device allocations and execution latency for that branch (costing ~55% of the runtime).

#### Fix:
Reuses the first `eqz(input)` mask across the backward calculation.
- Eliminates 1 redundant tensor allocation and 1 redundant elementwise device pass.
- Bit-identical output.