### PR TITLE
MoE/Combine/V2 - making the forwarding buffer dense

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.cpp
@@ -29,17 +29,18 @@ void validate_coverage(const std::map<StreamId, std::vector<Assignment>>& per_st
                 a.split_idx,
                 a.split_count);
             TT_FATAL(
-                claimed[a.dst_row].insert(a.split_idx).second,
-                "combine_fabric2d: two streams both claim share {} of {} for row {}",
+                claimed[a.dst_dg_index].insert(a.split_idx).second,
+                "combine_fabric2d: two streams both claim share {} of {} for dispatch-group index {}",
                 a.split_idx,
                 a.split_count,
-                a.dst_row);
-            auto& want = split_count[a.dst_row];
+                a.dst_dg_index);
+            auto& want = split_count[a.dst_dg_index];
             TT_FATAL(
                 want == 0 || want == a.split_count,
-                "combine_fabric2d: row {} is split {} ways by one stream and {} ways by another; the shares would "
+                "combine_fabric2d: dispatch-group index {} is split {} ways by one stream and {} ways by another; the "
+                "shares would "
                 "not tile the run",
-                a.dst_row,
+                a.dst_dg_index,
                 want,
                 a.split_count);
             want = a.split_count;
@@ -50,14 +51,15 @@ void validate_coverage(const std::map<StreamId, std::vector<Assignment>>& per_st
         "combine_fabric2d: streams cover {} of the {} remote chips on the ring",
         claimed.size(),
         ring_extent - 1);
-    for (const auto& [row, shares] : claimed) {
+    for (const auto& [dg_index, shares] : claimed) {
         TT_FATAL(
-            shares.size() == split_count.at(row),
-            "combine_fabric2d: row {} has {} of its {} shares claimed, so part of every run to that chip would "
+            shares.size() == split_count.at(dg_index),
+            "combine_fabric2d: dispatch-group index {} has {} of its {} shares claimed, so part of every run to that "
+            "chip would "
             "never be sent",
-            row,
+            dg_index,
             shares.size(),
-            split_count.at(row));
+            split_count.at(dg_index));
     }
 }
 
@@ -80,10 +82,10 @@ std::vector<std::pair<int32_t, int32_t>> emitted_offsets(uint32_t m) {
     return emitted;
 }
 
