### PR TITLE
[Refactor] Disagg Gemma4: models/demos/gemma4_d_p

### DIFF
--- a/models/demos/gemma4_d_p/ENV_VARS.md
+++ b/models/demos/gemma4_d_p/ENV_VARS.md
@@ -1,0 +1,45 @@
+# Gemma4 environment variables
+
+Variables read directly by `gemma4_d_p`, plus the external offline setting used
+in its README. Defaults below reflect the current code.
+
+## Model and cache paths
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `HF_MODEL` | Unset | Hugging Face model ID or local checkpoint directory. Set this for the demo; `create_tt_model(model_path=...)` can override it. |
+| `TT_CACHE_PATH` | Local checkpoint directory, or `$HF_HOME/tt_cache/<model-id-with-slashes-replaced-by-double-hyphens>` | Root for TT weight caches. |
+| `HF_HOME` | `~/.cache/huggingface` | Hugging Face cache location; also supplies the fallback TT-cache root. |
+| `HOME` | Process environment | Used indirectly by home-directory expansion for the default Hugging Face cache. |
+| `HF_HUB_OFFLINE` | Unset | External Hugging Face setting used in the README: `1` requests offline operation with cached model artifacts. Not read directly by Gemma code. |
+
+Cache directories must already exist; path resolution does not create or mirror them.
+
+Sources: `tt/common.py`, `tt/model_config.py`, `demo/text_demo_prefill.py`.
+
+## Prefill and demo
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `GEMMA4_MAX_SEQ_LEN` | Test context length | Overrides the model's KV-cache context capacity in the demo. |
+| `GEMMA4_PREFILL_TRACE_REGION_SIZE` | `256_000_000` bytes | Device trace-memory reservation for demo fixtures; read at module import. |
+| `GEMMA4_PREFILL_LOAD_FULL_WEIGHTS` | `0` | Force full checkpoint/state-dict loading instead of the cache-first path. |
+| `GEMMA4_PREFILL_L1_ACT` | `0` | Use L1 instead of DRAM for short-lived attention activations selected by `prefill_short_lived_memcfg()`. |
+
+Sources: `demo/text_demo_prefill.py`, `tt/attention/operations.py`.
+
+## Communication
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `GEMMA4_CCL_TOPOLOGY` | Ring | `linear`, `line`, or `l` selects Linear for TP collectives. Ring attention independently uses Linear. |
+| `GEMMA4_CCL_ASYNC` | `0` | Use asynchronous reduce-scatter + all-gather for TP all-reduce. |
+| `GEMMA4_CCL_PERSISTENT_BUF` | `1` | Reuse async collective destination buffers. Synchronous all-reduce ignores this. |
+| `GEMMA4_CCL_CHUNKS_PER_SYNC` | `10` | Async collective packet grouping; clamped to at least 1. |
+| `GEMMA4_CCL_NUM_WORKERS` | `2` | Async collective workers per link; clamped to at least 1. |
+| `GEMMA4_CCL_NUM_BUFFERS` | `2` | Async collective buffers per channel; clamped to at least 1. |
+
+Source: `tt/ccl.py`. Link count defaults to 2 on Blackhole and 1 otherwise.
+Explicit constructor arguments override the manager defaults.
+Boolean enable flags accept `1`, `true`, or `yes` (case-insensitive).
+`GEMMA4_CCL_PERSISTENT_BUF` is instead disabled by `0`, `false`, or `no`.

--- a/models/demos/gemma4_d_p/TENSORBIN_ALIGNMENT.md
+++ b/models/demos/gemma4_d_p/TENSORBIN_ALIGNMENT.md
@@ -1,0 +1,85 @@
+# Serializing tensorbins with 16-byte-aligned payloads
+
+The requirement discussed here is **16 bytes (128 bits), not 16 bits**.
+Blackhole's pinned-upload dispatch check uses 16-byte L1 read alignment; its
+current log misleadingly prints the 64-byte HOST read alignment instead.
+
+## Why file layout matters
+
+TTNN memory-maps tensorbins and uses pointers into the mapped file as upload
+sources. The mapping base is page-aligned, so each payload's file offset
+determines its alignment in memory. Pinning does not change that offset.
+
+The current format is:
+
+```text
+[8-byte header_size][FlatBuffer metadata][tensor data region]
+```
+
+Each shard's `InlineFileStorage.offset` is relative to the tensor data region.
+For a full-shard upload, the alignment requirement is:
+
+```python
+(8 + header_size + shard.offset) % 16 == 0
+```
+
+A partial upload must also include its source-region offset in this calculation.
+
+## Writer changes
+
+1. Align each unique shard's relative offset to 16 bytes while building the
+   metadata. Record that padded offset in `InlineFileStorage.offset`, retain
+   the original payload length in `size`, and reuse offsets for deduplicated shards.
+2. Finish the FlatBuffer metadata, then pad its trailing end so that
+   `8 + header_size` is divisible by 16. Include this padding in the stored
+   `header_size`; do not include the 8-byte size field itself in that value.
+3. Write each payload at its recorded offset, inserting padding between payloads
+   where necessary. Tensor values, shapes, dtypes and shard sizes stay unchanged.
+
+```python
+def align16(value):
+    return (value + 15) & ~15
+
+# During metadata construction, for each unique payload:
+shard_offset = align16(next_offset)
+next_offset = shard_offset + len(payload)
+# Record shard_offset and len(payload) in the metadata.
+
+# After finalizing the metadata:
+header_size = align16(8 + len(metadata)) - 8
+output.write(struct.pack("<Q", header_size))
+output.write(metadata)
+output.write(bytes(header_size - len(metadata)))
+# Write payloads with padding to their recorded relative offsets.
+```
+
+Aligning only the FlatBuffer itself is insufficient: the leading 8-byte size
+field must be included. Aligning only the first payload is insufficient if later
+shards start at unaligned offsets.
+
+## Existing files and validation
+
+If every existing shard offset is already divisible by 16, a local copy can be
+fixed by extending the metadata region with padding and updating `header_size`.
+Otherwise, repack the payload region and update the shard offsets as well.
+The existing reader accepts trailing metadata padding; no new field is needed.
+
+Our local MLP down-projection pair uses payload offsets **3000** (unaligned)
+and **3008** (aligned). Adding 8 bytes of metadata padding preserved all payload
+bytes, and both files matched exact device readback on all 32 shards.
+
+Validate all shard offsets, compare payload bytes and loaded tensor metadata,
+then compare device readback. Use `demo/compare_cache_alignment.py` for the local
+pair. Absence of alignment logs proves neither alignment nor fast-path use: small
+uploads and unsuccessful pin attempts bypass that check. Measure transfer time
+separately from file loading and readback.
+
+Implementation locations:
+
+- `ttnn/core/tensor/serialization.cpp`: file writer, header size and mmap reader.
+- `ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp`: shard offsets and deduplication.
+- `ttnn/core/tensor/flatbuffer/tensor.fbs`: `InlineFileStorage` schema.
+- `tt_metal/impl/buffers/dispatch.cpp`: pinned-source alignment check.
+
+Production serialization has not been changed. The experiment only created
+local files under `/tmp/gemma_tensorbin_alignment`; `/mnt` files were not modified.

--- a/models/demos/gemma4_d_p/WEIGHTS_CACHE_LAYOUT.md
+++ b/models/demos/gemma4_d_p/WEIGHTS_CACHE_LAYOUT.md
@@ -1,0 +1,29 @@
+# Gemma4 cache layout
+
+## On disk
+
+| Location | Contents |
+|---|---|
+| Local directory supplied as `HF_MODEL`, or Hugging Face's hub cache (normally `$HF_HOME/hub`) | Original checkpoint weights, model configuration and tokenizer files. `HF_HOME` defaults to `~/.cache/huggingface`. |
+| TT cache root | `TT_CACHE_PATH` if set; otherwise the local checkpoint directory, or `$HF_HOME/tt_cache/google--gemma-4-31B-it` for the model ID. |
+| `<TT cache root>/tensor_cache_<dtype>_mesh<rows>x<cols>/` | Converted weight cache for a dtype and mesh layout, e.g. `tensor_cache_bf16_mesh8x4`. |
+| `*.tensorbin` beneath that directory | Serialized TT tensors, including converted/sharded device weights. Module-specific dtype settings also affect filenames. |
+| `.host_weights.pt` in that directory | PyTorch dictionary of token embeddings and decoder-layer scalars needed on the CPU. |
+| `.weights_complete.<variant-digest>` in that directory | Completion metadata identifying the model, layers, mesh, build settings and cached tensor files. |
+
+A valid completion marker lets initialization load device weights from tensorbins
+and CPU weights from `.host_weights.pt`, skipping the full checkpoint load.
+`GEMMA4_PREFILL_LOAD_FULL_WEIGHTS=1` forces checkpoint loading in the demo.
+Cache-path resolution requires existing directories; it does not create or mirror them.
+
+## In memory
+
+- **CPU:** embeddings and layer scalars loaded from `.host_weights.pt`; the full
+  state dict is also loaded when building from the checkpoint.
+- **Device DRAM:** loaded model weights, global/sliding KV caches, RoPE tables,
+  metadata tensors and persistent communication buffers. These runtime caches
+  are separate from the weight files on disk.
+- **Device trace memory:** captured execution traces, within the reserved trace region.
+
+Implementation: `tt/model_config.py` resolves paths, `tt/common.py` selects the
+loading path, and `models/common/weight_cache.py` manages host weights and completion markers.

--- a/models/demos/gemma4_d_p/config.py
+++ b/models/demos/gemma4_d_p/config.py
@@ -15,14 +15,18 @@ def validate_galaxy_mesh(mesh_shape):
 
 
 class MeshConfig:
-    """Use all Galaxy rows for CP and columns for TP."""
+    """Bind an open device mesh to CP rows and TP columns; the caller owns its lifetime."""
 
-    def __init__(self, mesh_shape):
-        validate_galaxy_mesh(mesh_shape)
-        self.mesh_shape = tuple(mesh_shape)
+    def __init__(self, mesh_device):
+        validate_galaxy_mesh(mesh_device.shape)
+        self.device = mesh_device
         self.tp_axis = 1
         self.cp_axis = 0
         self.total_devices = 32
+
+    @property
+    def mesh_shape(self):
+        return tuple(self.device.shape)
 
     @property
     def cp_degree(self):
@@ -34,17 +38,17 @@ class MeshConfig:
         """Number of tensor-parallel ranks along the TP mesh axis."""
         return self.mesh_shape[self.tp_axis]
 
-    def shard_mapper(self, mesh_device, tensor_dim=None, mesh_dims=None):
+    def shard_mapper(self, tensor_dim=None, mesh_dims=None):
         if mesh_dims is None:
             mesh_dims = [None, None]
             mesh_dims[self.tp_axis] = tensor_dim
-        return ttnn.ShardTensor2dMesh(mesh_device, mesh_device.shape, dims=mesh_dims)
+        return ttnn.ShardTensor2dMesh(self.device, self.mesh_shape, dims=mesh_dims)
 
-    def column_parallel(self, mesh_device):
-        return self.shard_mapper(mesh_device, tensor_dim=-1)
+    def column_parallel(self):
+        return self.shard_mapper(tensor_dim=-1)
 
-    def row_parallel(self, mesh_device):
-        return self.shard_mapper(mesh_device, tensor_dim=-2)
+    def row_parallel(self):
+        return self.shard_mapper(tensor_dim=-2)
 
     def __repr__(self):
         return f"MeshConfig({self.mesh_shape}, CP={self.cp_degree}, TP={self.tp_degree})"

--- a/models/demos/gemma4_d_p/config.py
+++ b/models/demos/gemma4_d_p/config.py
@@ -35,9 +35,10 @@ class MeshConfig:
         return self.mesh_shape[self.tp_axis]
 
     def shard_mapper(self, mesh_device, tensor_dim=None, mesh_dims=None):
-        return ttnn.ShardTensor2dMesh(
-            mesh_device, mesh_device.shape, dims=mesh_dims if mesh_dims is not None else (None, tensor_dim)
-        )
+        if mesh_dims is None:
+            mesh_dims = [None, None]
+            mesh_dims[self.tp_axis] = tensor_dim
+        return ttnn.ShardTensor2dMesh(mesh_device, mesh_device.shape, dims=mesh_dims)
 
     def column_parallel(self, mesh_device):
         return self.shard_mapper(mesh_device, tensor_dim=-1)

--- a/models/demos/gemma4_d_p/config.py
+++ b/models/demos/gemma4_d_p/config.py
@@ -3,8 +3,6 @@
 
 """Parallelism configuration for Gemma4 prefill on one Galaxy."""
 
-from dataclasses import dataclass
-
 import ttnn
 
 GALAXY_MESH_SHAPES = ((8, 4), (4, 8))
@@ -16,29 +14,25 @@ def validate_galaxy_mesh(mesh_shape):
         raise ValueError(f"Gemma4 P/D requires a Galaxy mesh {GALAXY_MESH_SHAPES}, got {tuple(mesh_shape)}")
 
 
-@dataclass(frozen=True)
-class ModeConfig:
-    """Prefill parallelism across Galaxy rows and columns."""
-
-    tp: int
-    sp: int
-    ep: int = 1
-
-
 class MeshConfig:
     """Use all Galaxy rows for CP and columns for TP."""
 
-    def __init__(self, mesh_shape, prefill=None):
+    def __init__(self, mesh_shape):
         validate_galaxy_mesh(mesh_shape)
         self.mesh_shape = tuple(mesh_shape)
         self.tp_axis = 1
-        self.sp_axis = 0
-        self.ep_axis = 0
+        self.cp_axis = 0
         self.total_devices = 32
