### PR TITLE
[skip ci] [Experiment] Run Copilot cloud agent on Ubuntu 24.04

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
   # The job MUST be called 'copilot-setup-steps' to be recognized by GitHub Copilot Agent
   copilot-setup-steps:
     # Dedicated ARC scale set; capped separately from the build runner pool.
-    runs-on: tt-ubuntu-2204-copilot-stable
+    runs-on: tt-ubuntu-2404-copilot-stable
     # Copilot caps this at 59. Submodule checkout is the bulk of it.
     timeout-minutes: 50
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Run Copilot cloud agent on the existing dedicated `tt-ubuntu-2404-copilot-stable` ARC scale set. This moves the agent host to Ubuntu 24.04 so we can compare its behavior with the Ubuntu 22.04 session that aborted while writing validation output.

Relates to #56345.

### Notes for reviewers
This is a one-line runner selection change. The scale set is already defined in [github-ci-infra](https://github.com/tenstorrent/github-ci-infra/blob/main/ansible/inventories/prod/group_vars/arc_runnersets.yaml#L1620). C++ compilation continues inside the repository's Ubuntu 22.04 CI build image to preserve build and cache compatibility.

The OS change is an experiment; it is not yet established as a fix for the Copilot runtime panic. A complete cloud-agent session will be needed to assess that. This PR starts from `main` and does not depend on #56346.

Validation: [Copilot Setup Steps passed on the Ubuntu 24.04 runner](https://github.com/tenstorrent/tt-metal/actions/runs/34726552048/job/103641561386) in 31 seconds at commit `fd3c704`. Repository-configured yamllint and `git diff --check` also pass. This validates setup; a full Copilot task is still needed to assess the runtime panic.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/copilot-ubuntu-2404)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/copilot-ubuntu-2404)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/copilot-ubuntu-2404)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/copilot-ubuntu-2404)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/copilot-ubuntu-2404)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/copilot-ubuntu-2404)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/copilot-ubuntu-2404)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/copilot-ubuntu-2404)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/copilot-ubuntu-2404)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/copilot-ubuntu-2404)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/copilot-ubuntu-2404)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/copilot-ubuntu-2404)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/copilot-ubuntu-2404)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/copilot-ubuntu-2404)