-std::vector<ChunkDescriptor> chunks_at_offsets(
+std::vector<cmbf2d::ChunkDescriptor> chunks_at_offsets(
     const std::vector<std::pair<int32_t, int32_t>>& offsets,
     StreamId stream,
-    uint32_t my_row,
+    uint32_t my_dg_index,
     uint32_t extent,
     uint32_t num_links,
     int32_t hop_shift) {
@@ -92,17 +94,17 @@ std::vector<ChunkDescriptor> chunks_at_offsets(
     const uint32_t m = extent / 2;
     const int32_t travel = is_cw ? 1 : -1;
 
-    std::vector<ChunkDescriptor> chunks;
+    std::vector<cmbf2d::ChunkDescriptor> chunks;
     chunks.reserve(offsets.size());
     for (const auto& [origin_off, dst_off] : offsets) {
         const int32_t origin = origin_off + hop_shift;
         const int32_t dst = dst_off + hop_shift;
         const uint32_t distance = static_cast<uint32_t>(dst - origin);
-        chunks.push_back(ChunkDescriptor{
-            .origin_row = static_cast<uint32_t>(
-                (static_cast<int32_t>(my_row) + travel * origin + static_cast<int32_t>(extent)) % extent),
-            .dst_row = static_cast<uint32_t>(
-                (static_cast<int32_t>(my_row) + travel * dst + static_cast<int32_t>(extent)) % extent),
+        chunks.push_back(cmbf2d::ChunkDescriptor{
+            .origin_dg_index = static_cast<uint32_t>(
+                (static_cast<int32_t>(my_dg_index) + travel * origin + static_cast<int32_t>(extent)) % extent),
+            .dst_dg_index = static_cast<uint32_t>(
+                (static_cast<int32_t>(my_dg_index) + travel * dst + static_cast<int32_t>(extent)) % extent),
             .split_idx = distance == m ? stream : link,
             .split_count = distance == m ? stream_count(num_links) : num_links});
     }
@@ -111,22 +113,26 @@ std::vector<ChunkDescriptor> chunks_at_offsets(
 
 }  // namespace
 
-std::vector<ChunkDescriptor> incoming_chunks(
-    StreamId stream, uint32_t my_row, uint32_t ring_extent, uint32_t num_links) {
-    return chunks_at_offsets(emitted_offsets(ring_extent / 2), stream, my_row, ring_extent, num_links, -1);
+std::vector<cmbf2d::ChunkDescriptor> incoming_chunks(
+    StreamId stream, uint32_t my_dg_index, uint32_t ring_extent, uint32_t num_links) {
+    return chunks_at_offsets(emitted_offsets(ring_extent / 2), stream, my_dg_index, ring_extent, num_links, -1);
 }
 
-std::vector<ChunkDescriptor> outgoing_chunks(
-    StreamId stream, uint32_t my_row, uint32_t ring_extent, uint32_t num_links) {
-    return chunks_at_offsets(emitted_offsets(ring_extent / 2), stream, my_row, ring_extent, num_links, 0);
+std::vector<cmbf2d::ChunkDescriptor> outgoing_chunks(
+    StreamId stream, uint32_t my_dg_index, uint32_t ring_extent, uint32_t num_links) {
+    return chunks_at_offsets(emitted_offsets(ring_extent / 2), stream, my_dg_index, ring_extent, num_links, 0);
 }
 
 std::map<StreamId, std::vector<Assignment>> generate_assignments(
-    const std::vector<uint32_t>& ring_chip_ids, uint32_t my_row, uint32_t num_links) {
+    const std::vector<uint32_t>& ring_chip_ids, uint32_t my_dg_index, uint32_t num_links) {
     const uint32_t extent = static_cast<uint32_t>(ring_chip_ids.size());
     const uint32_t m = extent / 2;
     TT_FATAL(extent >= 3 && extent % 2 == 0, "combine_fabric2d: ring extent {} must be even and at least 3", extent);
-    TT_FATAL(my_row < extent, "combine_fabric2d: row {} is outside a {}-chip ring", my_row, extent);
+    TT_FATAL(
+        my_dg_index < extent,
+        "combine_fabric2d: dispatch-group index {} is outside a {}-chip ring",
+        my_dg_index,
+        extent);
 
     std::map<StreamId, std::vector<Assignment>> per_stream;
     for (uint32_t link = 0; link < num_links; link++) {
@@ -135,10 +141,10 @@ std::map<StreamId, std::vector<Assignment>> generate_assignments(
             auto& list = per_stream[stream];
 
             auto own = [&](uint32_t distance, uint32_t split_idx, uint32_t split_count) {
-                const uint32_t row = (my_row + (is_cw ? distance : extent - distance)) % extent;
+                const uint32_t dg_index = (my_dg_index + (is_cw ? distance : extent - distance)) % extent;
                 list.push_back(Assignment{
-                    .dst_chip_id = ring_chip_ids[row],
-                    .dst_row = row,
+                    .dst_chip_id = ring_chip_ids[dg_index],
+                    .dst_dg_index = dg_index,
                     .split_idx = split_idx,
                     .split_count = split_count});
             };

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.cpp
@@ -63,6 +63,64 @@ void validate_coverage(const std::map<StreamId, std::vector<Assignment>>& per_st
 
 }  // namespace
 
+namespace {
+
+// A chunk's (origin, destination) as hop offsets along the stream's own direction, in emission order. The
+// list a chip emits is its own forwarding destinations, furthest first, followed by the arrivals it passes
+// on — which is the same list one hop older with the arrivals for its neighbour removed. That recursion has
+// a fixed point, so the offsets are the same for every chip and need no simulation.
+std::vector<std::pair<int32_t, int32_t>> emitted_offsets(uint32_t m) {
+    std::vector<std::pair<int32_t, int32_t>> emitted;
+    emitted.reserve(relay_chunks_per_stream(2 * m));
+    for (uint32_t hop = 0; hop + 2 <= m; hop++) {
+        for (uint32_t dst = m - hop; dst >= 2; dst--) {
+            emitted.emplace_back(-static_cast<int32_t>(hop), static_cast<int32_t>(dst));
+        }
+    }
+    return emitted;
+}
+
+std::vector<ChunkDescriptor> chunks_at_offsets(
+    const std::vector<std::pair<int32_t, int32_t>>& offsets,
+    StreamId stream,
+    uint32_t my_row,
+    uint32_t extent,
+    uint32_t num_links,
+    int32_t hop_shift) {
+    const bool is_cw = (stream % 2) == 0;
+    const uint32_t link = stream / 2;
+    const uint32_t m = extent / 2;
+    const int32_t travel = is_cw ? 1 : -1;
+
+    std::vector<ChunkDescriptor> chunks;
+    chunks.reserve(offsets.size());
+    for (const auto& [origin_off, dst_off] : offsets) {
+        const int32_t origin = origin_off + hop_shift;
+        const int32_t dst = dst_off + hop_shift;
+        const uint32_t distance = static_cast<uint32_t>(dst - origin);
+        chunks.push_back(ChunkDescriptor{
+            .origin_row = static_cast<uint32_t>(
+                (static_cast<int32_t>(my_row) + travel * origin + static_cast<int32_t>(extent)) % extent),
+            .dst_row = static_cast<uint32_t>(
+                (static_cast<int32_t>(my_row) + travel * dst + static_cast<int32_t>(extent)) % extent),
+            .split_idx = distance == m ? stream : link,
+            .split_count = distance == m ? stream_count(num_links) : num_links});
+    }
+    return chunks;
+}
+
+}  // namespace
+
+std::vector<ChunkDescriptor> incoming_chunks(
+    StreamId stream, uint32_t my_row, uint32_t ring_extent, uint32_t num_links) {
+    return chunks_at_offsets(emitted_offsets(ring_extent / 2), stream, my_row, ring_extent, num_links, -1);
+}
+
+std::vector<ChunkDescriptor> outgoing_chunks(
+    StreamId stream, uint32_t my_row, uint32_t ring_extent, uint32_t num_links) {
+    return chunks_at_offsets(emitted_offsets(ring_extent / 2), stream, my_row, ring_extent, num_links, 0);
+}
+
 std::map<StreamId, std::vector<Assignment>> generate_assignments(
     const std::vector<uint32_t>& ring_chip_ids, uint32_t my_row, uint32_t num_links) {
     const uint32_t extent = static_cast<uint32_t>(ring_chip_ids.size());

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.cpp
@@ -67,60 +67,51 @@ void validate_coverage(const std::map<StreamId, std::vector<Assignment>>& per_st
 
 namespace {
 
-// A chunk's (origin, destination) as hop offsets along the stream's own direction, in emission order. The
-// list a chip emits is its own forwarding destinations, furthest first, followed by the arrivals it passes
-// on — which is the same list one hop older with the arrivals for its neighbour removed. That recursion has
-// a fixed point, so the offsets are the same for every chip and need no simulation.
-std::vector<std::pair<int32_t, int32_t>> emitted_offsets(uint32_t m) {
-    std::vector<std::pair<int32_t, int32_t>> emitted;
-    emitted.reserve(relay_chunks_per_stream(2 * m));
-    for (uint32_t hop = 0; hop + 2 <= m; hop++) {
-        for (uint32_t dst = m - hop; dst >= 2; dst--) {
-            emitted.emplace_back(-static_cast<int32_t>(hop), static_cast<int32_t>(dst));
+// Every chunk a chip forwards, as (source, destination) hop offsets from that chip along the stream's own
+// direction: sources upstream, so negative, destinations downstream, so positive. A chunk whose destination
+// is the forwarder itself is delivered rather than forwarded and so is not here, which is why the nearest
+// destination is 1 and the furthest source is -(dg_size/2 - 1). Offsets are the same on every chip, so this
+// takes only the size of the dispatch group, which is assumed even.
+//
+// The order is the order the upstream chip writes the chunks, which the forwarder must match: the region is
+// dense and holds no per-chunk addresses, so a chunk is found only by walking those before it. Upstream
+// emits its own destinations furthest first (the whole src == -1 group) before any chunk it is itself
+// relaying, so sources run outwards from -1.
+std::vector<std::pair<int32_t, int32_t>> chunks_in_forwarder_ref_frame(uint32_t dg_size) {
+    const int32_t half = static_cast<int32_t>(dg_size / 2);
+    std::vector<std::pair<int32_t, int32_t>> chunks;
+    chunks.reserve(relay_chunks_per_stream(dg_size));
+    for (int32_t src = -1; src > -half; src--) {
+        for (int32_t dst = src + half; dst >= 1; dst--) {
+            chunks.emplace_back(src, dst);
         }
-    }
-    return emitted;
-}
-
-std::vector<cmbf2d::ChunkDescriptor> chunks_at_offsets(
-    const std::vector<std::pair<int32_t, int32_t>>& offsets,
-    StreamId stream,
-    uint32_t my_dg_index,
-    uint32_t extent,
-    uint32_t num_links,
-    int32_t hop_shift) {
-    const bool is_cw = (stream % 2) == 0;
-    const uint32_t link = stream / 2;
-    const uint32_t m = extent / 2;
-    const int32_t travel = is_cw ? 1 : -1;
-
-    std::vector<cmbf2d::ChunkDescriptor> chunks;
-    chunks.reserve(offsets.size());
-    for (const auto& [origin_off, dst_off] : offsets) {
-        const int32_t origin = origin_off + hop_shift;
-        const int32_t dst = dst_off + hop_shift;
-        const uint32_t distance = static_cast<uint32_t>(dst - origin);
-        chunks.push_back(cmbf2d::ChunkDescriptor{
-            .origin_dg_index = static_cast<uint32_t>(
-                (static_cast<int32_t>(my_dg_index) + travel * origin + static_cast<int32_t>(extent)) % extent),
-            .dst_dg_index = static_cast<uint32_t>(
-                (static_cast<int32_t>(my_dg_index) + travel * dst + static_cast<int32_t>(extent)) % extent),
-            .split_idx = distance == m ? stream : link,
-            .split_count = distance == m ? stream_count(num_links) : num_links});
     }
     return chunks;
 }
 
 }  // namespace
 
-std::vector<cmbf2d::ChunkDescriptor> incoming_chunks(
+std::vector<cmbf2d::ChunkDescriptor> forwarding_chunks(
     StreamId stream, uint32_t my_dg_index, uint32_t ring_extent, uint32_t num_links) {
-    return chunks_at_offsets(emitted_offsets(ring_extent / 2), stream, my_dg_index, ring_extent, num_links, -1);
-}
+    const bool is_cw = (stream % 2) == 0;
+    const uint32_t link = stream / 2;
+    const uint32_t m = ring_extent / 2;
+    const int32_t travel = is_cw ? 1 : -1;
 
-std::vector<cmbf2d::ChunkDescriptor> outgoing_chunks(
-    StreamId stream, uint32_t my_dg_index, uint32_t ring_extent, uint32_t num_links) {
-    return chunks_at_offsets(emitted_offsets(ring_extent / 2), stream, my_dg_index, ring_extent, num_links, 0);
+    std::vector<cmbf2d::ChunkDescriptor> chunks;
+    for (const auto& [src, dst] : chunks_in_forwarder_ref_frame(ring_extent)) {
+        // A counter-clockwise stream mirrors the offsets through 0; then both land on a dispatch-group index
+        // by adding where this chip sits on the ring.
+        const uint32_t distance = static_cast<uint32_t>(dst - src);
+        chunks.push_back(cmbf2d::ChunkDescriptor{
+            .origin_dg_index = static_cast<uint32_t>(
+                (static_cast<int32_t>(my_dg_index) + travel * src + static_cast<int32_t>(ring_extent)) % ring_extent),
+            .dst_dg_index = static_cast<uint32_t>(
+                (static_cast<int32_t>(my_dg_index) + travel * dst + static_cast<int32_t>(ring_extent)) % ring_extent),
+            .split_idx = distance == m ? stream : link,
+            .split_count = distance == m ? stream_count(num_links) : num_links});
+    }
+    return chunks;
 }
 
 std::map<StreamId, std::vector<Assignment>> generate_assignments(
@@ -151,7 +142,8 @@ std::map<StreamId, std::vector<Assignment>> generate_assignments(
 
             // Furthest destination first, with relays interleaved so downstream streams get work early.
             // After the j-th own assignment the cumulative relay count is the triangular number
-            // T(j-2) = (j-2)(j-1)/2, which for m=4 gives own3 own2 relay0 own1 relay1 relay2 own0 relay3..5.
+            // T(j-2) = (j-2)(j-1)/2, which for m=4 gives own4 own3 own2 relay0 own1 relay1 relay2 relay3..5
+            // (own by distance, so own1 is the neighbour, which is delivered rather than forwarded).
             uint32_t relays = 0;
             for (uint32_t j = 1; j <= m; j++) {
                 const uint32_t distance = m - j + 1;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.hpp
@@ -67,8 +67,4 @@ constexpr uint32_t relay_chunks_per_stream(uint32_t ring_extent) {
     return m * (m - 1) / 2;
 }
 
-constexpr uint32_t relay_chunks_per_mesh(uint32_t ring_extent, uint32_t num_links) {
-    return relay_chunks_per_stream(ring_extent) * stream_count(num_links);
-}
-
 }  // namespace ttnn::operations::experimental::deepseek_prefill::combine_fabric2d

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.hpp
@@ -37,12 +37,8 @@ struct Assignment {
 std::map<StreamId, std::vector<Assignment>> generate_assignments(
     const std::vector<uint32_t>& ring_chip_ids, uint32_t my_dg_index, uint32_t num_links);
 
-// Chunks a stream receives in its own region, in the order the upstream chip emits them.
-std::vector<cmbf2d::ChunkDescriptor> incoming_chunks(
-    StreamId stream, uint32_t my_dg_index, uint32_t ring_extent, uint32_t num_links);
-
-// Chunks a stream emits into the downstream chip's region, in the order it emits them.
-std::vector<cmbf2d::ChunkDescriptor> outgoing_chunks(
+// Chunks a stream forwards, in the order the upstream chip emits them into its region.
+std::vector<cmbf2d::ChunkDescriptor> forwarding_chunks(
     StreamId stream, uint32_t my_dg_index, uint32_t ring_extent, uint32_t num_links);
 
 // Relay chunks a stream receives, which is also how many its upstream neighbour emits into this stream's

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "combine_fabric2d_placement.hpp"
+#include "kernels/dataflow/combine_fabric2d_kernel_interface.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::combine_fabric2d {
 
@@ -16,17 +17,17 @@ namespace ttnn::operations::experimental::deepseek_prefill::combine_fabric2d {
 //
 // A relay pushes an incoming forwarding chunk one hop further, whole. Otherwise the work is this chip's own
 // tokens for one destination chip, narrowed to a fraction of each run: halved between the routing planes for
-// destinations nearer than the opposite chip, quartered across all streams for the opposite chip, which is
+// destinations nearer than the opposite chip, split across all streams for the opposite chip, which is
 // equally far in both directions.
 //
 // Where a run starts and how long it is are NOT here. Run boundaries live in the caller's control tensors
-// and are only knowable on device, so an assignment names the run (`dst_row`) and the share
+// and are only knowable on device, so an assignment names the run (`dst_dg_index`) and the share
 // (`split_idx`/`split_count`) and the kernel resolves both to page ranges.
 struct Assignment {
     bool is_relay = false;
-    uint32_t relay_chunk = 0;  // is_relay: which chunk of this stream's quarter
+    uint32_t relay_chunk = 0;  // is_relay: which chunk of this stream's region
     uint32_t dst_chip_id = 0;  // !is_relay: fabric name of the destination chip
-    uint32_t dst_row = 0;      // !is_relay: that chip's row on the ring, indexing expert_offsets
+    uint32_t dst_dg_index = 0;  // !is_relay: that chip's index in the dispatch group, indexing expert_offsets
     uint32_t split_idx = 0;
     uint32_t split_count = 1;
 };
@@ -34,25 +35,15 @@ struct Assignment {
 // Work for every stream on `coord`. `ring_chip_ids` holds the fabric chip id of each row of the ring, so
 // this needs nothing from the mesh API.
 std::map<StreamId, std::vector<Assignment>> generate_assignments(
-    const std::vector<uint32_t>& ring_chip_ids, uint32_t my_row, uint32_t num_links);
-
-// One chunk of a stream's forwarding region: whose tokens it carries, for which destination, and the share
-// of each run those two chips agreed on. Enough to compute the chunk's token count from expert_offsets, and
-// so its page range once every chunk before it in the region has been counted too.
-struct ChunkDescriptor {
-    uint32_t origin_row = 0;
-    uint32_t dst_row = 0;
-    uint32_t split_idx = 0;
-    uint32_t split_count = 1;
-};
+    const std::vector<uint32_t>& ring_chip_ids, uint32_t my_dg_index, uint32_t num_links);
 
 // Chunks a stream receives in its own region, in the order the upstream chip emits them.
-std::vector<ChunkDescriptor> incoming_chunks(
-    StreamId stream, uint32_t my_row, uint32_t ring_extent, uint32_t num_links);
+std::vector<cmbf2d::ChunkDescriptor> incoming_chunks(
+    StreamId stream, uint32_t my_dg_index, uint32_t ring_extent, uint32_t num_links);
 
 // Chunks a stream emits into the downstream chip's region, in the order it emits them.
-std::vector<ChunkDescriptor> outgoing_chunks(
-    StreamId stream, uint32_t my_row, uint32_t ring_extent, uint32_t num_links);
+std::vector<cmbf2d::ChunkDescriptor> outgoing_chunks(
+    StreamId stream, uint32_t my_dg_index, uint32_t ring_extent, uint32_t num_links);
 
 // Relay chunks a stream receives, which is also how many its upstream neighbour emits into this stream's
 // share of the forwarding buffer. Equals (own forwarding) + (re-forwarded), so upstream writer and

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_assignments.hpp
@@ -36,6 +36,24 @@ struct Assignment {
 std::map<StreamId, std::vector<Assignment>> generate_assignments(
     const std::vector<uint32_t>& ring_chip_ids, uint32_t my_row, uint32_t num_links);
 
+// One chunk of a stream's forwarding region: whose tokens it carries, for which destination, and the share
+// of each run those two chips agreed on. Enough to compute the chunk's token count from expert_offsets, and
+// so its page range once every chunk before it in the region has been counted too.
+struct ChunkDescriptor {
+    uint32_t origin_row = 0;
+    uint32_t dst_row = 0;
+    uint32_t split_idx = 0;
+    uint32_t split_count = 1;
+};
+
+// Chunks a stream receives in its own region, in the order the upstream chip emits them.
+std::vector<ChunkDescriptor> incoming_chunks(
+    StreamId stream, uint32_t my_row, uint32_t ring_extent, uint32_t num_links);
+
+// Chunks a stream emits into the downstream chip's region, in the order it emits them.
+std::vector<ChunkDescriptor> outgoing_chunks(
+    StreamId stream, uint32_t my_row, uint32_t ring_extent, uint32_t num_links);
+
 // Relay chunks a stream receives, which is also how many its upstream neighbour emits into this stream's
 // share of the forwarding buffer. Equals (own forwarding) + (re-forwarded), so upstream writer and
 // downstream reader agree on the chunk count without exchanging anything.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
@@ -53,16 +53,17 @@ static_assert(DRAIN_SINK_OFF < PROD_BUF_OFF, "drain sink overlaps the token ring
 // receiver eRisc. Everything else goes to forwardign buffer. Op manages when will sender cores send
 // "home-made" tokens and when will they send tokens from the forwarding buffer.
 //
-// Worst case for one chunk, not an estimate: a chunk carries the destination chip's tokens that were routed
-// to experts hosted on the source chip. If every one of the destination's seq_len_per_chip tokens sent all
-// num_experts_per_tok of its copies to experts on that one source chip, the chunk holds all of them. Plus one
-// page for the sentinel that terminates it.
+// Pages one stream's region has to hold. The kernels pack their chunks densely, computing each chunk's
+// length from expert_offsets, so this only has to bound the region's TOTAL — which is why it does not grow
+// when a chunk count grows.
 //
-// Unreachable for every chunk at once — a destination's tokens cannot all be on one source chip and also on
-// another — so provisioning every chunk for it is deliberately wasteful. A later change makes the buffer
-// dense and this bound stops costing anything.
-uint32_t fwd_pages_per_chunk(uint32_t seq_len_per_chip, uint32_t num_experts_per_tok) {
-    return seq_len_per_chip * num_experts_per_tok + 1;
+// A chunk carries the destination chip's tokens routed to experts on the origin chip. Each of the
+// destination's seq_len_per_chip tokens picks num_experts_per_tok DISTINCT experts, so at most
+// min(num_experts_per_tok, experts_per_chip) of its copies can land on any one chip. The two chips split
+// each run num_links ways, or stream_count ways for the diametrically opposite chip.
+uint32_t fwd_pages_per_quarter(const CombineFabric2dParams& args, uint32_t experts_per_chip) {
+    const uint32_t per_chunk = args.seq_len_per_chip * std::min(args.num_experts_per_tok, experts_per_chip);
+    return relay_chunks_per_stream(ring_extent(args)) * (per_chunk / args.num_links + 1);
 }
 
 L1Layout compute_l1_layout(
@@ -171,7 +172,7 @@ RingSemaphores allocate_ring_semaphores(ttnn::MeshDevice* mesh) {
 struct ForwardingBuffer {
     std::shared_ptr<ttnn::Tensor> owner;
     tt::tt_metal::Buffer* buffer = nullptr;
-    uint32_t pages_per_chunk = 0;
+    uint32_t pages_per_quarter = 0;
 };
 
 // Never initialised and never read back: pure staging for tokens passing through a chip. One page per token,
@@ -183,11 +184,11 @@ struct ForwardingBuffer {
 ForwardingBuffer allocate_forwarding_buffer(
     ttnn::MeshDevice* mesh, const CombineFabric2dParams& args, const CombineFabric2dInputs& tensor_args) {
     ForwardingBuffer fwd;
-    fwd.pages_per_chunk = fwd_pages_per_chunk(args.seq_len_per_chip, args.num_experts_per_tok);
+    fwd.pages_per_quarter = fwd_pages_per_quarter(args, args.experts_per_chip);
     const uint32_t page_bytes = token_size_bytes(tensor_args) + cmbf2d::FORWARDING_METADATA_SIZE;
     TT_FATAL(
         page_bytes % 64 == 0, "combine_fabric2d: forwarding page {} B must be 64-byte aligned for DRAM", page_bytes);
-    const uint32_t pages = relay_chunks_per_mesh(ring_extent(args), args.num_links) * fwd.pages_per_chunk;
+    const uint32_t pages = stream_count(args.num_links) * fwd.pages_per_quarter;
     const tt::tt_metal::TensorSpec spec(
         ttnn::Shape({pages, page_bytes / static_cast<uint32_t>(sizeof(uint32_t))}),
         tt::tt_metal::TensorLayout(
@@ -213,9 +214,9 @@ KernelPlan make_kernel_plan(
     const CombineFabric2dInputs& tensor_args,
     const ttnn::MeshCoordinate& coord,
     const RingSemaphores& sems,
-    uint32_t pages_per_chunk) {
+    uint32_t pages_per_quarter) {
     KernelPlan plan;
-    plan.pages_per_chunk = pages_per_chunk;
+    plan.pages_per_quarter = pages_per_quarter;
     plan.ring_filled_addr = static_cast<uint32_t>(sems.filled.address());
     plan.ring_freed_addr = static_cast<uint32_t>(sems.freed.address());
     plan.fwd_arrived_addr = static_cast<uint32_t>(sems.fwd_arrived.address());
@@ -353,7 +354,7 @@ tt::tt_metal::WorkloadDescriptor CombineFabric2dProgramFactory::create_workload_
                  coord,
                  placement,
                  l1,
-                 make_kernel_plan(operation_attributes, tensor_args, coord, sems, fwd.pages_per_chunk),
+                 make_kernel_plan(operation_attributes, tensor_args, coord, sems, fwd.pages_per_quarter),
                  dram)});
     }
     return workload_descriptor;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
@@ -63,8 +63,8 @@ static_assert(DRAIN_SINK_OFF < PROD_BUF_OFF, "drain sink overlaps the token ring
 // than each reaching it. A stream relays half_extent - 1 distinct destinations: the nearer ones can have
 // their whole volume on an origin that splits the run num_links ways, while the farthest is reachable only
 // from the diametrically opposite chip, whose run is split across every stream.
-uint32_t fwd_pages_per_quarter(const CombineFabric2dParams& args, uint32_t experts_per_chip) {
-    const uint32_t per_destination = args.seq_len_per_chip * std::min(args.num_experts_per_tok, experts_per_chip);
+uint32_t fwd_pages_per_stream(const CombineFabric2dParams& args) {
+    const uint32_t per_destination = args.seq_len_per_chip * std::min(args.num_experts_per_tok, args.experts_per_chip);
     const uint32_t half_extent = ring_extent(args) / 2;
     return (half_extent - 2) * (per_destination / args.num_links) + per_destination / stream_count(args.num_links);
 }
@@ -175,7 +175,7 @@ RingSemaphores allocate_ring_semaphores(ttnn::MeshDevice* mesh) {
 struct ForwardingBuffer {
     std::shared_ptr<ttnn::Tensor> owner;
     tt::tt_metal::Buffer* buffer = nullptr;
-    uint32_t pages_per_quarter = 0;
+    uint32_t pages_per_stream = 0;
 };
 
 // Never initialised and never read back: pure staging for tokens passing through a chip. One page per token,
@@ -187,11 +187,11 @@ struct ForwardingBuffer {
 ForwardingBuffer allocate_forwarding_buffer(
     ttnn::MeshDevice* mesh, const CombineFabric2dParams& args, const CombineFabric2dInputs& tensor_args) {
     ForwardingBuffer fwd;
-    fwd.pages_per_quarter = fwd_pages_per_quarter(args, args.experts_per_chip);
+    fwd.pages_per_stream = fwd_pages_per_stream(args);
     const uint32_t page_bytes = token_size_bytes(tensor_args) + cmbf2d::FORWARDING_METADATA_SIZE;
     TT_FATAL(
         page_bytes % 64 == 0, "combine_fabric2d: forwarding page {} B must be 64-byte aligned for DRAM", page_bytes);
-    const uint32_t pages = stream_count(args.num_links) * fwd.pages_per_quarter;
+    const uint32_t pages = stream_count(args.num_links) * fwd.pages_per_stream;
     const tt::tt_metal::TensorSpec spec(
         ttnn::Shape({pages, page_bytes / static_cast<uint32_t>(sizeof(uint32_t))}),
         tt::tt_metal::TensorLayout(
@@ -217,9 +217,9 @@ KernelPlan make_kernel_plan(
     const CombineFabric2dInputs& tensor_args,
     const ttnn::MeshCoordinate& coord,
     const RingSemaphores& sems,
-    uint32_t pages_per_quarter) {
+    uint32_t pages_per_stream) {
     KernelPlan plan;
-    plan.pages_per_quarter = pages_per_quarter;
+    plan.pages_per_stream = pages_per_stream;
     plan.ring_filled_addr = static_cast<uint32_t>(sems.filled.address());
     plan.ring_freed_addr = static_cast<uint32_t>(sems.freed.address());
     plan.fwd_arrived_addr = static_cast<uint32_t>(sems.fwd_arrived.address());
@@ -230,7 +230,7 @@ KernelPlan make_kernel_plan(
     const uint32_t my_group = args.device->shape().dims() > 1 ? coord[static_cast<int32_t>(args.axis == 0 ? 1 : 0)] %
                                                                     num_dispatch_groups(args, tensor_args)
                                                               : 0u;
-    plan.my_expert_base = my_group * experts_per_group + my_row(args, coord) * args.experts_per_chip;
+    plan.my_expert_base = my_group * experts_per_group + my_dg_index(args, coord) * args.experts_per_chip;
     return plan;
 }
 
@@ -254,7 +254,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     const DramBuffers& dram) {
     tt::tt_metal::ProgramDescriptor desc;
     const auto work_by_stream =
-        generate_assignments(ring_chip_ids(args.device, coord, args.axis), my_row(args, coord), args.num_links);
+        generate_assignments(ring_chip_ids(args.device, coord, args.axis), my_dg_index(args, coord), args.num_links);
 
     for (const auto& [stream, self] : placement.at(coord)) {
         KernelPlan plan = chip_plan;
@@ -357,7 +357,7 @@ tt::tt_metal::WorkloadDescriptor CombineFabric2dProgramFactory::create_workload_
                  coord,
                  placement,
                  l1,
-                 make_kernel_plan(operation_attributes, tensor_args, coord, sems, fwd.pages_per_quarter),
+                 make_kernel_plan(operation_attributes, tensor_args, coord, sems, fwd.pages_per_stream),
                  dram)});
     }
     return workload_descriptor;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_program_factory.cpp
@@ -57,13 +57,16 @@ static_assert(DRAIN_SINK_OFF < PROD_BUF_OFF, "drain sink overlaps the token ring
 // length from expert_offsets, so this only has to bound the region's TOTAL — which is why it does not grow
 // when a chunk count grows.
 //
-// A chunk carries the destination chip's tokens routed to experts on the origin chip. Each of the
-// destination's seq_len_per_chip tokens picks num_experts_per_tok DISTINCT experts, so at most
-// min(num_experts_per_tok, experts_per_chip) of its copies can land on any one chip. The two chips split
-// each run num_links ways, or stream_count ways for the diametrically opposite chip.
+// A destination's whole return volume is seq_len_per_chip tokens x min(num_experts_per_tok,
+// experts_per_chip) copies, however the router spread those copies across origins, because that is just the
+// destination's output buffer. Chunks heading to the same destination therefore SHARE that volume rather
+// than each reaching it. A stream relays half_extent - 1 distinct destinations: the nearer ones can have
+// their whole volume on an origin that splits the run num_links ways, while the farthest is reachable only
+// from the diametrically opposite chip, whose run is split across every stream.
 uint32_t fwd_pages_per_quarter(const CombineFabric2dParams& args, uint32_t experts_per_chip) {
-    const uint32_t per_chunk = args.seq_len_per_chip * std::min(args.num_experts_per_tok, experts_per_chip);
-    return relay_chunks_per_stream(ring_extent(args)) * (per_chunk / args.num_links + 1);
+    const uint32_t per_destination = args.seq_len_per_chip * std::min(args.num_experts_per_tok, experts_per_chip);
+    const uint32_t half_extent = ring_extent(args) / 2;
+    return (half_extent - 2) * (per_destination / args.num_links) + per_destination / stream_count(args.num_links);
 }
 
 L1Layout compute_l1_layout(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_kernel_interface.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_kernel_interface.hpp
@@ -74,7 +74,7 @@ struct DramBuffers {
 struct KernelPlan {
     StreamId stream = 0;
     uint32_t my_expert_base = 0;
-    uint32_t pages_per_chunk = 0;
+    uint32_t pages_per_quarter = 0;
     uint32_t ring_filled_addr = 0;
     uint32_t ring_freed_addr = 0;
     uint32_t fwd_arrived_addr = 0;
@@ -102,6 +102,8 @@ constexpr uint32_t META_PAD_STRIDE = 64;
 
 // Words per assignment in the reader's assignment block: [dst_chip_id, dst_row, split_idx, split_count].
 constexpr uint32_t ASSIGNMENT_WORDS = 4;
+// Words per chunk descriptor: [origin_row, dst_row, split_idx, split_count].
+constexpr uint32_t CHUNK_WORDS = 4;
 // Marks a schedule entry as "relay forwarding chunk k" rather than "own assignment k".
 constexpr uint32_t SCHED_FWD = 0x80000000u;
 
@@ -114,7 +116,7 @@ constexpr uint32_t FORWARDING_METADATA_SIZE = 64;
 // fills it, the sender consumes it. All uint64_t so the sender needs no sub-word loads.
 struct FwdMetadata {
     uint64_t final_addr;  // destination DRAM address on the FINAL destination chip
-    uint64_t dst_chip;    // final destination chip id; SENTINEL_DST_CHIP marks a sentinel
+    uint64_t dst_chip;    // final destination chip id
     uint64_t cmd;
     uint64_t this_addr;  // the address THIS hop writes to
 };
@@ -134,9 +136,9 @@ static_assert(offsetof(FwdMetadata, this_addr) == 3 * sizeof(uint64_t));
 constexpr uint64_t CMD_END = 0;  // end of stream; the slot carries no token
 constexpr uint64_t CMD_FINAL_WRITE = 1;
 constexpr uint64_t CMD_FORWARD = 2;
-
-// A sentinel carries no usable token; it marks the end of a forwarding chunk. UINT64_MAX can never collide
-// with a real chip id.
-constexpr uint64_t SENTINEL_DST_CHIP = UINT64_MAX;
+// A forward that also ends a chunk. The sender bumps the downstream reader's arrival counter right after
+// sending it, because that reader is waiting on exactly this chunk's pages and the residual of a partial
+// bump batch would otherwise sit uncounted until end of stream — which, on a ring, is a deadlock.
+constexpr uint64_t CMD_FORWARD_END = 3;
 
 }  // namespace cmbf2d

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_kernel_interface.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_kernel_interface.hpp
@@ -20,7 +20,6 @@
 
 #include <tt-metalium/buffer.hpp>
 
-#include "../../combine_fabric2d_assignments.hpp"
 #include "../../combine_fabric2d_placement.hpp"
 #include "../../combine_fabric2d_types.hpp"
 
@@ -44,7 +43,7 @@ inline uint32_t num_dispatch_groups(const CombineFabric2dParams& args, const Com
     return num_routed_experts(tensor_args) / (args.experts_per_chip * ring_extent(args));
 }
 
-inline uint32_t my_row(const CombineFabric2dParams& args, const ttnn::MeshCoordinate& coord) {
+inline uint32_t my_dg_index(const CombineFabric2dParams& args, const ttnn::MeshCoordinate& coord) {
     return coord[static_cast<int32_t>(args.axis)];
 }
 
@@ -74,7 +73,7 @@ struct DramBuffers {
 struct KernelPlan {
     StreamId stream = 0;
     uint32_t my_expert_base = 0;
-    uint32_t pages_per_quarter = 0;
+    uint32_t pages_per_stream = 0;
     uint32_t ring_filled_addr = 0;
     uint32_t ring_freed_addr = 0;
     uint32_t fwd_arrived_addr = 0;
@@ -100,10 +99,44 @@ constexpr uint32_t BATCH = NUM_L1_SLOTS / 2;
 constexpr uint32_t META_PREFETCH = 64;
 constexpr uint32_t META_PAD_STRIDE = 64;
 
-// Words per assignment in the reader's assignment block: [dst_chip_id, dst_row, split_idx, split_count].
+// Words per assignment in the reader's assignment block: [dst_chip_id, dst_dg_index, split_idx, split_count].
 constexpr uint32_t ASSIGNMENT_WORDS = 4;
-// Words per chunk descriptor: [origin_row, dst_row, split_idx, split_count].
+// Words per chunk descriptor.
 constexpr uint32_t CHUNK_WORDS = 4;
+
+// One chunk of a stream's forwarding region: whose tokens it carries, for which chip, and the share of each
+// run those two chips agreed on. Enough to compute the chunk's token count, and so its page range once every
+// chunk before it in the region has been counted too.
+//
+// Packed by position into the reader's compile-time args. to_words below is the only place that order is
+// written down, and from_words mirrors it, so the host that emits a chunk and the kernel that reads it back
+// cannot drift apart.
+struct ChunkDescriptor {
+    uint32_t origin_dg_index = 0;
+    uint32_t dst_dg_index = 0;
+    uint32_t split_idx = 0;
+    uint32_t split_count = 1;
+
+    void to_words(uint32_t* words) const {
+        words[0] = origin_dg_index;
+        words[1] = dst_dg_index;
+        words[2] = split_idx;
+        words[3] = split_count;
+    }
+
+    static ChunkDescriptor from_words(const uint32_t* words) {
+        return ChunkDescriptor{words[0], words[1], words[2], words[3]};
+    }
+
+#ifndef KERNEL_BUILD
+    void append_to(std::vector<uint32_t>& out) const {
+        uint32_t words[CHUNK_WORDS];
+        to_words(words);
+        out.insert(out.end(), words, words + CHUNK_WORDS);
+    }
+#endif
+};
+static_assert(sizeof(ChunkDescriptor) == CHUNK_WORDS * sizeof(uint32_t));
 // Marks a schedule entry as "relay forwarding chunk k" rather than "own assignment k".
 constexpr uint32_t SCHED_FWD = 0x80000000u;
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
@@ -34,8 +34,8 @@ struct ReaderCtArgs {
     uint32_t ring_addr;
     uint32_t filled_addr;
     uint32_t freed_addr;
-    uint32_t fwd_pages_per_quarter;
-    uint32_t my_quarter;
+    uint32_t fwd_pages_per_stream;
+    uint32_t my_stream;
     uint32_t num_incoming_chunks;
     uint32_t fwd_sem_addr;
     uint32_t nbr_chip_id;
@@ -47,7 +47,7 @@ struct ReaderCtArgs {
     uint32_t num_experts_per_tok;
     uint32_t dispatch_group_size;
     uint32_t local_split_count;
-    uint32_t my_row;
+    uint32_t my_dg_index;
     uint32_t control_addr;
     uint32_t meta_prefetch_cap;
 
@@ -67,12 +67,12 @@ struct ReaderCtArgs {
         ring_addr(l1.ring),
         filled_addr(plan.ring_filled_addr),
         freed_addr(plan.ring_freed_addr),
-        fwd_pages_per_quarter(plan.pages_per_quarter),
-        // Our quarter of the forwarding buffer. (plane, direction) identifies the upstream sender uniquely
-        // from the downstream chip's point of view, so the reader WRITES quarter q of the neighbour's buffer
-        // and READS quarter q of its own — the same q, because every chip runs the same code. Doubles as
+        fwd_pages_per_stream(plan.pages_per_stream),
+        // Our region of the forwarding buffer. (plane, direction) identifies the upstream sender uniquely
+        // from the downstream chip's point of view, so the reader WRITES region q of the neighbour's buffer
+        // and READS region q of its own — the same q, because every chip runs the same code. Doubles as
         // this stream's share of the same-chip run, which it copies after the fabric work.
-        my_quarter(plan.stream),
+        my_stream(plan.stream),
         num_incoming_chunks(0),  // set from the descriptor block below, so the two cannot disagree
         fwd_sem_addr(plan.fwd_arrived_addr),
         nbr_chip_id(static_cast<uint32_t>(self.downstream_node.chip_id)),
@@ -84,7 +84,7 @@ struct ReaderCtArgs {
         num_experts_per_tok(args.num_experts_per_tok),
         dispatch_group_size(op::ring_extent(args)),
         local_split_count(op::stream_count(args.num_links)),
-        my_row(op::my_row(args, coord)),
+        my_dg_index(op::my_dg_index(args, coord)),
         control_addr(l1.control),
         meta_prefetch_cap(META_PREFETCH) {
         // Schedule: the work order, relays tagged. An own entry carries its index into the table that
@@ -98,22 +98,19 @@ struct ReaderCtArgs {
                 continue;
             }
             blocks_.push_back(w.dst_chip_id);
-            blocks_.push_back(w.dst_row);
+            blocks_.push_back(w.dst_dg_index);
             blocks_.push_back(w.split_idx);
             blocks_.push_back(w.split_count);
         }
-        // Chunk descriptors for our own quarter of the forwarding buffer, in arrival order — which is the
+        // Chunk descriptors for our own region of the forwarding buffer, in arrival order — which is the
         // order the upstream sender emits them, because both sides derive it from the same generator. They
         // are what lets the reader compute every chunk's length, and so its page range, with nothing
         // exchanged between the two chips.
         const auto incoming =
-            op::incoming_chunks(plan.stream, op::my_row(args, coord), op::ring_extent(args), args.num_links);
+            op::incoming_chunks(plan.stream, op::my_dg_index(args, coord), op::ring_extent(args), args.num_links);
         num_incoming_chunks = static_cast<uint32_t>(incoming.size());
         for (const auto& c : incoming) {
-            blocks_.push_back(c.origin_row);
-            blocks_.push_back(c.dst_row);
-            blocks_.push_back(c.split_idx);
-            blocks_.push_back(c.split_count);
+            c.append_to(blocks_);
         }
     }
 
@@ -126,8 +123,8 @@ struct ReaderCtArgs {
             ring_addr,
             filled_addr,
             freed_addr,
-            fwd_pages_per_quarter,
-            my_quarter,
+            fwd_pages_per_stream,
+            my_stream,
             num_incoming_chunks,
             fwd_sem_addr,
             nbr_chip_id,
@@ -139,7 +136,7 @@ struct ReaderCtArgs {
             num_experts_per_tok,
             dispatch_group_size,
             local_split_count,
-            my_row,
+            my_dg_index,
             control_addr,
             meta_prefetch_cap};
         word_arr.insert(word_arr.end(), blocks_.begin(), blocks_.end());
@@ -154,8 +151,8 @@ struct ReaderCtArgs {
         ring_addr(get_compile_time_arg_val(4)),
         filled_addr(get_compile_time_arg_val(5)),
         freed_addr(get_compile_time_arg_val(6)),
-        fwd_pages_per_quarter(get_compile_time_arg_val(7)),
-        my_quarter(get_compile_time_arg_val(8)),
+        fwd_pages_per_stream(get_compile_time_arg_val(7)),
+        my_stream(get_compile_time_arg_val(8)),
         num_incoming_chunks(get_compile_time_arg_val(9)),
         fwd_sem_addr(get_compile_time_arg_val(10)),
         nbr_chip_id(get_compile_time_arg_val(11)),
@@ -167,7 +164,7 @@ struct ReaderCtArgs {
         num_experts_per_tok(get_compile_time_arg_val(17)),
         dispatch_group_size(get_compile_time_arg_val(18)),
         local_split_count(get_compile_time_arg_val(19)),
-        my_row(get_compile_time_arg_val(20)),
+        my_dg_index(get_compile_time_arg_val(20)),
         control_addr(get_compile_time_arg_val(21)),
         meta_prefetch_cap(get_compile_time_arg_val(22)) {}
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
@@ -10,8 +10,9 @@
 //
 // Variable-length blocks follow the scalars, in this order:
 //   [SCALAR_CT_ARGS ..)          schedule, `schedule_len` words
-//   [schedule end ..)            assignments, ASSIGNMENT_WORDS each
-//   [assignments end ..)         TensorAccessorArgs, chained on by the program factory
+//   [schedule end ..)            own assignments, ASSIGNMENT_WORDS each
+//   [assignments end ..)         incoming chunk descriptors, CHUNK_WORDS each
+//   [descriptors end ..)         TensorAccessorArgs, chained on by the program factory
 
 #include "combine_fabric2d_kernel_interface.hpp"
 
@@ -21,8 +22,9 @@
 
 namespace cmbf2d {
 
-// Scalars packed before the variable-length blocks, i.e. the index the schedule starts at.
-constexpr uint32_t READER_SCALAR_CT_ARGS = 24;
+// Scalars packed before the variable-length blocks, i.e. the index the schedule starts at. Asserted against
+// the field list below, so it cannot drift out of step with it.
+constexpr uint32_t READER_SCALAR_CT_ARGS = 23;
 
 struct ReaderCtArgs {
     uint32_t num_l1_slots;
@@ -32,8 +34,7 @@ struct ReaderCtArgs {
     uint32_t ring_addr;
     uint32_t filled_addr;
     uint32_t freed_addr;
-    uint32_t fwd_chunks_per_quarter;
-    uint32_t fwd_pages_per_chunk;
+    uint32_t fwd_pages_per_quarter;
     uint32_t my_quarter;
     uint32_t num_incoming_chunks;
     uint32_t fwd_sem_addr;
@@ -66,14 +67,13 @@ struct ReaderCtArgs {
         ring_addr(l1.ring),
         filled_addr(plan.ring_filled_addr),
         freed_addr(plan.ring_freed_addr),
-        fwd_chunks_per_quarter(op::relay_chunks_per_stream(op::ring_extent(args))),
-        fwd_pages_per_chunk(plan.pages_per_chunk),
+        fwd_pages_per_quarter(plan.pages_per_quarter),
         // Our quarter of the forwarding buffer. (plane, direction) identifies the upstream sender uniquely
         // from the downstream chip's point of view, so the reader WRITES quarter q of the neighbour's buffer
         // and READS quarter q of its own — the same q, because every chip runs the same code. Doubles as
         // this stream's share of the same-chip run, which it copies after the fabric work.
         my_quarter(plan.stream),
-        num_incoming_chunks(op::relay_chunks_per_stream(op::ring_extent(args))),
+        num_incoming_chunks(0),  // set from the descriptor block below, so the two cannot disagree
         fwd_sem_addr(plan.fwd_arrived_addr),
         nbr_chip_id(static_cast<uint32_t>(self.downstream_node.chip_id)),
         num_assignments(count_own_assignments(work)),
@@ -102,6 +102,19 @@ struct ReaderCtArgs {
             blocks_.push_back(w.split_idx);
             blocks_.push_back(w.split_count);
         }
+        // Chunk descriptors for our own quarter of the forwarding buffer, in arrival order — which is the
+        // order the upstream sender emits them, because both sides derive it from the same generator. They
+        // are what lets the reader compute every chunk's length, and so its page range, with nothing
+        // exchanged between the two chips.
+        const auto incoming =
+            op::incoming_chunks(plan.stream, op::my_row(args, coord), op::ring_extent(args), args.num_links);
+        num_incoming_chunks = static_cast<uint32_t>(incoming.size());
+        for (const auto& c : incoming) {
+            blocks_.push_back(c.origin_row);
+            blocks_.push_back(c.dst_row);
+            blocks_.push_back(c.split_idx);
+            blocks_.push_back(c.split_count);
+        }
     }
 
     std::vector<uint32_t> to_ct_word_arr() const {
@@ -113,8 +126,7 @@ struct ReaderCtArgs {
             ring_addr,
             filled_addr,
             freed_addr,
-            fwd_chunks_per_quarter,
-            fwd_pages_per_chunk,
+            fwd_pages_per_quarter,
             my_quarter,
             num_incoming_chunks,
             fwd_sem_addr,
@@ -142,28 +154,29 @@ struct ReaderCtArgs {
         ring_addr(get_compile_time_arg_val(4)),
         filled_addr(get_compile_time_arg_val(5)),
         freed_addr(get_compile_time_arg_val(6)),
-        fwd_chunks_per_quarter(get_compile_time_arg_val(7)),
-        fwd_pages_per_chunk(get_compile_time_arg_val(8)),
-        my_quarter(get_compile_time_arg_val(9)),
-        num_incoming_chunks(get_compile_time_arg_val(10)),
-        fwd_sem_addr(get_compile_time_arg_val(11)),
-        nbr_chip_id(get_compile_time_arg_val(12)),
-        num_assignments(get_compile_time_arg_val(13)),
-        schedule_len(get_compile_time_arg_val(14)),
-        num_routed_experts(get_compile_time_arg_val(15)),
-        experts_per_chip(get_compile_time_arg_val(16)),
-        my_expert_base(get_compile_time_arg_val(17)),
-        num_experts_per_tok(get_compile_time_arg_val(18)),
-        dispatch_group_size(get_compile_time_arg_val(19)),
-        local_split_count(get_compile_time_arg_val(20)),
-        my_row(get_compile_time_arg_val(21)),
-        control_addr(get_compile_time_arg_val(22)),
-        meta_prefetch_cap(get_compile_time_arg_val(23)) {}
+        fwd_pages_per_quarter(get_compile_time_arg_val(7)),
+        my_quarter(get_compile_time_arg_val(8)),
+        num_incoming_chunks(get_compile_time_arg_val(9)),
+        fwd_sem_addr(get_compile_time_arg_val(10)),
+        nbr_chip_id(get_compile_time_arg_val(11)),
+        num_assignments(get_compile_time_arg_val(12)),
+        schedule_len(get_compile_time_arg_val(13)),
+        num_routed_experts(get_compile_time_arg_val(14)),
+        experts_per_chip(get_compile_time_arg_val(15)),
+        my_expert_base(get_compile_time_arg_val(16)),
+        num_experts_per_tok(get_compile_time_arg_val(17)),
+        dispatch_group_size(get_compile_time_arg_val(18)),
+        local_split_count(get_compile_time_arg_val(19)),
+        my_row(get_compile_time_arg_val(20)),
+        control_addr(get_compile_time_arg_val(21)),
+        meta_prefetch_cap(get_compile_time_arg_val(22)) {}
 
     static constexpr uint32_t schedule_base = READER_SCALAR_CT_ARGS;
-    static constexpr uint32_t assignment_base = schedule_base + get_compile_time_arg_val(14);  // schedule_len
+    static constexpr uint32_t assignment_base = schedule_base + get_compile_time_arg_val(13);  // schedule_len
+    static constexpr uint32_t incoming_chunk_base =
+        assignment_base + ASSIGNMENT_WORDS * get_compile_time_arg_val(12);  // num_assignments
     static constexpr uint32_t accessor_base =
-        assignment_base + ASSIGNMENT_WORDS * get_compile_time_arg_val(13);  // num_assignments
+        incoming_chunk_base + CHUNK_WORDS * get_compile_time_arg_val(9);  // num_incoming_chunks
 
     // One accessor per DRAM buffer the program factory chained on, in that order.
     static constexpr auto dram_in_args = TensorAccessorArgs<accessor_base>();
@@ -191,5 +204,12 @@ private:
     std::vector<uint32_t> blocks_;  // schedule then assignments, appended after the scalars
 #endif
 };
+
+#ifdef KERNEL_BUILD
+// The scalars are read back by index, so the base the variable-length blocks start at IS the field count.
+static_assert(
+    sizeof(ReaderCtArgs) == READER_SCALAR_CT_ARGS * sizeof(uint32_t),
+    "READER_SCALAR_CT_ARGS no longer matches the field list; the blocks after the scalars would be misread");
+#endif
 
 }  // namespace cmbf2d

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/combine_fabric2d_reader_ct_args.hpp
@@ -11,7 +11,7 @@
 // Variable-length blocks follow the scalars, in this order:
 //   [SCALAR_CT_ARGS ..)          schedule, `schedule_len` words
 //   [schedule end ..)            own assignments, ASSIGNMENT_WORDS each
-//   [assignments end ..)         incoming chunk descriptors, CHUNK_WORDS each
+//   [assignments end ..)         forwarding chunk descriptors, CHUNK_WORDS each
 //   [descriptors end ..)         TensorAccessorArgs, chained on by the program factory
 
 #include "combine_fabric2d_kernel_interface.hpp"
@@ -36,7 +36,7 @@ struct ReaderCtArgs {
     uint32_t freed_addr;
     uint32_t fwd_pages_per_stream;
     uint32_t my_stream;
-    uint32_t num_incoming_chunks;
+    uint32_t num_forwarding_chunks;
     uint32_t fwd_sem_addr;
     uint32_t nbr_chip_id;
     uint32_t num_assignments;
@@ -73,7 +73,7 @@ struct ReaderCtArgs {
         // and READS region q of its own — the same q, because every chip runs the same code. Doubles as
         // this stream's share of the same-chip run, which it copies after the fabric work.
         my_stream(plan.stream),
-        num_incoming_chunks(0),  // set from the descriptor block below, so the two cannot disagree
+        num_forwarding_chunks(0),  // set from the descriptor block below, so the two cannot disagree
         fwd_sem_addr(plan.fwd_arrived_addr),
         nbr_chip_id(static_cast<uint32_t>(self.downstream_node.chip_id)),
         num_assignments(count_own_assignments(work)),
@@ -106,10 +106,10 @@ struct ReaderCtArgs {
         // order the upstream sender emits them, because both sides derive it from the same generator. They
         // are what lets the reader compute every chunk's length, and so its page range, with nothing
         // exchanged between the two chips.
-        const auto incoming =
-            op::incoming_chunks(plan.stream, op::my_dg_index(args, coord), op::ring_extent(args), args.num_links);
-        num_incoming_chunks = static_cast<uint32_t>(incoming.size());
-        for (const auto& c : incoming) {
+        const auto forwarding =
+            op::forwarding_chunks(plan.stream, op::my_dg_index(args, coord), op::ring_extent(args), args.num_links);
+        num_forwarding_chunks = static_cast<uint32_t>(forwarding.size());
+        for (const auto& c : forwarding) {
             c.append_to(blocks_);
         }
     }
@@ -125,7 +125,7 @@ struct ReaderCtArgs {
             freed_addr,
             fwd_pages_per_stream,
             my_stream,
-            num_incoming_chunks,
+            num_forwarding_chunks,
             fwd_sem_addr,
             nbr_chip_id,
             num_assignments,
@@ -153,7 +153,7 @@ struct ReaderCtArgs {
         freed_addr(get_compile_time_arg_val(6)),
         fwd_pages_per_stream(get_compile_time_arg_val(7)),
         my_stream(get_compile_time_arg_val(8)),
-        num_incoming_chunks(get_compile_time_arg_val(9)),
+        num_forwarding_chunks(get_compile_time_arg_val(9)),
         fwd_sem_addr(get_compile_time_arg_val(10)),
         nbr_chip_id(get_compile_time_arg_val(11)),
         num_assignments(get_compile_time_arg_val(12)),
@@ -170,10 +170,10 @@ struct ReaderCtArgs {
 
     static constexpr uint32_t schedule_base = READER_SCALAR_CT_ARGS;
     static constexpr uint32_t assignment_base = schedule_base + get_compile_time_arg_val(13);  // schedule_len
-    static constexpr uint32_t incoming_chunk_base =
+    static constexpr uint32_t forwarding_chunk_base =
         assignment_base + ASSIGNMENT_WORDS * get_compile_time_arg_val(12);  // num_assignments
     static constexpr uint32_t accessor_base =
-        incoming_chunk_base + CHUNK_WORDS * get_compile_time_arg_val(9);  // num_incoming_chunks
+        forwarding_chunk_base + CHUNK_WORDS * get_compile_time_arg_val(9);  // num_forwarding_chunks
 
     // One accessor per DRAM buffer the program factory chained on, in that order.
     static constexpr auto dram_in_args = TensorAccessorArgs<accessor_base>();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
@@ -89,9 +89,9 @@ volatile tt_l1_ptr cmbf2d::FwdMetadata* slot_metadata(uint32_t slot) {
     return reinterpret_cast<volatile tt_l1_ptr cmbf2d::FwdMetadata*>(slot_addr_of(slot) + ct.token_size_bytes);
 }
 
-cmbf2d::ChunkDescriptor incoming_chunk(uint32_t chunk) {
+cmbf2d::ChunkDescriptor forwarding_chunk(uint32_t chunk) {
     return cmbf2d::ChunkDescriptor::from_words(
-        &kernel_compile_time_args[ct.incoming_chunk_base + chunk * cmbf2d::CHUNK_WORDS]);
+        &kernel_compile_time_args[ct.forwarding_chunk_base + chunk * cmbf2d::CHUNK_WORDS]);
 }
 
 // Experts hosted by any chip on our ring. The dispatch group's experts are laid out in dispatch-group-index order, so
@@ -333,7 +333,7 @@ struct Reader {
     // speculative about them: `batch` pages at a time, capped by what is left of the chunk and by what
     // upstream says has arrived. An EMPTY chunk occupies no pages at all and so is simply not there.
     void do_forward_chunk(uint32_t chunk) {
-        uint32_t remaining = chunk_tokens(incoming_chunk(chunk));
+        uint32_t remaining = chunk_tokens(forwarding_chunk(chunk));
         if (remaining == 0) {
             return;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
@@ -13,12 +13,12 @@
 //      immediate neighbour (=> CMD_FINAL_WRITE, the neighbour writes it straight into its output region) or
 //      further away (=> CMD_FORWARD into the neighbour's forwarding buffer).
 //
-//   B. The chunks that arrived in OUR quarter of the forwarding buffer, written by the upstream chip's
+//   B. The chunks that arrived in OUR region of the forwarding buffer, written by the upstream chip's
 //      sender on the same (plane, direction). Each is pushed one more hop: final-write if its destination
 //      is now our neighbour, re-forward otherwise.
 //
 // The forwarding buffer is DENSE: a chunk occupies exactly as many pages as it has tokens, and starts where
-// the previous one ended. Nothing is exchanged to make the writer and the reader of a quarter agree on those
+// the previous one ended. Nothing is exchanged to make the writer and the reader of a region agree on those
 // boundaries — both compute every chunk's length from the same replicated expert_offsets, using the chunk
 // descriptors the host packed in the same order the upstream sender emits them.
 //
@@ -67,13 +67,11 @@ constexpr uint32_t meta_pads_addr = ct.control_addr;
 constexpr uint32_t META_READ_BYTES = cmbf2d::META_PAD_STRIDE;  // fill the whole pad; the record is shorter
 constexpr uint32_t control_tables_addr = ct.control_addr + ct.meta_prefetch_cap * cmbf2d::META_PAD_STRIDE;
 
-// Page of our quarter of the forwarding buffer. The same formula serves both directions: the quarter index
+// Page of our region of the forwarding buffer. The same formula serves both directions: the stream index
 // is ours either way, only the chip differs, and the buffer's device-local address is uniform across the
 // mesh. Chunk boundaries do not appear here — a chunk is just a run of consecutive pages, so both sides
-// address the quarter by a single running page count.
-constexpr uint32_t fwd_page(uint32_t page_in_quarter) {
-    return ct.my_quarter * ct.fwd_pages_per_quarter + page_in_quarter;
-}
+// address the region by a single running page count.
+constexpr uint32_t fwd_page(uint32_t page_in_stream) { return ct.my_stream * ct.fwd_pages_per_stream + page_in_stream; }
 
 // Our slice of a run: of [begin, end) take [begin + n*idx/count, begin + n*(idx+1)/count). Integer
 // arithmetic, so consecutive slices meet exactly — no gaps, no overlap, whatever n is.
@@ -91,28 +89,15 @@ volatile tt_l1_ptr cmbf2d::FwdMetadata* slot_metadata(uint32_t slot) {
     return reinterpret_cast<volatile tt_l1_ptr cmbf2d::FwdMetadata*>(slot_addr_of(slot) + ct.token_size_bytes);
 }
 
-// Which chip's tokens a chunk carries, for which chip, and the share of each run the two agreed on. Enough
-// to compute its token count, which is what places it in the quarter.
-struct ChunkDesc {
-    uint32_t origin_row;
-    uint32_t dst_row;
-    uint32_t split_idx;
-    uint32_t split_count;
-};
-
-ChunkDesc incoming_chunk(uint32_t chunk) {
-    const uint32_t w = ct.incoming_chunk_base + chunk * cmbf2d::CHUNK_WORDS;
-    return ChunkDesc{
-        kernel_compile_time_args[w + 0],
-        kernel_compile_time_args[w + 1],
-        kernel_compile_time_args[w + 2],
-        kernel_compile_time_args[w + 3]};
+cmbf2d::ChunkDescriptor incoming_chunk(uint32_t chunk) {
+    return cmbf2d::ChunkDescriptor::from_words(
+        &kernel_compile_time_args[ct.incoming_chunk_base + chunk * cmbf2d::CHUNK_WORDS]);
 }
 
-// Experts hosted by any chip on our ring. The dispatch group's experts are laid out in row order, so our
-// own base locates every other chip's — which is what lets us size a chunk we neither produced nor receive.
-constexpr uint32_t group_expert_base = ct.my_expert_base - ct.my_row * ct.experts_per_chip;
-constexpr uint32_t expert_base(uint32_t row) { return group_expert_base + row * ct.experts_per_chip; }
+// Experts hosted by any chip on our ring. The dispatch group's experts are laid out in dispatch-group-index order, so
+// our own base locates every other chip's — which is what lets us size a chunk we neither produced nor receive.
+constexpr uint32_t group_expert_base = ct.my_expert_base - ct.my_dg_index * ct.experts_per_chip;
+constexpr uint32_t expert_base(uint32_t dg_index) { return group_expert_base + dg_index * ct.experts_per_chip; }
 
 // Every DRAM buffer this kernel touches, so the phases take one argument instead of seven.
 struct Dram {
@@ -137,7 +122,7 @@ Dram open_dram() {
         TensorAccessor(ct.dram_expert_offsets_args, rt.dram_expert_offsets)};
 }
 
-// Where origin chip `row`'s tokens for expert `e` start, and where they end. The runs are laid out in
+// Where origin chip `dg_index`'s tokens for expert `e` start, and where they end. The runs are laid out in
 // origin-chip order inside the expert's region, so one run ends where the next begins; the last one ends
 // at the expert's total count past its region base, which is the only thing expert_offsets cannot say.
 struct ControlTables {
@@ -145,10 +130,10 @@ struct ControlTables {
     volatile tt_l1_ptr uint32_t* counts;
     volatile tt_l1_ptr uint32_t* region;
 
-    uint32_t run_begin(uint32_t row, uint32_t e) const { return offsets[row * ct.num_routed_experts + e]; }
-    uint32_t run_end(uint32_t row, uint32_t e) const {
-        return row + 1 < ct.dispatch_group_size ? offsets[(row + 1) * ct.num_routed_experts + e]
-                                                : region[e] + counts[e];
+    uint32_t run_begin(uint32_t dg_index, uint32_t e) const { return offsets[dg_index * ct.num_routed_experts + e]; }
+    uint32_t run_end(uint32_t dg_index, uint32_t e) const {
+        return dg_index + 1 < ct.dispatch_group_size ? offsets[(dg_index + 1) * ct.num_routed_experts + e]
+                                                     : region[e] + counts[e];
     }
 };
 
@@ -175,7 +160,7 @@ ControlTables read_control_tables(const Dram& dram) {
 }
 
 // Everything the phases share: the ring's flow control, where the next downstream chunk goes, and how far
-// into our own quarter we have consumed.
+// into our own region we have consumed.
 //
 // `published` counts slots ANNOUNCED to the sender; `claimed` counts slots we have taken. They differ
 // because reads are issued in batches: a batch's slots are all claimed and their reads all issued before
@@ -192,12 +177,12 @@ struct Reader {
     uint32_t claimed = 0;
     // Publishing is batched so the atomic is amortised, matching the sender's batch.
     uint32_t pending_publish = 0;
-    // How far into the downstream chip's quarter we have written, and where the chunk in progress ends. The
+    // How far into the downstream chip's region we have written, and where the chunk in progress ends. The
     // downstream reader walks its chunks in exactly the order we emit them, sizing each the same way we do,
     // so this single counter is all the two chips need to agree on to place every page.
     uint32_t out_page = 0;
     uint32_t out_chunk_end = 0;
-    // Pages taken out of our own quarter, which for the same reason IS the page the next chunk starts at.
+    // Pages taken out of our own region, which for the same reason IS the page the next chunk starts at.
     uint32_t consumed = 0;
 
     void flush_publish() {
@@ -247,26 +232,25 @@ struct Reader {
     // chip's experts, narrowed to the share the two chips agreed on. Every term is readable on any chip of
     // the ring, which is what makes a chunk's length agree between the chip that writes it and the chip that
     // reads it without either telling the other.
-    uint32_t chunk_tokens(const ChunkDesc& desc) const {
-        const uint32_t base = expert_base(desc.origin_row);
+    uint32_t chunk_tokens(const cmbf2d::ChunkDescriptor& desc) const {
+        const uint32_t base = expert_base(desc.origin_dg_index);
         uint32_t tokens = 0;
         for (uint32_t le = 0; le < ct.experts_per_chip; le++) {
             const uint32_t e = base + le;
-            const uint32_t begin = ctl.run_begin(desc.dst_row, e);
-            const uint32_t n = ctl.run_end(desc.dst_row, e) - begin;
+            const uint32_t begin = ctl.run_begin(desc.dst_dg_index, e);
+            const uint32_t n = ctl.run_end(desc.dst_dg_index, e) - begin;
             tokens += slice_begin(begin, n, desc.split_idx + 1, desc.split_count) -
                       slice_begin(begin, n, desc.split_idx, desc.split_count);
         }
         return tokens;
     }
 
-    // Point one slot at its page in the downstream chip's quarter. The chunk's last page is marked so the
+    // Point one slot at `page` of the downstream chip's region. The chunk's last page is marked so the
     // sender bumps that chip's arrival counter right there, rather than leaving a partial bump batch
     // uncounted until end of stream.
-    void aim_at_downstream(volatile tt_l1_ptr cmbf2d::FwdMetadata* metadata) {
-        metadata->cmd = (out_page + 1 == out_chunk_end) ? cmbf2d::CMD_FORWARD_END : cmbf2d::CMD_FORWARD;
-        metadata->this_addr = dram.fwd.get_noc_addr(fwd_page(out_page));
-        out_page++;
+    void aim_at_downstream(volatile tt_l1_ptr cmbf2d::FwdMetadata* metadata, uint32_t page) const {
+        metadata->cmd = (page + 1 == out_chunk_end) ? cmbf2d::CMD_FORWARD_END : cmbf2d::CMD_FORWARD;
+        metadata->this_addr = dram.fwd.get_noc_addr(fwd_page(page));
     }
 
     // Issues one token's read and fills its metadata but does NOT barrier or announce it: the caller does
@@ -291,7 +275,7 @@ struct Reader {
         } else {
             metadata->final_addr = final_addr;
             metadata->dst_chip = (uint64_t)dst_chip_id;
-            aim_at_downstream(metadata);
+            aim_at_downstream(metadata, out_page++);
         }
     }
 
@@ -320,8 +304,8 @@ struct Reader {
     void do_own_assignment(uint32_t a) {
         const uint32_t w = ct.assignment_base + a * cmbf2d::ASSIGNMENT_WORDS;
         const uint32_t dst_chip_id = kernel_compile_time_args[w + 0];
-        const ChunkDesc desc{
-            ct.my_row,
+        const cmbf2d::ChunkDescriptor desc{
+            ct.my_dg_index,
             kernel_compile_time_args[w + 1],
             kernel_compile_time_args[w + 2],
             kernel_compile_time_args[w + 3]};
@@ -330,8 +314,8 @@ struct Reader {
         out_chunk_end = out_page + (direct ? 0 : chunk_tokens(desc));
         for (uint32_t le = 0; le < ct.experts_per_chip; le++) {
             const uint32_t e = ct.my_expert_base + le;
-            const uint32_t begin = ctl.run_begin(desc.dst_row, e);
-            const uint32_t n = ctl.run_end(desc.dst_row, e) - begin;
+            const uint32_t begin = ctl.run_begin(desc.dst_dg_index, e);
+            const uint32_t n = ctl.run_end(desc.dst_dg_index, e) - begin;
             stage_run_slice(
                 dst_chip_id,
                 slice_begin(begin, n, desc.split_idx, desc.split_count),
@@ -369,7 +353,7 @@ struct Reader {
                     decided = true;
                 }
                 if (reforward) {
-                    aim_at_downstream(metadata);
+                    aim_at_downstream(metadata, out_page++);
                 } else {
                     metadata->cmd = cmbf2d::CMD_FINAL_WRITE;
                     metadata->this_addr = metadata->final_addr;
@@ -417,7 +401,7 @@ struct Reader {
     }
 
     // Walk the schedule. Forwarding chunks always appear in increasing order, so `consumed` stays a valid
-    // watermark into our quarter however the own assignments are interleaved around them.
+    // watermark into our region however the own assignments are interleaved around them.
     void run_schedule() {
         for (uint32_t si = 0; si < ct.schedule_len; si++) {
             const uint32_t entry = kernel_compile_time_args[ct.schedule_base + si];
@@ -447,10 +431,10 @@ struct Reader {
         const uint32_t slot_addr = slot_addr_of(claim_slot());
         for (uint32_t le = 0; le < ct.experts_per_chip; le++) {
             const uint32_t e = ct.my_expert_base + le;
-            const uint32_t begin = ctl.run_begin(ct.my_row, e);
-            const uint32_t n = ctl.run_end(ct.my_row, e) - begin;
-            const uint32_t lo = slice_begin(begin, n, ct.my_quarter, ct.local_split_count);
-            const uint32_t hi = slice_begin(begin, n, ct.my_quarter + 1, ct.local_split_count);
+            const uint32_t begin = ctl.run_begin(ct.my_dg_index, e);
+            const uint32_t n = ctl.run_end(ct.my_dg_index, e) - begin;
+            const uint32_t lo = slice_begin(begin, n, ct.my_stream, ct.local_split_count);
+            const uint32_t hi = slice_begin(begin, n, ct.my_stream + 1, ct.local_split_count);
             for (uint32_t base = lo; base < hi; base += ct.meta_prefetch_cap) {
                 const uint32_t end = (hi - base) > ct.meta_prefetch_cap ? base + ct.meta_prefetch_cap : hi;
                 prefetch_metadata(base, end);
@@ -490,7 +474,7 @@ void kernel_main() {
     reader.end_stream();
 
     // Back to zero for the next launch, which starts its own count at zero. The upstream sender cannot bump
-    // this again: its bumps sum to exactly the pages of our quarter and we consumed all of them, so the last
+    // this again: its bumps sum to exactly the pages of our region and we consumed all of them, so the last
     // one has already landed — and its drain targets a sink address rather than this semaphore.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ct.fwd_sem_addr), 0);
     // Do not exit with `filled` increments still in the NIU.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/reader_combine_fabric2d.cpp
@@ -11,13 +11,16 @@
 //
 //   A. Its OWN assignments — its plane's share of this chip's movements. Each destination is either our
 //      immediate neighbour (=> CMD_FINAL_WRITE, the neighbour writes it straight into its output region) or
-//      further away (=> CMD_FORWARD into the neighbour's forwarding buffer). A forwarding assignment ends
-//      with a SENTINEL token so the downstream reader knows where the chunk stops.
+//      further away (=> CMD_FORWARD into the neighbour's forwarding buffer).
 //
 //   B. The chunks that arrived in OUR quarter of the forwarding buffer, written by the upstream chip's
 //      sender on the same (plane, direction). Each is pushed one more hop: final-write if its destination
-//      is now our neighbour, re-forward otherwise. A sentinel is passed on only when re-forwarding — a final
-//      write leaves no chunk downstream to terminate.
+//      is now our neighbour, re-forward otherwise.
+//
+// The forwarding buffer is DENSE: a chunk occupies exactly as many pages as it has tokens, and starts where
+// the previous one ended. Nothing is exchanged to make the writer and the reader of a quarter agree on those
+// boundaries — both compute every chunk's length from the same replicated expert_offsets, using the chunk
+// descriptors the host packed in the same order the upstream sender emits them.
 //
 // The stream ends with a CMD_END slot, because its length is not knowable up front: how much this core
 // re-forwards depends on chunk sizes decided upstream.
@@ -64,10 +67,12 @@ constexpr uint32_t meta_pads_addr = ct.control_addr;
 constexpr uint32_t META_READ_BYTES = cmbf2d::META_PAD_STRIDE;  // fill the whole pad; the record is shorter
 constexpr uint32_t control_tables_addr = ct.control_addr + ct.meta_prefetch_cap * cmbf2d::META_PAD_STRIDE;
 
-// Page of a chunk within OUR quarter. The same formula serves both directions: the quarter index is ours
-// either way, only the chip differs, and the buffer's device-local address is uniform across the mesh.
-constexpr uint32_t fwd_page(uint32_t chunk, uint32_t token) {
-    return ct.my_quarter * ct.fwd_chunks_per_quarter * ct.fwd_pages_per_chunk + chunk * ct.fwd_pages_per_chunk + token;
+// Page of our quarter of the forwarding buffer. The same formula serves both directions: the quarter index
+// is ours either way, only the chip differs, and the buffer's device-local address is uniform across the
+// mesh. Chunk boundaries do not appear here — a chunk is just a run of consecutive pages, so both sides
+// address the quarter by a single running page count.
+constexpr uint32_t fwd_page(uint32_t page_in_quarter) {
+    return ct.my_quarter * ct.fwd_pages_per_quarter + page_in_quarter;
 }
 
 // Our slice of a run: of [begin, end) take [begin + n*idx/count, begin + n*(idx+1)/count). Integer
@@ -85,6 +90,29 @@ bool is_direct(uint32_t dst_chip_id) { return dst_chip_id == ct.nbr_chip_id; }
 volatile tt_l1_ptr cmbf2d::FwdMetadata* slot_metadata(uint32_t slot) {
     return reinterpret_cast<volatile tt_l1_ptr cmbf2d::FwdMetadata*>(slot_addr_of(slot) + ct.token_size_bytes);
 }
+
+// Which chip's tokens a chunk carries, for which chip, and the share of each run the two agreed on. Enough
+// to compute its token count, which is what places it in the quarter.
+struct ChunkDesc {
+    uint32_t origin_row;
+    uint32_t dst_row;
+    uint32_t split_idx;
+    uint32_t split_count;
+};
+
+ChunkDesc incoming_chunk(uint32_t chunk) {
+    const uint32_t w = ct.incoming_chunk_base + chunk * cmbf2d::CHUNK_WORDS;
+    return ChunkDesc{
+        kernel_compile_time_args[w + 0],
+        kernel_compile_time_args[w + 1],
+        kernel_compile_time_args[w + 2],
+        kernel_compile_time_args[w + 3]};
+}
+
+// Experts hosted by any chip on our ring. The dispatch group's experts are laid out in row order, so our
+// own base locates every other chip's — which is what lets us size a chunk we neither produced nor receive.
+constexpr uint32_t group_expert_base = ct.my_expert_base - ct.my_row * ct.experts_per_chip;
+constexpr uint32_t expert_base(uint32_t row) { return group_expert_base + row * ct.experts_per_chip; }
 
 // Every DRAM buffer this kernel touches, so the phases take one argument instead of seven.
 struct Dram {
@@ -164,11 +192,12 @@ struct Reader {
     uint32_t claimed = 0;
     // Publishing is batched so the atomic is amortised, matching the sender's batch.
     uint32_t pending_publish = 0;
-    // Which chunk of the neighbour's quarter the next forwarding batch goes into. Our own forwarding
-    // assignments take 0.., then our re-forwards continue from there — and the downstream reader walks its
-    // chunks in exactly that order, which is what makes the two agree with no negotiation.
-    uint32_t out_chunk = 0;
-    // Forwarded pages (sentinels included) taken out of our quarter.
+    // How far into the downstream chip's quarter we have written, and where the chunk in progress ends. The
+    // downstream reader walks its chunks in exactly the order we emit them, sizing each the same way we do,
+    // so this single counter is all the two chips need to agree on to place every page.
+    uint32_t out_page = 0;
+    uint32_t out_chunk_end = 0;
+    // Pages taken out of our own quarter, which for the same reason IS the page the next chunk starts at.
     uint32_t consumed = 0;
 
     void flush_publish() {
@@ -214,10 +243,35 @@ struct Reader {
         noc_async_read_barrier();
     }
 
+    // The token count of one forwarding chunk: the destination chip's tokens sitting under the origin
+    // chip's experts, narrowed to the share the two chips agreed on. Every term is readable on any chip of
+    // the ring, which is what makes a chunk's length agree between the chip that writes it and the chip that
+    // reads it without either telling the other.
+    uint32_t chunk_tokens(const ChunkDesc& desc) const {
+        const uint32_t base = expert_base(desc.origin_row);
+        uint32_t tokens = 0;
+        for (uint32_t le = 0; le < ct.experts_per_chip; le++) {
+            const uint32_t e = base + le;
+            const uint32_t begin = ctl.run_begin(desc.dst_row, e);
+            const uint32_t n = ctl.run_end(desc.dst_row, e) - begin;
+            tokens += slice_begin(begin, n, desc.split_idx + 1, desc.split_count) -
+                      slice_begin(begin, n, desc.split_idx, desc.split_count);
+        }
+        return tokens;
+    }
+
+    // Point one slot at its page in the downstream chip's quarter. The chunk's last page is marked so the
+    // sender bumps that chip's arrival counter right there, rather than leaving a partial bump batch
+    // uncounted until end of stream.
+    void aim_at_downstream(volatile tt_l1_ptr cmbf2d::FwdMetadata* metadata) {
+        metadata->cmd = (out_page + 1 == out_chunk_end) ? cmbf2d::CMD_FORWARD_END : cmbf2d::CMD_FORWARD;
+        metadata->this_addr = dram.fwd.get_noc_addr(fwd_page(out_page));
+        out_page++;
+    }
+
     // Issues one token's read and fills its metadata but does NOT barrier or announce it: the caller does
-    // both once per batch, so several reads are in flight together. `chunk_page` is where the token goes in
-    // the downstream forwarding chunk, and is ignored for a direct write.
-    void issue_token(uint32_t dst_chip_id, uint32_t in_page, uint32_t pad, uint32_t chunk_page) {
+    // both once per batch, so several reads are in flight together.
+    void issue_token(uint32_t dst_chip_id, uint32_t in_page, uint32_t pad) {
         const uint32_t slot = claim_slot();
         volatile tt_l1_ptr cmbf2d::FwdMetadata* metadata = slot_metadata(slot);
         volatile tt_l1_ptr uint32_t* meta =
@@ -227,25 +281,22 @@ struct Reader {
         // Everything below runs while that read is in flight, which is the point of prefetching the metadata.
         // Record layout: [0] linearized_coord, [1] token_idx, [2] topk_idx; the destination chip is already
         // known from the run this token came out of.
-        const uint32_t out_page = meta[1] * ct.num_experts_per_tok + meta[2];
+        const uint32_t token_out_page = meta[1] * ct.num_experts_per_tok + meta[2];
         // Computed once and then travelling with the token for however many hops it takes. Valid on any chip
         // because the output buffer's base address and interleaved bank mapping are uniform across the mesh.
-        const uint64_t final_addr = dram.out.get_noc_addr(out_page);
+        const uint64_t final_addr = dram.out.get_noc_addr(token_out_page);
         if (is_direct(dst_chip_id)) {
             metadata->cmd = cmbf2d::CMD_FINAL_WRITE;
             metadata->this_addr = final_addr;
         } else {
             metadata->final_addr = final_addr;
             metadata->dst_chip = (uint64_t)dst_chip_id;
-            metadata->cmd = cmbf2d::CMD_FORWARD;
-            metadata->this_addr = dram.fwd.get_noc_addr(fwd_page(out_chunk, chunk_page));
+            aim_at_downstream(metadata);
         }
     }
 
     // Stage [lo, hi) of one run: prefetch their metadata, then issue and announce them `batch` at a time.
-    // Returns how many were staged, which is what advances the caller's position in the downstream chunk.
-    uint32_t stage_run_slice(uint32_t dst_chip_id, uint32_t lo, uint32_t hi, uint32_t chunk_page) {
-        uint32_t staged = 0;
+    void stage_run_slice(uint32_t dst_chip_id, uint32_t lo, uint32_t hi) {
         for (uint32_t base = lo; base < hi; base += ct.meta_prefetch_cap) {
             const uint32_t end = (hi - base) > ct.meta_prefetch_cap ? base + ct.meta_prefetch_cap : hi;
             prefetch_metadata(base, end);
@@ -253,38 +304,13 @@ struct Reader {
             for (uint32_t q = base; q < end;) {
                 const uint32_t k = (end - q) > ct.batch ? ct.batch : (end - q);
                 for (uint32_t j = 0; j < k; j++) {
-                    issue_token(dst_chip_id, q + j, q + j - base, chunk_page + staged);
-                    if (!is_direct(dst_chip_id)) {
-                        staged++;
-                    }
+                    issue_token(dst_chip_id, q + j, q + j - base);
                 }
                 noc_async_read_barrier();  // every token of the ct.batch is in L1 before any is announced
                 publish_n(k);
                 q += k;
             }
         }
-        return staged;
-    }
-
-    // Sentinel: terminates this chunk for the downstream reader. Carries no usable token, so no DRAM read —
-    // only the metadata matters. Chunk lengths are data-dependent now, which is exactly what the sentinel
-    // exists for: nothing downstream assumes a chunk is full.
-    //
-    // It carries the chunk's destination in the otherwise-unused FINAL_ADDR word, because from phase 10 a
-    // chunk can be EMPTY — a sender's slice of a run may hold no tokens at all. The relay decides
-    // final-write-vs-re-forward from the first token it sees, and an empty chunk has none, so without this
-    // the decision would be undecidable and the chunk count downstream would drift. Both words travel with a
-    // forwarded packet (token + 16 bytes), so it propagates hop to hop for free.
-    void close_chunk(uint32_t dst_chip_id, uint32_t chunk_page) {
-        volatile tt_l1_ptr cmbf2d::FwdMetadata* metadata = slot_metadata(claim_slot());
-        metadata->final_addr = (uint64_t)dst_chip_id;
-        metadata->dst_chip = cmbf2d::SENTINEL_DST_CHIP;
-        metadata->cmd = cmbf2d::CMD_FORWARD;
-        metadata->this_addr = dram.fwd.get_noc_addr(fwd_page(out_chunk, chunk_page));
-        published++;
-        pending_publish++;
-        flush_publish();  // a chunk boundary: do not let it sit unpublished
-        out_chunk++;
     }
 
     // One own assignment: everything this chip owes ONE destination chip, over all the experts it hosts,
@@ -292,24 +318,24 @@ struct Reader {
     // one (this chip -> that chip) term, and which expert a token sat under is not something the forwarding
     // protocol needs to know.
     void do_own_assignment(uint32_t a) {
-        const uint32_t dst_chip_id = kernel_compile_time_args[ct.assignment_base + a * cmbf2d::ASSIGNMENT_WORDS + 0];
-        const uint32_t dst_row = kernel_compile_time_args[ct.assignment_base + a * cmbf2d::ASSIGNMENT_WORDS + 1];
-        const uint32_t split_idx = kernel_compile_time_args[ct.assignment_base + a * cmbf2d::ASSIGNMENT_WORDS + 2];
-        const uint32_t split_count = kernel_compile_time_args[ct.assignment_base + a * cmbf2d::ASSIGNMENT_WORDS + 3];
-        uint32_t chunk_page = 0;  // position in the downstream chunk, continuous across our experts
+        const uint32_t w = ct.assignment_base + a * cmbf2d::ASSIGNMENT_WORDS;
+        const uint32_t dst_chip_id = kernel_compile_time_args[w + 0];
+        const ChunkDesc desc{
+            ct.my_row,
+            kernel_compile_time_args[w + 1],
+            kernel_compile_time_args[w + 2],
+            kernel_compile_time_args[w + 3]};
+        const bool direct = is_direct(dst_chip_id);
+        // Sized before the first page is placed, because the last page has to be recognisable when it comes.
+        out_chunk_end = out_page + (direct ? 0 : chunk_tokens(desc));
         for (uint32_t le = 0; le < ct.experts_per_chip; le++) {
             const uint32_t e = ct.my_expert_base + le;
-            const uint32_t begin = ctl.run_begin(dst_row, e);
-            const uint32_t n = ctl.run_end(dst_row, e) - begin;
-            chunk_page += stage_run_slice(
+            const uint32_t begin = ctl.run_begin(desc.dst_row, e);
+            const uint32_t n = ctl.run_end(desc.dst_row, e) - begin;
+            stage_run_slice(
                 dst_chip_id,
-                slice_begin(begin, n, split_idx, split_count),
-                slice_begin(begin, n, split_idx + 1, split_count),
-                chunk_page);
-        }
-
-        if (!is_direct(dst_chip_id)) {
-            close_chunk(dst_chip_id, chunk_page);
+                slice_begin(begin, n, desc.split_idx, desc.split_count),
+                slice_begin(begin, n, desc.split_idx + 1, desc.split_count));
         }
     }
 
@@ -319,92 +345,49 @@ struct Reader {
     // sender puts H*H/2 = 8 tok packets on its cable but only ~1.75 tok of those are its own, so ~78% is
     // relayed. Batching the reads here is therefore what the reader's throughput actually turns on.
     //
-    // Batching has to be SPECULATIVE, because a chunk's length is only discovered by reading its sentinel.
-    // Two facts bound the speculation:
-    //   * having read a non-sentinel page, the next page of this chunk certainly exists;
-    //   * the upstream watermark says how many pages upstream has written, though not how they divide
-    //     between this chunk and later ones.
-    // So we read up to `batch` pages at once and stop at the sentinel. Pages read past a sentinel are
-    // garbage upstream never wrote — harmless, since they are discarded and their slots handed straight back
-    // (nothing was announced for them, so the sender never saw them). The waste is at most batch-1 reads
-    // per chunk against a mean chunk of tok pages, and it buys `batch` reads in flight.
+    // The chunk's length is computed rather than discovered, so the reads are batched with nothing
+    // speculative about them: `batch` pages at a time, capped by what is left of the chunk and by what
+    // upstream says has arrived. An EMPTY chunk occupies no pages at all and so is simply not there.
     void do_forward_chunk(uint32_t chunk) {
+        uint32_t remaining = chunk_tokens(incoming_chunk(chunk));
+        if (remaining == 0) {
+            return;
+        }
+        out_chunk_end = out_page + remaining;  // where the marker goes, should this chunk be re-forwarded
+
         // Every token of a chunk shares one final destination (a chunk IS one (chip -> chip) term), so the
         // first page decides for the whole chunk whether this hop is the last one.
         bool reforward = false;
         bool decided = false;
-        uint32_t i = 0;  // page index within the chunk
-        bool at_end = false;
-
-        while (!at_end) {
-            const uint32_t k = read_arrived_pages(chunk, i);
-
-            uint32_t used = 0;  // pages of this ct.batch that really belong to the chunk
-            uint32_t pub = 0;   // of those, the ones we hand to the sender
+        while (remaining > 0) {
+            const uint32_t k = read_arrived_pages(remaining);
             const uint32_t first_slot = claimed - k;
             for (uint32_t j = 0; j < k; j++) {
                 volatile tt_l1_ptr cmbf2d::FwdMetadata* metadata = slot_metadata((first_slot + j) % ct.num_l1_slots);
-                const uint64_t dst_chip = metadata->dst_chip;
-                used++;
-
-                if (dst_chip == cmbf2d::SENTINEL_DST_CHIP) {
-                    // An EMPTY chunk reaches its sentinel with nothing having decided for it, so the
-                    // sentinel's own destination word decides. The chunk still has to be passed on when it is
-                    // not for our neighbour: the downstream reader counts chunks positionally, so silently
-                    // dropping one would shift every chunk after it.
-                    if (!decided) {
-                        reforward = (metadata->final_addr != (uint64_t)ct.nbr_chip_id);
-                        decided = true;
-                    }
-                    if (reforward) {
-                        // Pass the terminator on, at the end of the chunk we have been writing downstream.
-                        // Its destination word is already in place — it came in with the sentinel.
-                        metadata->cmd = cmbf2d::CMD_FORWARD;
-                        metadata->this_addr = dram.fwd.get_noc_addr(fwd_page(out_chunk, i + j));
-                        pub++;
-                    }
-                    at_end = true;
-                    break;
-                }
-
                 if (!decided) {
-                    reforward = (dst_chip != (uint64_t)ct.nbr_chip_id);
+                    reforward = (metadata->dst_chip != (uint64_t)ct.nbr_chip_id);
                     decided = true;
                 }
                 if (reforward) {
-                    metadata->cmd = cmbf2d::CMD_FORWARD;
-                    metadata->this_addr = dram.fwd.get_noc_addr(fwd_page(out_chunk, i + j));
+                    aim_at_downstream(metadata);
                 } else {
                     metadata->cmd = cmbf2d::CMD_FINAL_WRITE;
                     metadata->this_addr = metadata->final_addr;
                 }
-                pub++;
             }
-
-            // Announce only the pages we are passing on, in claim order. A sentinel we swallow (last hop) and
-            // any speculative reads past it are not announced, so their slots go back by rewinding `claimed`
-            // — legitimate precisely because the sender was never told about them.
-            if (pub > 0) {
-                publish_n(pub);
-            }
-            claimed -= (k - pub);
-            consumed += used;
-            i += used;
-            if (at_end) {
-                flush_publish();  // a chunk boundary: do not let it sit unannounced
-            }
-        }
-        if (reforward) {
-            out_chunk++;
+            publish_n(k);
+            consumed += k;
+            remaining -= k;
         }
     }
 
-    // Wait for upstream to have written past `consumed`, then read as many of chunk `chunk`'s pages from
-    // page `i` as are both available and still inside the chunk. Returns how many slots were claimed.
-    uint32_t read_arrived_pages(uint32_t chunk, uint32_t i) {
+    // Wait for upstream to have written past `consumed`, then read as many of the chunk in progress as are
+    // both available and still inside it — `remaining` is what is left of it. Returns how many slots were
+    // claimed, all of which belong to the chunk.
+    uint32_t read_arrived_pages(uint32_t remaining) {
         volatile tt_l1_ptr uint32_t* fwd_arrived = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ct.fwd_sem_addr);
-        // Do not outpace the upstream sender. It bumps this counter every fwd_bump_every pages and ALWAYS
-        // right after a sentinel, so a chunk boundary is never left unreachable.
+        // Do not outpace the upstream sender. It bumps this counter every fwd_bump_every pages and ALWAYS on
+        // the last page of a chunk, so a chunk boundary is never left unreachable.
         invalidate_l1_cache();
         if (*fwd_arrived <= consumed) {
             flush_publish();  // let the sender work while we wait on upstream
@@ -419,15 +402,15 @@ struct Reader {
         if (k > ct.batch) {
             k = ct.batch;
         }
-        if (k > ct.fwd_pages_per_chunk - i) {
-            k = ct.fwd_pages_per_chunk - i;  // never read outside this chunk's own page range
+        if (k > remaining) {
+            k = remaining;
         }
 
         for (uint32_t j = 0; j < k; j++) {
             const uint32_t slot = claim_slot();
             // ONE read brings the token AND the [final_addr][dst_chip] pair straight into the slot's
             // metadata, because the page layout was chosen to match the slot layout exactly.
-            noc_async_read(dram.fwd.get_noc_addr(fwd_page(chunk, i + j)), slot_addr_of(slot), fwd_read_bytes);
+            noc_async_read(dram.fwd.get_noc_addr(fwd_page(consumed + j)), slot_addr_of(slot), fwd_read_bytes);
         }
         noc_async_read_barrier();
         return k;
@@ -507,8 +490,8 @@ void kernel_main() {
     reader.end_stream();
 
     // Back to zero for the next launch, which starts its own count at zero. The upstream sender cannot bump
-    // this again: we only got past the last chunk by reading its sentinel, so everything it owes us has
-    // arrived, and its drain targets a sink address rather than this semaphore.
+    // this again: its bumps sum to exactly the pages of our quarter and we consumed all of them, so the last
+    // one has already landed — and its drain targets a sink address rather than this semaphore.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ct.fwd_sem_addr), 0);
     // Do not exit with `filled` increments still in the NIU.
     noc_async_atomic_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/sender_combine_fabric2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/sender_combine_fabric2d.cpp
@@ -63,7 +63,7 @@ uint32_t wait_for_filled(uint32_t sent) {
     }
 }
 
-// Tell the downstream reader how far its quarter is filled. A chunk's last page always forces a bump: that
+// Tell the downstream reader how far its region is filled. A chunk's last page always forces a bump: that
 // reader consumes a whole chunk before moving on, so leaving the tail uncounted would strand it.
 template <typename FabricSender>
 void bump_downstream(FabricSender& fabric, uint32_t count) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/sender_combine_fabric2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/kernels/dataflow/sender_combine_fabric2d.cpp
@@ -23,7 +23,7 @@
 #include "fabric/fabric_edm_packet_header.hpp"
 #include "combine_fabric2d_sender_ct_args.hpp"
 
-// Forwarded tokens between semaphore bumps to the downstream reader. A bump always follows a sentinel
+// Forwarded tokens between semaphore bumps to the downstream reader. A chunk's last page forces a bump
 // regardless, so this only sets how finely that reader can pipeline within a chunk.
 constexpr uint32_t FWD_BUMP_EVERY = 32;
 constexpr cmbf2d::SenderCtArgs ct{};
@@ -63,8 +63,8 @@ uint32_t wait_for_filled(uint32_t sent) {
     }
 }
 
-// Tell the downstream reader how far its quarter is filled. A sentinel always forces a bump: it is the chunk
-// boundary that reader switches on, so leaving it uncounted would strand it.
+// Tell the downstream reader how far its quarter is filled. A chunk's last page always forces a bump: that
+// reader consumes a whole chunk before moving on, so leaving the tail uncounted would strand it.
 template <typename FabricSender>
 void bump_downstream(FabricSender& fabric, uint32_t count) {
     volatile PACKET_HEADER_TYPE* hdr_bump = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(ct.pkt_hdr_drain_addr);
@@ -84,7 +84,7 @@ uint64_t send_slot(FabricSender& fabric, uint32_t slot, uint32_t& fwd_since_bump
     if (cmd == cmbf2d::CMD_END) {
         return cmd;
     }
-    const bool forwarding = (cmd == cmbf2d::CMD_FORWARD);
+    const bool forwarding = (cmd == cmbf2d::CMD_FORWARD || cmd == cmbf2d::CMD_FORWARD_END);
     const uint32_t payload_bytes = forwarding ? (ct.token_size_bytes + cmbf2d::FWD_EXTRA_BYTES) : ct.token_size_bytes;
 
     volatile PACKET_HEADER_TYPE* hdr = slot_hdr(slot);
@@ -101,7 +101,7 @@ uint64_t send_slot(FabricSender& fabric, uint32_t slot, uint32_t& fwd_since_bump
 
     if (forwarding) {
         fwd_since_bump++;
-        if (metadata->dst_chip == cmbf2d::SENTINEL_DST_CHIP || fwd_since_bump >= FWD_BUMP_EVERY) {
+        if (cmd == cmbf2d::CMD_FORWARD_END || fwd_since_bump >= FWD_BUMP_EVERY) {
             bump_downstream(fabric, fwd_since_bump);
             fwd_since_bump = 0;
         }


### PR DESCRIPTION
### PR Category - Feature

### Summary
The issue with current forwarding buffer in combine v2 op is that it is very sparse tensor. For every link, for every forwarding direction, for every forwarding chunk, which is 2 x 2 x 10 = 40, it allocates worst case size, roughly allowing all ISL (not ISL-per-chip) tokens to be in that chunk. This makes the forwarding buffer huge - GBs for even small ISLs.
This PR makes the buffer dense by making each chip calculate independently, from expert offsets tensor, how much tokens will be in every chunk. With both sender and receiver having this shared knowledge of each chunk size, the buffer is allocated only to house all tokens together in all chunks, while division in chunks is dynamic and depends on expert offsets tensor.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dlukic/dense-forwarding-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dlukic/dense-forwarding-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dlukic/dense-forwarding-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dlukic/dense-forwarding-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dlukic/dense-forwarding-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dlukic/dense-forwarding-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dlukic/dense-forwarding-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dlukic/dense-forwarding-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dlukic/dense-forwarding-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dlukic/dense-forwarding-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dlukic/dense-forwarding-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dlukic/dense-forwarding-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dlukic/dense-forwarding-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dlukic/dense-forwarding-buffer)