### PR TITLE
[Bug fix] Prevent silent drop of subsequent ops in unary_chain (#55298)

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -411,7 +411,7 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
 
     const std::string compute_path = fmt::format(
         "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/{}",
-        get_compute_kernel_path(ops_chain[0].type(), input.dtype()));
+        ops_chain.size() > 1 ? "eltwise_sfpu.cpp" : get_compute_kernel_path(ops_chain[0].type(), input.dtype()));
 
     DataFormat cb_data_format_for_input =
         (ops_chain[0].type() == unary::UnaryOpType::BITCAST) ? cb_data_format_output : cb_data_format;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #55298.

`ttnn.unary_chain` selects the compute kernel from the head operation alone via `get_compute_kernel_path(ops_chain[0].type(), ...)`. When the head operation dispatches to a specialised compute kernel (such as `hardswish_kernel.cpp`, `logit_kernel.cpp`, `logsigmoid_kernel.cpp`, or `lgamma_kernel.cpp`) that does not expand `SFPU_OP_CHAIN_0`, every subsequent operation in `ops_chain` is silently dropped, returning only the result of the first op without error.

#### Fix:
In `ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp`, ensure that multi-op chains (`ops_chain.size() > 1`) fall back to `eltwise_sfpu.cpp` which properly expands `SFPU_OP_CHAIN_0`, rather than binding to single-op specialised kernels.

### Checklist
- [x] Multi-op chains route to chaining kernel
- [x] Single op invocations retain specialised kernel dispatch