-        self.tp = mesh_shape[1]
-        self.prefill = prefill or ModeConfig(tp=self.tp, sp=mesh_shape[0])
-        if self.prefill != ModeConfig(tp=self.tp, sp=mesh_shape[0]):
-            raise ValueError("Prefill must use all Galaxy rows for CP and columns for TP")
+
+    @property
+    def cp_degree(self):
+        """Number of context-parallel ranks along the CP mesh axis."""
+        return self.mesh_shape[self.cp_axis]
+
+    @property
+    def tp_degree(self):
+        """Number of tensor-parallel ranks along the TP mesh axis."""
+        return self.mesh_shape[self.tp_axis]
 
     def shard_mapper(self, mesh_device, tensor_dim=None, mesh_dims=None):
         return ttnn.ShardTensor2dMesh(
@@ -52,4 +46,4 @@ class MeshConfig:
         return self.shard_mapper(mesh_device, tensor_dim=-2)
 
     def __repr__(self):
-        return f"MeshConfig({self.mesh_shape}, CP={self.prefill.sp}, TP={self.tp})"
+        return f"MeshConfig({self.mesh_shape}, CP={self.cp_degree}, TP={self.tp_degree})"

--- a/models/demos/gemma4_d_p/demo/compare_cache_alignment.py
+++ b/models/demos/gemma4_d_p/demo/compare_cache_alignment.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare aligned/unaligned tensorbin uploads, including exact device readback."""
+
+import argparse
+import hashlib
+import json
+import statistics
+import struct
+import time
+from pathlib import Path
+
+import torch
+
+import ttnn
+
+PAIR_DIR = Path("/tmp/gemma_tensorbin_alignment")
+
+
+def file_info(path):
+    with path.open("rb") as stream:
+        offset = 8 + struct.unpack("<Q", stream.read(8))[0]
+        stream.seek(offset)
+        digest = hashlib.file_digest(stream, "sha256").hexdigest()
+    return {"path": str(path), "payload_offset": offset, "payload_sha256": digest}
+
+
+def check_readback(device_tensor, host):
+    readback = ttnn.from_device(device_tensor)
+    expected = ttnn.get_device_tensors(host)
+    actual = ttnn.get_device_tensors(readback)
+    assert len(expected) == len(actual) == 32
+    for rank, (reference, result) in enumerate(zip(expected, actual)):
+        assert torch.equal(ttnn.to_torch(reference), ttnn.to_torch(result)), f"Readback mismatch on rank {rank}"
+    print("READBACK_MATCH all_32_shards", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--unaligned", type=Path, default=PAIR_DIR / "down_proj_unaligned.tensorbin")
+    parser.add_argument("--aligned", type=Path, default=PAIR_DIR / "down_proj_aligned.tensorbin")
+    parser.add_argument("--repeats", type=int, default=6)
+    parser.add_argument("--output", type=Path, default=PAIR_DIR / "comparison.json")
+    args = parser.parse_args()
+    if args.repeats < 1:
+        parser.error("--repeats must be positive")
+    paths = {"unaligned": args.unaligned, "aligned": args.aligned}
+    info = {name: file_info(path) for name, path in paths.items()}
+    assert info["unaligned"]["payload_sha256"] == info["aligned"]["payload_sha256"]
+    assert info["unaligned"]["payload_offset"] % 16 != 0
+    assert info["aligned"]["payload_offset"] % 16 == 0
+    samples = {name: [] for name in paths}
+    ttnn.set_fabric_config(ttnn.FabricConfig.FABRIC_1D)
+    mesh_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(8, 4))
+    try:
+        hosts = {name: ttnn.load_tensor(path) for name, path in paths.items()}
+        a, b = hosts.values()
+        assert a.shape == b.shape and a.dtype == b.dtype and a.layout == b.layout
+        # Keep mappings alive to compare repeated uploads with a warm pin cache.
+        # Round zero warms up and checks correctness; alternate order afterwards.
+        for iteration in range(args.repeats + 1):
+            order = list(paths) if iteration % 2 == 0 else list(reversed(paths))
+            for name in order:
+                print(f"BEGIN_UPLOAD {name} iteration={iteration} warmup={iteration == 0}", flush=True)
+                ttnn.synchronize_device(mesh_device)
+                start = time.perf_counter()
+                device_tensor = ttnn.to_device(hosts[name], mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+                ttnn.synchronize_device(mesh_device)
+                elapsed = (time.perf_counter() - start) * 1000
+                print(f"END_UPLOAD {name} elapsed_ms={elapsed:.3f}", flush=True)
+                try:
+                    if iteration == 0:
+                        check_readback(device_tensor, hosts[name])
+                    else:
+                        samples[name].append(elapsed)
+                finally:
+                    device_tensor.deallocate(True)
+    finally:
+        ttnn.close_mesh_device(mesh_device)
+    assert all(file_info(path) == info[name] for name, path in paths.items())
+    result = {
+        "files": info,
+        "samples_ms": samples,
+        "median_ms": {name: statistics.median(values) for name, values in samples.items()},
+        "readback": "exact match on all 32 shards for both files",
+        "timing": "synchronized upload including allocation/pinning/dispatch/logging; excludes load and readback",
+    }
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/gemma4_d_p/demo/text_demo_prefill.py
+++ b/models/demos/gemma4_d_p/demo/text_demo_prefill.py
@@ -49,7 +49,6 @@ def _load_full_weights():
 
 
 def _mesh_config(mesh_device):
-    tp = mesh_device.shape[1]
     return MeshConfig(mesh_device.shape)
 
 
@@ -141,7 +140,7 @@ def _cp_gather_torch(tensor, mesh_device, mesh_config):
     The output of a CP prefill is sharded along the sequence axis and replicated
     across TP (the TP all-reduce leaves every column identical), so take one device
     per CP row and concatenate along the sequence. Device tensors come back in the
-    mesh's row-major order, so CP row r at column 0 is index ``r * num_cols``.
+    mesh's row-major order; the CP axis determines the stride between ranks.
 
     Falls back to device 0 alone when CP is off, matching ``_first_device_torch``.
     """
@@ -151,8 +150,8 @@ def _cp_gather_torch(tensor, mesh_device, mesh_config):
     if cp <= 1:
         return ttnn.to_torch(shards[0]).float()
 
-    num_cols = mesh_device.shape[1]
-    rows = [ttnn.to_torch(shards[r * num_cols]).float() for r in range(cp)]
+    cp_stride = mesh_config.tp_degree if mesh_config.cp_axis == 0 else 1
+    rows = [ttnn.to_torch(shards[r * cp_stride]).float() for r in range(cp)]
     return torch.cat(rows, dim=-2)
 
 
@@ -176,14 +175,15 @@ def _build_prefill_model(mesh_device, model_path, chunk_size, context_len=None):
     mesh_config = _mesh_config(mesh_device)
     if mesh_config.cp_degree <= 1:
         raise ValueError("This demo requires context parallel prefill")
-    tp = mesh_device.shape[1]
     context_len = context_len or chunk_size
     max_seq_len = int(os.environ.get("GEMMA4_MAX_SEQ_LEN", context_len))
 
     hf_config = Gemma4ModelArgs.load_hf_config(model_path)
     num_layers = Gemma4ModelArgs.from_hf_config(hf_config).num_hidden_layers
 
-    logger.info(f"Creating Gemma4 ({num_layers} layers, TP={tp}, max_seq_len={max_seq_len})...")
+    logger.info(
+        f"Creating Gemma4 ({num_layers} layers, CP={mesh_config.cp_degree}, TP={mesh_config.tp_degree}, max_seq_len={max_seq_len})..."
+    )
     t0 = time.time()
     model_args, model, kv_cache, _state_dict = create_tt_model(
         mesh_device=mesh_device,

--- a/models/demos/gemma4_d_p/demo/text_demo_prefill.py
+++ b/models/demos/gemma4_d_p/demo/text_demo_prefill.py
@@ -49,13 +49,13 @@ def _load_full_weights():
 
 
 def _mesh_config(mesh_device):
-    return MeshConfig(mesh_device.shape)
+    return MeshConfig(mesh_device)
 
 
 # ── Prefill inputs ────────────────────────────────────────────────────────────
 
 
-def _host_tensor(mesh_device, torch_tensor, dtype, layout, mesh_config=None, seq_dim=-2):
+def _host_tensor(mesh_config, torch_tensor, dtype, layout, seq_dim=-2):
     """Host-resident ttnn tensor, replicated across the mesh.
 
     Kept on host (``device=None``) so it can be pushed into the same device buffer
@@ -70,17 +70,19 @@ def _host_tensor(mesh_device, torch_tensor, dtype, layout, mesh_config=None, seq
     hidden states ``[1, 1, S, H]``, but **-1** for a 2D token-id tensor ``[1, S]``,
     where -2 is the size-1 batch dim and sharding it would be wrong.
     """
+    mesh_device = mesh_config.device
     return ttnn.from_torch(
         torch_tensor,
         device=None,
         dtype=dtype,
         layout=layout,
-        mesh_mapper=_cp_or_replicate_mapper(mesh_device, mesh_config, seq_dim=seq_dim),
+        mesh_mapper=_cp_or_replicate_mapper(mesh_config, seq_dim=seq_dim),
     )
 
 
-def _cp_or_replicate_mapper(mesh_device, mesh_config, seq_dim=-2):
+def _cp_or_replicate_mapper(mesh_config, seq_dim=-2):
     """Create a CP sharding mapper for ``seq_dim``, or a replication mapper."""
+    mesh_device = mesh_config.device
 
     if mesh_config is not None and mesh_config.cp_degree > 1:
         shard_dims = (seq_dim, None) if mesh_config.cp_axis == 0 else (None, seq_dim)
@@ -134,7 +136,7 @@ def _get_prefill_tokens(model_path, context_len, vocab_size, source="text"):
     return ids
 
 
-def _cp_gather_torch(tensor, mesh_device, mesh_config):
+def _cp_gather_torch(tensor, mesh_config):
     """Read a CP-sharded mesh tensor back to one torch tensor, in position order.
 
     The output of a CP prefill is sharded along the sequence axis and replicated
@@ -144,6 +146,7 @@ def _cp_gather_torch(tensor, mesh_device, mesh_config):
 
     Falls back to device 0 alone when CP is off, matching ``_first_device_torch``.
     """
+    mesh_device = mesh_config.device
 
     shards = ttnn.get_device_tensors(tensor)
     cp = mesh_config.cp_degree if mesh_config is not None else 1
@@ -170,9 +173,8 @@ def _hf_text_config(model_path):
 # ── The prefill model under test ────────────────────────────────────────────
 
 
-def _build_prefill_model(mesh_device, model_path, chunk_size, context_len=None):
+def _build_prefill_model(mesh_config, model_path, chunk_size, context_len=None):
     """Create a CP prefill model with ring caches for one or more chunks."""
-    mesh_config = _mesh_config(mesh_device)
     if mesh_config.cp_degree <= 1:
         raise ValueError("This demo requires context parallel prefill")
     context_len = context_len or chunk_size
@@ -186,13 +188,12 @@ def _build_prefill_model(mesh_device, model_path, chunk_size, context_len=None):
     )
     t0 = time.time()
     model_args, model, kv_cache, _state_dict = create_tt_model(
-        mesh_device=mesh_device,
+        mesh_config=mesh_config,
         max_batch_size=1,
         max_seq_len=max_seq_len,
         dtype=MODEL_DTYPE,
         force_rebuild=_load_full_weights(),
         model_path=model_path,
-        mesh_config=mesh_config,
         prefill_chunk_size=chunk_size,
     )
     logger.info(f"Model ready in {time.time() - t0:.1f}s")
@@ -230,7 +231,7 @@ def test_prefill_long_context_traced(
     model_path = _model_path()
     n_chunks = context_len // chunk_size
     model_args, model, kv_cache = _build_prefill_model(
-        mesh_device=mesh_device,
+        mesh_config=mesh_config,
         model_path=model_path,
         chunk_size=chunk_size,
         context_len=context_len,
@@ -239,21 +240,15 @@ def test_prefill_long_context_traced(
 
     rope_local_seq = chunk_size // cp
     host_input = _host_tensor(
-        mesh_device,
-        tokens_all[:, :chunk_size].contiguous(),
-        ttnn.uint32,
-        ttnn.ROW_MAJOR_LAYOUT,
-        mesh_config=mesh_config,
-        seq_dim=-1,
+        mesh_config, tokens_all[:, :chunk_size].contiguous(), ttnn.uint32, ttnn.ROW_MAJOR_LAYOUT, seq_dim=-1
     )
     device_input = ttnn.to_device(host_input, device=mesh_device)
     device_positions = ttnn.to_device(
         _host_tensor(
-            mesh_device,
+            mesh_config,
             torch.arange(0, chunk_size, dtype=torch.int32).unsqueeze(0),
             ttnn.uint32,
             ttnn.ROW_MAJOR_LAYOUT,
-            mesh_config=mesh_config,
             seq_dim=-1,
         ),
         device=mesh_device,
@@ -268,11 +263,10 @@ def test_prefill_long_context_traced(
         chunk_start = chunk_idx * chunk_size
         _t = time.time()
         staged = _host_tensor(
-            mesh_device,
+            mesh_config,
             tokens_all[:, chunk_start : chunk_start + chunk_size].contiguous(),
             ttnn.uint32,
             ttnn.ROW_MAJOR_LAYOUT,
-            mesh_config=mesh_config,
             seq_dim=-1,
         )
         ttnn.copy_host_to_device_tensor(staged, device_input)
@@ -296,11 +290,10 @@ def test_prefill_long_context_traced(
         # Contiguous sharding of [chunk_start, chunk_start+chunk) hands rank r exactly the
         # rows chunk-major CP assigns it, so the gather inside the trace lands correctly.
         pos_host = _host_tensor(
-            mesh_device,
+            mesh_config,
             torch.arange(chunk_start, chunk_start + chunk_size, dtype=torch.int32).unsqueeze(0),
             ttnn.uint32,
             ttnn.ROW_MAJOR_LAYOUT,
-            mesh_config=mesh_config,
             seq_dim=-1,
         )
         ttnn.copy_host_to_device_tensor(pos_host, device_positions)
@@ -348,7 +341,7 @@ def test_prefill_long_context_traced(
             # for finiteness instead of only the last.
             if readback_all or chunk_idx == n_chunks - 1:
                 t_rb = time.time()
-                hidden = _cp_gather_torch(out, mesh_device, mesh_config)
+                hidden = _cp_gather_torch(out, mesh_config)
                 assert torch.isfinite(hidden).all(), f"chunk {chunk_idx} produced non-finite output"
                 readback_s += time.time() - t_rb
             # Report per-chunk latency and cumulative device and wall time.
@@ -441,7 +434,7 @@ def test_prefill_layer_perf_chunk_n(mesh_device, chunk_idx, layer_type, chunk_si
     model_path = _model_path()
     text_config = _hf_text_config(model_path)
     model_args, model, _ = _build_prefill_model(
-        mesh_device=mesh_device,
+        mesh_config=mesh_config,
         model_path=model_path,
         chunk_size=chunk_size,
         context_len=context_len,
@@ -457,21 +450,15 @@ def test_prefill_layer_perf_chunk_n(mesh_device, chunk_idx, layer_type, chunk_si
     )
 
     host_input = _host_tensor(
-        mesh_device,
-        tokens_all[:, :chunk_size].contiguous(),
-        ttnn.uint32,
-        ttnn.ROW_MAJOR_LAYOUT,
-        mesh_config=mesh_config,
-        seq_dim=-1,
+        mesh_config, tokens_all[:, :chunk_size].contiguous(), ttnn.uint32, ttnn.ROW_MAJOR_LAYOUT, seq_dim=-1
     )
     device_input = ttnn.to_device(host_input, device=mesh_device)
     device_positions = ttnn.to_device(
         _host_tensor(
-            mesh_device,
+            mesh_config,
             torch.arange(0, chunk_size, dtype=torch.int32).unsqueeze(0),
             ttnn.uint32,
             ttnn.ROW_MAJOR_LAYOUT,
-            mesh_config=mesh_config,
             seq_dim=-1,
         ),
         device=mesh_device,
@@ -483,11 +470,10 @@ def test_prefill_layer_perf_chunk_n(mesh_device, chunk_idx, layer_type, chunk_si
         """Refresh tokens, ring metadata, semaphores, and RoPE positions before replay."""
         chunk_start = idx * chunk_size
         staged = _host_tensor(
-            mesh_device,
+            mesh_config,
             tokens_all[:, chunk_start : chunk_start + chunk_size].contiguous(),
             ttnn.uint32,
             ttnn.ROW_MAJOR_LAYOUT,
-            mesh_config=mesh_config,
             seq_dim=-1,
         )
         ttnn.copy_host_to_device_tensor(staged, device_input)
@@ -496,11 +482,10 @@ def test_prefill_layer_perf_chunk_n(mesh_device, chunk_idx, layer_type, chunk_si
         for semaphore in model.ccl_manager.ring_attention_ccl_semaphore_handles:
             ttnn.reset_global_semaphore_value(semaphore, 0)
         pos_host = _host_tensor(
-            mesh_device,
+            mesh_config,
             torch.arange(chunk_start, chunk_start + chunk_size, dtype=torch.int32).unsqueeze(0),
             ttnn.uint32,
             ttnn.ROW_MAJOR_LAYOUT,
-            mesh_config=mesh_config,
             seq_dim=-1,
         )
         ttnn.copy_host_to_device_tensor(pos_host, device_positions)
@@ -609,7 +594,7 @@ def test_prefill_layer_perf_chunk_n(mesh_device, chunk_idx, layer_type, chunk_si
                     f"tok_s={chunk_size / measured_s:.0f} signposts={sp_start},{sp_stop}"
                 )
 
-        hidden = _cp_gather_torch(outs[layer_types[-1]], mesh_device, mesh_config)
+        hidden = _cp_gather_torch(outs[layer_types[-1]], mesh_config)
     finally:
         for tid in traces.values():
             ttnn.release_trace(mesh_device, tid)

--- a/models/demos/gemma4_d_p/demo/text_demo_prefill.py
+++ b/models/demos/gemma4_d_p/demo/text_demo_prefill.py
@@ -37,7 +37,7 @@ TRACE_REGION_SIZE = int(os.environ.get("GEMMA4_PREFILL_TRACE_REGION_SIZE", 256_0
 
 
 def _model_path():
-    return os.getenv("HF_MODEL") or os.getenv("GEMMA4_MODEL_PATH", "google/gemma-4-31B-it")
+    return os.getenv("HF_MODEL")
 
 
 def _load_full_weights():

--- a/models/demos/gemma4_d_p/demo/text_demo_prefill.py
+++ b/models/demos/gemma4_d_p/demo/text_demo_prefill.py
@@ -82,10 +82,9 @@ def _host_tensor(mesh_device, torch_tensor, dtype, layout, mesh_config=None, seq
 
 def _cp_or_replicate_mapper(mesh_device, mesh_config, seq_dim=-2):
     """Create a CP sharding mapper for ``seq_dim``, or a replication mapper."""
-    from models.demos.gemma4_d_p.tt.ccl import cp_degree
 
-    if mesh_config is not None and cp_degree(mesh_config) > 1:
-        shard_dims = (seq_dim, None) if mesh_config.sp_axis == 0 else (None, seq_dim)
+    if mesh_config is not None and mesh_config.cp_degree > 1:
+        shard_dims = (seq_dim, None) if mesh_config.cp_axis == 0 else (None, seq_dim)
         return ttnn.ShardTensor2dMesh(mesh_device, mesh_device.shape, dims=shard_dims)
     return ttnn.ReplicateTensorToMesh(mesh_device)
 
@@ -146,10 +145,9 @@ def _cp_gather_torch(tensor, mesh_device, mesh_config):
 
     Falls back to device 0 alone when CP is off, matching ``_first_device_torch``.
     """
-    from models.demos.gemma4_d_p.tt.ccl import cp_degree
 
     shards = ttnn.get_device_tensors(tensor)
-    cp = cp_degree(mesh_config) if mesh_config is not None else 1
+    cp = mesh_config.cp_degree if mesh_config is not None else 1
     if cp <= 1:
         return ttnn.to_torch(shards[0]).float()
 
@@ -176,7 +174,7 @@ def _hf_text_config(model_path):
 def _build_prefill_model(mesh_device, model_path, chunk_size, context_len=None):
     """Create a CP prefill model with ring caches for one or more chunks."""
     mesh_config = _mesh_config(mesh_device)
-    if mesh_config.prefill.sp <= 1:
+    if mesh_config.cp_degree <= 1:
         raise ValueError("This demo requires context parallel prefill")
     tp = mesh_device.shape[1]
     context_len = context_len or chunk_size
@@ -215,10 +213,9 @@ def test_prefill_long_context_traced(
     mesh_device, context_len, chunk_size, readback_all, token_source, reset_seeds, request
 ):
     """Measure all prefill chunks using one replayed ring-attention trace."""
-    from models.demos.gemma4_d_p.tt.ccl import cp_degree
 
     mesh_config = _mesh_config(mesh_device)
-    cp = cp_degree(mesh_config)
+    cp = mesh_config.cp_degree
     if cp <= 1:
         pytest.skip(f"targets CP>1; mesh {tuple(mesh_device.shape)} gives CP={cp}")
     if chunk_size < GEMMA4_SLIDING_WINDOW_TOKENS * cp:
@@ -421,10 +418,9 @@ def test_prefill_layer_perf_chunk_n(mesh_device, chunk_idx, layer_type, chunk_si
     """
     from models.demos.gemma4_d_p.tt.attention.global_kv_cache import pack_global_rope_device, pack_sliding_rope_device
     from models.demos.gemma4_d_p.tt.attention.ring_prefill import PackedRingKVCache
-    from models.demos.gemma4_d_p.tt.ccl import cp_degree
 
     mesh_config = _mesh_config(mesh_device)
-    cp = cp_degree(mesh_config)
+    cp = mesh_config.cp_degree
     if cp <= 1:
         pytest.skip(f"targets CP>1; mesh {tuple(mesh_device.shape)} gives CP={cp}")
     if chunk_size < GEMMA4_SLIDING_WINDOW_TOKENS * cp:

--- a/models/demos/gemma4_d_p/demo/upload_cache_diagnostic.py
+++ b/models/demos/gemma4_d_p/demo/upload_cache_diagnostic.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Upload existing tensorbins without modifying them; capture stdout/stderr for analysis."""
+
+import argparse
+import hashlib
+import struct
+import time
+from pathlib import Path
+
+import ttnn
+
+CACHE_ROOT = Path("/mnt/models/huggingface/tt_cache/gemma4_d_p/google--gemma-4-31B-it/tensor_cache_bf16_mesh8x4")
+DEFAULT_FILES = [
+    CACHE_ROOT / "layer_59/mlp/down_proj.weight_tp4_bfp8_dtype_BFLOAT8_B_layout_TILE.tensorbin",
+    CACHE_ROOT / "final_norm/weight_dtype_BFLOAT16_layout_ROW_MAJOR.tensorbin",
+]
+
+
+def digest(path):
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="*", type=Path, default=DEFAULT_FILES)
+    parser.add_argument("--cache-dir", type=Path, help="Recursively upload every tensorbin in this directory")
+    args = parser.parse_args()
+    if args.cache_dir is not None:
+        args.files = sorted(args.cache_dir.rglob("*.tensorbin"))
+    if not args.files:
+        parser.error("No tensorbins found")
+    print(f"FILES={len(args.files)}; hashing source files before upload", flush=True)
+    originals = {path: digest(path) for path in args.files}
+    print(f"TTNN_MODULE={ttnn.__file__}", flush=True)
+    ttnn.set_fabric_config(ttnn.FabricConfig.FABRIC_1D)
+    mesh_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(8, 4))
+    try:
+        print(f"MESH_OPEN devices={mesh_device.get_num_devices()}", flush=True)
+        for index, path in enumerate(args.files):
+            with path.open("rb") as stream:
+                header_size = struct.unpack("<Q", stream.read(8))[0]
+            offset = 8 + header_size
+            print(
+                f"BEGIN_TENSOR {index} path={path} payload_offset={offset} "
+                f"mod16={offset % 16} mod64={offset % 64} payload_bytes={path.stat().st_size - offset}",
+                flush=True,
+            )
+            host = ttnn.load_tensor(path)
+            print(f"HOST shape={host.shape} dtype={host.dtype} layout={host.layout}", flush=True)
+            ttnn.synchronize_device(mesh_device)
+            start = time.perf_counter()
+            device_tensor = ttnn.to_device(host, mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            ttnn.synchronize_device(mesh_device)
+            print(f"UPLOAD_DONE {index} elapsed_ms={(time.perf_counter() - start) * 1000:.3f}", flush=True)
+            device_tensor.deallocate(True)
+            del device_tensor, host
+            print(f"END_TENSOR {index}", flush=True)
+    finally:
+        ttnn.close_mesh_device(mesh_device)
+        for path, expected in originals.items():
+            assert digest(path) == expected, f"File contents changed: {path}"
+        print("SOURCE_SHA256_UNCHANGED", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/gemma4_d_p/tests/unit/test_kv_caches.py
+++ b/models/demos/gemma4_d_p/tests/unit/test_kv_caches.py
@@ -28,7 +28,7 @@ def test_external_cache_allocation_preserves_semantic_layer_order(monkeypatch):
         num_hidden_layers=3,
         layer_types=["sliding_attention", "full_attention", "sliding_attention"],
     )
-    mesh_config = SimpleNamespace(prefill=SimpleNamespace(sp=8), tp=4)
+    mesh_config = SimpleNamespace(cp_degree=8, tp_degree=4)
 
     result = kv_caches.allocate_ring_kv_caches(object(), hf, mesh_config, num_users=8, max_seq_len=262144)
 
@@ -48,7 +48,7 @@ def test_chunk_locations_match_user_head_major_nd_shards():
         iter_cache_chunk_locations(
             seq_len=1024,
             chunk_size=256,
-            sp=2,
+            cp=2,
             num_users=2,
             heads_per_device=4,
             local_head=3,

--- a/models/demos/gemma4_d_p/tests/unit/test_kv_caches.py
+++ b/models/demos/gemma4_d_p/tests/unit/test_kv_caches.py
@@ -28,16 +28,16 @@ def test_external_cache_allocation_preserves_semantic_layer_order(monkeypatch):
         num_hidden_layers=3,
         layer_types=["sliding_attention", "full_attention", "sliding_attention"],
     )
-    mesh_config = SimpleNamespace(cp_degree=8, tp_degree=4)
+    mesh_config = SimpleNamespace(device=object(), cp_degree=8, tp_degree=4)
 
-    result = kv_caches.allocate_ring_kv_caches(object(), hf, mesh_config, num_users=8, max_seq_len=262144)
+    result = kv_caches.allocate_ring_kv_caches(mesh_config, hf, num_users=8, max_seq_len=262144)
 
     assert result.layers == ["sliding-cache", "global-cache", "sliding-cache"]
     assert result.global_layers == (1,)
     assert result.sliding_layers == (0, 2)
     assert [call[0] for call in calls] == ["sliding", "global", "sliding"]
-    assert calls[0][1][2:] == (4, 256, 262144)
-    assert calls[1][1][2:] == (1, 262144)
+    assert calls[0][1][1:] == (4, 256, 262144)
+    assert calls[1][1][1:] == (1, 262144)
     assert all(call[2]["num_users"] == 8 for call in calls)
 
 

--- a/models/demos/gemma4_d_p/tests/unit/test_prefill_dispatch.py
+++ b/models/demos/gemma4_d_p/tests/unit/test_prefill_dispatch.py
@@ -81,11 +81,10 @@ def test_attention_reuses_external_ring_cache_without_auxiliary_allocations(monk
     monkeypatch.setattr(attention, "init_packed_ring_kv_cache", allocate)
     monkeypatch.setattr(ttnn, "zeros", allocate)
     result = attention.Gemma4Attention(
-        mesh_device=object(),
         config=SimpleNamespace(is_sliding=not is_global, sliding_window=1024),
         state_dict={},
         ccl_manager=object(),
-        mesh_config=MeshConfig((8, 4)),
+        mesh_config=MeshConfig(SimpleNamespace(shape=(8, 4))),
         layer_idx=0,
         ring_kv_cache=cache,
     )
@@ -107,15 +106,16 @@ def test_projection_loads_only_required_weight(monkeypatch, is_global):
 
     monkeypatch.setattr(ttnn, "as_tensor", as_tensor)
     mesh_config = SimpleNamespace(
+        device=object(),
         tp_degree=4,
         cp_degree=8,
-        column_parallel=lambda _: None,
-        row_parallel=lambda _: None,
+        column_parallel=lambda: None,
+        row_parallel=lambda: None,
     )
     config = SimpleNamespace(
         use_kv_tying=is_global, num_attention_heads=32, num_key_value_heads=4, head_dim=512, hidden_size=5376
     )
-    result = weights.load_attention_weights(object(), config, {}, mesh_config, tensor_cache_path="/tmp/weights")
+    result = weights.load_attention_weights(mesh_config, config, {}, tensor_cache_path="/tmp/weights")
     assert (result.wqk is not None) == is_global
     assert (result.wqkv is not None) != is_global
     assert len([name for name in loaded if "/wqk" in name]) == 1

--- a/models/demos/gemma4_d_p/tests/unit/test_prefill_dispatch.py
+++ b/models/demos/gemma4_d_p/tests/unit/test_prefill_dispatch.py
@@ -107,8 +107,8 @@ def test_projection_loads_only_required_weight(monkeypatch, is_global):
 
     monkeypatch.setattr(ttnn, "as_tensor", as_tensor)
     mesh_config = SimpleNamespace(
-        tp=4,
-        prefill=SimpleNamespace(sp=8),
+        tp_degree=4,
+        cp_degree=8,
         column_parallel=lambda _: None,
         row_parallel=lambda _: None,
     )

--- a/models/demos/gemma4_d_p/tests/unit/test_standalone.py
+++ b/models/demos/gemma4_d_p/tests/unit/test_standalone.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from models.demos.gemma4_d_p.config import GALAXY_MESH_SHAPES, MeshConfig, ModeConfig
+from models.demos.gemma4_d_p.config import GALAXY_MESH_SHAPES, MeshConfig
 from models.demos.gemma4_d_p.tt.common import create_tt_model
 from models.demos.gemma4_d_p.tt.model import _cp_chunk_major_row_order
 
@@ -19,8 +19,10 @@ from models.demos.gemma4_d_p.tt.model import _cp_chunk_major_row_order
 @pytest.mark.parametrize("shape", GALAXY_MESH_SHAPES)
 def test_galaxy_parallelism_uses_all_rows_and_columns(shape):
     config = MeshConfig(shape)
-    assert config.prefill.sp == shape[0]
-    assert config.prefill.tp == shape[1]
+    assert config.cp_axis == 0
+    assert config.cp_degree == shape[config.cp_axis]
+    assert config.tp_axis == 1
+    assert config.tp_degree == shape[config.tp_axis]
     assert config.total_devices == 32
 
 
@@ -28,11 +30,6 @@ def test_galaxy_parallelism_uses_all_rows_and_columns(shape):
 def test_smaller_or_multiple_galaxies_are_rejected(shape, expect_error):
     with expect_error(ValueError, "requires a Galaxy mesh"):
         MeshConfig(shape)
-
-
-def test_disabling_cp_is_rejected(expect_error):
-    with expect_error(ValueError, "must use all Galaxy rows"):
-        MeshConfig((8, 4), prefill=ModeConfig(tp=4, sp=1))
 
 
 @pytest.mark.parametrize("chunk_size", [0, -8192, 4096, 8193])

--- a/models/demos/gemma4_d_p/tests/unit/test_standalone.py
+++ b/models/demos/gemma4_d_p/tests/unit/test_standalone.py
@@ -18,7 +18,10 @@ from models.demos.gemma4_d_p.tt.model import _cp_chunk_major_row_order
 
 @pytest.mark.parametrize("shape", GALAXY_MESH_SHAPES)
 def test_galaxy_parallelism_uses_all_rows_and_columns(shape):
-    config = MeshConfig(shape)
+    mesh_device = SimpleNamespace(shape=shape)
+    config = MeshConfig(mesh_device)
+    assert config.device is mesh_device
+    assert config.mesh_shape == shape
     assert config.cp_axis == 0
     assert config.cp_degree == shape[config.cp_axis]
     assert config.tp_axis == 1
@@ -29,13 +32,13 @@ def test_galaxy_parallelism_uses_all_rows_and_columns(shape):
 @pytest.mark.parametrize("shape", [(1, 1), (1, 2), (2, 4), (1, 8), (1, 32), (8, 8)])
 def test_smaller_or_multiple_galaxies_are_rejected(shape, expect_error):
     with expect_error(ValueError, "requires a Galaxy mesh"):
-        MeshConfig(shape)
+        MeshConfig(SimpleNamespace(shape=shape))
 
 
 @pytest.mark.parametrize("chunk_size", [0, -8192, 4096, 8193])
 def test_invalid_chunk_geometry_fails_before_weight_loading(chunk_size, expect_error):
     with expect_error(ValueError, "positive|whole CP-local tiles|sliding window"):
-        create_tt_model(SimpleNamespace(shape=(8, 4)), max_seq_len=32768, prefill_chunk_size=chunk_size)
+        create_tt_model(MeshConfig(SimpleNamespace(shape=(8, 4))), max_seq_len=32768, prefill_chunk_size=chunk_size)
 
 
 @pytest.mark.parametrize("cp,chunk_size", [(8, 8192), (4, 4096), (8, 16384), (8, 32768)])
@@ -100,3 +103,20 @@ def test_non_31b_architectures_are_rejected(field, value, expect_error):
     setattr(config, field, value)
     with expect_error(ValueError, "Only Gemma4-31B-it is supported"):
         Gemma4ModelArgs.from_hf_config(config)
+
+
+@pytest.mark.parametrize("shape", GALAXY_MESH_SHAPES)
+def test_shard_mappers_use_bound_device(monkeypatch, shape):
+    import ttnn
+
+    mesh_device = SimpleNamespace(shape=shape)
+    mesh_config = MeshConfig(mesh_device)
+    calls = []
+    monkeypatch.setattr(
+        ttnn, "ShardTensor2dMesh", lambda device, mesh_shape, dims: calls.append((device, mesh_shape, dims))
+    )
+    mesh_config.column_parallel()
+    mesh_config.row_parallel()
+    mesh_config.shard_mapper(mesh_dims=(-2, None))
+    assert all(device is mesh_device and mesh_shape == shape for device, mesh_shape, _ in calls)
+    assert [tuple(dims) for _, _, dims in calls] == [(None, -1), (None, -2), (-2, None)]

--- a/models/demos/gemma4_d_p/tt/attention/__init__.py
+++ b/models/demos/gemma4_d_p/tt/attention/__init__.py
@@ -20,7 +20,7 @@ class Gemma4AttentionConfig:
         self.rms_norm_eps = hf_config.rms_norm_eps
 
         self.is_sliding = self.layer_type == "sliding_attention"
-        self.use_kv_tying = getattr(hf_config, "attention_k_eq_v", False) and not self.is_sliding
+        self.use_kv_tying = hf_config.attention_k_eq_v and not self.is_sliding
 
         if self.is_sliding:
             self.num_key_value_heads = hf_config.num_key_value_heads
@@ -29,10 +29,8 @@ class Gemma4AttentionConfig:
             self.rope_theta = hf_config.rope_theta
             self.partial_rotary_factor = 1.0
         else:
-            # Global KV heads: use num_global_key_value_heads if set, else fall back to sliding
-            global_kv = getattr(hf_config, "num_global_key_value_heads", None)
-            self.num_key_value_heads = global_kv if global_kv else hf_config.num_key_value_heads
-            self.head_dim = getattr(hf_config, "global_head_dim", hf_config.head_dim)
+            self.num_key_value_heads = hf_config.num_global_key_value_heads
+            self.head_dim = hf_config.global_head_dim
             self.sliding_window = None
             self.rope_theta = hf_config.global_rope_theta
             self.partial_rotary_factor = hf_config.partial_rotary_factor

--- a/models/demos/gemma4_d_p/tt/attention/__init__.py
+++ b/models/demos/gemma4_d_p/tt/attention/__init__.py
@@ -43,11 +43,10 @@ class Gemma4AttentionConfig:
 class Gemma4Attention:
     def __init__(
         self,
-        mesh_device,
+        mesh_config,
         config,
         state_dict,
         ccl_manager,
-        mesh_config,
         layer_idx,
         tensor_cache_path=None,
         max_batch_size=1,
@@ -57,6 +56,7 @@ class Gemma4Attention:
         ring_layer_idx=0,
         ring_num_layers=1,
     ):
+        mesh_device = mesh_config.device
         self.mesh_device = mesh_device
         self.config = config
         self.ccl_manager = ccl_manager
@@ -69,10 +69,9 @@ class Gemma4Attention:
                 raise ValueError("External ring cache is too small for the configured prefill capacity")
 
         self.weights = load_attention_weights(
-            mesh_device=mesh_device,
+            mesh_config=mesh_config,
             config=config,
             state_dict=state_dict,
-            mesh_config=mesh_config,
             tensor_cache_path=tensor_cache_path,
             weight_dtype=weight_dtype,
         )
@@ -87,7 +86,6 @@ class Gemma4Attention:
             )
             if self.weights.is_global:
                 self.ring_kv_cache = init_packed_ring_kv_cache(
-                    mesh_device=mesh_device,
                     mesh_config=mesh_config,
                     num_local_kv_heads=num_local_kv_heads,
                     max_seq_len=max_seq_len,
@@ -96,7 +94,6 @@ class Gemma4Attention:
                 )
             else:
                 self.ring_kv_cache = init_ring_kv_cache(
-                    mesh_device=mesh_device,
                     mesh_config=mesh_config,
                     num_local_kv_heads=num_local_kv_heads,
                     head_dim=config.head_dim,

--- a/models/demos/gemma4_d_p/tt/attention/__init__.py
+++ b/models/demos/gemma4_d_p/tt/attention/__init__.py
@@ -65,7 +65,7 @@ class Gemma4Attention:
 
         if ring_kv_cache is not None:
             cache = ring_kv_cache.kv if hasattr(ring_kv_cache, "kv") else ring_kv_cache[0]
-            if cache.shape[-2] * mesh_config.prefill.sp < max_seq_len:
+            if cache.shape[-2] * mesh_config.cp_degree < max_seq_len:
                 raise ValueError("External ring cache is too small for the configured prefill capacity")
 
         self.weights = load_attention_weights(
@@ -80,9 +80,11 @@ class Gemma4Attention:
         self.ring_kv_cache = ring_kv_cache
         self.ring_layer_idx = ring_layer_idx
         self.ring_num_layers = ring_num_layers
-        self.ring_max_seq_len = cache.shape[-2] * mesh_config.prefill.sp if ring_kv_cache is not None else None
+        self.ring_max_seq_len = cache.shape[-2] * mesh_config.cp_degree if ring_kv_cache is not None else None
         if self.ring_kv_cache is None:
-            num_local_kv_heads = 1 if self.weights.kv_replicated else config.num_key_value_heads // mesh_config.tp
+            num_local_kv_heads = (
+                1 if self.weights.kv_replicated else config.num_key_value_heads // mesh_config.tp_degree
+            )
             if self.weights.is_global:
                 self.ring_kv_cache = init_packed_ring_kv_cache(
                     mesh_device=mesh_device,

--- a/models/demos/gemma4_d_p/tt/attention/__init__.py
+++ b/models/demos/gemma4_d_p/tt/attention/__init__.py
@@ -50,7 +50,7 @@ class Gemma4Attention:
         layer_idx,
         tensor_cache_path=None,
         max_batch_size=1,
-        max_seq_len=131072,
+        max_seq_len=262144,
         weight_dtype=ttnn.bfloat16,
         ring_kv_cache=None,
         ring_layer_idx=0,

--- a/models/demos/gemma4_d_p/tt/attention/prefill.py
+++ b/models/demos/gemma4_d_p/tt/attention/prefill.py
@@ -44,7 +44,7 @@ def prefill_forward(
     """Write a user's chunk and attend its cached prefix."""
     if ring_kv_cache is None:
         raise ValueError("Galaxy prefill requires a ring KV cache")
-    tp = mesh_config.tp
+    tp = mesh_config.tp_degree
     chunk_offset = int(chunk_start_idx)
     kv_tied = weights.is_global
     xqkv = apply_qkv_projection(hidden_states, weights, kv_tied=kv_tied)

--- a/models/demos/gemma4_d_p/tt/attention/prefill.py
+++ b/models/demos/gemma4_d_p/tt/attention/prefill.py
@@ -165,7 +165,6 @@ def prefill_forward(
         tt_sdpa = ring_packed_prefill_attention(
             packed_q,
             ring_kv_cache.kv,
-            mesh_device=tt_q.device(),
             mesh_config=mesh_config,
             ccl_manager=ccl_manager,
             num_local_kv_heads=num_local_kv_heads_ring,
@@ -183,13 +182,11 @@ def prefill_forward(
             tt_q,
             ring_kv_cache[0],
             ring_kv_cache[1],
-            mesh_device=tt_q.device(),
             mesh_config=mesh_config,
             ccl_manager=ccl_manager,
             num_local_kv_heads=num_local_kv_heads_ring,
             head_dim=config.head_dim,
             max_seq_len=ring_max_seq_len,
-            # Captured traces reserve the full history; device metadata bounds valid reads.
             logical_n=ring_logical_n,
             kv_actual_global=chunk_offset,
             sliding_window=sliding_window,

--- a/models/demos/gemma4_d_p/tt/attention/ring_prefill.py
+++ b/models/demos/gemma4_d_p/tt/attention/ring_prefill.py
@@ -69,14 +69,7 @@ def ring_cache_seq_len(max_seq_len, cp):
 
 
 def init_ring_kv_cache(
-    mesh_device,
-    mesh_config,
-    num_local_kv_heads,
-    head_dim,
-    max_seq_len,
-    num_layers=1,
-    num_users=1,
-    cache_dtype=ttnn.bfloat8_b,
+    mesh_config, num_local_kv_heads, head_dim, max_seq_len, num_layers=1, num_users=1, cache_dtype=ttnn.bfloat8_b
 ):
     """Contiguous CP-sharded K/V caches for the ring path.
 
@@ -91,6 +84,7 @@ def init_ring_kv_cache(
 
     bfloat8_b because ring_joint requires BFP8_B K/V (BF16 Q).
     """
+    mesh_device = mesh_config.device
     cp = mesh_config.cp_degree
     seq_local = ring_cache_seq_len(max_seq_len, cp)
     shape = [num_users * num_layers, num_local_kv_heads, seq_local, head_dim]
@@ -110,15 +104,10 @@ class PackedRingKVCache:
 
 
 def init_packed_ring_kv_cache(
-    mesh_device,
-    mesh_config,
-    num_local_kv_heads,
-    max_seq_len,
-    num_layers=1,
-    num_users=1,
-    cache_dtype=ttnn.bfloat8_b,
+    mesh_config, num_local_kv_heads, max_seq_len, num_layers=1, num_users=1, cache_dtype=ttnn.bfloat8_b
 ):
     """Allocate the global [Krot128 | Vordered512] CP-sharded cache."""
+    mesh_device = mesh_config.device
     cp = mesh_config.cp_degree
     seq_local = ring_cache_seq_len(max_seq_len, cp)
     shape = [num_users * num_layers, num_local_kv_heads, seq_local, GLOBAL_PACKED_DIM]
@@ -166,7 +155,6 @@ def write_chunk_to_packed_ring_cache(
 def ring_packed_prefill_attention(
     tt_q,
     cache_kv,
-    mesh_device,
     mesh_config,
     ccl_manager,
     num_local_kv_heads,
@@ -194,7 +182,6 @@ def ring_packed_prefill_attention(
         tt_q,
         cache_k,
         cache_v,
-        mesh_device,
         mesh_config,
         ccl_manager,
         num_local_kv_heads,
@@ -289,7 +276,6 @@ def ring_prefill_attention(
     tt_q,
     cache_k,
     cache_v,
-    mesh_device,
     mesh_config,
     ccl_manager,
     num_local_kv_heads,
@@ -314,6 +300,7 @@ def ring_prefill_attention(
     Returns ``[1, num_local_q_heads, q_local, head_dim]`` — this rank's rows only, so
     the output stays CP-sharded exactly like the input.
     """
+    mesh_device = mesh_config.device
     if program_config is None:
         # Global (non-sliding) layers take a wider K chunk. ring_joint SDPA's
         # `q in {64,128}` / `k == 128` allowlist lives inside `if (args.has_sliding_window())`

--- a/models/demos/gemma4_d_p/tt/attention/ring_prefill.py
+++ b/models/demos/gemma4_d_p/tt/attention/ring_prefill.py
@@ -14,7 +14,6 @@ Local layers also apply the sliding window. Every chunk uses this path.
 from dataclasses import dataclass
 
 import ttnn
-from models.demos.gemma4_d_p.tt.ccl import cp_degree
 
 from .global_kv_cache import GLOBAL_HEAD_DIM, GLOBAL_PACKED_DIM, GLOBAL_ROTARY_DIM
 
@@ -92,7 +91,7 @@ def init_ring_kv_cache(
 
     bfloat8_b because ring_joint requires BFP8_B K/V (BF16 Q).
     """
-    cp = cp_degree(mesh_config)
+    cp = mesh_config.cp_degree
     seq_local = ring_cache_seq_len(max_seq_len, cp)
     shape = [num_users * num_layers, num_local_kv_heads, seq_local, head_dim]
 
@@ -120,7 +119,7 @@ def init_packed_ring_kv_cache(
     cache_dtype=ttnn.bfloat8_b,
 ):
     """Allocate the global [Krot128 | Vordered512] CP-sharded cache."""
-    cp = cp_degree(mesh_config)
+    cp = mesh_config.cp_degree
     seq_local = ring_cache_seq_len(max_seq_len, cp)
     shape = [num_users * num_layers, num_local_kv_heads, seq_local, GLOBAL_PACKED_DIM]
     cache = _allocate_migration_ring_cache(mesh_device, shape, cache_dtype, GLOBAL_PACKED_DIM)
@@ -148,7 +147,7 @@ def write_chunk_to_packed_ring_cache(
             kv_t,
             layer_idx=layer_idx,
             num_layers=num_layers,
-            cluster_axis=mesh_config.sp_axis,
+            cluster_axis=mesh_config.cp_axis,
         )
     else:
         ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
@@ -158,7 +157,7 @@ def write_chunk_to_packed_ring_cache(
             layer_idx=layer_idx,
             num_layers=num_layers,
             kv_actual_global=kv_actual_global,
-            cluster_axis=mesh_config.sp_axis,
+            cluster_axis=mesh_config.cp_axis,
         )
     if chunk is not packed_kv:
         chunk.deallocate(True)
@@ -272,7 +271,7 @@ def write_chunk_to_ring_cache(
                 kv_t,
                 layer_idx=layer_idx,
                 num_layers=num_layers,
-                cluster_axis=mesh_config.sp_axis,
+                cluster_axis=mesh_config.cp_axis,
             )
         else:
             ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
@@ -282,7 +281,7 @@ def write_chunk_to_ring_cache(
                 layer_idx=layer_idx,
                 num_layers=num_layers,
                 kv_actual_global=kv_actual_global,
-                cluster_axis=mesh_config.sp_axis,
+                cluster_axis=mesh_config.cp_axis,
             )
 
 
@@ -326,7 +325,7 @@ def ring_prefill_attention(
         program_config = ring_prefill_program_config(mesh_device, ccl_manager, head_dim, k_chunk_size=_k_chunk)
     # Shared by every layer; the caller sets them once per chunk via set_ring_metadata.
     metadata = ccl_manager.get_ring_metadata()
-    cp = cp_degree(mesh_config)
+    cp = mesh_config.cp_degree
     cache_seq = ring_cache_seq_len(max_seq_len, cp)
 
     # Buffer size depends on the mode, and the two requirements are opposites.
@@ -369,7 +368,7 @@ def ring_prefill_attention(
         dim=2,
         multi_device_global_semaphore=ccl_manager.ring_attention_ccl_semaphore_handles,
         num_links=ccl_manager.num_links,
-        cluster_axis=mesh_config.sp_axis,
+        cluster_axis=mesh_config.cp_axis,
         mesh_device=mesh_device,
         topology=ttnn.Topology.Linear,
         ccl_core_grid_offset=ttnn.CoreCoord(*ccl_manager.ring_attention_ccl_core_grid_offset),

--- a/models/demos/gemma4_d_p/tt/attention/weights.py
+++ b/models/demos/gemma4_d_p/tt/attention/weights.py
@@ -164,10 +164,6 @@ def load_attention_weights(
     if is_global and is_context_parallel:
         o_proj_cache_suffix += "_packed640"
     tp_suffix = f"_tp{tp}" if tp > 1 else ""
-    # Tag the wqkv / o_proj cache filenames with their dtype so flipping
-    # ``attention`` precision in precision_overrides.json doesn't reuse a
-    # stale cached tensor at the previous dtype. q_norm / k_norm stay at
-    # bfloat16 (no override) and don't need the suffix.
     from models.demos.gemma4_d_p.tt.precision import dtype_to_str
 
     dtype_suffix = f"_{dtype_to_str(weight_dtype)}"

--- a/models/demos/gemma4_d_p/tt/attention/weights.py
+++ b/models/demos/gemma4_d_p/tt/attention/weights.py
@@ -84,10 +84,10 @@ def load_attention_weights(
         k_w = k_w.reshape(config.num_key_value_heads, config.head_dim, -1).index_select(1, adjacent_order)
         k_w = k_w.reshape(kv_size, -1)
 
-    if not is_global:
-        v_w = state_dict["v_proj.weight"]  # [kv_size, H]
-    else:
+    if is_global:
         v_w = k_w  # K=V tying: duplicate K as V
+    else:
+        v_w = state_dict["v_proj.weight"]  # [kv_size, H]
 
     if tp > 1:
         # Chunk Q/K/V per TP device, fuse per-device, then concatenate across devices

--- a/models/demos/gemma4_d_p/tt/attention/weights.py
+++ b/models/demos/gemma4_d_p/tt/attention/weights.py
@@ -55,8 +55,8 @@ def load_attention_weights(
     tied_qkv = is_global
     q_size = config.num_attention_heads * config.head_dim
     kv_size = config.num_key_value_heads * config.head_dim
-    tp = mesh_config.tp
-    is_context_parallel = bool(mesh_config and mesh_config.prefill.sp > 1)
+    tp = mesh_config.tp_degree
+    is_context_parallel = bool(mesh_config and mesh_config.cp_degree > 1)
 
     # When KV heads < TP, each device gets the KV head(s) its Q heads map to via GQA.
     # E.g. 16 Q / 2 KV / 8 TP: devices 0-3 get KV head 0, devices 4-7 get KV head 1.

--- a/models/demos/gemma4_d_p/tt/attention/weights.py
+++ b/models/demos/gemma4_d_p/tt/attention/weights.py
@@ -20,6 +20,7 @@ import torch
 
 import ttnn
 from models.demos.gemma4_d_p.config import MeshConfig
+from models.demos.gemma4_d_p.tt.precision import dtype_to_str
 from models.demos.gemma4_d_p.utils.general_utils import get_cache_file_name
 
 from .global_kv_cache import GLOBAL_ROTARY_DIM, global_kv_indices, sliding_kv_indices
@@ -164,8 +165,6 @@ def load_attention_weights(
     if is_global and is_context_parallel:
         o_proj_cache_suffix += "_packed640"
     tp_suffix = f"_tp{tp}" if tp > 1 else ""
-    from models.demos.gemma4_d_p.tt.precision import dtype_to_str
-
     dtype_suffix = f"_{dtype_to_str(weight_dtype)}"
 
     packed_cache_suffix = (

--- a/models/demos/gemma4_d_p/tt/attention/weights.py
+++ b/models/demos/gemma4_d_p/tt/attention/weights.py
@@ -43,14 +43,14 @@ class AttentionWeights:
 
 
 def load_attention_weights(
-    mesh_device,
+    mesh_config: MeshConfig,
     config,
     state_dict,
-    mesh_config: MeshConfig,
     weight_dtype=ttnn.bfloat16,
     tensor_cache_path=None,
 ) -> AttentionWeights:
     """Load TP-sharded QKV or tied QK weights with the packed-cache permutations."""
+    mesh_device = mesh_config.device
     is_global = config.use_kv_tying
     tied_qkv = is_global
     q_size = config.num_attention_heads * config.head_dim
@@ -178,8 +178,8 @@ def load_attention_weights(
 
     # Mesh mappers
     if tp > 1:
-        col_mapper = mesh_config.column_parallel(mesh_device)
-        row_mapper = mesh_config.row_parallel(mesh_device)
+        col_mapper = mesh_config.column_parallel()
+        row_mapper = mesh_config.row_parallel()
         replicate_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     else:
         col_mapper = None

--- a/models/demos/gemma4_d_p/tt/attention/weights.py
+++ b/models/demos/gemma4_d_p/tt/attention/weights.py
@@ -85,54 +85,36 @@ def load_attention_weights(
         k_w = k_w.reshape(kv_size, -1)
 
     if is_global:
-        v_w = k_w  # K=V tying: duplicate K as V
+        projection_weights = (q_w, k_w)
     else:
-        v_w = state_dict["v_proj.weight"]  # [kv_size, H]
+        projection_weights = (q_w, k_w, state_dict["v_proj.weight"])
 
     if tp > 1:
-        # Chunk Q/K/V per TP device, fuse per-device, then concatenate across devices
-        # When kv_replicated, keep full K/V on each device instead of chunking
+        # Fuse each TP device's QK or QKV weights before concatenating devices.
         num_q_heads = config.num_attention_heads
         num_kv_heads = config.num_key_value_heads
         head_dim = config.head_dim
         q_per_device = num_q_heads // tp
 
-        qkv_list = []
-        qk_list = []
+        projection_chunks = []
         for i in range(tp):
-            wq_chunk = torch.chunk(q_w, tp, dim=0)[i].transpose(-2, -1)
-            if kv_replicated:
-                # GQA-aware KV assignment: each device gets the KV head its Q heads map to
-                kv_idx = (i * q_per_device) * num_kv_heads // num_q_heads
-                wk_chunk = k_w[kv_idx * head_dim : (kv_idx + 1) * head_dim].transpose(-2, -1)
-                wv_chunk = v_w[kv_idx * head_dim : (kv_idx + 1) * head_dim].transpose(-2, -1)
-            else:
-                wk_chunk = torch.chunk(k_w, tp, dim=0)[i].transpose(-2, -1)
-                wv_chunk = torch.chunk(v_w, tp, dim=0)[i].transpose(-2, -1)
-            qkv_list.append(torch.cat([wq_chunk, wk_chunk, wv_chunk], dim=-1))
-            if tied_qkv:
-                qk_list.append(torch.cat([wq_chunk, wk_chunk], dim=-1))
-        qkv = torch.cat(qkv_list, dim=-1).unsqueeze(0).unsqueeze(0)
-        qk = torch.cat(qk_list, dim=-1).unsqueeze(0).unsqueeze(0) if tied_qkv else None
+            chunks = [torch.chunk(q_w, tp, dim=0)[i].transpose(-2, -1)]
+            for weight in projection_weights[1:]:
+                if kv_replicated:
+                    # Assign each device the KV head its Q heads map to.
+                    kv_idx = (i * q_per_device) * num_kv_heads // num_q_heads
+                    chunk = weight[kv_idx * head_dim : (kv_idx + 1) * head_dim]
+                else:
+                    chunk = torch.chunk(weight, tp, dim=0)[i]
+                chunks.append(chunk.transpose(-2, -1))
+            projection_chunks.append(torch.cat(chunks, dim=-1))
+        projection = torch.cat(projection_chunks, dim=-1).unsqueeze(0).unsqueeze(0)
     else:
-        # Single device: fuse Q+K+V directly
-        qkv = (
-            torch.cat(
-                [
-                    q_w.transpose(-2, -1),
-                    k_w.transpose(-2, -1),
-                    v_w.transpose(-2, -1),
-                ],
-                dim=-1,
-            )
-            .unsqueeze(0)
-            .unsqueeze(0)
-        )
-        qk = (
-            torch.cat([q_w.transpose(-2, -1), k_w.transpose(-2, -1)], dim=-1).unsqueeze(0).unsqueeze(0)
-            if tied_qkv
-            else None
-        )
+        projection = torch.cat([weight.transpose(-2, -1) for weight in projection_weights], dim=-1)
+        projection = projection.unsqueeze(0).unsqueeze(0)
+
+    qk = projection if is_global else None
+    qkv = None if is_global else projection
 
     # Output projection
     o_w = state_dict["o_proj.weight"].transpose(-2, -1).unsqueeze(0).unsqueeze(0)

--- a/models/demos/gemma4_d_p/tt/attention/weights.py
+++ b/models/demos/gemma4_d_p/tt/attention/weights.py
@@ -68,113 +68,105 @@ def load_attention_weights(
     padded_local_hidden = ((local_hidden + 31) // 32) * 32
     o_proj_pad_size = padded_local_hidden - local_hidden
 
-    if state_dict:
-        q_w = state_dict["q_proj.weight"]  # [q_size, H]
-        k_w = state_dict["k_proj.weight"]  # [kv_size, H]
-        if is_global and is_context_parallel:
-            rotary, nonrotary, value_order = global_kv_indices(config.head_dim, GLOBAL_ROTARY_DIM)
-            query_order = torch.cat((rotary, nonrotary))
-            q_w = q_w.reshape(config.num_attention_heads, config.head_dim, -1).index_select(1, query_order)
-            q_w = q_w.reshape(q_size, -1)
-            k_w = k_w.reshape(config.num_key_value_heads, config.head_dim, -1).index_select(1, value_order)
-            k_w = k_w.reshape(kv_size, -1)
-        elif is_context_parallel:
-            adjacent_order = sliding_kv_indices(config.head_dim)
-            q_w = q_w.reshape(config.num_attention_heads, config.head_dim, -1).index_select(1, adjacent_order)
-            q_w = q_w.reshape(q_size, -1)
-            k_w = k_w.reshape(config.num_key_value_heads, config.head_dim, -1).index_select(1, adjacent_order)
-            k_w = k_w.reshape(kv_size, -1)
+    q_w = state_dict["q_proj.weight"]  # [q_size, H]
+    k_w = state_dict["k_proj.weight"]  # [kv_size, H]
+    if is_global and is_context_parallel:
+        rotary, nonrotary, value_order = global_kv_indices(config.head_dim, GLOBAL_ROTARY_DIM)
+        query_order = torch.cat((rotary, nonrotary))
+        q_w = q_w.reshape(config.num_attention_heads, config.head_dim, -1).index_select(1, query_order)
+        q_w = q_w.reshape(q_size, -1)
+        k_w = k_w.reshape(config.num_key_value_heads, config.head_dim, -1).index_select(1, value_order)
+        k_w = k_w.reshape(kv_size, -1)
+    elif is_context_parallel:
+        adjacent_order = sliding_kv_indices(config.head_dim)
+        q_w = q_w.reshape(config.num_attention_heads, config.head_dim, -1).index_select(1, adjacent_order)
+        q_w = q_w.reshape(q_size, -1)
+        k_w = k_w.reshape(config.num_key_value_heads, config.head_dim, -1).index_select(1, adjacent_order)
+        k_w = k_w.reshape(kv_size, -1)
 
-        if not is_global:
-            v_w = state_dict["v_proj.weight"]  # [kv_size, H]
-        else:
-            v_w = k_w  # K=V tying: duplicate K as V
-
-        if tp > 1:
-            # Chunk Q/K/V per TP device, fuse per-device, then concatenate across devices
-            # When kv_replicated, keep full K/V on each device instead of chunking
-            num_q_heads = config.num_attention_heads
-            num_kv_heads = config.num_key_value_heads
-            head_dim = config.head_dim
-            q_per_device = num_q_heads // tp
-
-            qkv_list = []
-            qk_list = []
-            for i in range(tp):
-                wq_chunk = torch.chunk(q_w, tp, dim=0)[i].transpose(-2, -1)
-                if kv_replicated:
-                    # GQA-aware KV assignment: each device gets the KV head its Q heads map to
-                    kv_idx = (i * q_per_device) * num_kv_heads // num_q_heads
-                    wk_chunk = k_w[kv_idx * head_dim : (kv_idx + 1) * head_dim].transpose(-2, -1)
-                    wv_chunk = v_w[kv_idx * head_dim : (kv_idx + 1) * head_dim].transpose(-2, -1)
-                else:
-                    wk_chunk = torch.chunk(k_w, tp, dim=0)[i].transpose(-2, -1)
-                    wv_chunk = torch.chunk(v_w, tp, dim=0)[i].transpose(-2, -1)
-                qkv_list.append(torch.cat([wq_chunk, wk_chunk, wv_chunk], dim=-1))
-                if tied_qkv:
-                    qk_list.append(torch.cat([wq_chunk, wk_chunk], dim=-1))
-            qkv = torch.cat(qkv_list, dim=-1).unsqueeze(0).unsqueeze(0)
-            qk = torch.cat(qk_list, dim=-1).unsqueeze(0).unsqueeze(0) if tied_qkv else None
-        else:
-            # Single device: fuse Q+K+V directly
-            qkv = (
-                torch.cat(
-                    [
-                        q_w.transpose(-2, -1),
-                        k_w.transpose(-2, -1),
-                        v_w.transpose(-2, -1),
-                    ],
-                    dim=-1,
-                )
-                .unsqueeze(0)
-                .unsqueeze(0)
-            )
-            qk = (
-                torch.cat([q_w.transpose(-2, -1), k_w.transpose(-2, -1)], dim=-1).unsqueeze(0).unsqueeze(0)
-                if tied_qkv
-                else None
-            )
-
-        # Output projection
-        o_w = state_dict["o_proj.weight"].transpose(-2, -1).unsqueeze(0).unsqueeze(0)
-        if is_global and is_context_parallel:
-            _, _, value_order = global_kv_indices(config.head_dim, GLOBAL_ROTARY_DIM)
-            o_w = o_w.reshape(1, 1, config.num_attention_heads, config.head_dim, config.hidden_size)
-            o_w = o_w.index_select(3, value_order)
-            o_w = o_w.reshape(1, 1, q_size, config.hidden_size)
-        if o_proj_pad_size > 0 and tp > 1:
-            padded_hidden = padded_local_hidden * tp
-            o_w = torch.nn.functional.pad(o_w, (0, padded_hidden - hidden_size), "constant", 0.0)
-
-        # Per-head norm weights: [head_dim] -> [1, 1, head_dim/TILE_SIZE, TILE_SIZE]
-        q_norm_flat = state_dict["q_norm.weight"].reshape(-1)
-        k_norm_flat = state_dict["k_norm.weight"].reshape(-1)
-        k_norm_w = k_norm_flat.reshape(1, 1, -1, ttnn.TILE_SIZE)
-        if is_global:
-            rotary, nonrotary, _ = global_kv_indices(config.head_dim, GLOBAL_ROTARY_DIM)
-            # The 128-wide rotary op consumes NeoX halves, not adjacent pairs.
-            rotary_neox = torch.sort(rotary).values
-            k_norm_rotary_w = k_norm_flat.index_select(0, rotary_neox).reshape(1, 1, 1, -1)
-            if is_context_parallel:
-                query_order = torch.cat((rotary, nonrotary))
-                packed_q_scale = torch.cat(
-                    (torch.ones(GLOBAL_ROTARY_DIM, dtype=k_norm_flat.dtype), k_norm_flat.index_select(0, nonrotary))
-                )
-                q_norm_flat = q_norm_flat.index_select(0, query_order) * packed_q_scale
-        else:
-            k_norm_rotary_w = None
-            if is_context_parallel:
-                adjacent_order = sliding_kv_indices(config.head_dim)
-                q_norm_flat = q_norm_flat.index_select(0, adjacent_order)
-                k_norm_w = k_norm_flat.index_select(0, adjacent_order).reshape(1, 1, -1, ttnn.TILE_SIZE)
-        q_norm_w = q_norm_flat.reshape(1, 1, -1, ttnn.TILE_SIZE)
+    if not is_global:
+        v_w = state_dict["v_proj.weight"]  # [kv_size, H]
     else:
-        qkv = None
-        qk = None
-        o_w = None
-        q_norm_w = None
-        k_norm_w = None
+        v_w = k_w  # K=V tying: duplicate K as V
+
+    if tp > 1:
+        # Chunk Q/K/V per TP device, fuse per-device, then concatenate across devices
+        # When kv_replicated, keep full K/V on each device instead of chunking
+        num_q_heads = config.num_attention_heads
+        num_kv_heads = config.num_key_value_heads
+        head_dim = config.head_dim
+        q_per_device = num_q_heads // tp
+
+        qkv_list = []
+        qk_list = []
+        for i in range(tp):
+            wq_chunk = torch.chunk(q_w, tp, dim=0)[i].transpose(-2, -1)
+            if kv_replicated:
+                # GQA-aware KV assignment: each device gets the KV head its Q heads map to
+                kv_idx = (i * q_per_device) * num_kv_heads // num_q_heads
+                wk_chunk = k_w[kv_idx * head_dim : (kv_idx + 1) * head_dim].transpose(-2, -1)
+                wv_chunk = v_w[kv_idx * head_dim : (kv_idx + 1) * head_dim].transpose(-2, -1)
+            else:
+                wk_chunk = torch.chunk(k_w, tp, dim=0)[i].transpose(-2, -1)
+                wv_chunk = torch.chunk(v_w, tp, dim=0)[i].transpose(-2, -1)
+            qkv_list.append(torch.cat([wq_chunk, wk_chunk, wv_chunk], dim=-1))
+            if tied_qkv:
+                qk_list.append(torch.cat([wq_chunk, wk_chunk], dim=-1))
+        qkv = torch.cat(qkv_list, dim=-1).unsqueeze(0).unsqueeze(0)
+        qk = torch.cat(qk_list, dim=-1).unsqueeze(0).unsqueeze(0) if tied_qkv else None
+    else:
+        # Single device: fuse Q+K+V directly
+        qkv = (
+            torch.cat(
+                [
+                    q_w.transpose(-2, -1),
+                    k_w.transpose(-2, -1),
+                    v_w.transpose(-2, -1),
+                ],
+                dim=-1,
+            )
+            .unsqueeze(0)
+            .unsqueeze(0)
+        )
+        qk = (
+            torch.cat([q_w.transpose(-2, -1), k_w.transpose(-2, -1)], dim=-1).unsqueeze(0).unsqueeze(0)
+            if tied_qkv
+            else None
+        )
+
+    # Output projection
+    o_w = state_dict["o_proj.weight"].transpose(-2, -1).unsqueeze(0).unsqueeze(0)
+    if is_global and is_context_parallel:
+        _, _, value_order = global_kv_indices(config.head_dim, GLOBAL_ROTARY_DIM)
+        o_w = o_w.reshape(1, 1, config.num_attention_heads, config.head_dim, config.hidden_size)
+        o_w = o_w.index_select(3, value_order)
+        o_w = o_w.reshape(1, 1, q_size, config.hidden_size)
+    if o_proj_pad_size > 0 and tp > 1:
+        padded_hidden = padded_local_hidden * tp
+        o_w = torch.nn.functional.pad(o_w, (0, padded_hidden - hidden_size), "constant", 0.0)
+
+    # Per-head norm weights: [head_dim] -> [1, 1, head_dim/TILE_SIZE, TILE_SIZE]
+    q_norm_flat = state_dict["q_norm.weight"].reshape(-1)
+    k_norm_flat = state_dict["k_norm.weight"].reshape(-1)
+    k_norm_w = k_norm_flat.reshape(1, 1, -1, ttnn.TILE_SIZE)
+    if is_global:
+        rotary, nonrotary, _ = global_kv_indices(config.head_dim, GLOBAL_ROTARY_DIM)
+        # The 128-wide rotary op consumes NeoX halves, not adjacent pairs.
+        rotary_neox = torch.sort(rotary).values
+        k_norm_rotary_w = k_norm_flat.index_select(0, rotary_neox).reshape(1, 1, 1, -1)
+        if is_context_parallel:
+            query_order = torch.cat((rotary, nonrotary))
+            packed_q_scale = torch.cat(
+                (torch.ones(GLOBAL_ROTARY_DIM, dtype=k_norm_flat.dtype), k_norm_flat.index_select(0, nonrotary))
+            )
+            q_norm_flat = q_norm_flat.index_select(0, query_order) * packed_q_scale
+    else:
         k_norm_rotary_w = None
+        if is_context_parallel:
+            adjacent_order = sliding_kv_indices(config.head_dim)
+            q_norm_flat = q_norm_flat.index_select(0, adjacent_order)
+            k_norm_w = k_norm_flat.index_select(0, adjacent_order).reshape(1, 1, -1, ttnn.TILE_SIZE)
+    q_norm_w = q_norm_flat.reshape(1, 1, -1, ttnn.TILE_SIZE)
 
     # Mesh mappers
     if tp > 1:

--- a/models/demos/gemma4_d_p/tt/ccl.py
+++ b/models/demos/gemma4_d_p/tt/ccl.py
@@ -292,11 +292,6 @@ class CCLManager:
         return [inter, out]
 
 
-def cp_degree(mesh_config):
-    """Number of context-parallel ranks in the Galaxy mesh."""
-    return mesh_config.prefill.sp
-
-
 def ccl_allreduce(tensor, mesh_config, ccl_manager, memory_config=None):
     """All-reduce across TP devices.
 
@@ -304,7 +299,7 @@ def ccl_allreduce(tensor, mesh_config, ccl_manager, memory_config=None):
     reduce_scatter_minimal_async + all_gather_async (tt_transformers composite
     pattern) on ``ccl_manager.topology`` (Ring on P150x8).
     """
-    if mesh_config is None or mesh_config.tp <= 1:
+    if mesh_config is None or mesh_config.tp_degree <= 1:
         return tensor
 
     memory_config = memory_config or ttnn.DRAM_MEMORY_CONFIG
@@ -315,7 +310,7 @@ def ccl_allreduce(tensor, mesh_config, ccl_manager, memory_config=None):
     workers = ccl_num_workers_per_link()
     nbuf = ccl_num_buffers_per_channel()
     if ccl_async_enabled():
-        tp = mesh_config.tp
+        tp = mesh_config.tp_degree
         rs_bufs = ccl_manager.get_persistent_rs_buffers(tensor, memory_config, tp)
         scattered = ttnn.experimental.reduce_scatter_minimal_async(
             tensor,
@@ -367,7 +362,7 @@ def ccl_allreduce(tensor, mesh_config, ccl_manager, memory_config=None):
 
 def ccl_allgather(tensor, mesh_config, ccl_manager, dim=3, memory_config=None):
     """All-gather across TP devices."""
-    if mesh_config is None or mesh_config.tp <= 1:
+    if mesh_config is None or mesh_config.tp_degree <= 1:
         return tensor
 
     memory_config = memory_config or ttnn.DRAM_MEMORY_CONFIG

--- a/models/demos/gemma4_d_p/tt/ccl.py
+++ b/models/demos/gemma4_d_p/tt/ccl.py
@@ -11,31 +11,8 @@ from models.common.utility_functions import is_blackhole
 from models.demos.gemma4_d_p.config import MeshConfig
 
 
-def default_num_links():
-    # GEMMA4_NUM_LINKS overrides the CCL link count. Used to test whether the ring
-    # replay deadlock involves the two parallel link workers racing each other.
-    import os as _os
-
-    _forced = _os.environ.get("GEMMA4_NUM_LINKS")
-    if _forced:
-        return int(_forced)
-    return _default_num_links_impl()
-
-
 def _default_num_links_impl():
-    """Default TP-collective link count for the current arch.
-
-    Blackhole boards expose 2 ethernet links between adjacent mesh devices, so
-    reduce-scatter / all-gather can run at ~2x bandwidth vs a single link — and
-    on Gemma4 prefill the per-layer all-reduces are ~31% of device time, so this
-    is the single highest-ROI CCL knob. Wormhole (T3K) defaults to 1 link here
-    (its multi-link tuning needs a separate sweep).
-
-    Override with ``GEMMA4_CCL_NUM_LINKS``.
-    """
-    env = os.environ.get("GEMMA4_CCL_NUM_LINKS")
-    if env is not None:
-        return max(1, int(env))
+    """Return the default link count: two on Blackhole, one otherwise."""
     return 2 if is_blackhole() else 1
 
 
@@ -89,7 +66,7 @@ class CCLManager:
 
     def __init__(self, mesh_device, num_links=None, topology=None):
         if num_links is None:
-            num_links = default_num_links()
+            num_links = _default_num_links_impl()
         if topology is None:
             topology = default_ccl_topology()
         self.mesh_device = mesh_device
@@ -134,12 +111,8 @@ class CCLManager:
         # asserts ccl_core_grid_offset.x < sdpa_grid.x, so both must derive from this
         # same grid (Blackhole is wider than 8x8).
         self.ring_attention_ccl_core_grid_offset = (self.compute_grid_size.x - 1, 0)
-        # THREE, not the usual forward/backward pair. The third is the neighbor-halo
-        # exchange's own counter. With only two, the halo reuses semaphores[0] — the
-        # all-gather's backward semaphore — and lands on the same worker core, so two
-        # protocols with different arrival counts share one counter. The halo's completion
-        # then destroys all-gather increments and the ring deadlocks at depth. See
-        # docs/superpowers/specs/2026-08-06-ring-trace-replay-deadlock.md.
+        # Three semaphores are needed: two for forward/backward all-gather
+        # and one for neighbor-halo exchange.
         self.ring_attention_ccl_semaphore_handles = [
             ttnn.create_global_semaphore(mesh_device, core_range_set, 0) for _ in range(3)
         ]

--- a/models/demos/gemma4_d_p/tt/ccl.py
+++ b/models/demos/gemma4_d_p/tt/ccl.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.gemma4_d_p.config import MeshConfig
 
 
 def default_num_links():
@@ -213,14 +214,14 @@ class CCLManager:
         CP rows — the layout the ring op reconstructs into.
 
         ``n_kv_local`` is the per-device head count. The buffer is built at the global
-        size ``n_kv_local * tp_cols`` and sharded across the TP columns so each device
+        size ``n_kv_local * tp_degree`` and sharded across the TP columns so each device
         ends up with its own ``n_kv_local`` heads. Passing the local count straight to
         the sharder fails ("number of chunks N to match the mesh dimension size"), and
         it also has to work for kv-replicated layers where the model's global KV head
         count is smaller than the TP width.
         """
-        rows, cols = tuple(self.mesh_device.shape)
-        n_kv_global = n_kv_local * cols
+        mesh_config = MeshConfig(self.mesh_device.shape)
+        n_kv_global = n_kv_local * mesh_config.tp_degree
         cache_key = (key, n_kv_global, seq, head_dim, str(dtype), str(memory_config))
         if cache_key not in self._ring_gather_buffers:
             self._ring_gather_buffers[cache_key] = ttnn.from_torch(
@@ -229,7 +230,7 @@ class CCLManager:
                 layout=ttnn.TILE_LAYOUT,
                 device=self.mesh_device,
                 memory_config=memory_config,
-                mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, mesh_shape=(rows, cols), dims=[None, 1]),
+                mesh_mapper=mesh_config.shard_mapper(self.mesh_device, tensor_dim=1),
             )
         return self._ring_gather_buffers[cache_key]
 

--- a/models/demos/gemma4_d_p/tt/ccl.py
+++ b/models/demos/gemma4_d_p/tt/ccl.py
@@ -8,7 +8,6 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_blackhole
-from models.demos.gemma4_d_p.config import MeshConfig
 
 
 def _default_num_links_impl():
@@ -64,7 +63,9 @@ class CCLManager:
     so repeated collectives of the same activation shape skip realloc+barrier.
     """
 
-    def __init__(self, mesh_device, num_links=None, topology=None):
+    def __init__(self, mesh_config, num_links=None, topology=None):
+        self.mesh_config = mesh_config
+        mesh_device = mesh_config.device
         if num_links is None:
             num_links = _default_num_links_impl()
         if topology is None:
@@ -193,7 +194,7 @@ class CCLManager:
         it also has to work for kv-replicated layers where the model's global KV head
         count is smaller than the TP width.
         """
-        mesh_config = MeshConfig(self.mesh_device.shape)
+        mesh_config = self.mesh_config
         n_kv_global = n_kv_local * mesh_config.tp_degree
         cache_key = (key, n_kv_global, seq, head_dim, str(dtype), str(memory_config))
         if cache_key not in self._ring_gather_buffers:
@@ -203,7 +204,7 @@ class CCLManager:
                 layout=ttnn.TILE_LAYOUT,
                 device=self.mesh_device,
                 memory_config=memory_config,
-                mesh_mapper=mesh_config.shard_mapper(self.mesh_device, tensor_dim=1),
+                mesh_mapper=mesh_config.shard_mapper(tensor_dim=1),
             )
         return self._ring_gather_buffers[cache_key]
 

--- a/models/demos/gemma4_d_p/tt/common.py
+++ b/models/demos/gemma4_d_p/tt/common.py
@@ -9,7 +9,6 @@ from loguru import logger
 
 import ttnn
 from models.common.weight_cache import build_cached_state_dict, mark_weight_cache_complete, weight_cache_is_complete
-from models.demos.gemma4_d_p.config import MeshConfig, validate_galaxy_mesh
 from models.demos.gemma4_d_p.tt.ccl import CCLManager
 from models.demos.gemma4_d_p.tt.model import Gemma4Model
 from models.demos.gemma4_d_p.tt.model_config import Gemma4ModelArgs
@@ -27,14 +26,13 @@ def _gemma4_is_host_weight(key):
 
 
 def create_tt_model(
-    mesh_device,
+    mesh_config,
     prefill_chunk_size,
     max_batch_size=1,
     max_seq_len=8192,
     dtype=ttnn.bfloat16,
     state_dict=None,
     num_layers=None,
-    mesh_config=None,
     model_path=None,
     ring_kv_caches=None,
     force_rebuild=False,
@@ -45,10 +43,7 @@ def create_tt_model(
     Returns:
         (model_args, model, tt_kv_cache, state_dict)
     """
-    mesh_config = mesh_config or MeshConfig(mesh_device.shape)
-    validate_galaxy_mesh(mesh_device.shape)
-    if tuple(mesh_device.shape) != mesh_config.mesh_shape:
-        raise ValueError("mesh_config must match the device mesh")
+    mesh_device = mesh_config.device
     SLIDING_WINDOW_SIZE = 1024
     if max_seq_len <= 0 or prefill_chunk_size <= 0:
         raise ValueError("sequence and chunk lengths must be positive")
@@ -69,7 +64,7 @@ def create_tt_model(
     if num_layers is not None:
         model_args.num_hidden_layers = num_layers
 
-    ccl_manager = CCLManager(mesh_device)
+    ccl_manager = CCLManager(mesh_config)
 
     # Reuse cached device weights; load embeddings and layer scalars from the host weight cache.
     _worker_mesh = tuple(mesh_device.shape)
@@ -104,13 +99,12 @@ def create_tt_model(
     precision = _precision_for_variant
 
     model = Gemma4Model(
-        mesh_device=mesh_device,
+        mesh_config=mesh_config,
         hf_config=model_args,
         state_dict=state_dict,
         ccl_manager=ccl_manager,
         dtype=dtype,
         tensor_cache_path=tensor_cache_path,
-        mesh_config=mesh_config,
         max_seq_len=max_seq_len,
         prefill_chunk_size=prefill_chunk_size,
         max_local_batch_size=max_batch_size,

--- a/models/demos/gemma4_d_p/tt/common.py
+++ b/models/demos/gemma4_d_p/tt/common.py
@@ -28,6 +28,7 @@ def _gemma4_is_host_weight(key):
 
 def create_tt_model(
     mesh_device,
+    prefill_chunk_size,
     max_batch_size=1,
     max_seq_len=8192,
     dtype=ttnn.bfloat16,
@@ -35,7 +36,6 @@ def create_tt_model(
     num_layers=None,
     mesh_config=None,
     model_path=None,
-    prefill_chunk_size=None,
     ring_kv_caches=None,
     force_rebuild=False,
 ):
@@ -49,8 +49,6 @@ def create_tt_model(
     validate_galaxy_mesh(mesh_device.shape)
     if tuple(mesh_device.shape) != mesh_config.mesh_shape:
         raise ValueError("mesh_config must match the device mesh")
-    if prefill_chunk_size is None:
-        prefill_chunk_size = min(8192, max_seq_len)
     SLIDING_WINDOW_SIZE = 1024
     if max_seq_len <= 0 or prefill_chunk_size <= 0:
         raise ValueError("sequence and chunk lengths must be positive")

--- a/models/demos/gemma4_d_p/tt/common.py
+++ b/models/demos/gemma4_d_p/tt/common.py
@@ -103,13 +103,13 @@ def create_tt_model(
         hf_config=model_args,
         state_dict=state_dict,
         ccl_manager=ccl_manager,
+        prefill_chunk_size=prefill_chunk_size,
+        precision=precision,
         dtype=dtype,
         tensor_cache_path=tensor_cache_path,
         max_seq_len=max_seq_len,
-        prefill_chunk_size=prefill_chunk_size,
         max_local_batch_size=max_batch_size,
         num_layers=num_layers,
-        precision=precision,
         ring_kv_caches=ring_kv_caches,
     )
 

--- a/models/demos/gemma4_d_p/tt/common.py
+++ b/models/demos/gemma4_d_p/tt/common.py
@@ -58,7 +58,7 @@ def create_tt_model(
     if prefill_chunk_size < 1024 * mesh_config.cp_degree:
         raise ValueError("prefill chunk size must cover the sliding window on each CP rank")
 
-    model_path = model_path or os.getenv("HF_MODEL") or os.getenv("GEMMA4_MODEL_PATH", "google/gemma-4-31B-it")
+    model_path = model_path or os.getenv("HF_MODEL")
 
     hf_config = Gemma4ModelArgs.load_hf_config(model_path)
     model_args = Gemma4ModelArgs.from_hf_config(hf_config)

--- a/models/demos/gemma4_d_p/tt/common.py
+++ b/models/demos/gemma4_d_p/tt/common.py
@@ -51,11 +51,12 @@ def create_tt_model(
         raise ValueError("mesh_config must match the device mesh")
     if prefill_chunk_size is None:
         prefill_chunk_size = min(8192, max_seq_len)
+    SLIDING_WINDOW_SIZE = 1024
     if max_seq_len <= 0 or prefill_chunk_size <= 0:
         raise ValueError("sequence and chunk lengths must be positive")
     if prefill_chunk_size % (mesh_config.cp_degree * ttnn.TILE_SIZE) or max_seq_len % prefill_chunk_size:
         raise ValueError("prefill chunks must divide max_seq_len and contain whole CP-local tiles")
-    if prefill_chunk_size < 1024 * mesh_config.cp_degree:
+    if prefill_chunk_size < SLIDING_WINDOW_SIZE * mesh_config.cp_degree:
         raise ValueError("prefill chunk size must cover the sliding window on each CP rank")
 
     model_path = model_path or os.getenv("HF_MODEL")
@@ -72,22 +73,10 @@ def create_tt_model(
 
     ccl_manager = CCLManager(mesh_device)
 
-    # Warm ttnn cache => skip the full HF weight load and build from .tensorbin. Hybrid: the few
-    # host-consumed weights (token embedding and layer scalars) are served real from the
-    # sidecar, the rest as dataless placeholders. Generalizes PR #50550 to gemma4 (#45400).
-    # Qualify the cache by mesh geometry BEFORE resolving cache_dir: ttnn.as_tensor
-    # reloads tensorbins as-is and ignores mesh_mapper, so a TP=4 cache built on
-    # MeshShape([2,4]) must not be reused on [1,4] (QB2). Setting cluster_shape here
-    # keeps the warm-cache marker (cache_dir) and the tensorbin path on the same
-    # directory instead of letting them diverge.
+    # Reuse cached device weights; load embeddings and layer scalars from the host weight cache.
     _worker_mesh = tuple(mesh_device.shape)
     model_args.cluster_shape = _worker_mesh
     cache_dir = model_args.weight_cache_path(dtype)
-    # Resolved early so it can key the cache identity: gemma4 embeds each module's dtype in its
-    # tensorbin FILENAME (attention/shared_mlp *_{dtype} suffixes), so an edit to
-    # precision_overrides.json changes which files a build needs. Without the precision in the
-    # variant, a marker seeded under the old overrides would certify a warm build whose files do
-    # not exist -- and as_tensor would persist placeholders for them. (#45400 review, finding B2)
     _precision_for_variant = Gemma4Precision.load(model_path, _worker_mesh)
     cache_identity = dict(
         model_name=os.path.basename(str(model_path).rstrip("/")) or "gemma4",
@@ -102,7 +91,7 @@ def create_tt_model(
     loaded_real_weights = False
     if state_dict is None:
         if not force_rebuild and num_layers is None and weight_cache_is_complete(cache_dir, **cache_identity):
-            logger.info("Warm ttnn weight cache detected -- skipping HF state_dict load (gemma4 hybrid).")
+            logger.info("Warm ttnn weight cache detected -- skipping HF state_dict load.")
             state_dict = build_cached_state_dict(
                 cache_dir, args=model_args, build_variant=cache_identity["build_variant"]
             )

--- a/models/demos/gemma4_d_p/tt/common.py
+++ b/models/demos/gemma4_d_p/tt/common.py
@@ -53,9 +53,9 @@ def create_tt_model(
         prefill_chunk_size = min(8192, max_seq_len)
     if max_seq_len <= 0 or prefill_chunk_size <= 0:
         raise ValueError("sequence and chunk lengths must be positive")
-    if prefill_chunk_size % (mesh_config.prefill.sp * ttnn.TILE_SIZE) or max_seq_len % prefill_chunk_size:
+    if prefill_chunk_size % (mesh_config.cp_degree * ttnn.TILE_SIZE) or max_seq_len % prefill_chunk_size:
         raise ValueError("prefill chunks must divide max_seq_len and contain whole CP-local tiles")
-    if prefill_chunk_size < 1024 * mesh_config.prefill.sp:
+    if prefill_chunk_size < 1024 * mesh_config.cp_degree:
         raise ValueError("prefill chunk size must cover the sliding window on each CP rank")
 
     model_path = model_path or os.getenv("HF_MODEL") or os.getenv("GEMMA4_MODEL_PATH", "google/gemma-4-31B-it")

--- a/models/demos/gemma4_d_p/tt/layer.py
+++ b/models/demos/gemma4_d_p/tt/layer.py
@@ -40,13 +40,7 @@ class Gemma4DecoderLayer:
         self.hidden_size = hf_config.hidden_size
         self.layer_type = hf_config.layer_types[layer_idx]
 
-        # Try both key formats (HF uses "model.language_model.layers", tests use "model.layers")
-        layer_state = {}
-        if state_dict:
-            for prefix in [f"model.language_model.layers.{layer_idx}", f"model.layers.{layer_idx}"]:
-                layer_state = substate(state_dict, prefix)
-                if layer_state:
-                    break
+        layer_state = substate(state_dict, f"model.language_model.layers.{layer_idx}") if state_dict else {}
 
         def _norm(name, with_scale=True):
             return RMSNorm(
@@ -64,10 +58,7 @@ class Gemma4DecoderLayer:
         self.post_feedforward_layernorm = _norm("post_feedforward_layernorm")
 
         # Layer scalar
-        if layer_state and "layer_scalar" in layer_state:
-            self.layer_scalar = layer_state["layer_scalar"].item()
-        else:
-            self.layer_scalar = 1.0
+        self.layer_scalar = layer_state["layer_scalar"].item()
 
         # Attention
         attn_config = Gemma4AttentionConfig(hf_config, layer_idx)

--- a/models/demos/gemma4_d_p/tt/layer.py
+++ b/models/demos/gemma4_d_p/tt/layer.py
@@ -3,7 +3,6 @@
 
 """Gemma4-31B dense decoder layer: attention, MLP, residuals and layer scalar."""
 
-
 import ttnn
 from models.demos.gemma4_d_p.tt.attention import Gemma4Attention, Gemma4AttentionConfig
 from models.demos.gemma4_d_p.tt.mlp import MLP
@@ -14,14 +13,13 @@ from models.demos.gemma4_d_p.utils.substate import substate
 class Gemma4DecoderLayer:
     def __init__(
         self,
-        mesh_device,
+        mesh_config,
         hf_config,
         state_dict,
         layer_idx,
         ccl_manager,
         dtype,
         tensor_cache_path,
-        mesh_config,
         max_seq_len,
         max_local_batch_size,
         mlp_dtype=None,
@@ -32,6 +30,7 @@ class Gemma4DecoderLayer:
     ):
         # Per-module dtype overrides default to the model-wide ``dtype`` so
         # callers that don't care about precision config see no change.
+        mesh_device = mesh_config.device
         if mlp_dtype is None:
             mlp_dtype = dtype
         if attention_dtype is None:
@@ -51,11 +50,10 @@ class Gemma4DecoderLayer:
 
         def _norm(name, with_scale=True):
             return RMSNorm(
-                mesh_device=mesh_device,
+                mesh_config=mesh_config,
                 hf_config=hf_config,
                 state_dict=substate(layer_state, name) if layer_state else {},
                 tensor_cache_path=f"{tensor_cache_path}/layer_{layer_idx}/{name}" if tensor_cache_path else None,
-                mesh_config=mesh_config,
                 with_scale=with_scale,
             )
 
@@ -74,11 +72,10 @@ class Gemma4DecoderLayer:
         # Attention
         attn_config = Gemma4AttentionConfig(hf_config, layer_idx)
         self.self_attn = Gemma4Attention(
-            mesh_device=mesh_device,
+            mesh_config=mesh_config,
             config=attn_config,
             state_dict=substate(layer_state, "self_attn") if layer_state else {},
             ccl_manager=ccl_manager,
-            mesh_config=mesh_config,
             layer_idx=layer_idx,
             tensor_cache_path=f"{tensor_cache_path}/layer_{layer_idx}/self_attn" if tensor_cache_path else None,
             weight_dtype=attention_dtype,
@@ -91,10 +88,9 @@ class Gemma4DecoderLayer:
 
         # Dense MLP (HF key: "mlp")
         self.mlp = MLP(
-            mesh_device=mesh_device,
+            mesh_config=mesh_config,
             hf_config=hf_config,
             state_dict=substate(layer_state, "mlp") if layer_state else {},
-            mesh_config=mesh_config,
             ccl_manager=ccl_manager,
             dtype=mlp_dtype,
             tensor_cache_path=f"{tensor_cache_path}/layer_{layer_idx}/mlp" if tensor_cache_path else None,

--- a/models/demos/gemma4_d_p/tt/mlp.py
+++ b/models/demos/gemma4_d_p/tt/mlp.py
@@ -27,7 +27,7 @@ class MLP:
         self.hidden_size = hf_config.hidden_size
         self.intermediate_size = hf_config.intermediate_size
 
-        tp = mesh_config.tp if mesh_config else 1
+        tp = mesh_config.tp_degree if mesh_config else 1
         tp_suffix = f"_tp{tp}" if tp > 1 else ""
 
         # Tag the cache filenames with the weight dtype so that flipping a
@@ -103,6 +103,6 @@ class MLP:
         up.deallocate(True)
         output = ttnn.linear(hidden, self.down_proj, compute_kernel_config=self.compute_kernel_config)
         hidden.deallocate(True)
-        if self.mesh_config is not None and self.mesh_config.tp > 1:
+        if self.mesh_config is not None and self.mesh_config.tp_degree > 1:
             output = ccl_allreduce(output, self.mesh_config, self.ccl_manager)
         return output

--- a/models/demos/gemma4_d_p/tt/mlp.py
+++ b/models/demos/gemma4_d_p/tt/mlp.py
@@ -3,7 +3,6 @@
 
 """Tensor-parallel dense MLP for Gemma4-31B prefill."""
 
-
 import ttnn
 from models.demos.gemma4_d_p.tt.ccl import ccl_allreduce
 from models.demos.gemma4_d_p.tt.precision import dtype_to_str
@@ -12,15 +11,9 @@ from models.demos.gemma4_d_p.utils.general_utils import get_cache_file_name
 
 class MLP:
     def __init__(
-        self,
-        mesh_device,
-        hf_config,
-        state_dict,
-        mesh_config,
-        ccl_manager=None,
-        dtype=ttnn.bfloat8_b,
-        tensor_cache_path=None,
+        self, mesh_config, hf_config, state_dict, ccl_manager=None, dtype=ttnn.bfloat8_b, tensor_cache_path=None
     ):
+        mesh_device = mesh_config.device
         self.mesh_device = mesh_device
         self.mesh_config = mesh_config
         self.ccl_manager = ccl_manager
@@ -56,8 +49,8 @@ class MLP:
         )
 
         if tp > 1:
-            col_mapper = mesh_config.column_parallel(mesh_device)
-            row_mapper = mesh_config.row_parallel(mesh_device)
+            col_mapper = mesh_config.column_parallel()
+            row_mapper = mesh_config.row_parallel()
         else:
             col_mapper = None
             row_mapper = None

--- a/models/demos/gemma4_d_p/tt/model.py
+++ b/models/demos/gemma4_d_p/tt/model.py
@@ -181,12 +181,14 @@ class Gemma4Model:
         ring_kv_caches=None,
     ):
         mesh_device = mesh_config.device
+
         if max_seq_len <= 0 or prefill_chunk_size <= 0:
             raise ValueError("sequence and chunk lengths must be positive")
         if max_seq_len % prefill_chunk_size or prefill_chunk_size % (mesh_config.cp_degree * ttnn.TILE_SIZE):
             raise ValueError("prefill chunks must divide max_seq_len and contain whole CP-local tiles")
         if prefill_chunk_size < 1024 * mesh_config.cp_degree:
             raise ValueError("prefill chunk size must cover the sliding window on each CP rank")
+
         self.mesh_device = mesh_device
         self.hf_config = hf_config
         self.prefill_chunk_size = prefill_chunk_size
@@ -199,7 +201,8 @@ class Gemma4Model:
         self.ccl_manager = ccl_manager
         self._rope_prefill_positions = None
         self._packed_global_rope_trans_mat = None
-        if mesh_config is not None and mesh_config.cp_degree > 1:
+
+        if mesh_config.cp_degree > 1:
             self._packed_global_rope_trans_mat = ttnn.from_torch(
                 get_rot_transformation_mat(),
                 device=mesh_device,
@@ -208,28 +211,22 @@ class Gemma4Model:
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
             )
+
         # When True the caller refreshes the ring metadata itself, outside any trace.
         self._ring_metadata_external = False
         self._prefill_trace_controller = None
         self.max_seq_len = max_seq_len
         n_layers = num_layers or hf_config.num_hidden_layers
 
-        # Per-module dtype resolution. ``precision`` (Gemma4Precision) holds
-        # any overrides loaded from precision_overrides.json; modules without
-        # an override fall back to ``dtype`` (the model-wide default). Dtypes
-        # are then threaded explicitly through DecoderLayer / used directly
-        # for embedding + lm_head, so each weight loads at the right precision
-        # and lands in a cache file tagged with that dtype.
         from models.demos.gemma4_d_p.tt.precision import Gemma4Precision
 
         if precision is None:
             precision = Gemma4Precision()
+
         mlp_dtype = precision.get("shared_mlp", dtype)
         attention_dtype = precision.get("attention", dtype)
         embedding_dtype = precision.get("embedding", dtype)
         lm_head_dtype = precision.get("lm_head", dtype)
-        # Paged K/V storage, not a weight: it sizes with context rather than with the model,
-        # so it is the one tensor whose precision trades against how long a prompt fits.
         kv_cache_dtype = precision.get("kv_cache", dtype)
 
         # RoPE caches per layer type (sliding vs global)

--- a/models/demos/gemma4_d_p/tt/model.py
+++ b/models/demos/gemma4_d_p/tt/model.py
@@ -171,6 +171,8 @@ class Gemma4Model:
         hf_config,
         state_dict,
         ccl_manager,
+        # Global prefill chunk size; determines RoPE ordering and ring KV cache layout.
+        prefill_chunk_size,
         dtype=ttnn.bfloat16,
         tensor_cache_path=None,
         mesh_config=None,
@@ -178,10 +180,6 @@ class Gemma4Model:
         max_local_batch_size=1,
         num_layers=None,
         precision=None,
-        # Global prefill chunk size. Only needed under context parallelism with more
-        # than one chunk: it sets the RoPE cache's chunk-major row order and sizes the
-        # ring KV cache slabs. None means single-chunk prefill.
-        prefill_chunk_size=None,
         ring_kv_caches=None,
     ):
         from models.demos.gemma4_d_p.config import validate_galaxy_mesh
@@ -189,8 +187,6 @@ class Gemma4Model:
         validate_galaxy_mesh(mesh_device.shape)
         if mesh_config is None or mesh_config.mesh_shape != tuple(mesh_device.shape):
             raise ValueError("Galaxy prefill requires a matching mesh_config")
-        if prefill_chunk_size is None:
-            prefill_chunk_size = min(8192, max_seq_len)
         if max_seq_len <= 0 or prefill_chunk_size <= 0:
             raise ValueError("sequence and chunk lengths must be positive")
         if max_seq_len % prefill_chunk_size or prefill_chunk_size % (mesh_config.cp_degree * ttnn.TILE_SIZE):

--- a/models/demos/gemma4_d_p/tt/model.py
+++ b/models/demos/gemma4_d_p/tt/model.py
@@ -172,12 +172,12 @@ class Gemma4Model:
         state_dict,
         ccl_manager,
         prefill_chunk_size,
+        precision,
         dtype=ttnn.bfloat16,
         tensor_cache_path=None,
         max_seq_len=262144,
         max_local_batch_size=1,
         num_layers=None,
-        precision=None,
         ring_kv_caches=None,
     ):
         mesh_device = mesh_config.device
@@ -217,11 +217,6 @@ class Gemma4Model:
         self._prefill_trace_controller = None
         self.max_seq_len = max_seq_len
         n_layers = num_layers or hf_config.num_hidden_layers
-
-        from models.demos.gemma4_d_p.tt.precision import Gemma4Precision
-
-        if precision is None:
-            precision = Gemma4Precision()
 
         mlp_dtype = precision.get("shared_mlp", dtype)
         attention_dtype = precision.get("attention", dtype)

--- a/models/demos/gemma4_d_p/tt/model.py
+++ b/models/demos/gemma4_d_p/tt/model.py
@@ -174,7 +174,7 @@ class Gemma4Model:
         prefill_chunk_size,
         dtype=ttnn.bfloat16,
         tensor_cache_path=None,
-        max_seq_len=131072,
+        max_seq_len=262144,
         max_local_batch_size=1,
         num_layers=None,
         precision=None,

--- a/models/demos/gemma4_d_p/tt/model.py
+++ b/models/demos/gemma4_d_p/tt/model.py
@@ -181,6 +181,9 @@ class Gemma4Model:
         num_layers=None,
         ring_kv_caches=None,
     ):
+        assert state_dict and any(
+            key.startswith("model.language_model.") for key in state_dict
+        ), "Expected a multimodal Gemma4 state_dict with model.language_model.* keys"
         mesh_device = mesh_config.device
 
         if max_seq_len <= 0 or prefill_chunk_size <= 0:
@@ -243,14 +246,8 @@ class Gemma4Model:
         tp = mesh_config.tp_degree
         tp_suffix = f"_tp{tp}" if tp > 1 else ""
 
-        if state_dict and "model.language_model.embed_tokens.weight" in state_dict:
-            embed_key = "model.language_model.embed_tokens.weight"
-        elif state_dict and "model.embed_tokens.weight" in state_dict:
-            embed_key = "model.embed_tokens.weight"
-        else:
-            embed_key = None
-
-        if embed_key:
+        embed_key = "model.language_model.embed_tokens.weight"
+        if embed_key in state_dict:
             embed_weight = state_dict[embed_key]
 
             # Embedding: column-parallel (shard hidden dim across TP devices)
@@ -298,12 +295,7 @@ class Gemma4Model:
         self.tt_kv_cache = [layer.self_attn.ring_kv_cache for layer in self.layers]
 
         # Final norm
-        if state_dict and "model.language_model.norm.weight" in state_dict:
-            norm_state = substate(state_dict, "model.language_model.norm")
-        elif state_dict and "model.norm.weight" in state_dict:
-            norm_state = substate(state_dict, "model.norm")
-        else:
-            norm_state = {}
+        norm_state = substate(state_dict, "model.language_model.norm")
 
         self.norm = RMSNorm(
             mesh_config=mesh_config,

--- a/models/demos/gemma4_d_p/tt/model.py
+++ b/models/demos/gemma4_d_p/tt/model.py
@@ -3,7 +3,6 @@
 
 """Gemma4 Galaxy prefill model with context-parallel ring attention."""
 
-
 import torch
 
 import ttnn
@@ -86,8 +85,9 @@ def _cp_chunk_major_row_order(max_seq_len, cp, chunk_size):
     return order
 
 
-def create_rope_caches(mesh_device, hf_config, max_seq_len, mesh_config=None, prefill_chunk_size=None):
+def create_rope_caches(mesh_config, hf_config, max_seq_len, prefill_chunk_size=None):
     """Create chunk-major CP-sharded RoPE tables and replicated tables for traced position lookup."""
+    mesh_device = mesh_config.device
     from transformers.models.gemma4.modeling_gemma4 import Gemma4TextRotaryEmbedding
 
     is_mesh = hasattr(mesh_device, "shape")
@@ -167,26 +167,20 @@ class Gemma4Model:
 
     def __init__(
         self,
-        mesh_device,
+        mesh_config,
         hf_config,
         state_dict,
         ccl_manager,
-        # Global prefill chunk size; determines RoPE ordering and ring KV cache layout.
         prefill_chunk_size,
         dtype=ttnn.bfloat16,
         tensor_cache_path=None,
-        mesh_config=None,
         max_seq_len=131072,
         max_local_batch_size=1,
         num_layers=None,
         precision=None,
         ring_kv_caches=None,
     ):
-        from models.demos.gemma4_d_p.config import validate_galaxy_mesh
-
-        validate_galaxy_mesh(mesh_device.shape)
-        if mesh_config is None or mesh_config.mesh_shape != tuple(mesh_device.shape):
-            raise ValueError("Galaxy prefill requires a matching mesh_config")
+        mesh_device = mesh_config.device
         if max_seq_len <= 0 or prefill_chunk_size <= 0:
             raise ValueError("sequence and chunk lengths must be positive")
         if max_seq_len % prefill_chunk_size or prefill_chunk_size % (mesh_config.cp_degree * ttnn.TILE_SIZE):
@@ -243,11 +237,7 @@ class Gemma4Model:
         hf_text_config = getattr(hf_config, "_hf_text_config", None)
         if hf_text_config is not None:
             self.rope_caches, self.rope_caches_2d = create_rope_caches(
-                mesh_device,
-                hf_text_config,
-                max_seq_len,
-                mesh_config=self.mesh_config,
-                prefill_chunk_size=prefill_chunk_size,
+                self.mesh_config, hf_text_config, max_seq_len, prefill_chunk_size=prefill_chunk_size
             )
         else:
             # Fallback: no automatic RoPE — caller must pass rope_mats explicitly
@@ -275,7 +265,7 @@ class Gemma4Model:
             # Embedding: column-parallel (shard hidden dim across TP devices)
             # Each device holds [vocab, hidden/TP]; all-gather after lookup.
             if tp > 1:
-                embed_mapper = mesh_config.column_parallel(mesh_device)
+                embed_mapper = mesh_config.column_parallel()
             else:
                 embed_mapper = replicate
             embed_suffix = f"_{dtype_to_str(embedding_dtype)}"
@@ -296,7 +286,7 @@ class Gemma4Model:
             # need the DRAM relief and can tolerate the precision loss.
             lm_head_weight = embed_weight.transpose(0, 1).unsqueeze(0).unsqueeze(0)
             if tp > 1:
-                lm_mapper = mesh_config.column_parallel(mesh_device)
+                lm_mapper = mesh_config.column_parallel()
             else:
                 lm_mapper = replicate
             lm_head_suffix = f"_{dtype_to_str(lm_head_dtype)}"
@@ -319,7 +309,7 @@ class Gemma4Model:
             raise ValueError(f"expected {n_layers} external ring caches, got {len(ring_kv_caches)}")
         for i in range(n_layers):
             layer = Gemma4DecoderLayer(
-                mesh_device=mesh_device,
+                mesh_config=mesh_config,
                 hf_config=hf_config,
                 state_dict=state_dict,
                 layer_idx=i,
@@ -328,10 +318,9 @@ class Gemma4Model:
                 mlp_dtype=mlp_dtype,
                 attention_dtype=attention_dtype,
                 tensor_cache_path=tensor_cache_path,
-                mesh_config=mesh_config,
                 max_seq_len=self.ring_cache_max_seq_len,
                 max_local_batch_size=max_local_batch_size,
-                ring_kv_cache=(ring_kv_caches[i] if ring_kv_caches is not None else None),
+                ring_kv_cache=ring_kv_caches[i] if ring_kv_caches is not None else None,
             )
             self.layers.append(layer)
 
@@ -346,11 +335,10 @@ class Gemma4Model:
             norm_state = {}
 
         self.norm = RMSNorm(
-            mesh_device=mesh_device,
+            mesh_config=mesh_config,
             hf_config=hf_config,
             state_dict=norm_state,
             tensor_cache_path=f"{tensor_cache_path}/final_norm" if tensor_cache_path else None,
-            mesh_config=mesh_config,
         )
 
     def _get_rope_mats(self, layer_idx, seq_len=None, start_pos=0):

--- a/models/demos/gemma4_d_p/tt/model.py
+++ b/models/demos/gemma4_d_p/tt/model.py
@@ -90,15 +90,13 @@ def create_rope_caches(mesh_device, hf_config, max_seq_len, mesh_config=None, pr
     """Create chunk-major CP-sharded RoPE tables and replicated tables for traced position lookup."""
     from transformers.models.gemma4.modeling_gemma4 import Gemma4TextRotaryEmbedding
 
-    from models.demos.gemma4_d_p.tt.ccl import cp_degree
-
     is_mesh = hasattr(mesh_device, "shape")
     replicate = ttnn.ReplicateTensorToMesh(mesh_device) if is_mesh else None
-    cp = cp_degree(mesh_config) if (is_mesh and mesh_config is not None) else 1
+    cp = mesh_config.cp_degree if (is_mesh and mesh_config is not None) else 1
     row_order = None
     if cp > 1:
         assert max_seq_len % cp == 0, f"max_seq_len {max_seq_len} must be divisible by CP degree {cp}"
-        shard_dims = (-2, None) if mesh_config.sp_axis == 0 else (None, -2)
+        shard_dims = (-2, None) if mesh_config.cp_axis == 0 else (None, -2)
         prefill_mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_device.shape, dims=shard_dims)
         # Multi-chunk needs the rows reordered so one scalar slice serves every rank;
         # single-chunk (max_seq_len == chunk) is already correct without it.
@@ -195,9 +193,9 @@ class Gemma4Model:
             prefill_chunk_size = min(8192, max_seq_len)
         if max_seq_len <= 0 or prefill_chunk_size <= 0:
             raise ValueError("sequence and chunk lengths must be positive")
-        if max_seq_len % prefill_chunk_size or prefill_chunk_size % (mesh_config.prefill.sp * ttnn.TILE_SIZE):
+        if max_seq_len % prefill_chunk_size or prefill_chunk_size % (mesh_config.cp_degree * ttnn.TILE_SIZE):
             raise ValueError("prefill chunks must divide max_seq_len and contain whole CP-local tiles")
-        if prefill_chunk_size < 1024 * mesh_config.prefill.sp:
+        if prefill_chunk_size < 1024 * mesh_config.cp_degree:
             raise ValueError("prefill chunk size must cover the sliding window on each CP rank")
         self.mesh_device = mesh_device
         self.hf_config = hf_config
@@ -211,7 +209,7 @@ class Gemma4Model:
         self.ccl_manager = ccl_manager
         self._rope_prefill_positions = None
         self._packed_global_rope_trans_mat = None
-        if mesh_config is not None and mesh_config.prefill.sp > 1:
+        if mesh_config is not None and mesh_config.cp_degree > 1:
             self._packed_global_rope_trans_mat = ttnn.from_torch(
                 get_rot_transformation_mat(),
                 device=mesh_device,
@@ -263,7 +261,7 @@ class Gemma4Model:
         # Embedding
         is_mesh = hasattr(mesh_device, "shape")
         replicate = ttnn.ReplicateTensorToMesh(mesh_device) if is_mesh else None
-        tp = mesh_config.tp if mesh_config else 1
+        tp = mesh_config.tp_degree if mesh_config else 1
         tp_suffix = f"_tp{tp}" if tp > 1 else ""
 
         from models.demos.gemma4_d_p.tt.precision import dtype_to_str
@@ -416,7 +414,7 @@ class Gemma4Model:
                 layer_rope = gathered_rope[layer_type]
             else:
                 layer_rope = self._get_rope_mats(
-                    i, seq_len=seq_len, start_pos=chunk_start_idx // self.mesh_config.prefill.sp
+                    i, seq_len=seq_len, start_pos=chunk_start_idx // self.mesh_config.cp_degree
                 )
             if layer_type not in packed_rope_by_type and self._packed_global_rope_trans_mat is not None:
                 pack_rope = pack_global_rope_device if layer_type == "full_attention" else pack_sliding_rope_device
@@ -442,14 +440,13 @@ class Gemma4Model:
 
     def _cp_gather_prefill_sequence(self, hidden_states):
         """Gather a chunk across CP ranks without freeing the caller-owned hidden states."""
-        from models.demos.gemma4_d_p.tt.ccl import cp_degree
 
-        if cp_degree(self.mesh_config) <= 1:
+        if self.mesh_config.cp_degree <= 1:
             return hidden_states
         return ttnn.all_gather(
             hidden_states,
             dim=2,
-            cluster_axis=self.mesh_config.sp_axis,
+            cluster_axis=self.mesh_config.cp_axis,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
@@ -483,7 +480,7 @@ class Gemma4Model:
         embeds = ttnn.mul(embeds, self.embed_scale)
 
         # All-gather sharded hidden dim back to full hidden
-        if self.mesh_config is not None and self.mesh_config.tp > 1:
+        if self.mesh_config is not None and self.mesh_config.tp_degree > 1:
             embeds = ttnn.unsqueeze_to_4D(embeds)
             from models.demos.gemma4_d_p.tt.ccl import ccl_allgather
 
@@ -513,7 +510,7 @@ class Gemma4Model:
         Under TP, Gemma4 all-gathers logits inside the model so a single
         device tensor already holds the full vocab.
         """
-        if self.mesh_config is not None and self.mesh_config.tp > 1:
+        if self.mesh_config is not None and self.mesh_config.tp_degree > 1:
             torch_output = ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0])
         else:
             torch_output = ttnn.to_torch(tt_out)

--- a/models/demos/gemma4_d_p/tt/model.py
+++ b/models/demos/gemma4_d_p/tt/model.py
@@ -10,8 +10,9 @@ from models.common.tensor_utils import get_rot_transformation_mat
 from models.demos.gemma4_d_p.tt.attention.global_kv_cache import pack_global_rope_device, pack_sliding_rope_device
 from models.demos.gemma4_d_p.tt.attention.ring_prefill import ring_cache_capacity
 from models.demos.gemma4_d_p.tt.layer import Gemma4DecoderLayer
+from models.demos.gemma4_d_p.tt.precision import dtype_to_str
 from models.demos.gemma4_d_p.tt.rms_norm import RMSNorm
-from models.demos.gemma4_d_p.utils.general_utils import cast_host_for_ttnn, get_cache_file_name
+from models.demos.gemma4_d_p.utils.general_utils import get_cache_file_name
 from models.demos.gemma4_d_p.utils.substate import substate
 
 
@@ -239,10 +240,8 @@ class Gemma4Model:
         # Embedding
         is_mesh = hasattr(mesh_device, "shape")
         replicate = ttnn.ReplicateTensorToMesh(mesh_device) if is_mesh else None
-        tp = mesh_config.tp_degree if mesh_config else 1
+        tp = mesh_config.tp_degree
         tp_suffix = f"_tp{tp}" if tp > 1 else ""
-
-        from models.demos.gemma4_d_p.tt.precision import dtype_to_str
 
         if state_dict and "model.language_model.embed_tokens.weight" in state_dict:
             embed_key = "model.language_model.embed_tokens.weight"
@@ -251,7 +250,7 @@ class Gemma4Model:
         else:
             embed_key = None
 
-        if embed_key and state_dict:
+        if embed_key:
             embed_weight = state_dict[embed_key]
 
             # Embedding: column-parallel (shard hidden dim across TP devices)
@@ -262,7 +261,7 @@ class Gemma4Model:
                 embed_mapper = replicate
             embed_suffix = f"_{dtype_to_str(embedding_dtype)}"
             self.embedding_weight = ttnn.as_tensor(
-                cast_host_for_ttnn(embed_weight.unsqueeze(0).unsqueeze(0), embedding_dtype),
+                embed_weight.unsqueeze(0).unsqueeze(0),
                 device=mesh_device,
                 dtype=embedding_dtype,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -271,29 +270,9 @@ class Gemma4Model:
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
 
-            # LM head (tied with embeddings): column-parallel (shard vocab dim)
-            # Each device holds [hidden, vocab/TP]; all-gather logits after softcapping.
-            # Default is bfloat16 — bfloat8_b is generally too lossy for 262k-vocab
-            # argmax, but the override is exposed for systems that genuinely
-            # need the DRAM relief and can tolerate the precision loss.
-            lm_head_weight = embed_weight.transpose(0, 1).unsqueeze(0).unsqueeze(0)
-            if tp > 1:
-                lm_mapper = mesh_config.column_parallel()
-            else:
-                lm_mapper = replicate
-            lm_head_suffix = f"_{dtype_to_str(lm_head_dtype)}"
-            self.lm_head_weight = ttnn.as_tensor(
-                lm_head_weight,
-                device=mesh_device,
-                dtype=lm_head_dtype,
-                layout=ttnn.TILE_LAYOUT,
-                mesh_mapper=lm_mapper,
-                cache_file_name=get_cache_file_name(tensor_cache_path, f"lm_head.weight{tp_suffix}{lm_head_suffix}"),
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            )
+            # Don't load LM head
         else:
             self.embedding_weight = None
-            self.lm_head_weight = None
 
         # Each layer owns a ring cache unless the caller supplies one.
         self.layers = []

--- a/models/demos/gemma4_d_p/tt/model_config.py
+++ b/models/demos/gemma4_d_p/tt/model_config.py
@@ -192,7 +192,7 @@ class Gemma4ModelArgs:
 
     @property
     def max_seq_len(self):
-        return getattr(self, "_max_seq_len", 131072)
+        return getattr(self, "_max_seq_len", 262144)
 
     @max_seq_len.setter
     def max_seq_len(self, value):

--- a/models/demos/gemma4_d_p/tt/model_config.py
+++ b/models/demos/gemma4_d_p/tt/model_config.py
@@ -3,7 +3,6 @@
 
 """Configuration and checkpoint loading for Gemma4-31B-it."""
 
-import errno
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,45 +13,6 @@ from tqdm import tqdm
 from transformers import AutoConfig, AutoModelForCausalLM
 
 from models.demos.gemma4_d_p.tt.precision import dtype_to_str
-
-_RO_ERRNOS = (errno.EROFS, errno.EACCES, errno.EPERM)
-
-
-def _writable_cache_mirror(preferred: Path) -> Path:
-    """Writable mirror for a preferred cache dir on RO mounts (CI MLPerf :ro)."""
-    root = Path(os.environ.get("TT_METAL_HOME") or os.environ.get("HOME") or "/tmp")
-    suffix = Path(*preferred.parts[-2:]) if len(preferred.parts) >= 2 else Path(preferred.name)
-    return root / "generated" / "gemma4_tt_cache" / suffix
-
-
-def _ensure_cache_dir(path: Path) -> Path:
-    """Return ``path``, creating it when possible.
-
-    CI mounts ``/mnt/MLPerf/huggingface`` read-only (``MLPERF_READ_ONLY``).
-    ``Path.mkdir`` then raises ``OSError: [Errno 30] Read-only file system``
-    when the cache subdir is missing. Reuse an existing dir; otherwise mirror
-    under ``$TT_METAL_HOME/generated/gemma4_tt_cache/...`` so cold builds can
-    still write.
-    """
-    if path.is_dir():
-        return path
-    try:
-        path.mkdir(parents=True, exist_ok=True)
-        return path
-    except OSError as e:
-        if e.errno not in _RO_ERRNOS:
-            raise
-        if path.is_dir():
-            return path
-        alt = _writable_cache_mirror(path)
-        logger.warning(
-            "Gemma4 weight cache: {} is not writable ({}); using {}.",
-            path,
-            e,
-            alt,
-        )
-        alt.mkdir(parents=True, exist_ok=True)
-        return alt
 
 
 def validate_31b_config(config):
@@ -240,7 +200,7 @@ class Gemma4ModelArgs:
 
     @staticmethod
     def resolve_model_cache_path(model_path):
-        """Resolve the cache root for model artifacts."""
+        """Resolve an existing cache root for model artifacts."""
         cache_dir = os.getenv("TT_CACHE_PATH")
         if cache_dir:
             cache_dir = Path(cache_dir)
@@ -256,10 +216,12 @@ class Gemma4ModelArgs:
             hf_home = os.getenv("HF_HOME") or os.path.expanduser("~/.cache/huggingface")
             sanitized = str(model_path).replace("/", "--")
             cache_dir = Path(hf_home) / "tt_cache" / sanitized
-        return _ensure_cache_dir(cache_dir)
+        if not cache_dir.is_dir():
+            raise FileNotFoundError(f"Cache directory does not exist or is not a directory: {cache_dir}")
+        return cache_dir
 
     def weight_cache_path(self, dtype, mesh_shape=None):
-        """Return the weight cache directory for this dtype and Galaxy mesh geometry."""
+        """Return an existing weight cache directory for this dtype and mesh geometry."""
         if self.model_cache_path is None:
             raise ValueError("model_cache_path must be initialized before requesting a weight cache path")
         dtype_str = dtype_to_str(dtype)
@@ -267,4 +229,7 @@ class Gemma4ModelArgs:
         if shape is None:
             raise ValueError("Mesh shape must be initialized before requesting a weight cache path")
         mesh_suffix = "x".join(str(d) for d in shape)
-        return _ensure_cache_dir(self.model_cache_path / f"tensor_cache_{dtype_str}_mesh{mesh_suffix}")
+        path = self.model_cache_path / f"tensor_cache_{dtype_str}_mesh{mesh_suffix}"
+        if not path.is_dir():
+            raise FileNotFoundError(f"Weight cache directory does not exist or is not a directory: {path}")
+        return path

--- a/models/demos/gemma4_d_p/tt/precision.py
+++ b/models/demos/gemma4_d_p/tt/precision.py
@@ -5,7 +5,6 @@
 
 import json
 import os
-import re
 
 import ttnn
 
@@ -65,25 +64,14 @@ class Gemma4Precision:
         model_path: full path to the HF checkpoint; we key on the basename.
         mesh_shape: (rows, cols) tuple, formatted as "RxC" for the JSON key.
         """
-        path = str(model_path).rstrip("/")
-        model_key = os.path.basename(path)
-        # Under HF_HUB_OFFLINE vLLM replaces the repo id with the resolved
-        # snapshot directory (.../models--{org}--{name}/snapshots/{hash}), so
-        # the basename is the snapshot hash and the variant lookup silently
-        # misses every override (31B then loads all-bf16: +~7.9 GB/chip at
-        # tp=4, which OOM'd the QB2 vLLM CI cell at 256k context). Recover the
-        # repo basename from the hub layout.
-        hub_match = re.search(r"models--[^/]+--([^/]+)/snapshots/[^/]+$", path)
-        if hub_match:
-            model_key = hub_match.group(1)
-        mesh_key = f"{mesh_shape[0]}x{mesh_shape[1]}"
-
         try:
             with open(_PATH) as f:
                 table = json.load(f)
         except FileNotFoundError:
             return cls({})
 
+        model_key = os.path.basename(str(model_path).rstrip("/"))
+        mesh_key = f"{mesh_shape[0]}x{mesh_shape[1]}"
         model_entry = table.get(model_key)
         if not model_entry:
             return cls({})

--- a/models/demos/gemma4_d_p/tt/rms_norm.py
+++ b/models/demos/gemma4_d_p/tt/rms_norm.py
@@ -4,12 +4,12 @@
 from torch import nn
 
 import ttnn
-from models.demos.gemma4_d_p.config import MeshConfig
 from models.demos.gemma4_d_p.utils.general_utils import get_cache_file_name
 
 
 class RMSNorm(nn.Module):
-    def __init__(self, mesh_device, hf_config, state_dict, tensor_cache_path=None, mesh_config=None, with_scale=True):
+    def __init__(self, mesh_config, hf_config, state_dict, tensor_cache_path=None, with_scale=True):
+        mesh_device = mesh_config.device
         super().__init__()
         self.with_scale = with_scale
 
@@ -18,7 +18,7 @@ class RMSNorm(nn.Module):
         else:
             torch_weight = None
 
-        self.mesh_config = mesh_config or MeshConfig(mesh_device.shape)
+        self.mesh_config = mesh_config
 
         if with_scale:
             self.tt_weight = ttnn.as_tensor(

--- a/models/demos/gemma4_d_p/tt/runners/kv_caches.py
+++ b/models/demos/gemma4_d_p/tt/runners/kv_caches.py
@@ -44,9 +44,8 @@ class Gemma4KvCaches(KvCaches):
 
 
 def allocate_ring_kv_caches(
-    mesh_device,
-    hf_config,
     mesh_config,
+    hf_config,
     *,
     num_users: int,
     max_seq_len: int,
@@ -68,7 +67,6 @@ def allocate_ring_kv_caches(
         local_heads = 1 if layer_type == "full_attention" else config.num_key_value_heads // mesh_config.tp_degree
         if layer_type == "full_attention":
             cache = init_packed_ring_kv_cache(
-                mesh_device,
                 mesh_config,
                 local_heads,
                 max_seq_len,
@@ -77,7 +75,6 @@ def allocate_ring_kv_caches(
             )
         elif layer_type == "sliding_attention":
             cache = init_ring_kv_cache(
-                mesh_device,
                 mesh_config,
                 local_heads,
                 config.head_dim,

--- a/models/demos/gemma4_d_p/tt/runners/kv_caches.py
+++ b/models/demos/gemma4_d_p/tt/runners/kv_caches.py
@@ -25,7 +25,7 @@ class Gemma4KvCaches(KvCaches):
     layer_types: tuple[str, ...]
     num_users: int
     max_seq_len: int
-    sp: int
+    cp: int
     tp: int
 
     def __len__(self):
@@ -58,14 +58,14 @@ def allocate_ring_kv_caches(
     num_layers = num_layers or hf_config.num_hidden_layers
     if num_users <= 0 or num_layers <= 0:
         raise ValueError(f"num_users and num_layers must be positive, got {num_users}, {num_layers}")
-    if mesh_config.prefill.sp <= 1:
+    if mesh_config.cp_degree <= 1:
         raise ValueError("migration-ready Gemma 4 caches require context parallel prefill")
     max_seq_len = ring_cache_capacity(max_seq_len, prefill_chunk_size)
     layer_types = tuple(hf_config.layer_types[:num_layers])
     caches = []
     for layer_idx, layer_type in enumerate(layer_types):
         config = Gemma4AttentionConfig(hf_config, layer_idx)
-        local_heads = 1 if layer_type == "full_attention" else config.num_key_value_heads // mesh_config.tp
+        local_heads = 1 if layer_type == "full_attention" else config.num_key_value_heads // mesh_config.tp_degree
         if layer_type == "full_attention":
             cache = init_packed_ring_kv_cache(
                 mesh_device,
@@ -93,6 +93,6 @@ def allocate_ring_kv_caches(
         layer_types=layer_types,
         num_users=num_users,
         max_seq_len=max_seq_len,
-        sp=mesh_config.prefill.sp,
-        tp=mesh_config.tp,
+        cp=mesh_config.cp_degree,
+        tp=mesh_config.tp_degree,
     )

--- a/models/demos/gemma4_d_p/tt/runners/kv_chunk_table.py
+++ b/models/demos/gemma4_d_p/tt/runners/kv_chunk_table.py
@@ -77,7 +77,7 @@ def build_kv_chunk_address_table(*, mesh_device, kv_caches: Gemma4KvCaches, chun
     """Describe global packed rows and sliding K/V rows directly from compute caches."""
     if not isinstance(kv_caches, Gemma4KvCaches):
         raise TypeError(f"expected Gemma4KvCaches, got {type(kv_caches).__name__}")
-    mesh_config = MeshConfig(tuple(mesh_device.shape))
+    mesh_config = MeshConfig(mesh_device)
     cp = mesh_config.cp_degree
     tp = mesh_config.tp_degree
     if (cp, tp) != (8, 4) or kv_caches.cp != cp or kv_caches.tp != tp:

--- a/models/demos/gemma4_d_p/tt/runners/kv_chunk_table.py
+++ b/models/demos/gemma4_d_p/tt/runners/kv_chunk_table.py
@@ -10,6 +10,7 @@ import zlib
 
 import ttnn
 from models.demos.common.prefill.runners.migration import get_num_dram_banks, serialize_prebuilt_kv_chunk_table
+from models.demos.gemma4_d_p.config import MeshConfig
 from models.demos.gemma4_d_p.tt.attention.global_kv_cache import GLOBAL_PACKED_DIM, SLIDING_HEAD_DIM
 from models.demos.gemma4_d_p.tt.attention.ring_prefill import TILE_HEIGHT, PackedRingKVCache
 from models.demos.gemma4_d_p.tt.runners.kv_caches import Gemma4KvCaches
@@ -33,7 +34,7 @@ def iter_cache_chunk_locations(
     *,
     seq_len: int,
     chunk_size: int,
-    sp: int,
+    cp: int,
     num_users: int,
     heads_per_device: int,
     local_head: int,
@@ -43,13 +44,13 @@ def iter_cache_chunk_locations(
     """Yield the ROUND_ROBIN_1D address walk for one head in one layer buffer."""
     if not 0 <= local_head < heads_per_device:
         raise ValueError(f"local_head {local_head} outside [0, {heads_per_device})")
-    if seq_len % chunk_size or chunk_size % (sp * TILE_HEIGHT):
+    if seq_len % chunk_size or chunk_size % (cp * TILE_HEIGHT):
         raise ValueError("sequence and prefill chunks must align to CP-local 32-token rows")
-    local_seq = seq_len // sp
-    local_chunk = chunk_size // sp
+    local_seq = seq_len // cp
+    local_chunk = chunk_size // cp
     blocks_local = local_seq // TILE_HEIGHT
     blocks_per_chunk = local_chunk // TILE_HEIGHT
-    for cp_row in range(sp):
+    for cp_row in range(cp):
         for slot in range(num_users):
             for prefill_chunk in range(seq_len // chunk_size):
                 for block_in_chunk in range(blocks_per_chunk):
@@ -72,14 +73,14 @@ def _config(*, num_layers, max_seq_len, num_users, chunk_size_bytes):
     return config
 
 
-def build_kv_chunk_address_table(*, mesh_device, kv_caches: Gemma4KvCaches, chunk_size: int, sp_axis: int = 0):
+def build_kv_chunk_address_table(*, mesh_device, kv_caches: Gemma4KvCaches, chunk_size: int):
     """Describe global packed rows and sliding K/V rows directly from compute caches."""
     if not isinstance(kv_caches, Gemma4KvCaches):
         raise TypeError(f"expected Gemma4KvCaches, got {type(kv_caches).__name__}")
-    tp_axis = 1 - sp_axis
-    sp = int(mesh_device.shape[sp_axis])
-    tp = int(mesh_device.shape[tp_axis])
-    if (sp, tp) != (8, 4) or kv_caches.sp != sp or kv_caches.tp != tp:
+    mesh_config = MeshConfig(tuple(mesh_device.shape))
+    cp = mesh_config.cp_degree
+    tp = mesh_config.tp_degree
+    if (cp, tp) != (8, 4) or kv_caches.cp != cp or kv_caches.tp != tp:
         raise ValueError(f"Gemma 4 migration currently requires CP8/TP4, got mesh={tuple(mesh_device.shape)}")
     num_layers = len(kv_caches)
     configs = {
@@ -103,7 +104,10 @@ def build_kv_chunk_address_table(*, mesh_device, kv_caches: Gemma4KvCaches, chun
     def device_group(cp_row, tp_column):
         key = (cp_row, tp_column)
         if key not in group_cache:
-            fnid = mesh_device.get_fabric_node_id(ttnn.MeshCoordinate(cp_row, tp_column))
+            coordinates = [0, 0]
+            coordinates[mesh_config.cp_axis] = cp_row
+            coordinates[mesh_config.tp_axis] = tp_column
+            fnid = mesh_device.get_fabric_node_id(ttnn.MeshCoordinate(*coordinates))
             group_cache[key] = table.add_device_group([fnid])
             host_key = (int(fnid.mesh_id), int(fnid.chip_id))
             if host_key not in mapped_hosts:
@@ -118,7 +122,7 @@ def build_kv_chunk_address_table(*, mesh_device, kv_caches: Gemma4KvCaches, chun
         for cp_row, slot, position, bank_id, bank_offset in iter_cache_chunk_locations(
             seq_len=kv_caches.max_seq_len,
             chunk_size=chunk_size,
-            sp=sp,
+            cp=cp,
             num_users=kv_caches.num_users,
             heads_per_device=heads_per_device,
             local_head=local_head,

--- a/models/demos/gemma4_d_p/utils/general_utils.py
+++ b/models/demos/gemma4_d_p/utils/general_utils.py
@@ -14,29 +14,3 @@ def get_cache_file_name(tensor_cache_path, name):
     CI then hits those cached tensorbins.
     """
     return f"{tensor_cache_path}/{name}" if tensor_cache_path else None
-
-
-def cast_host_for_ttnn(torch_tensor, ttnn_dtype):
-    """Cast a host torch tensor to the torch dtype matching ``ttnn_dtype``.
-
-    ``ttnn.as_tensor``/``from_torch`` run a C++ ``to_dtype`` conversion whenever the
-    source dtype differs from the requested one. That conversion queries tile metadata
-    on a ROW_MAJOR host intermediate and emits the #18536 "extract tile information out
-    of a ROW MAJOR layout" warning. Matching the host dtype up front lets ``to_dtype``
-    short-circuit, so no warning is emitted.
-
-    Only float targets representable in torch are handled; block formats (bfloat8_b /
-    bfloat4_b) have no torch equivalent and are returned unchanged.
-    """
-    import ttnn
-
-    try:
-        import torch
-    except ImportError:
-        return torch_tensor
-
-    mapping = {ttnn.bfloat16: torch.bfloat16, ttnn.float32: torch.float32}
-    target = mapping.get(ttnn_dtype)
-    if target is not None and torch_tensor.dtype != target:
-        return torch_tensor.to(target)
-    return torch_tensor


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Simplify the Gemma4 prefill implementation and make ownership and configuration explicit.

The disaggregated prefiil implementation was initially written in `models/demos/gemma4` and then moved to a standalone dir: `models/demos/gemma4_d_p`. This PR sheds unnecessary fat that was used to support multiple HW impls and all gemma4 variants, and many other things, greatly simplifying the codeflow and improving readability.

- **Configuration:** bind the device to `MeshConfig`, standardize CP/TP naming, remove unused mode/expert settings, and require precision and chunk-size arguments.
- **Weight loading:** use multimodal checkpoint keys, remove redundant guards and casts, skip LM head and final norm, and build only the required QK or QKV projection.
- **Attention and caches:** inline forwarding wrappers, standardize global/sliding function names, use named cache containers, and explicitly release temporary cast tensors.
- **Request metadata:** move slot and KV-position tensors from `CCLManager` into model-owned `PrefillMetadata`, preserving stable addresses for trace replay.
- **Trace and memory handling:** remove host semaphore resets, correct async all-gather semaphore counts.
- **Readability:** simplify conditionals, argument handling, variable names, comments, and input staging.

### Notes for reviewers
Focus on metadata propagation, tensor lifetimes, and trace replay behavior. Final model output is now the last decoder layer’s hidden states, without final normalization.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=svuckovic/gemma4-readability-improvements-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:svuckovic/gemma4-readability-improvements-pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=svuckovic/gemma4-readability-improvements-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:svuckovic/gemma4-readability-improvements-pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=svuckovic/gemma4-readability-improvements-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:svuckovic/gemma4-readability-improvements-pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=svuckovic/gemma4-readability-improvements-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:svuckovic/gemma4-readability-improvements-pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=svuckovic/gemma4-readability-improvements-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:svuckovic/gemma4-readability-improvements-pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=svuckovic/gemma4-readability-improvements-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:svuckovic/gemma4-readability-improvements-pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=svuckovic/gemma4-readability-improvements-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:svuckovic/gemma4-readability-improvements-pr)