### PR TITLE
[Bug fix] Include padded_output_shape in ReshapeView program hash (#55237)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -54,6 +54,7 @@ ttsl::hash::hash_t ReshapeViewDeviceOperation::compute_program_hash(
     // don't hash on operation_attributes_t::recreate_mapping_tensor
     return tt::tt_metal::operation::hash_operation<ReshapeViewDeviceOperation>(
         operation_attributes.logical_output_shape,
+        operation_attributes.padded_output_shape,
         operation_attributes.output_mem_config,
         operation_attributes.sub_core_grid.has_value(),
         operation_attributes.sub_core_grid.has_value() ? operation_attributes.sub_core_grid.value()


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #55237.

`ReshapeViewDeviceOperation::compute_program_hash` keyed `logical_output_shape` but omitted `padded_output_shape`, while `compute_output_specs` passes `padded_output_shape` to `TensorLayout::fromPaddedShape` — determining the output tensor's page size and strides. Two `ttnn.reshape` calls that share `logical_shape` but differ in `padded_shape` produced identical program hashes, leading to an incorrect program-cache collision where the second call reuses the first call's kernel configuration and output page stride.

#### Fix:
Include `operation_attributes.padded_output_shape` in the `hash_operation<ReshapeViewDeviceOperation>` invocation within `ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp`, ensuring cache keys uniquely differentiate invocations across distinct padding dimensions.

### Checklist
- [x] Program hash includes all layout-determining attributes
- [x] Zero architectural regression on identical padded shapes